### PR TITLE
TimeGrain parameter not supported

### DIFF
--- a/src/WebSiteManagement/Generated/Models/WebSiteGetHistoricalUsageMetricsParameters.cs
+++ b/src/WebSiteManagement/Generated/Models/WebSiteGetHistoricalUsageMetricsParameters.cs
@@ -66,6 +66,17 @@ namespace Microsoft.WindowsAzure.Management.WebSites.Models
             get { return this._startTime; }
             set { this._startTime = value; }
         }
+
+        private string _timeGrain;
+
+        /// <summary>
+        /// The interval which the metrics are returned.
+        /// </summary>
+        public string TimeGrain
+        {
+            get { return this._timeGrain; }
+            set { this._timeGrain = value; }
+        }
         
         /// <summary>
         /// Initializes a new instance of the

--- a/src/WebSiteManagement/Generated/Models/WebSiteGetHistoricalUsageMetricsParameters.cs
+++ b/src/WebSiteManagement/Generated/Models/WebSiteGetHistoricalUsageMetricsParameters.cs
@@ -70,7 +70,7 @@ namespace Microsoft.WindowsAzure.Management.WebSites.Models
         private string _timeGrain;
 
         /// <summary>
-        /// The interval which the metrics are returned.
+        /// The aggregation interval of metrics that are returned.
         /// </summary>
         public string TimeGrain
         {

--- a/src/WebSiteManagement/Generated/WebSiteOperations.cs
+++ b/src/WebSiteManagement/Generated/WebSiteOperations.cs
@@ -2607,6 +2607,10 @@ namespace Microsoft.WindowsAzure.Management.WebSites
             {
                 url = url + "&EndTime=" + Uri.EscapeUriString(parameters.EndTime.Value.ToString());
             }
+            if (!string.IsNullOrEmpty(parameters.TimeGrain))
+            {
+                url = url + "&TimeGrain=" + Uri.EscapeUriString(parameters.TimeGrain);
+            }
             
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = null;


### PR DESCRIPTION
When getting historical usage metrics, there looks to be a parameter named TimeGrain which controls granularity (e.g. &amp;TimeGrain=PT1M). However, the Azure SDK does not seem to support this with its WebSiteGetHistoricalUsageMetricsParameters class. Seeing as how the code is auto-generated for the class, the changes I've made in this pull request may not be applicable, but perhaps it will serve as a bug notification for the code generation tool instead.

I also recently noticed that flipping TimeGrain to explicitly say &quot;PT1M&quot; no longer return values over a certain time frame, whereas using &quot;PT1H&quot; still works in retrieving metrics for the same time frame. Has support for by-the-minute polling been removed?<p><a href="https://github.com/Azure/azure-sdk-for-net/pull/523">https://github.com/Azure/azure-sdk-for-net/pull/523</a></p>

<!---@tfsbridge:{"tfsId":2115033}-->
