### PR TITLE
Compute WAML: OsVersion fix

### DIFF
--- a/src/ComputeManagement/ComputeManagement.csproj
+++ b/src/ComputeManagement/ComputeManagement.csproj
@@ -174,6 +174,6 @@
   <Import Project="..\..\packages\Hydra.Generator.1.0.5085.22928-prerelease\build\Hydra.Generator.targets" Condition="Exists('..\..\packages\Hydra.Generator.1.0.5085.22928-prerelease\build\Hydra.Generator.targets')" />
   <Target Name="BeforeBuild" DependsOnTargets="RestorePackages;GenerateCodeFromSpecs" />
   <Target Name="CopyMicrosoftWindowsAzureManagementComputeSpecification" BeforeTargets="GenerateCodeFromSpecs">
-    <Copy SourceFiles="..\..\packages\Microsoft.WindowsAzure.Management.Compute.Specification.1.0.5085.30244-prerelease\tools\Microsoft.WindowsAzure.Management.Compute.Specification.dll" DestinationFolder="." />
+    <Copy SourceFiles="..\..\packages\Microsoft.WindowsAzure.Management.Compute.Specification.1.0.5093.26248-prerelease\tools\Microsoft.WindowsAzure.Management.Compute.Specification.dll" DestinationFolder="." />
   </Target>
 </Project>

--- a/src/ComputeManagement/Generated/DeploymentOperations.cs
+++ b/src/ComputeManagement/Generated/DeploymentOperations.cs
@@ -3841,11 +3841,11 @@ namespace Microsoft.WindowsAzure.Management.Compute
                                     roleInstance.RoleName = roleNameInstance2;
                                 }
                                 
-                                XElement oSVersionElement = roleListElement.Element(XName.Get("OSVersion", "http://schemas.microsoft.com/windowsazure"));
-                                if (oSVersionElement != null)
+                                XElement osVersionElement = roleListElement.Element(XName.Get("OsVersion", "http://schemas.microsoft.com/windowsazure"));
+                                if (osVersionElement != null)
                                 {
-                                    string oSVersionInstance = oSVersionElement.Value;
-                                    roleInstance.OSVersion = oSVersionInstance;
+                                    string osVersionInstance = osVersionElement.Value;
+                                    roleInstance.OSVersion = osVersionInstance;
                                 }
                                 
                                 XElement roleTypeElement = roleListElement.Element(XName.Get("RoleType", "http://schemas.microsoft.com/windowsazure"));
@@ -4974,11 +4974,11 @@ namespace Microsoft.WindowsAzure.Management.Compute
                                     roleInstance.RoleName = roleNameInstance2;
                                 }
                                 
-                                XElement oSVersionElement = roleListElement.Element(XName.Get("OSVersion", "http://schemas.microsoft.com/windowsazure"));
-                                if (oSVersionElement != null)
+                                XElement osVersionElement = roleListElement.Element(XName.Get("OsVersion", "http://schemas.microsoft.com/windowsazure"));
+                                if (osVersionElement != null)
                                 {
-                                    string oSVersionInstance = oSVersionElement.Value;
-                                    roleInstance.OSVersion = oSVersionInstance;
+                                    string osVersionInstance = osVersionElement.Value;
+                                    roleInstance.OSVersion = osVersionInstance;
                                 }
                                 
                                 XElement roleTypeElement = roleListElement.Element(XName.Get("RoleType", "http://schemas.microsoft.com/windowsazure"));

--- a/src/ComputeManagement/Generated/HostedServiceOperations.cs
+++ b/src/ComputeManagement/Generated/HostedServiceOperations.cs
@@ -1726,11 +1726,11 @@ namespace Microsoft.WindowsAzure.Management.Compute
                                             roleInstance.RoleName = roleNameInstance2;
                                         }
                                         
-                                        XElement oSVersionElement = roleListElement.Element(XName.Get("OSVersion", "http://schemas.microsoft.com/windowsazure"));
-                                        if (oSVersionElement != null)
+                                        XElement osVersionElement = roleListElement.Element(XName.Get("OsVersion", "http://schemas.microsoft.com/windowsazure"));
+                                        if (osVersionElement != null)
                                         {
-                                            string oSVersionInstance = oSVersionElement.Value;
-                                            roleInstance.OSVersion = oSVersionInstance;
+                                            string osVersionInstance = osVersionElement.Value;
+                                            roleInstance.OSVersion = osVersionInstance;
                                         }
                                         
                                         XElement roleTypeElement = roleListElement.Element(XName.Get("RoleType", "http://schemas.microsoft.com/windowsazure"));

--- a/src/ComputeManagement/Generated/VirtualMachineOperations.cs
+++ b/src/ComputeManagement/Generated/VirtualMachineOperations.cs
@@ -1004,9 +1004,9 @@ namespace Microsoft.WindowsAzure.Management.Compute
                     
                     if (roleListItem.OSVersion != null)
                     {
-                        XElement oSVersionElement = new XElement(XName.Get("OSVersion", "http://schemas.microsoft.com/windowsazure"));
-                        oSVersionElement.Value = roleListItem.OSVersion;
-                        roleElement.Add(oSVersionElement);
+                        XElement osVersionElement = new XElement(XName.Get("OsVersion", "http://schemas.microsoft.com/windowsazure"));
+                        osVersionElement.Value = roleListItem.OSVersion;
+                        roleElement.Add(osVersionElement);
                     }
                     
                     if (roleListItem.RoleType != null)

--- a/src/ComputeManagement/Microsoft.WindowsAzure.Management.Compute.nuget.proj
+++ b/src/ComputeManagement/Microsoft.WindowsAzure.Management.Compute.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.WindowsAzure.Management.Compute
     -->
     <SdkNuGetPackage Include="Microsoft.WindowsAzure.Management.Compute">
-      <PackageVersion>0.9.3-preview</PackageVersion>
+      <PackageVersion>0.9.4-preview</PackageVersion>
 
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>

--- a/src/ComputeManagement/packages.config
+++ b/src/ComputeManagement/packages.config
@@ -6,5 +6,5 @@
   <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="portable-net45+sl50+wp80+win" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="portable-net45+sl50+wp80+win" />
   <package id="Hydra.Generator" version="1.0.5085.22928-prerelease" targetFramework="portable-net45+sl50+wp80+win" />
-  <package id="Microsoft.WindowsAzure.Management.Compute.Specification" version="1.0.5085.30244-prerelease" targetFramework="portable-net45+sl50+wp80+win" />
+  <package id="Microsoft.WindowsAzure.Management.Compute.Specification" version="1.0.5093.26248-prerelease" targetFramework="portable-net45+sl50+wp80+win" />
 </packages>


### PR DESCRIPTION
The REST specification needs to be updated as the property over the wire is `OsVersion`, although the property name is consistent with the .NET naming guidelines as `OSVersion`'.

This is the round-tripped fix essentially as recommended by @martinoberg<p><a href="https://github.com/WindowsAzure/azure-sdk-for-net/pull/366">https://github.com/WindowsAzure/azure-sdk-for-net/pull/366</a></p>

<!---@tfsbridge:{"tfsId":1169039}-->
