### PR TITLE
Bug 211.

### DIFF
--- a/microsoft-azure-api/Services/Storage/Lib/RT/Blob/BlobWriteStream.cs
+++ b/microsoft-azure-api/Services/Storage/Lib/RT/Blob/BlobWriteStream.cs
@@ -271,7 +271,10 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             this.noPendingWritesEvent.Reset();
 
             await this.parallelOperationSemaphore.WaitAsync();
-            this.blockBlob.PutBlockAsync(blockId, blockData.AsInputStream(), blockMD5, this.accessCondition, this.options, this.operationContext).AsTask().ContinueWith(task =>
+
+            // Without await have found last block doesn't get uploaded properly and noPendingWritesEvent will always equal 1.
+            // Then the putblocklist will never happen, therefore no blob. Bug #211
+            await this.blockBlob.PutBlockAsync(blockId, blockData.AsInputStream(), blockMD5, this.accessCondition, this.options, this.operationContext).AsTask().ContinueWith(task =>
                 {
                     if (task.Exception != null)
                     {

--- a/microsoft-azure-api/Services/Storage/Lib/RT/Core/Executor/Executor.cs
+++ b/microsoft-azure-api/Services/Storage/Lib/RT/Core/Executor/Executor.cs
@@ -145,7 +145,6 @@ namespace Microsoft.WindowsAzure.Storage.Core.Executor
                         }
                         finally
                         {
-                            cmd.ResponseStream.Flush();
                             cmd.ResponseStream.Dispose();
                             cmd.ResponseStream = null;
                         }

--- a/microsoft-azure-api/Services/Storage/Lib/RT/Core/Executor/Executor.cs
+++ b/microsoft-azure-api/Services/Storage/Lib/RT/Core/Executor/Executor.cs
@@ -145,6 +145,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Executor
                         }
                         finally
                         {
+                            cmd.ResponseStream.Flush();
                             cmd.ResponseStream.Dispose();
                             cmd.ResponseStream = null;
                         }


### PR DESCRIPTION
When performing upload with chunking into 4M blocks BlobWriteStream::WriteBlockAsync calls PutBlockAsync without async declaration. This caused one of the final blocks (second last usually) to not be uploaded correctly. This in turn caused the noPendingWritesEvent  ManualResetEvent to always have the value of 1 (since the write wasn't complete). This would "hang" at the WaitOne method called and blob would never be reconstructed properly.

Have added "async" call to PutBlockAsync, all blocks write correctly and no hanging occurs.
