### PR TITLE
Error handling

### DIFF
--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ErrorSource.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ErrorSource.cs
@@ -14,14 +14,19 @@
 //
 
 using System;
-using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Microsoft.WindowsAzure.ServiceLayer
 {
     /// <summary>
-    /// Base class for all Windows Azure exceptions.
+    /// Specifies source of an error.
     /// </summary>
-    internal class WindowsAzureException: COMException
+    enum ErrorSource
     {
+        ServiceBus,                                     // The error comes from the service bus call.
+        WrapAuthentication,                             // The error comes from WRAP authentication call.
     }
 }

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/WindowsAzureHttpException.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/WindowsAzureHttpException.cs
@@ -1,0 +1,66 @@
+﻿//
+// Copyright 2012 Microsoft Corporation
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.ServiceLayer.Http
+{
+    /// <summary>
+    /// Exception that occurs when HTTP call to Azure service fails.
+    /// </summary>
+    internal class WindowsAzureHttpException: WindowsAzureException
+    {
+        /// <summary>
+        /// Initializes the exception with data from the given HTTP response.
+        /// </summary>
+        /// <param name="response">HTTP response.</param>
+        internal WindowsAzureHttpException(HttpResponse response)
+        {
+            HResult = GetComErrorCode(response.StatusCode, ErrorSource.ServiceBus);
+
+            //TODO: error message.
+        }
+
+        /// <summary>
+        /// Initializes an empty exception.
+        /// </summary>
+        /// <remarks>This constructor is only used from derived classes that 
+        /// set required properties directly.</remarks>
+        protected WindowsAzureHttpException()
+        {
+        }
+
+        /// <summary>
+        /// Generates HRESULT for the given HTTP status code.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="errorSource">Error source.</param>
+        /// <returns>HRESULT with embedded status code and source.</returns>
+        internal static int GetComErrorCode(int statusCode, ErrorSource errorSource)
+        {
+            // 10 bits should be enough for the error code!
+            Debug.Assert((statusCode & 0xFC00) == 0);
+            uint code = 0x80040000;
+            code |= ((uint)errorSource) << 10;
+            code |= (uint)statusCode;
+            return (int)code;
+        }
+    }
+}

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/WrapAuthenticationException.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/WrapAuthenticationException.cs
@@ -18,33 +18,23 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.ServiceLayer.Http;
 
-namespace Microsoft.WindowsAzure.ServiceLayer
+namespace Microsoft.WindowsAzure.ServiceLayer.Http
 {
     /// <summary>
-    /// Exception that occurs as a result of calls to Windows Azure service.
+    /// WRAP authentication exception.
     /// </summary>
-    internal class WindowsAzureServiceException: WindowsAzureException
+    /// <remarks>The exception occurs when WRAP authentication request fails.</remarks>
+    internal class WrapAuthenticationException: WindowsAzureHttpException
     {
         /// <summary>
-        /// Gets the HTTP status code.
+        /// Initializes the exception.
         /// </summary>
-        internal int StatusCode { get; private set; }
-
-        /// <summary>
-        /// Gets the reason string fore th exception.
-        /// </summary>
-        internal string ReasonPhrase { get; private set; }
-
-        /// <summary>
-        /// Constructor. 
-        /// </summary>
-        /// <param name="response">Source HTTP response.</param>
-        internal WindowsAzureServiceException(HttpResponse response)
+        /// <param name="response">Response.</param>
+        internal WrapAuthenticationException(HttpResponse response)
         {
-            StatusCode = response.StatusCode;
-            ReasonPhrase = response.ReasonPhrase;
+            HResult = GetComErrorCode(response.StatusCode, ErrorSource.WrapAuthentication);
+            //TODO: error message!
         }
     }
 }

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/WrapAuthenticationHandler.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/WrapAuthenticationHandler.cs
@@ -122,6 +122,10 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
                 request.Content = HttpContent.CreateFromByteArray(netContent.ReadAsByteArrayAsync().Result);
 
                 HttpResponse response = _nextHandler.ProcessRequest(request);
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new WrapAuthenticationException(response);
+                }
                 token = new WrapToken(resourcePath, response);
 
                 lock (_syncObject)

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/WrapAuthenticationHandler.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/WrapAuthenticationHandler.cs
@@ -38,8 +38,8 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
         private Object _syncObject;                                     // Synchronization object for accessing cached tokens.
 
         private string _namespace;                                      // Service namespace.
-        private string _userName;                                       // User name.
-        private string _password;                                       // Password.
+        private string _issuerName;                                     // Issuer name.
+        private string _issuerPassword;                                 // Password.
         private Uri _authenticationUri;                                 // URI for processing authentication requests.
         private Uri _serviceHostUri;                                    // Host part of the URI for accessing service resources.
 
@@ -47,19 +47,19 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
         /// Initializes WARP authentication handler for use in Service Bus.
         /// </summary>
         /// <param name="serviceNamespace">Namespace.</param>
-        /// <param name="userName">User name.</param>
-        /// <param name="password">Password.</param>
+        /// <param name="issuerName">User name.</param>
+        /// <param name="issuerPassword">Password.</param>
         /// <param name="nextHandler">Next HTTP handler in the chain.</param>
-        public WrapAuthenticationHandler(string serviceNamespace, string userName, string password, IHttpHandler nextHandler)
+        public WrapAuthenticationHandler(string serviceNamespace, string issuerName, string issuerPassword, IHttpHandler nextHandler)
         {
             Validator.ArgumentIsValidPath("serviceNamespace", serviceNamespace);
-            Validator.ArgumentIsNotNullOrEmptyString("userName", userName);
-            Validator.ArgumentIsNotNull("password", password);
+            Validator.ArgumentIsNotNullOrEmptyString("issuerName", issuerName);
+            Validator.ArgumentIsNotNull("issuerPassword", issuerPassword);
             Validator.ArgumentIsNotNull("nextHandler", nextHandler);
 
             _namespace = serviceNamespace;
-            _userName = userName;
-            _password = password;
+            _issuerName = issuerName;
+            _issuerPassword = issuerPassword;
             _nextHandler = nextHandler;
             _syncObject = new object();
             _tokens = new Dictionary<string, WrapToken>(StringComparer.OrdinalIgnoreCase);
@@ -110,8 +110,8 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
                 HttpRequest request = new HttpRequest(HttpMethod.Post, _authenticationUri);
                 Dictionary<string, string> settings = new Dictionary<string, string>()
                 {
-                    {"wrap_name",       _userName},
-                    {"wrap_password",   _password},
+                    {"wrap_name",       _issuerName},
+                    {"wrap_password",   _issuerPassword},
                     {"wrap_scope",      scopeUri.ToString()},
                 };
 

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Microsoft.WindowsAzure.ServiceLayer.csproj
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Microsoft.WindowsAzure.ServiceLayer.csproj
@@ -105,6 +105,7 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ErrorSource.cs" />
     <Compile Include="Http\HttpContent.cs" />
     <Compile Include="Http\HttpDefaultHandler.cs" />
     <Compile Include="Http\HttpMethod.cs" />
@@ -114,6 +115,8 @@
     <Compile Include="Http\IHttpHandler.cs" />
     <Compile Include="Http\MemoryContent.cs" />
     <Compile Include="Http\StreamContent.cs" />
+    <Compile Include="Http\WindowsAzureHttpException.cs" />
+    <Compile Include="Http\WrapAuthenticationException.cs" />
     <Compile Include="ServiceBus\BrokeredMessageInfo.cs" />
     <Compile Include="ServiceBus\BrokeredMessageSettings.cs" />
     <Compile Include="ServiceBus\BrokerProperties.cs" />
@@ -136,7 +139,6 @@
     <Compile Include="ServiceBus\TrueRuleFilter.cs" />
     <Compile Include="Validator.cs" />
     <Compile Include="WindowsAzureException.cs" />
-    <Compile Include="WindowsAzureServiceException.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Http\HttpQueryStringParser.cs" />
     <Compile Include="ServiceBus\ServiceBusRestProxy.cs" />

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/ServiceBusRestProxy.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/ServiceBusRestProxy.cs
@@ -826,7 +826,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.ServiceBus
         {
             if (!response.IsSuccessStatusCode)
             {
-                throw new WindowsAzureServiceException(response);
+                throw new WindowsAzureHttpException(response);
             }
 
             // Pass the response through all validators.
@@ -857,7 +857,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.ServiceBus
         {
             if (response.StatusCode == (int)System.Net.HttpStatusCode.NoContent || response.StatusCode == (int)System.Net.HttpStatusCode.ResetContent)
             {
-                throw new WindowsAzureServiceException(response);
+                throw new WindowsAzureHttpException(response);
             }
             return response;
         }

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/ServiceBusService.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/ServiceBusService.cs
@@ -32,18 +32,18 @@ namespace Microsoft.WindowsAzure.ServiceLayer.ServiceBus
         /// default pipeline.
         /// </summary>
         /// <param name="serviceNamespace">Service namespace.</param>
-        /// <param name="userName">User name.</param>
-        /// <param name="password">Password.</param>
+        /// <param name="issuerName">User name.</param>
+        /// <param name="issuerPassword">Password.</param>
         /// <returns>A service bus service with the given parameters.</returns>
-        public static IServiceBusService Create(string serviceNamespace, string userName, string password)
+        public static IServiceBusService Create(string serviceNamespace, string issuerName, string issuerPassword)
         {
             Validator.ArgumentIsValidPath("serviceNamespace", serviceNamespace);
-            Validator.ArgumentIsNotNullOrEmptyString("userName", userName);
-            Validator.ArgumentIsNotNull("password", password);
+            Validator.ArgumentIsNotNullOrEmptyString("issuerName", issuerName);
+            Validator.ArgumentIsNotNull("issuerPassword", issuerPassword);
 
             ServiceConfiguration config = new ServiceConfiguration(serviceNamespace);
             IHttpHandler pipeline = new HttpDefaultHandler();
-            pipeline = new WrapAuthenticationHandler(serviceNamespace, userName, password, pipeline);
+            pipeline = new WrapAuthenticationHandler(serviceNamespace, issuerName, issuerPassword, pipeline);
             return new ServiceBusRestProxy(config, pipeline);
         }
 


### PR DESCRIPTION
HRESULT-based error handling. Quick summary:
- Custom exceptions are inherited from COMException
- HTTP-related exceptions encode HTTP result into last 10 bits of HRESULT
- Exception source (service bus or wrap) is encoded in bits 11 - 16 of HRESULT
