### PR TITLE
TableQuery assert prevents querying against empty strings, which are valid

### DIFF
--- a/microsoft-azure-api/Services/Storage/Lib/Common/Table/TableQueryBase.cs
+++ b/microsoft-azure-api/Services/Storage/Lib/Common/Table/TableQueryBase.cs
@@ -47,7 +47,7 @@ namespace Microsoft.WindowsAzure.Storage.Table
         /// <returns>A string containing the formatted filter condition.</returns>
         public static string GenerateFilterCondition(string propertyName, string operation, string givenValue)
         {
-            CommonUtils.AssertNotNullOrEmpty("givenValue", givenValue);
+            CommonUtils.AssertNotNull("givenValue", givenValue);
             return GenerateFilterCondition(propertyName, operation, givenValue, EdmType.String);
         }
 


### PR DESCRIPTION
The assert is preventing us from querying against columns holding an
empty string value, which are perfectly valid.
