### PR TITLE
Added property to conditionally enable/disable spec generation.

### DIFF
--- a/libraries.msbuild
+++ b/libraries.msbuild
@@ -106,16 +106,23 @@
     <NuGetSymbolPublishingSource></NuGetSymbolPublishingSource>
     <NuGetKey></NuGetKey>
   </PropertyGroup>
+  
+  <!--
+  Hydra related profiles
+  -->
+  <PropertyGroup>
+    <GenerateHydraSpecs></GenerateHydraSpecs>
+  </PropertyGroup>
 
   <!--
   Build profiles
   -->
   <PropertyGroup>
-    <DeveloperBuildProperties>Configuration=Debug;Platform=Any CPU;CopyToBinaries=true</DeveloperBuildProperties>
-    <OfficialMSBuildProperties>Configuration=Release;OfficialBuild=true;Platform=Any CPU</OfficialMSBuildProperties>
+    <DeveloperBuildProperties>Configuration=Debug;Platform=Any CPU;CopyToBinaries=true;GenerateHydraSpecs=true</DeveloperBuildProperties>
+    <OfficialMSBuildProperties>Configuration=Release;OfficialBuild=true;Platform=Any CPU;GenerateHydraSpecs=true</OfficialMSBuildProperties>
     <Net40BuildProperty>BuildSecondConfiguration=true</Net40BuildProperty>
   </PropertyGroup>
-
+  
   <!--
   Regular developer build
   -->

--- a/libraries.msbuild
+++ b/libraries.msbuild
@@ -335,7 +335,7 @@
   PRIVATE_FEED_USER_NAME: User name for access to the feed
   PRIVATE_FEED_PASSWORD: Password for access to the feed
   -->
-  <Target Name="ForceRestorePackages">
+  <Target Name="ForceRestorePackages" Condition="$(GenerateHydraSpecs)!=''">
     <PropertyGroup>
       <NuGetRestoreConfigFile>$(MSBuildProjectDirectory)\restore.config</NuGetRestoreConfigFile>
       <NuGetRestoreConfigSwitch>-ConfigFile &quot;$(NuGetRestoreConfigFile)&quot;</NuGetRestoreConfigSwitch>
@@ -347,9 +347,9 @@
 
     <!-- Create config for user name and password for private feed access -->
     <Delete Files="$(NuGetRestoreConfigFile)" />
-    <Exec Command='$(NuGetCommand) sources add -Name Hydra -Source &quot;$(PRIVATE_FEED_URL)&quot; $(NuGetRestoreConfigSwitch)' Condition="$(GenerateHydraSpecs)!=''"/>
+    <Exec Command='$(NuGetCommand) sources add -Name Hydra -Source &quot;$(PRIVATE_FEED_URL)&quot; $(NuGetRestoreConfigSwitch)'/>
     <Exec Command='$(NuGetCommand) sources Update -Name Hydra -UserName $(PRIVATE_FEED_USER_NAME) -Password &quot;$(PRIVATE_FEED_PASSWORD)&quot; $(NuGetRestoreConfigSwitch)'
-      EchoOff="true" Condition="$(GenerateHydraSpecs)!=''"/>
+      EchoOff="true"/>
 
     <Exec Command="$(NuGetCommand) restore WindowsAzureLibraries.sln $(NuGetRestoreConfigSwitch)"
       ContinueOnError="ErrorAndContinue" />

--- a/libraries.msbuild
+++ b/libraries.msbuild
@@ -347,9 +347,9 @@
 
     <!-- Create config for user name and password for private feed access -->
     <Delete Files="$(NuGetRestoreConfigFile)" />
-    <Exec Command='$(NuGetCommand) sources add -Name Hydra -Source &quot;$(PRIVATE_FEED_URL)&quot; $(NuGetRestoreConfigSwitch)' />
+    <Exec Command='$(NuGetCommand) sources add -Name Hydra -Source &quot;$(PRIVATE_FEED_URL)&quot; $(NuGetRestoreConfigSwitch)' Condition="$(GenerateHydraSpecs)!=''"/>
     <Exec Command='$(NuGetCommand) sources Update -Name Hydra -UserName $(PRIVATE_FEED_USER_NAME) -Password &quot;$(PRIVATE_FEED_PASSWORD)&quot; $(NuGetRestoreConfigSwitch)'
-      EchoOff="true"/>
+      EchoOff="true" Condition="$(GenerateHydraSpecs)!=''"/>
 
     <Exec Command="$(NuGetCommand) restore WindowsAzureLibraries.sln $(NuGetRestoreConfigSwitch)"
       ContinueOnError="ErrorAndContinue" />


### PR DESCRIPTION
Resolves RDTask #1166304 - Support .NET builds without Hydra generator access

Related PR in Hydra is https://github.com/WindowsAzure/hydra/pull/252.<p><a href="https://github.com/WindowsAzure/azure-sdk-for-net/pull/365">https://github.com/WindowsAzure/azure-sdk-for-net/pull/365</a></p>

<!---@tfsbridge:{"tfsId":1168277}-->
