### PR TITLE
Fix for NullReferenceException creating Cloud Exception

### DIFF
--- a/src/Common.Test/CloudExceptionTest.cs
+++ b/src/Common.Test/CloudExceptionTest.cs
@@ -39,10 +39,12 @@ namespace Microsoft.WindowsAzure.Common.Test
         }
 
         [Fact]
-        public void ExceptionIsCreatedFromEmptyResponse()
+        public void ExceptionIsCreatedFromHeaderlessResponse()
         {
             var ex = CloudException.Create(genericMessage, genericMessageString, notFoundResponse,
                                            "", CloudExceptionType.Json);
+
+            Assert.Null(notFoundResponse.Content.Headers.ContentType);
             Assert.NotNull(ex);
             Assert.Equal("", ex.Message);
         }

--- a/src/Common.Test/CloudExceptionTest.cs
+++ b/src/Common.Test/CloudExceptionTest.cs
@@ -1,0 +1,50 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.WindowsAzure.Common.Test
+{
+    public class CloudExceptionTest
+    {
+        private HttpResponseMessage notFoundResponse;
+        private string genericMessageString = "{'key'='value'}";
+        private HttpRequestMessage genericMessage;
+
+        public CloudExceptionTest()
+        {
+            genericMessage = new HttpRequestMessage(HttpMethod.Get, "http//test/url");
+            genericMessage.Content = new StringContent(genericMessageString);
+            notFoundResponse = new HttpResponseMessage(System.Net.HttpStatusCode.NotFound);
+            notFoundResponse.Content = new StreamContent(new MemoryStream());
+        }
+
+        [Fact]
+        public void ExceptionIsCreatedFromEmptyResponse()
+        {
+            var ex = CloudException.Create(genericMessage, genericMessageString, notFoundResponse,
+                                           "", CloudExceptionType.Json);
+            Assert.NotNull(ex);
+            Assert.Equal("", ex.Message);
+        }
+    }
+}

--- a/src/Common.Test/Common.Test.csproj
+++ b/src/Common.Test/Common.Test.csproj
@@ -62,6 +62,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CloudExceptionTest.cs" />
     <Compile Include="Fakes\BadResponseDelegatingHandler.cs" />
     <Compile Include="Fakes\FakeHttpHandler.cs" />
     <Compile Include="Fakes\FakeServiceClientWithCredentials.cs" />

--- a/src/Common/Exception/CloudException.cs
+++ b/src/Common/Exception/CloudException.cs
@@ -117,20 +117,29 @@ namespace Microsoft.WindowsAzure
             CloudExceptionType defaultTo,
             Exception innerException = null)
         {
-            if (response.Content.Headers.ContentType.MediaType.Equals("application/json") ||
-                response.Content.Headers.ContentType.MediaType.Equals("text/json"))
+            if (response.Content != null && response.Content.Headers.ContentType != null)
             {
-                return CreateFromJson(request, requestContent, response, responseContent, innerException);
-            } else if (response.Content.Headers.ContentType.MediaType.Equals("application/xml") ||
-                       response.Content.Headers.ContentType.MediaType.Equals("text/xml"))
-            {
-                return CreateFromXml(request, requestContent, response, responseContent, innerException);
-            } else if (defaultTo == CloudExceptionType.Json)
-            {
-                return CreateFromJson(request, requestContent, response, responseContent, innerException);
+                if (response.Content.Headers.ContentType.MediaType.Equals("application/json") ||
+                    response.Content.Headers.ContentType.MediaType.Equals("text/json"))
+                {
+                    return CreateFromJson(request, requestContent, response, responseContent, innerException);
+                }
+                else
+                {
+                    return CreateFromXml(request, requestContent, response, responseContent, innerException);
+                }
             }
-
-            return CreateFromXml(request, requestContent, response, responseContent, innerException);
+            else
+            {
+                if (defaultTo == CloudExceptionType.Json)
+                {
+                    return CreateFromJson(request, requestContent, response, responseContent, innerException);
+                }
+                else
+                {
+                    return CreateFromXml(request, requestContent, response, responseContent, innerException);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed NullReferenceException that was thrown when response didn't contain headers (TFS issue 1261798)
