### PR TITLE
Updated sample code for 2.0.0 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ http://nuget.org/packages/System.Spatial/5.0.2<br/>
 
 <p>First, include the classes you need (in this case we'll include the StorageClient
 and further demonstrate creating a table):<br/>
-<pre>using Microsoft.WindowsAzure;
-using Microsoft.WindowsAzure.StorageClient;</pre></p>
+<pre>using System.Configuration;
+using Microsoft.WindowsAzure.Storage;</pre></p>
 
 <p>To perform an operation on any Windows Azure resource you will first instantiate
 a <strong>client</strong> which allows performing actions on it. The resource is known as an
 <strong>entity</strong>. To do so for Table you also have to authenticate your request:<br/>
 <pre>var storageAccount = 
-    CloudStorageAccount.FromConfigurationSetting("StorageConnectionString");
+    CloudStorageAccount.Parse(ConfigurationManager.ConnectionStrings["StorageConnectionString"].ConnectionString);
 var tableClient = storageAccount.CreateCloudTableClient();</pre></p>
 
 <p>Now, to create a table entity using the client:<br/>

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ http://nuget.org/packages/System.Spatial/5.0.2<br/>
 and further demonstrate creating a table):<br/>
 <pre>using System.Configuration;
 using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table</pre></p>
+using Microsoft.WindowsAzure.Storage.Table;</pre></p>
 
 <p>To perform an operation on any Windows Azure resource you will first instantiate
 a <strong>client</strong> which allows performing actions on it. The resource is known as an

--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ http://nuget.org/packages/System.Spatial/5.0.2<br/>
     Developer Center</a>.</li>
 </ul>
 
-<p>First, include the classes you need (in this case we'll include the StorageClient
+<p>First, include the classes you need (in this case we'll include the lightweight TableClient
 and further demonstrate creating a table):<br/>
 <pre>using System.Configuration;
-using Microsoft.WindowsAzure.Storage;</pre></p>
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table</pre></p>
 
 <p>To perform an operation on any Windows Azure resource you will first instantiate
 a <strong>client</strong> which allows performing actions on it. The resource is known as an


### PR DESCRIPTION
The namespace is now Microsoft.WindowsAzure.Storage, and the static method CloudStorageAccount.FromConfigurationSetting no longer exists in the latest API, so Parse (or ideally TryParse) should be used instead

Source: http://msdn.microsoft.com/en-us/library/windowsazure/microsoft.windowsazure.storage.cloudstorageaccount_members.aspx
