### PR TITLE
Adding dependency on common azure libraries

### DIFF
--- a/src/Microsoft.WindowsAzure.Management.Libraries.nuspec
+++ b/src/Microsoft.WindowsAzure.Management.Libraries.nuspec
@@ -33,6 +33,7 @@ Management operations require the X509Certificate2 type that is not present in t
     <tags>windowsazureofficial management cloud libraries "windows azure management"</tags>
     <dependencies>
       <group>
+        <dependency id="Microsoft.WindowsAzure.Common" version="0.9.1-preview" />
         <dependency id="Microsoft.WindowsAzure.Management" version="__VERSION_Microsoft.WindowsAzure.Management__" />
         <dependency id="Microsoft.WindowsAzure.Management.Compute" version="__VERSION_Microsoft.WindowsAzure.Management.Compute__" />
         <dependency id="Microsoft.WindowsAzure.Management.ServiceBus" version="__VERSION_Microsoft.WindowsAzure.Management.ServiceBus__" />


### PR DESCRIPTION
As noted in both issue #464 and http://stackoverflow.com/questions/21762563/missing-microsoft-threading-tasks-with-azure-sdk/21792267?noredirect=1#21792267 there is a missing dependency on the Azure common libraries in the created nuget package. In most cases people will already have references to this library but it is not true for all users.

This fix has the issue of hard coding the version of the common libraries, it would be better if this could be injected but I'm unaware of any way to do that. 

Fixes #464
