### PR TITLE
Adding Service Bus Management NuGet package specification

### DIFF
--- a/src/SchedulerManagement/Microsoft.WindowsAzure.Management.Scheduler.nuspec
+++ b/src/SchedulerManagement/Microsoft.WindowsAzure.Management.Scheduler.nuspec
@@ -10,7 +10,7 @@
     <licenseUrl>http://aka.ms/windowsazureapache2</licenseUrl>
     <projectUrl>https://github.com/WindowsAzure/azure-sdk-for-net</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</iconUrl>
-    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Provides Windows Azure Scheduler management operations including the ability to create, update and delete scheduled jobs and get job status and history.</summary>
     <description>Provides Windows Azure Scheduler management operations including the ability to create, update and delete scheduled jobs and get job status and history.</description>
     <copyright>Copyright © Microsoft Corporation</copyright>

--- a/src/ServiceBusManagement/Microsoft.WindowsAzure.Management.ServiceBus.nuget.proj
+++ b/src/ServiceBusManagement/Microsoft.WindowsAzure.Management.ServiceBus.nuget.proj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <!--
+    Microsoft.WindowsAzure.Management.ServiceBus
+    -->
+    <SdkNuGetPackage Include="Microsoft.WindowsAzure.Management.ServiceBus">
+      <PackageVersion>0.9.0-preview</PackageVersion>
+
+      <Folder>$(MSBuildThisFileDirectory)</Folder>
+    </SdkNuGetPackage>
+  </ItemGroup>
+</Project>

--- a/src/ServiceBusManagement/Microsoft.WindowsAzure.Management.ServiceBus.nuspec
+++ b/src/ServiceBusManagement/Microsoft.WindowsAzure.Management.ServiceBus.nuspec
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata minClientVersion="2.5">
+    <id>Microsoft.WindowsAzure.Management.ServiceBus</id>
+    <title>Windows Azure Service Bus Management Library</title>
+    <releaseNotes>__BASELINE_RELEASE_NOTES__</releaseNotes>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>azure-sdk, Microsoft</owners>
+    <licenseUrl>http://aka.ms/windowsazureapache2</licenseUrl>
+    <projectUrl>https://github.com/WindowsAzure/azure-sdk-for-net</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>Provides Windows Azure Service Bus management operations for Windows Azure including the ability to create, delete, list and update Namespaces, Topics, Queues and Notification Hubs.</summary>
+    <description>Provides Windows Azure Service Bus management operations for Windows Azure including the ability to create, delete, list and update Namespaces, Topics, Queues and Notification Hubs.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags>Microsoft "Windows Azure" Azure servicebus "service bus" REST HTTP client windowsazureofficial</tags>
+    <references>
+      <group targetFramework="portable-net45+sl50+wp80+win">
+        <reference file="Microsoft.WindowsAzure.Management.ServiceBus.dll" />
+      </group>
+      <group targetFramework="net40">
+        <reference file="Microsoft.WindowsAzure.Management.ServiceBus.dll" />
+      </group>
+    </references>
+    <dependencies>
+      <dependency id="Microsoft.WindowsAzure.Common" version="__VERSION_Microsoft.WindowsAzure.Common__" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="ServiceBusManagement\**\*.cs" target="src" />
+
+    <file src="..\binaries\Microsoft.WindowsAzure.Management.ServiceBus.dll" target="lib\portable-net45+sl50+wp80+win" />
+    <file src="..\binaries\Microsoft.WindowsAzure.Management.ServiceBus.pdb" target="lib\portable-net45+sl50+wp80+win" />
+    <file src="..\binaries\Microsoft.WindowsAzure.Management.ServiceBus.xml" target="lib\portable-net45+sl50+wp80+win" />
+
+    <file src="..\binaries\net40\Microsoft.WindowsAzure.Management.ServiceBus.dll" target="lib\net40" />
+    <file src="..\binaries\net40\Microsoft.WindowsAzure.Management.ServiceBus.pdb" target="lib\net40" />
+    <file src="..\binaries\net40\Microsoft.WindowsAzure.Management.ServiceBus.xml" target="lib\net40" />
+  </files>
+</package>

--- a/src/ServiceBusManagement/ServiceBusManagement.csproj
+++ b/src/ServiceBusManagement/ServiceBusManagement.csproj
@@ -65,6 +65,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="GenerateCode.props" />
+    <None Include="Microsoft.WindowsAzure.Management.ServiceBus.nuget.proj" />
+    <None Include="Microsoft.WindowsAzure.Management.ServiceBus.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Adds Service Bus Management NuGet package specification
- Updates license acceptance for the scheduler client
  - All libraries that depend on the `Common` package get license acceptance as the `Common` library requires it
  - Simplifies WAML story
