### PR TITLE
Issue #206

### DIFF
--- a/microsoft-azure-api/Services/Storage/Lib/RT/Blob/BlobWriteStream.cs
+++ b/microsoft-azure-api/Services/Storage/Lib/RT/Blob/BlobWriteStream.cs
@@ -271,7 +271,10 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             this.noPendingWritesEvent.Reset();
 
             await this.parallelOperationSemaphore.WaitAsync();
-            this.blockBlob.PutBlockAsync(blockId, blockData.AsInputStream(), blockMD5, this.accessCondition, this.options, this.operationContext).AsTask().ContinueWith(task =>
+
+            // Without await have found last block doesn't get uploaded properly and noPendingWritesEvent will always equal 1.
+            // Then the putblocklist will never happen, therefore no blob. Bug #211
+            await this.blockBlob.PutBlockAsync(blockId, blockData.AsInputStream(), blockMD5, this.accessCondition, this.options, this.operationContext).AsTask().ContinueWith(task =>
                 {
                     if (task.Exception != null)
                     {

--- a/microsoft-azure-api/Services/Storage/Lib/RT/Core/Executor/Executor.cs
+++ b/microsoft-azure-api/Services/Storage/Lib/RT/Core/Executor/Executor.cs
@@ -145,6 +145,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Executor
                         }
                         finally
                         {
+                            cmd.ResponseStream.Flush();
                             cmd.ResponseStream.Dispose();
                             cmd.ResponseStream = null;
                         }


### PR DESCRIPTION
Flushing otherwise downloaded blob is often missing bytes off the end
after download.

Issue with bug is easily replicated and have found that all bytes are downloaded fine but not successfully written to the output stream. Adding in a flush (didn't use flushasync) at the end of ExecuteAsyncInternal after the writing has occurred fixes the problem. Haven't tested all code paths, but just did the fix to test out the idea. Seems solid enough.

Hope it's useful.
