### PR TITLE
Removing monitoring from 1.0

### DIFF
--- a/src/Microsoft.WindowsAzure.Management.Libraries.nuspec
+++ b/src/Microsoft.WindowsAzure.Management.Libraries.nuspec
@@ -16,7 +16,6 @@
 - Microsoft Azure Virtual Machines
 - Hosted Services
 - Infrastructure services
-- Monitoring
 - Scheduler
 - Service Bus
 - Storage Accounts
@@ -40,7 +39,6 @@ Management operations require the X509Certificate2 type that is not present in t
         <dependency id="Microsoft.WindowsAzure.Management.Network" version="__VERSION_Microsoft.WindowsAzure.Management.Network__" />
         <dependency id="Microsoft.WindowsAzure.Management.WebSites" version="__VERSION_Microsoft.WindowsAzure.Management.WebSites__" />
         <dependency id="Microsoft.WindowsAzure.Management.Scheduler" version="__VERSION_Microsoft.WindowsAzure.Management.Scheduler__" />
-        <dependency id="Microsoft.WindowsAzure.Management.Monitoring" version="__VERSION_Microsoft.WindowsAzure.Management.Monitoring__" />
         <dependency id="Microsoft.WindowsAzure.Management.MediaServices" version="__VERSION_Microsoft.WindowsAzure.Management.MediaServices__" />
       </group>
     </dependencies>

--- a/src/Monitoring/Microsoft.WindowsAzure.Management.Monitoring.nuget.proj
+++ b/src/Monitoring/Microsoft.WindowsAzure.Management.Monitoring.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.WindowsAzure.Management.Monitoring
     -->
     <SdkNuGetPackage Include="Microsoft.WindowsAzure.Management.Monitoring">
-      <PackageVersion>1.0.0</PackageVersion>
+      <PackageVersion>0.9.7</PackageVersion>
 
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>


### PR DESCRIPTION
Monitoring confirmed they have some pre-release features in their API and therefore we need to keep them in pre-release for their SDK. 
