### PR TITLE
[Suggestion] Remove notion of Fabric from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ To get all of the management libraries setup in your project:
 
 ### Code Samples
 
-This code would result with a list of the regions in the Windows Azure fabric. The location object provided in the result provides properties to define which assets are supported by each region. 
+This code would result with a list of the regions in the Windows Azure. The location object provided in the result provides properties to define which assets are supported by each region. 
 
 ```csharp
 using (ManagementClient client = CloudContext.Clients.CreateManagementClient(Credentials))
@@ -219,7 +219,7 @@ using (StorageManagementClient client =
 }
 ```
 
-The following code will create a new (empty) Cloud Service in the Windows Azure fabric. 
+The following code will create a new (empty) Cloud Service in the Windows Azure subscription. 
 
 ```csharp
 var cloudServiceName = "MyCloudService";


### PR DESCRIPTION
Fabric is not a detail exposed to customer on management portal or API documentation. This term should not be used here.
