### PR TITLE
Making SB client and HTTP pipeline objects disposable

### DIFF
--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer.UnitTests/HttpTests/PipelineTests.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer.UnitTests/HttpTests/PipelineTests.cs
@@ -60,15 +60,13 @@ namespace Microsoft.WindowsAzure.ServiceLayer.UnitTests.HttpTests
         [TestMethod]
         public void InvalidArgsInHandlers()
         {
-            HttpChannel validChannel = new HttpChannel();
-            Assert.ThrowsException<ArgumentNullException>(() => new WrapAuthenticationHandler(null, "namespace", "user", "password"));
-            Assert.ThrowsException<ArgumentNullException>(() => new WrapAuthenticationHandler(validChannel, null, "user", "password"));
-            Assert.ThrowsException<ArgumentException>(() => new WrapAuthenticationHandler(validChannel, "", "user", "password"));
-            Assert.ThrowsException<ArgumentException>(() => new WrapAuthenticationHandler(validChannel, " ", "user", "password"));
-            Assert.ThrowsException<ArgumentNullException>(() => new WrapAuthenticationHandler(validChannel, "namespace", null, "password"));
-            Assert.ThrowsException<ArgumentException>(() => new WrapAuthenticationHandler(validChannel, "namespace", "", "password"));
-            Assert.ThrowsException<ArgumentException>(() => new WrapAuthenticationHandler(validChannel, "namespace", " ", "password"));
-            Assert.ThrowsException<ArgumentNullException>(() => new WrapAuthenticationHandler(validChannel, "namespace", "user", null));
+            Assert.ThrowsException<ArgumentNullException>(() => new WrapAuthenticationHandler(null, "user", "password"));
+            Assert.ThrowsException<ArgumentException>(() => new WrapAuthenticationHandler("", "user", "password"));
+            Assert.ThrowsException<ArgumentException>(() => new WrapAuthenticationHandler(" ", "user", "password"));
+            Assert.ThrowsException<ArgumentNullException>(() => new WrapAuthenticationHandler("namespace", null, "password"));
+            Assert.ThrowsException<ArgumentException>(() => new WrapAuthenticationHandler("namespace", "", "password"));
+            Assert.ThrowsException<ArgumentException>(() => new WrapAuthenticationHandler("namespace", " ", "password"));
+            Assert.ThrowsException<ArgumentNullException>(() => new WrapAuthenticationHandler("namespace", "user", null));
         }
 
         /// <summary>

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer.UnitTests/HttpTests/TestHttpHandler.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer.UnitTests/HttpTests/TestHttpHandler.cs
@@ -60,5 +60,13 @@ namespace Microsoft.WindowsAzure.ServiceLayer.UnitTests.HttpTests
             ResponseCount++;
             return response;
         }
+
+        /// <summary>
+        /// Disposes the handler.
+        /// </summary>
+        public void Dispose()
+        { 
+            // Do nothing.
+        }
     }
 }

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer.UnitTests/ServiceBusTests/MessageSettingsTests.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer.UnitTests/ServiceBusTests/MessageSettingsTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.UnitTests.ServiceBusTests
         [TestMethod]
         public void InvalidArgumentsInMethods()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => new BrokeredMessageSettings(null));
+            Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromContent(null));
             Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromText(null));
             Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromText(null, "Test"));
             Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromText("Test", null));

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer.UnitTests/ServiceBusTests/MessageSettingsTests.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer.UnitTests/ServiceBusTests/MessageSettingsTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.UnitTests.ServiceBusTests
         {
             Assert.ThrowsException<ArgumentNullException>(() => new BrokeredMessageSettings(null));
             Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromText(null));
+            Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromText(null, "Test"));
             Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromText("Test", null));
             Assert.ThrowsException<ArgumentException>(() => BrokeredMessageSettings.CreateFromText("Test", ""));
             Assert.ThrowsException<ArgumentException>(() => BrokeredMessageSettings.CreateFromText("Test", " "));

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer.UnitTests/ServiceBusTests/MessageSettingsTests.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer.UnitTests/ServiceBusTests/MessageSettingsTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.UnitTests.ServiceBusTests
         [TestMethod]
         public void InvalidArgumentsInMethods()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromContent(null));
+            Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromHttpContent(null));
             Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromText(null));
             Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromText(null, "Test"));
             Assert.ThrowsException<ArgumentNullException>(() => BrokeredMessageSettings.CreateFromText("Test", null));

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/HttpChannel.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/HttpChannel.cs
@@ -27,15 +27,17 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
     /// <summary>
     /// A channel for processing HTTP requests.
     /// </summary>
-    public sealed class HttpChannel
+    public sealed class HttpChannel: IDisposable
     {
         private System.Net.Http.HttpClient _client;         // HTTP client.
+        private HttpChannel _nextChannel;                   // Chained channel.
         private List<IHttpHandler> _handlers;               // HTTP handlers.
 
         /// <summary>
-        /// Initializes the channel with the given handlers.
+        /// Initializes the new channel with the given handlers.
         /// </summary>
         /// <param name="handlers">Handlers to put to the channel.</param>
+        /// <remarks>Use this constructor to start a new channel.</remarks>
         public HttpChannel(params IHttpHandler[] handlers)
         {
             Validator.ArgumentIsNotNull("handlers", handlers);
@@ -45,8 +47,8 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
         }
 
         /// <summary>
-        /// Creates a new channel by taking handlers from the given channel
-        /// and adding extra handlers at the head of the queue.
+        /// Creates a channel with the given handlers and chains it to the
+        /// given channel.
         /// </summary>
         /// <param name="originalChannel">Original HTTP processing channel.</param>
         /// <param name="handlers">Handlers to add to new channel's queue.</param>
@@ -55,9 +57,8 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
             Validator.ArgumentIsNotNull("originalChannel", originalChannel);
             Validator.ArgumentIsNotNull("handlers", handlers);
 
-            _client = originalChannel._client;
             _handlers = new List<IHttpHandler>(handlers);
-            _handlers.AddRange(originalChannel._handlers);
+            _nextChannel = originalChannel;
         }
 
         /// <summary>
@@ -75,11 +76,31 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
             Validator.ArgumentIsNotNull("issuerName", issuerName);
             Validator.ArgumentIsNotNull("issuerPassword", issuerPassword);
 
-            WrapAuthenticationHandler wrapHandler = new WrapAuthenticationHandler(
-                new HttpChannel(), serviceNamespace, issuerName, issuerPassword);
+            WrapAuthenticationHandler wrapHandler = new WrapAuthenticationHandler(serviceNamespace, issuerName, issuerPassword);
             return new HttpChannel(wrapHandler);
         }
-        
+
+
+        /// <summary>
+        /// Disposes the HTTP channel and closes the underlying session.
+        /// </summary>
+        public void Dispose()
+        {
+            // Dispose the handlers
+            foreach (IHttpHandler handler in _handlers)
+            {
+                handler.Dispose();
+            }
+
+            // Dispose the client, if any
+            if (_client != null)
+            {
+                _client.Dispose();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
         /// <summary>
         /// Sends the request.
         /// </summary>
@@ -90,10 +111,51 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
             Validator.ArgumentIsNotNull("request", request);
 
             return Task.Factory
-                .StartNew(() => ProcessRequest(request))
-                .ContinueWith(t => SendRequest(request), TaskContinuationOptions.OnlyOnRanToCompletion)
-                .ContinueWith(t => ProcessResponse(t.Result), TaskContinuationOptions.OnlyOnRanToCompletion)
+                .StartNew(() => SendRequest(request))
                 .AsAsyncOperation();
+        }
+
+        /// <summary>
+        /// Sends HTTP requests passing it through all handlers.
+        /// </summary>
+        /// <param name="request">Request to send.</param>
+        /// <returns>Response to the request.</returns>
+        internal HttpResponse SendRequest(HttpRequest request)
+        {
+            // Pass through all handlers
+            for (int i = 0; i < _handlers.Count; i++)
+            {
+                request = _handlers[i].ProcessRequest(request);
+            }
+
+            // Get the response
+            HttpResponse response;
+
+            if (_nextChannel != null)
+            {
+                Debug.Assert(_client == null);
+                response = _nextChannel.SendRequest(request);
+            }
+            else
+            {
+                Debug.Assert(_client != null);
+                System.Net.Http.HttpRequestMessage netRequest = request.CreateNetRequest();
+                System.Net.Http.HttpResponseMessage netResponse = _client.SendAsync(netRequest).Result;
+                response = new HttpResponse(request, netResponse);
+            }
+
+            // Pass the response through all handlers in the reverse order.
+            for (int i = _handlers.Count - 1; i >= 0; i--)
+            {
+                response = _handlers[i].ProcessResponse(response);
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new WindowsAzureHttpException(Resources.ErrorFailedRequest, response);
+            }
+
+            return response;
         }
 
         /// <summary>
@@ -106,54 +168,6 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
         {
             return SendAsync(request).AsTask()
                 .ContinueWith(t => ProcessResponse(t.Result, handlers), TaskContinuationOptions.OnlyOnRanToCompletion);
-        }
-
-        /// <summary>
-        /// Passes the request through all registered handlers.
-        /// </summary>
-        /// <param name="request">Request to process.</param>
-        /// <returns>Processed request.</returns>
-        private HttpRequest ProcessRequest(HttpRequest request)
-        {
-            for (int i = 0; i < _handlers.Count; i++)
-            {
-                request = _handlers[i].ProcessRequest(request);
-            }
-
-            return request;
-        }
-
-        /// <summary>
-        /// Sends the HTTP request.
-        /// </summary>
-        /// <param name="request">Request to send.</param>
-        /// <returns>Response to the given request.</returns>
-        private HttpResponse SendRequest(HttpRequest request)
-        {
-            return _client
-                .SendAsync(request.CreateNetRequest())
-                .ContinueWith(t => new HttpResponse(request, t.Result), TaskContinuationOptions.OnlyOnRanToCompletion)
-                .Result;
-        }
-
-        /// <summary>
-        /// Passes the response through all registered handlers.
-        /// </summary>
-        /// <param name="response">Response to process.</param>
-        /// <returns>Processed response.</returns>
-        private HttpResponse ProcessResponse(HttpResponse response)
-        {
-            for (int i = _handlers.Count - 1; i >= 0; i--)
-            {
-                response = _handlers[i].ProcessResponse(response);
-            }
-
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new WindowsAzureHttpException(Resources.ErrorFailedRequest, response);
-            }
-
-            return response;
         }
 
         /// <summary>

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/HttpChannel.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/HttpChannel.cs
@@ -150,11 +150,6 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
                 response = _handlers[i].ProcessResponse(response);
             }
 
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new WindowsAzureHttpException(Resources.ErrorFailedRequest, response);
-            }
-
             return response;
         }
 
@@ -178,6 +173,13 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
         /// <returns>Processed response.</returns>
         private HttpResponse ProcessResponse(HttpResponse response, Func<HttpResponse, HttpResponse>[] handlers)
         {
+            // HTTP protocol failures should result in exceptions.
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new WindowsAzureHttpException(Resources.ErrorFailedRequest, response);
+            }
+
+            // Pass response to extra handlers.
             for (int i = 0; i < handlers.Length; i++)
             {
                 response = handlers[i](response);

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/HttpContent.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/HttpContent.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Storage.Streams;
@@ -67,7 +68,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
         /// </summary>
         /// <param name="bytes">Binary data.</param>
         /// <returns>Content object.</returns>
-        public static HttpContent CreateFromByteArray(byte[] bytes)
+        public static HttpContent CreateFromByteArray([ReadOnlyArray] byte[] bytes)
         {
             Validator.ArgumentIsNotNull("bytes", bytes);
 

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/IHttpHandler.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/IHttpHandler.cs
@@ -24,7 +24,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
     /// <summary>
     /// HTTP handler processes HTTP requests.
     /// </summary>
-    public interface IHttpHandler
+    public interface IHttpHandler: IDisposable
     {
         /// <summary>
         /// Processes HTTP request.

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/WrapAuthenticationHandler.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/Http/WrapAuthenticationHandler.cs
@@ -46,18 +46,16 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
         /// <summary>
         /// Initializes WARP authentication handler for use in Service Bus.
         /// </summary>
-        /// <param name="channel">Channel for processing authentication requests.</param>
         /// <param name="serviceNamespace">Namespace.</param>
         /// <param name="issuerName">User name.</param>
         /// <param name="issuerPassword">Password.</param>
-        public WrapAuthenticationHandler(HttpChannel channel, string serviceNamespace, string issuerName, string issuerPassword)
+        public WrapAuthenticationHandler(string serviceNamespace, string issuerName, string issuerPassword)
         {
-            Validator.ArgumentIsNotNull("channel", channel);
             Validator.ArgumentIsValidPath("serviceNamespace", serviceNamespace);
             Validator.ArgumentIsNotNullOrEmptyString("issuerName", issuerName);
             Validator.ArgumentIsNotNull("issuerPassword", issuerPassword);
 
-            _channel = new HttpChannel(channel);
+            _channel = new HttpChannel();
             _namespace = serviceNamespace;
             _issuerName = issuerName;
             _issuerPassword = issuerPassword;
@@ -70,6 +68,15 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
 
             uriString = string.Format(CultureInfo.InvariantCulture, Constants.ServiceBusScopeUri, serviceNamespace);
             _serviceHostUri = new Uri(uriString, UriKind.Absolute);
+        }
+
+        /// <summary>
+        /// Disposes the handler.
+        /// </summary>
+        public void Dispose()
+        {
+            _channel.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
@@ -97,6 +104,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.Http
 
             return response;
         }
+
         /// <summary>
         /// Gets authentication token for a resource with the given path.
         /// </summary>

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/BrokeredMessageSettings.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/BrokeredMessageSettings.cs
@@ -136,13 +136,23 @@ namespace Microsoft.WindowsAzure.ServiceLayer.ServiceBus
         }
 
         /// <summary>
-        /// Constructor.
+        /// Creates a message with the given content.
         /// </summary>
-        /// <param name="content">Message content.</param>
-        public BrokeredMessageSettings(HttpContent content)
+        /// <param name="content">Content of the message.</param>
+        /// <returns>Brokered message.</returns>
+        public static BrokeredMessageSettings CreateFromContent(HttpContent content)
         {
             Validator.ArgumentIsNotNull("content", content);
 
+            return new BrokeredMessageSettings(content);
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="content">Message content.</param>
+        private BrokeredMessageSettings(HttpContent content)
+        {
             Content = content;
             _brokerProperties = new BrokerProperties();
             _customProperties = new CustomPropertiesDictionary();

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/BrokeredMessageSettings.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/BrokeredMessageSettings.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.ServiceLayer.Http;
@@ -148,14 +149,24 @@ namespace Microsoft.WindowsAzure.ServiceLayer.ServiceBus
         }
 
         /// <summary>
-        /// Creates a message from the given text. This method exists only
-        /// because JavaScript cannot work with multiple constructors with
-        /// identical number of parameters.
+        /// Creates a message with the default content type from the given 
+        /// text.
+        /// </summary>
+        /// <param name="messageText">Message text.</param>
+        /// <returns>Message settings.</returns>
+        public static BrokeredMessageSettings CreateFromText(string messageText)
+        {
+            return CreateFromText(messageText, Constants.DefaultMessageContentType);
+        }
+
+        /// <summary>
+        /// Creates a message with the specified content type from the given 
+        /// text.
         /// </summary>
         /// <param name="messageText">Message text.</param>
         /// <param name="contentType">Content type.</param>
         /// <returns>Message settings.</returns>
-        public static BrokeredMessageSettings CreateFromText(string messageText, string contentType = Constants.DefaultMessageContentType)
+        public static BrokeredMessageSettings CreateFromText(string messageText, string contentType)
         {
             Validator.ArgumentIsNotNull("messageText", messageText);
             Validator.ArgumentIsNotNullOrEmptyString("contentType", contentType);
@@ -171,7 +182,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.ServiceBus
         /// </summary>
         /// <param name="messageBytes">Array of bytes.</param>
         /// <returns>Message settings.</returns>
-        public static BrokeredMessageSettings CreateFromByteArray(byte[] messageBytes)
+        public static BrokeredMessageSettings CreateFromByteArray([ReadOnlyArray] byte[] messageBytes)
         {
             Validator.ArgumentIsNotNull("messageBytes", messageBytes);
 

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/BrokeredMessageSettings.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/BrokeredMessageSettings.cs
@@ -140,7 +140,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.ServiceBus
         /// </summary>
         /// <param name="content">Content of the message.</param>
         /// <returns>Brokered message.</returns>
-        public static BrokeredMessageSettings CreateFromContent(HttpContent content)
+        public static BrokeredMessageSettings CreateFromHttpContent(HttpContent content)
         {
             Validator.ArgumentIsNotNull("content", content);
 

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/MessageHelper.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/MessageHelper.cs
@@ -35,7 +35,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.ServiceBus
         internal static BrokeredMessageSettings CreateTextMessage(string messageText)
         {
             HttpContent content = HttpContent.CreateFromText(messageText, "text/plain");
-            BrokeredMessageSettings message = BrokeredMessageSettings.CreateFromContent(content);
+            BrokeredMessageSettings message = BrokeredMessageSettings.CreateFromHttpContent(content);
             return message;
         }
     }

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/MessageHelper.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/MessageHelper.cs
@@ -35,7 +35,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer.ServiceBus
         internal static BrokeredMessageSettings CreateTextMessage(string messageText)
         {
             HttpContent content = HttpContent.CreateFromText(messageText, "text/plain");
-            BrokeredMessageSettings message = new BrokeredMessageSettings(content);
+            BrokeredMessageSettings message = BrokeredMessageSettings.CreateFromContent(content);
             return message;
         }
     }

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/ServiceBusClient.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/ServiceBus/ServiceBusClient.cs
@@ -27,9 +27,15 @@ using Windows.Web.Syndication;
 namespace Microsoft.WindowsAzure.ServiceLayer.ServiceBus
 {
     /// <summary>
-    /// REST proxy for the service bus interface.
+    /// Service bus client.
     /// </summary>
-    public sealed class ServiceBusClient
+    /// <remarks>The class serves as an entry point to the Service Bus
+    /// functionality. Explicitly disposing the class will close its underlying
+    /// connection and will make all other classes that are using that
+    /// connection unusable. Therefore, if you have created multiple instance
+    /// of this object by specifying HTTP handlers in the constructor, you
+    /// should dispose only one of them and only when it is no longer used.</remarks>
+    public sealed class ServiceBusClient: IDisposable
     {
         private HttpChannel _channel;                       // HTTP channel.
 
@@ -685,6 +691,15 @@ namespace Microsoft.WindowsAzure.ServiceLayer.ServiceBus
         private static void InitRule(SyndicationItem feedItem, RuleInfo ruleInfo)
         {
             ruleInfo.Initialize(feedItem);
+        }
+
+        /// <summary>
+        /// Disposes the client by closing underlying connection.
+        /// </summary>
+        public void Dispose()
+        {
+            _channel.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/WindowsAzureErrorCode.cs
+++ b/microsoft-azure-servicelayer/Microsoft.WindowsAzure.ServiceLayer/WindowsAzureErrorCode.cs
@@ -25,7 +25,7 @@ namespace Microsoft.WindowsAzure.ServiceLayer
     /// <summary>
     /// A collection of well-known error codes.
     /// </summary>
-    public static class WindowsAzureErrorCode2
+    public static class WindowsAzureErrorCode
     {
         // Internal HRESULT structure: 
         // Bits 31 - 16:    HRESULT flags indicating an error (Severity: ERROR; facility: ITF)
@@ -83,68 +83,5 @@ namespace Microsoft.WindowsAzure.ServiceLayer
         public static int HttpServiceUnavailable              { get { return Constants.HttpErrorMask | (int)HttpStatusCode.ServiceUnavailable; } }
         public static int HttpGatewayTimeout                  { get { return Constants.HttpErrorMask | (int)HttpStatusCode.GatewayTimeout; } }
         public static int HttpVersionNotSupported             { get { return Constants.HttpErrorMask | (int)HttpStatusCode.HttpVersionNotSupported; } }
-    }
-
-    /// <summary>
-    /// A collection of well-known error codes.
-    /// </summary>
-    public enum WindowsAzureErrorCode
-    {
-        // Internal HRESULT structure: 
-        // Bits 31 - 16:    HRESULT flags indicating an error (Severity: ERROR; facility: ITF)
-        // Bits 12 - 15:    error source (HTTP, WRAP, etc)
-        // Bits 0 - 11:     source-specific information, if any. Contains status code for HTTP errors.
-
-        // Generic WRAP authentication failure.
-        WrapAuthenticationFailure = Constants.WrapErrorMask,
-
-        // HTTP status exceptions
-        HttpContinue                        = Constants.HttpErrorMask | HttpStatusCode.Continue,
-        HttpSwitchingProtocols              = Constants.HttpErrorMask | HttpStatusCode.SwitchingProtocols,
-        HttpOK                              = Constants.HttpErrorMask | HttpStatusCode.OK,
-        HttpCreated                         = Constants.HttpErrorMask | HttpStatusCode.Created,
-        HttpAccepted                        = Constants.HttpErrorMask | HttpStatusCode.Accepted,
-        HttpNonAuthoritativeInformation     = Constants.HttpErrorMask | HttpStatusCode.NonAuthoritativeInformation,
-        HttpNoContent                       = Constants.HttpErrorMask | HttpStatusCode.NoContent,
-        HttpResetContent                    = Constants.HttpErrorMask | HttpStatusCode.ResetContent,
-        HttpPartialContent                  = Constants.HttpErrorMask | HttpStatusCode.PartialContent,
-        HttpMultipleChoices                 = Constants.HttpErrorMask | HttpStatusCode.MultipleChoices,
-        HttpAmbiguous                       = Constants.HttpErrorMask | HttpStatusCode.Ambiguous,
-        HttpMovedPermanently                = Constants.HttpErrorMask | HttpStatusCode.MovedPermanently,
-        HttpMoved                           = Constants.HttpErrorMask | HttpStatusCode.Moved,
-        HttpFound                           = Constants.HttpErrorMask | HttpStatusCode.Found,
-        HttpRedirect                        = Constants.HttpErrorMask | HttpStatusCode.Redirect,
-        HttpSeeOther                        = Constants.HttpErrorMask | HttpStatusCode.SeeOther,
-        HttpRedirectMethod                  = Constants.HttpErrorMask | HttpStatusCode.RedirectMethod,
-        HttpNotModified                     = Constants.HttpErrorMask | HttpStatusCode.NotModified,
-        HttpUseProxy                        = Constants.HttpErrorMask | HttpStatusCode.UseProxy,
-        HttpUnused                          = Constants.HttpErrorMask | HttpStatusCode.Unused,
-        HttpRedirectKeepVerb                = Constants.HttpErrorMask | HttpStatusCode.RedirectKeepVerb,
-        HttpTemporaryRedirect               = Constants.HttpErrorMask | HttpStatusCode.TemporaryRedirect,
-        HttpBadRequest                      = Constants.HttpErrorMask | HttpStatusCode.BadRequest,
-        HttpUnauthorized                    = Constants.HttpErrorMask | HttpStatusCode.Unauthorized,
-        HttpPaymentRequired                 = Constants.HttpErrorMask | HttpStatusCode.PaymentRequired,
-        HttpForbidden                       = Constants.HttpErrorMask | HttpStatusCode.Forbidden,
-        HttpNotFound                        = Constants.HttpErrorMask | HttpStatusCode.NotFound,
-        HttpMethodNotAllowed                = Constants.HttpErrorMask | HttpStatusCode.MethodNotAllowed,
-        HttpNotAcceptable                   = Constants.HttpErrorMask | HttpStatusCode.NotAcceptable,
-        HttpProxyAuthenticationRequired     = Constants.HttpErrorMask | HttpStatusCode.ProxyAuthenticationRequired,
-        HttpRequestTimeout                  = Constants.HttpErrorMask | HttpStatusCode.RequestTimeout,
-        HttpConflict                        = Constants.HttpErrorMask | HttpStatusCode.Conflict,
-        HttpGone                            = Constants.HttpErrorMask | HttpStatusCode.Gone,
-        HttpLengthRequired                  = Constants.HttpErrorMask | HttpStatusCode.LengthRequired,
-        HttpPreconditionFailed              = Constants.HttpErrorMask | HttpStatusCode.PreconditionFailed,
-        HttpRequestEntityTooLarge           = Constants.HttpErrorMask | HttpStatusCode.RequestEntityTooLarge,
-        HttpRequestUriTooLong               = Constants.HttpErrorMask | HttpStatusCode.RequestUriTooLong,
-        HttpUnsupportedMediaType            = Constants.HttpErrorMask | HttpStatusCode.UnsupportedMediaType,
-        HttpRequestedRangeNotSatisfiable    = Constants.HttpErrorMask | HttpStatusCode.RequestedRangeNotSatisfiable,
-        HttpExpectationFailed               = Constants.HttpErrorMask | HttpStatusCode.ExpectationFailed,
-        HttpUpgradeRequired                 = Constants.HttpErrorMask | HttpStatusCode.UpgradeRequired,
-        HttpInternalServerError             = Constants.HttpErrorMask | HttpStatusCode.InternalServerError,
-        HttpNotImplemented                  = Constants.HttpErrorMask | HttpStatusCode.NotImplemented,
-        HttpBadGateway                      = Constants.HttpErrorMask | HttpStatusCode.BadGateway,
-        HttpServiceUnavailable              = Constants.HttpErrorMask | HttpStatusCode.ServiceUnavailable,
-        HttpGatewayTimeout                  = Constants.HttpErrorMask | HttpStatusCode.GatewayTimeout,
-        HttpVersionNotSupported             = Constants.HttpErrorMask | HttpStatusCode.HttpVersionNotSupported,
     }
 }


### PR DESCRIPTION
- Addressed build breaks in the most recent VS build;
- Addressed code analysis issues;
- Made HttpClient and SB client disposable. Disposing the object disposes enclosed HttpClient object, releasing the connection pool.
