### PR TITLE
Update TryParse so invalid URI's don't throw

### DIFF
--- a/microsoft-azure-api/CloudStorageAccount.cs
+++ b/microsoft-azure-api/CloudStorageAccount.cs
@@ -460,7 +460,7 @@ namespace Microsoft.WindowsAzure
             if (MatchesSpecification(
                 settings,
                 AllRequired(DefaultEndpointsProtocolSetting, AccountNameSetting, AccountKeySetting),
-                Optional(BlobEndpointSetting, QueueEndpointSetting, TableEndpointSetting)))
+                Optional(BlobEndpointSetting, QueueEndpointSetting, TableEndpointSetting, AccountKeyNameSetting)))
             {
                 blobEndpoint = settings[BlobEndpointSettingString] ?? GetDefaultBlobEndpoint(settings);
                 queueEndpoint = settings[QueueEndpointSettingString] ?? GetDefaultQueueEndpoint(settings);
@@ -469,7 +469,7 @@ namespace Microsoft.WindowsAzure
             }
 
             // explicit case
-            else if (MatchesSpecification(
+            if (MatchesSpecification(
                 settings,
                 AtLeastOne(BlobEndpointSetting, QueueEndpointSetting, TableEndpointSetting),
                 ValidCredentials()))

--- a/microsoft-azure-api/CloudStorageAccount.cs
+++ b/microsoft-azure-api/CloudStorageAccount.cs
@@ -451,38 +451,52 @@ namespace Microsoft.WindowsAzure
                 return true;
             }
 
+            string blobEndpoint = null;
+            string queueEndpoint = null;
+            string tableEndpoint = null;
+            var shouldParse = false;
+
             // automatic case
             if (MatchesSpecification(
                 settings,
                 AllRequired(DefaultEndpointsProtocolSetting, AccountNameSetting, AccountKeySetting),
-                Optional(BlobEndpointSetting, QueueEndpointSetting, TableEndpointSetting, AccountKeyNameSetting)))
+                Optional(BlobEndpointSetting, QueueEndpointSetting, TableEndpointSetting)))
             {
-                var blobEndpoint = settings[BlobEndpointSettingString];
-                var queueEndpoint = settings[QueueEndpointSettingString];
-                var tableEndpoint = settings[TableEndpointSettingString];
-
-                accountInformation = new CloudStorageAccount(
-                    GetCredentials(settings),
-                    new Uri(blobEndpoint ?? GetDefaultBlobEndpoint(settings)),
-                    new Uri(queueEndpoint ?? GetDefaultQueueEndpoint(settings)),
-                    new Uri(tableEndpoint ?? GetDefaultTableEndpoint(settings)));
-
-                return true;
+                blobEndpoint = settings[BlobEndpointSettingString] ?? GetDefaultBlobEndpoint(settings);
+                queueEndpoint = settings[QueueEndpointSettingString] ?? GetDefaultQueueEndpoint(settings);
+                tableEndpoint = settings[TableEndpointSettingString] ?? GetDefaultTableEndpoint(settings);
+                shouldParse = true;
             }
 
             // explicit case
-            if (MatchesSpecification(
+            else if (MatchesSpecification(
                 settings,
                 AtLeastOne(BlobEndpointSetting, QueueEndpointSetting, TableEndpointSetting),
                 ValidCredentials()))
             {
-                var blobUri = settings[BlobEndpointSettingString] == null ? null : new Uri(settings[BlobEndpointSettingString]);
-                var queueUri = settings[QueueEndpointSettingString] == null ? null : new Uri(settings[QueueEndpointSettingString]);
-                var tableUri = settings[TableEndpointSettingString] == null ? null : new Uri(settings[TableEndpointSettingString]);
-
-                accountInformation = new CloudStorageAccount(GetCredentials(settings), blobUri, queueUri, tableUri);
-
-                return true;
+                blobEndpoint = settings[BlobEndpointSettingString];
+                queueEndpoint = settings[QueueEndpointSettingString];
+                tableEndpoint = settings[TableEndpointSettingString];
+                shouldParse = true;
+            }
+            if (shouldParse)
+            {
+                try
+                {
+                    accountInformation = new CloudStorageAccount(
+                        GetCredentials(settings),
+                        blobEndpoint == null ? null : new Uri(blobEndpoint),
+                        queueEndpoint == null ? null : new Uri(queueEndpoint),
+                        tableEndpoint == null ? null : new Uri(tableEndpoint)
+                    );
+                    return true;
+                }
+                catch (UriFormatException)
+                {
+                    error("One or more endpoints specified are not valid URIs, or account name is malformed.");
+                    accountInformation = null;
+                    return false;
+                }
             }
 
             // not valid


### PR DESCRIPTION
Update TryParse so invalid URI's don't throw (would throw when spaces/invalid characters were included in AccountName, or invalid characters in URI specified)
This is an update of the original pull request for master, now rewritten for 1.7.1
