### PR TITLE
Role.OSVersion is missing

### DIFF
--- a/libraries/src/ComputeManagement/ComputeManagementClient.cs
+++ b/libraries/src/ComputeManagement/ComputeManagementClient.cs
@@ -17903,7 +17903,7 @@ namespace Microsoft.WindowsAzure.Management.Compute
                                     roleInstance.RoleName = roleNameInstance2;
                                 }
                                 
-                                XElement oSVersionElement = roleListElement.Element(XName.Get("OSVersion", "http://schemas.microsoft.com/windowsazure"));
+                                XElement oSVersionElement = roleListElement.Element(XName.Get("OsVersion", "http://schemas.microsoft.com/windowsazure"));
                                 if (oSVersionElement != null)
                                 {
                                     string oSVersionInstance = oSVersionElement.Value;
@@ -19036,7 +19036,7 @@ namespace Microsoft.WindowsAzure.Management.Compute
                                     roleInstance.RoleName = roleNameInstance2;
                                 }
                                 
-                                XElement oSVersionElement = roleListElement.Element(XName.Get("OSVersion", "http://schemas.microsoft.com/windowsazure"));
+                                XElement oSVersionElement = roleListElement.Element(XName.Get("OsVersion", "http://schemas.microsoft.com/windowsazure"));
                                 if (oSVersionElement != null)
                                 {
                                     string oSVersionInstance = oSVersionElement.Value;
@@ -24624,7 +24624,7 @@ namespace Microsoft.WindowsAzure.Management.Compute
                                             roleInstance.RoleName = roleNameInstance2;
                                         }
                                         
-                                        XElement oSVersionElement = roleListElement.Element(XName.Get("OSVersion", "http://schemas.microsoft.com/windowsazure"));
+                                        XElement oSVersionElement = roleListElement.Element(XName.Get("OsVersion", "http://schemas.microsoft.com/windowsazure"));
                                         if (oSVersionElement != null)
                                         {
                                             string oSVersionInstance = oSVersionElement.Value;
@@ -36427,7 +36427,7 @@ namespace Microsoft.WindowsAzure.Management.Compute
                     
                     if (roleListItem.OSVersion != null)
                     {
-                        XElement oSVersionElement = new XElement(XName.Get("OSVersion", "http://schemas.microsoft.com/windowsazure"));
+                        XElement oSVersionElement = new XElement(XName.Get("OsVersion", "http://schemas.microsoft.com/windowsazure"));
                         oSVersionElement.Value = roleListItem.OSVersion;
                         roleElement.Add(oSVersionElement);
                     }


### PR DESCRIPTION
The ComputeManagementClient does not populate the Role.OSVersion property when retrieving deployment details (Deployments.GetBySlot(), Deployments.GetByName(), etc).

The following code will always throw an exception:

```
            using (var client = CloudContext.Clients.CreateComputeManagementClient(myCredentials))
            {
                var deployment = client.Deployments.GetBySlot(&quot;MyService&quot;, DeploymentSlot.Production);

                if (deployment.Roles.Any(r =&gt; string.IsNullOrEmpty(r.OSVersion)))
                {
                    throw new Exception();
                }
            }
```

I believe the problem lies in inproper casing of element &quot;OsVersion&quot; when parsing the result.

This:
XElement oSVersionElement = roleListElement.Element(XName.Get(&quot;OSVersion&quot;, &quot;http://schemas.microsoft.com/windowsazure&quot;));

Should be:
XElement oSVersionElement = roleListElement.Element(XName.Get(&quot;OsVersion&quot;, &quot;http://schemas.microsoft.com/windowsazure&quot;));<p><a href="https://github.com/WindowsAzure/azure-sdk-for-net/pull/333">https://github.com/WindowsAzure/azure-sdk-for-net/pull/333</a></p>

<!---@tfsbridge:{"tfsId":1163906}-->
