### PR TITLE
Fix emulator devstore connection string parsing

### DIFF
--- a/microsoft-azure-api/Services/Storage/Lib/Common/CloudStorageAccount.cs
+++ b/microsoft-azure-api/Services/Storage/Lib/Common/CloudStorageAccount.cs
@@ -483,7 +483,8 @@ namespace Microsoft.WindowsAzure.Storage
                 AllRequired(UseDevelopmentStorageSetting),
                 Optional(DevelopmentStorageProxyUriSetting)))
             {
-                var proxyUri = settings[DevelopmentStorageProxyUriSettingString];
+                string proxyUri = null;
+                settings.TryGetValue(DevelopmentStorageProxyUriSettingString, out proxyUri);
 
                 accountInformation = GetDevelopmentStorageAccount(proxyUri == null ? null : new Uri(proxyUri));
 


### PR DESCRIPTION
When parsing a connection string for the Azure Emulator ("UseDevelopmentStorage=true"), the "DevelopmentStorageProxyUri" is optional. If not defined, however, creating a CloudStorageAccount using a Connection String for the emulator will throw a KeyNotFound exception since it does not exist in the settings dictionary. Instead, it should use TryGetValue as other optional settings do.
