### PR TITLE
404 on Delete yields client SDK nullref (1420534)

### DIFF
--- a/WindowsAzureLibraries.sln
+++ b/WindowsAzureLibraries.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
+# Visual Studio 2012
 VisualStudioVersion = 12.0.21005.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{868850B4-1073-41A1-ABA8-A3B465880148}"

--- a/src/Common.Test/CloudExceptionTest.cs
+++ b/src/Common.Test/CloudExceptionTest.cs
@@ -17,10 +17,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Microsoft.WindowsAzure.Common.Test
 {
@@ -29,6 +31,8 @@ namespace Microsoft.WindowsAzure.Common.Test
         private HttpResponseMessage notFoundResponse;
         private HttpResponseMessage serverErrorResponse;
         private HttpResponseMessage serverErrorResponseWithCamelCase;
+        private HttpResponseMessage serverErrorResponseWithParent;
+        private HttpResponseMessage serverErrorResponseWithParent2;
         private string genericMessageString = "{'key'='value'}";
         private string jsonErrorMessageString = @"{
                                     'code': 'BadRequest',
@@ -54,25 +58,57 @@ namespace Microsoft.WindowsAzure.Common.Test
                                       }
                                     ]
                                 }";
+        private string jsonErrorMessageWithParent = @"{
+                                    'error' : {
+                                        'code': 'BadRequest',
+                                        'message': 'The provided database ‘foo’ has an invalid username.',
+                                        'target': 'query',
+                                        'details': [
+                                        {
+                                            'code': '301',
+                                            'target': '$search',
+                                            'message': '$search query option not supported.',
+                                        }
+                                        ]
+                                    }
+                                }";
+        private string jsonErrorMessageWithParent2 = @"{'error':{'code':'ResourceGroupNotFound','message':
+                'Resource group `ResourceGroup_crosoftAwillAofferAmoreAWebAservicemnopqrstuvwxyz1` could not be found.'}}";
+
+        private string htmlDefaultError = @"<html>error<h1>details</h1></html>";
         private HttpRequestMessage genericMessage;
+        private HttpRequestMessage genericMessageWithoutBody;
 
         public CloudExceptionTest()
         {
             genericMessage = new HttpRequestMessage(HttpMethod.Get, "http//test/url");
             genericMessage.Content = new StringContent(genericMessageString);
-            notFoundResponse = new HttpResponseMessage(System.Net.HttpStatusCode.NotFound);
+            genericMessageWithoutBody = new HttpRequestMessage(HttpMethod.Get, "http//test/url");
+            notFoundResponse = new HttpResponseMessage(HttpStatusCode.NotFound);
             notFoundResponse.Content = new StreamContent(new MemoryStream());
-            serverErrorResponse = new HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError);
+            serverErrorResponse = new HttpResponseMessage(HttpStatusCode.InternalServerError);
             serverErrorResponse.Content = new StringContent(jsonErrorMessageString);
-            serverErrorResponseWithCamelCase = new HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError);
+            serverErrorResponseWithCamelCase = new HttpResponseMessage(HttpStatusCode.InternalServerError);
             serverErrorResponseWithCamelCase.Content = new StringContent(jsonErrorMessageStringWithCamelCase);
+            serverErrorResponseWithParent = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            serverErrorResponseWithParent.Content = new StringContent(jsonErrorMessageWithParent);
+            serverErrorResponseWithParent2 = new HttpResponseMessage(HttpStatusCode.NotFound);
+            serverErrorResponseWithParent2.Content = new StringContent(jsonErrorMessageWithParent2);
         }
 
         [Fact]
         public void ExceptionIsCreatedFromHeaderlessResponse()
         {
-            var ex = CloudException.Create(genericMessage, genericMessageString, notFoundResponse,
-                                           "", CloudExceptionType.Json);
+            var ex = CloudException.Create(genericMessage, genericMessageString, notFoundResponse, "");
+
+            Assert.Null(notFoundResponse.Content.Headers.ContentType);
+            Assert.NotNull(ex);
+        }
+
+        [Fact]
+        public void ExceptionIsCreatedFromNullResponseString()
+        {
+            var ex = CloudException.Create(genericMessage, genericMessageString, notFoundResponse, null);
 
             Assert.Null(notFoundResponse.Content.Headers.ContentType);
             Assert.NotNull(ex);
@@ -81,8 +117,7 @@ namespace Microsoft.WindowsAzure.Common.Test
         [Fact]
         public void ExceptionContainsHttpStatusCodeIfBodyIsEmpty()
         {
-            var ex = CloudException.Create(genericMessage, genericMessageString, notFoundResponse,
-                                           "", CloudExceptionType.Json);
+            var ex = CloudException.Create(genericMessage, genericMessageString, notFoundResponse, "");
 
             Assert.Equal("Not Found", ex.Message);
         }
@@ -90,8 +125,7 @@ namespace Microsoft.WindowsAzure.Common.Test
         [Fact]
         public void JsonExceptionIsParsedCorrectlyWithLowerCase()
         {
-            var ex = CloudException.Create(genericMessage, genericMessageString, serverErrorResponse,
-                                           jsonErrorMessageString, CloudExceptionType.Json);
+            var ex = CloudException.Create(genericMessage, genericMessageString, serverErrorResponse, jsonErrorMessageString);
 
             Assert.Equal("BadRequest: The provided database ‘foo’ has an invalid username.", ex.Message);
             Assert.Equal("The provided database ‘foo’ has an invalid username.", ex.ErrorMessage);
@@ -102,11 +136,163 @@ namespace Microsoft.WindowsAzure.Common.Test
         public void JsonExceptionIsParsedCorrectlyWithCamelCase()
         {
             var ex = CloudException.Create(genericMessage, genericMessageString, serverErrorResponseWithCamelCase,
-                                           jsonErrorMessageStringWithCamelCase, CloudExceptionType.Json);
+                                           jsonErrorMessageStringWithCamelCase);
 
             Assert.Equal("BadRequest: The provided database ‘foo’ has an invalid username.", ex.Message);
             Assert.Equal("The provided database ‘foo’ has an invalid username.", ex.ErrorMessage);
             Assert.Equal("BadRequest", ex.ErrorCode);
+        }
+
+        [Fact]
+        public void JsonExceptionIsParsedCorrectlyWithParent()
+        {
+            var ex = CloudException.Create(genericMessage, genericMessageString, serverErrorResponseWithParent,
+                                           jsonErrorMessageWithParent);
+
+            Assert.Equal("BadRequest: The provided database ‘foo’ has an invalid username.", ex.Message);
+            Assert.Equal("The provided database ‘foo’ has an invalid username.", ex.ErrorMessage);
+            Assert.Equal("BadRequest", ex.ErrorCode);
+        }
+
+        [Fact]
+        public void JsonExceptionIsParsedCorrectlyWithoutMessageBody()
+        {
+            var ex = CloudException.Create(genericMessageWithoutBody, null, serverErrorResponseWithParent2, jsonErrorMessageWithParent2);
+
+            Assert.Equal("ResourceGroupNotFound: Resource group `ResourceGroup_crosoftAwillAofferAmoreAWebAservicemnopqrstuvwxyz1` could not be found.", ex.Message);
+            Assert.Equal("Resource group `ResourceGroup_crosoftAwillAofferAmoreAWebAservicemnopqrstuvwxyz1` could not be found.", ex.ErrorMessage);
+            Assert.Equal("ResourceGroupNotFound", ex.ErrorCode);
+        }
+
+        [Fact]
+        public void ParseJsonErrorSupportsFlatErrors()
+        {
+            string message = @"{
+                                    'code': 'BadRequest',
+                                    'message': 'The provided database ‘foo’ has an invalid username.',
+                                    'target': 'query',
+                                    'details': [
+                                      {
+                                       'code': '301',
+                                       'target': '$search',
+                                       'message': '$search query option not supported.',
+                                      }
+                                    ]
+                                }";
+
+            var error = CloudException.ParseJsonError(message);
+
+            Assert.Equal("The provided database ‘foo’ has an invalid username.", error.Message);
+            Assert.Equal("BadRequest", error.Code);
+            Assert.Equal(message, error.OriginalMessage);
+        }
+
+        [Fact]
+        public void ParseJsonErrorDeepErrors()
+        {
+            string message = @"{
+                                    'error' : {
+                                        'code': 'BadRequest',
+                                        'message': 'The provided database ‘foo’ has an invalid username.',
+                                        'target': 'query',
+                                        'details': [
+                                        {
+                                            'code': '301',
+                                            'target': '$search',
+                                            'message': '$search query option not supported.',
+                                        }
+                                        ]
+                                    }
+                                }";
+
+            var error = CloudException.ParseJsonError(message);
+
+            Assert.Equal("The provided database ‘foo’ has an invalid username.", error.Message);
+            Assert.Equal("BadRequest", error.Code);
+            Assert.Equal(message, error.OriginalMessage);
+        }
+
+        [Fact]
+        public void ParseJsonErrorSupportsEmptyErrors()
+        {
+            Assert.Null(CloudException.ParseJsonError(null).Code);
+            Assert.Null(CloudException.ParseJsonError(string.Empty).Message);
+        }
+
+        [Theory]
+        [InlineData(@"{'some error' : {'some message': 'The provided database ‘foo’ has an invalid username.',}}")]
+        [InlineData(@"{'error' : {'some message': 'The provided database ‘foo’ has an invalid username.',}}")]
+        [InlineData(@"{'error' : {'some message': 'The provided database ‘foo’ has an invalid username.'")]
+        public void ParseJsonErrorSupportsIncorrectlyFormattedJsonErrors(string message)
+        {
+            var error = CloudException.ParseJsonError(message);
+
+            Assert.Equal(message, error.OriginalMessage);
+            Assert.Null(error.Message);
+            Assert.Null(error.Code);
+        }
+
+        [Fact]
+        public void ParseXmlErrorSupportsErrorsWithCamelCase()
+        {
+            string message = @"<Error>
+                                        <Code>BadRequest</Code>
+                                        <Message>The provided database ‘foo’ has an invalid username.</Message>
+                                    </Error>";
+
+            var error = CloudException.ParseXmlError(message);
+            Assert.Equal("The provided database ‘foo’ has an invalid username.", error.Message);
+            Assert.Equal("BadRequest", error.Code);
+            Assert.Equal(message, error.OriginalMessage);
+        }
+
+        [Fact]
+        public void ParseXmlErrorSupportsErrorsWithLowerCase()
+        {
+            string message = @"<error>
+                                        <code>BadRequest</code>
+                                        <message>The provided database ‘foo’ has an invalid username.</message>
+                                    </error>";
+
+            var error = CloudException.ParseXmlError(message);
+            Assert.Equal("The provided database ‘foo’ has an invalid username.", error.Message);
+            Assert.Equal(message, error.OriginalMessage);
+        }
+
+        [Fact]
+        public void ParseXmlErrorSupportsEmptyErrors()
+        {
+            Assert.Null(CloudException.ParseXmlError(null).Code);
+            Assert.Null(CloudException.ParseXmlError(null).Message);
+            Assert.Null(CloudException.ParseXmlError(null).OriginalMessage);
+            Assert.Null(CloudException.ParseXmlError(string.Empty).Code);
+            Assert.Null(CloudException.ParseXmlError(string.Empty).Message);
+            Assert.Equal(string.Empty, CloudException.ParseXmlError(string.Empty).OriginalMessage);
+        }
+
+        [Fact]
+        public void ParseXmlErrorIgnoresParentElement()
+        {
+            string xmlErrorMessageWithBadParent = @"<SomeError>
+                                        <Code>BadRequest</Code>
+                                        <Message>The provided database ‘foo’ has an invalid username.</Message>
+                                    </SomeError>";
+
+            Assert.Equal("The provided database ‘foo’ has an invalid username.", CloudException.ParseXmlError(xmlErrorMessageWithBadParent).Message);
+            Assert.Equal("BadRequest", CloudException.ParseXmlError(xmlErrorMessageWithBadParent).Code);
+        }
+
+        [Theory]
+        [InlineData("<error><some-message>The provided database ‘foo’ has an invalid username.</some-message></error>")]
+        [InlineData("<some-error><some-message>The provided database ‘foo’ has an invalid username.</some-message></some-error>")]
+        [InlineData("<some-error><some-message>The provided database ‘foo’ has an invalid username.")]
+        [InlineData(@"<Error><SomeCode>BadRequest</SomeCode><SomeMessage>The provided database ‘foo’ has an invalid username.</SomeMode></Error>}")]
+        public void ParseXmlErrorSupportsIncorrectlyFormattedXmlErrors(string message)
+        {
+            var error = CloudException.ParseXmlError(message);
+            Assert.Equal(message, error.OriginalMessage);
+            Assert.Null(error.Message);
+            Assert.Null(error.Code);
         }
     }
 }

--- a/src/Common.Test/Common.Test.csproj
+++ b/src/Common.Test/Common.Test.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Fakes\FakeServiceClientWithCredentials.cs" />
     <Compile Include="Fakes\FakeServiceClient.cs" />
     <Compile Include="Fakes\RecordedDelegatingHandler.cs" />
+    <Compile Include="Internals\ParserHelperTests.cs" />
     <Compile Include="OData\FilterStringTest.cs" />
     <Compile Include="Internals\UriHelperTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Common.Test/Internals/ParserHelperTests.cs
+++ b/src/Common.Test/Internals/ParserHelperTests.cs
@@ -1,0 +1,91 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using Microsoft.WindowsAzure.Common.Internals;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Microsoft.WindowsAzure.Common.Test.Internals
+{
+    public class ParserHelperTests
+    {
+        [Theory]
+        [InlineData("{ error }", true)]
+        [InlineData(" { error }", true)]
+        [InlineData("		{ error }", true)]
+        [InlineData("		}", false)]
+        [InlineData(" }", false)]
+        [InlineData("}", false)]
+        [InlineData("", false)]
+        [InlineData(" ", false)]
+        [InlineData(" 		", false)]
+        [InlineData(null, false)]
+        public void IsJsonWorksWithoutValidation(string body, bool expectedResult)
+        {
+            Assert.Equal(expectedResult, ParserHelper.IsJson(body));
+        }
+
+        [Theory]
+        [InlineData("{ }", true)]
+        [InlineData("{ 'error' : 'message' }", true)]
+        [InlineData(" { 'error' : 'message' }", true)]
+        [InlineData("		{ 'error' : 'message' }", true)]
+        [InlineData("		{ 'error' : ", false)]
+        [InlineData("		}", false)]
+        [InlineData(" }", false)]
+        [InlineData("}", false)]
+        [InlineData("", false)]
+        [InlineData(" ", false)]
+        [InlineData(" 		", false)]
+        [InlineData(null, false)]
+        public void IsJsonWorksWithValidation(string body, bool expectedResult)
+        {
+            Assert.Equal(expectedResult, ParserHelper.IsJson(body, true));
+        }
+
+        [Theory]
+        [InlineData("<error/>", true)]
+        [InlineData(" <error/>", true)]
+        [InlineData("		<error/>", true)]
+        [InlineData("		>", false)]
+        [InlineData(" >", false)]
+        [InlineData(">", false)]
+        [InlineData("", false)]
+        [InlineData(" ", false)]
+        [InlineData(" 		", false)]
+        [InlineData(null, false)]
+        public void IsXmlWorksWithoutValidation(string body, bool expectedResult)
+        {
+            Assert.Equal(expectedResult, ParserHelper.IsXml(body));
+        }
+
+        [Theory]
+        [InlineData("<error/>", true)]
+        [InlineData(" <error/>", true)]
+        [InlineData("		<error/>", true)]
+        [InlineData("		<error>", false)]
+        [InlineData("		>", false)]
+        [InlineData(" >", false)]
+        [InlineData(">", false)]
+        [InlineData("", false)]
+        [InlineData(" ", false)]
+        [InlineData(" 		", false)]
+        [InlineData(null, false)]
+        public void IsXmlWorksWithValidation(string body, bool expectedResult)
+        {
+            Assert.Equal(expectedResult, ParserHelper.IsXml(body, true));
+        }
+    }
+}

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -31,6 +31,7 @@
     <Compile Include="Credentials\BasicAuthenticationCloudCredentials.cs" />
     <Compile Include="Credentials\TokenCloudCredentials.cs" />
     <Compile Include="Credentials\SubscriptionCloudCredentials.cs" />
+    <Compile Include="Exception\CloudError.cs" />
     <Compile Include="Exception\CloudExceptionType.cs" />
     <Compile Include="Exception\CloudHttpErrorInfo.cs" />
     <Compile Include="Exception\CloudHttpRequestErrorInfo.cs" />
@@ -40,6 +41,7 @@
     <Compile Include="Internals\ICloudSettingsFormat.cs" />
     <Compile Include="Configuration\JsonSettingsFormat.cs" />
     <Compile Include="Internals\IndisposableDelegatingHandler.cs" />
+    <Compile Include="Internals\ParserHelper.cs" />
     <Compile Include="Internals\TypeConversion.cs" />
     <Compile Include="Internals\UriHelper.cs" />
     <Compile Include="Models\OperationResponse.cs" />

--- a/src/Common/Exception/CloudError.cs
+++ b/src/Common/Exception/CloudError.cs
@@ -1,0 +1,38 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+namespace Microsoft.WindowsAzure
+{
+    /// <summary>
+    /// Representation of the error object from the server.
+    /// </summary>
+    public class CloudError
+    {
+        /// <summary>
+        /// Parsed error message.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Parsed error code.
+        /// </summary>
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Original error body
+        /// </summary>
+        public string OriginalMessage { get; set; }
+    }
+}

--- a/src/Common/Exception/CloudException.cs
+++ b/src/Common/Exception/CloudException.cs
@@ -84,6 +84,7 @@ namespace Microsoft.WindowsAzure
         /// <param name="defaultTo">The content type to default to if none of the types matches.</param>
         /// <param name="innerException">Optional inner exception.</param>
         /// <returns>A CloudException representing the failure.</returns>
+        [Obsolete("This method is obsolete. Use Create without defaultTo parameter.")]
         public static CloudException Create(
             HttpRequestMessage request,
             string requestContent,
@@ -92,78 +93,7 @@ namespace Microsoft.WindowsAzure
             CloudExceptionType defaultTo,
             Exception innerException = null)
         {
-            if (response.Content != null && response.Content.Headers.ContentType != null)
-            {
-                if (response.Content.Headers.ContentType.MediaType.Equals("application/json") ||
-                    response.Content.Headers.ContentType.MediaType.Equals("text/json"))
-                {
-                    return CreateFromJson(request, requestContent, response, responseContent, innerException);
-                } 
-                else if (response.Content.Headers.ContentType.MediaType.Equals("application/xml") ||
-                       response.Content.Headers.ContentType.MediaType.Equals("text/xml"))
-                {
-                    return CreateFromXml(request, requestContent, response, responseContent, innerException);
-                }
-            }
-
-            if (defaultTo == CloudExceptionType.Json)
-            {
-                return CreateFromJson(request, requestContent, response, responseContent, innerException);
-            }
-            else
-            {
-                return CreateFromXml(request, requestContent, response, responseContent, innerException);
-            }
-        }
-
-        /// <summary>
-        /// Create a CloudException from a failed response sending XML content.
-        /// </summary>
-        /// <param name="request">The HTTP request.</param>
-        /// <param name="requestContent">The HTTP request content.</param>
-        /// <param name="response">The HTTP response.</param>
-        /// <param name="responseContent">The HTTP response content.</param>
-        /// <param name="innerException">Optional inner exception.</param>
-        /// <returns>A CloudException representing the failure.</returns>
-        public static CloudException CreateFromXml(
-            HttpRequestMessage request,
-            string requestContent,
-            HttpResponseMessage response,
-            string responseContent,
-            Exception innerException = null)
-        {
-            return Create(
-                request,
-                requestContent,
-                response,
-                responseContent,
-                innerException,
-                ParseXmlError);
-        }
-
-        /// <summary>
-        /// Create a CloudException from a failed response sending JSON content.
-        /// </summary>
-        /// <param name="request">The HTTP request.</param>
-        /// <param name="requestContent">The HTTP request content.</param>
-        /// <param name="response">The HTTP response.</param>
-        /// <param name="responseContent">The HTTP response content.</param>
-        /// <param name="innerException">Optional inner exception.</param>
-        /// <returns>A CloudException representing the failure.</returns>
-        public static CloudException CreateFromJson(
-            HttpRequestMessage request,
-            string requestContent,
-            HttpResponseMessage response,
-            string responseContent,
-            Exception innerException = null)
-        {
-            return Create(
-                request,
-                requestContent,
-                response,
-                responseContent,
-                innerException,
-                ParseJsonError);
+            return Create(request, requestContent, response, responseContent, innerException);
         }
 
         /// <summary>
@@ -174,24 +104,19 @@ namespace Microsoft.WindowsAzure
         /// <param name="response">The HTTP response.</param>
         /// <param name="responseContent">The HTTP response content.</param>
         /// <param name="innerException">Optional inner exception.</param>
-        /// <param name="parseError">
-        /// Function to parse the response content and return the error code
-        /// and error message as a Tuple.
-        /// </param>
         /// <returns>A CloudException representing the failure.</returns>
-        private static CloudException Create(
+        public static CloudException Create(
             HttpRequestMessage request,
             string requestContent,
             HttpResponseMessage response,
             string responseContent,
-            Exception innerException,
-            Func<string, Tuple<string, string>> parseError)
+            Exception innerException = null)
         {
             // Get the error code and message
-            Tuple<string, string> tuple = parseError(responseContent);
-            string code = tuple.Item1;
-            string message = tuple.Item2;
-            
+            CloudError cloudError = ParseXmlOrJsonError(responseContent);
+            string code = cloudError.Code;
+            string message = cloudError.Message;
+
             // Get the most descriptive message that we can
             string exceptionMessage =
                 (code != null && message != null) ? code + ": " + message :
@@ -213,13 +138,43 @@ namespace Microsoft.WindowsAzure
         }
 
         /// <summary>
+        /// Parse the response content as either XML or JSON error message.
+        /// </summary>
+        /// <param name="content">The response content.</param>
+        /// <returns>
+        /// An object containing the parsed error code and message.
+        /// </returns>
+        public static CloudError ParseXmlOrJsonError(string content)
+        {
+            if (string.IsNullOrEmpty(content))
+            {
+                return new CloudError {OriginalMessage = content};
+            }
+            else
+            {
+                if (ParserHelper.IsJson(content))
+                {
+                    return ParseJsonError(content);
+                } 
+                else if (ParserHelper.IsXml(content))
+                {
+                    return ParseXmlError(content);
+                }
+                else
+                {
+                    return new CloudError { OriginalMessage = content };
+                }
+            }
+        }
+
+        /// <summary>
         /// Parse the response content as an XML error message.
         /// </summary>
         /// <param name="content">The response content.</param>
         /// <returns>
-        /// A tuple containing the parsed error code and message.
+        /// An object containing the parsed error code and message.
         /// </returns>
-        private static Tuple<string, string> ParseXmlError(string content)
+        public static CloudError ParseXmlError(string content)
         {
             string code = null;
             string message = null;
@@ -233,11 +188,11 @@ namespace Microsoft.WindowsAzure
                     {
                         // Check local names only because some services will
                         // use different namespaces or no namespace at all
-                        if (element.Name.LocalName == "Code")
+                        if ("Code".Equals(element.Name.LocalName, StringComparison.CurrentCultureIgnoreCase))
                         {
                             code = element.Value;
                         }
-                        else if (element.Name.LocalName == "Message")
+                        else if ("Message".Equals(element.Name.LocalName, StringComparison.CurrentCultureIgnoreCase))
                         {
                             message = element.Value;
                         }
@@ -249,7 +204,7 @@ namespace Microsoft.WindowsAzure
                 }
             }
 
-            return Tuple.Create(code, message);
+            return new CloudError { Code = code, Message = message, OriginalMessage = content };
         }
 
         /// <summary>
@@ -257,9 +212,9 @@ namespace Microsoft.WindowsAzure
         /// </summary>
         /// <param name="content">The response content.</param>
         /// <returns>
-        /// A tuple containing the parsed error code and message.
+        /// An object containing the parsed error code and message.
         /// </returns>
-        private static Tuple<string, string> ParseJsonError(string content)
+        public static CloudError ParseJsonError(string content)
         {
             string code = null;
             string message = null;
@@ -268,9 +223,19 @@ namespace Microsoft.WindowsAzure
             {
                 try
                 {
-                    JObject response = JObject.Parse(content);
-                    code = response.GetValue("Code", StringComparison.CurrentCultureIgnoreCase).ToString();
-                    message = response.GetValue("Message", StringComparison.CurrentCultureIgnoreCase).ToString();
+                    var response = JObject.Parse(content);
+                    
+                    if (response.GetValue("error", StringComparison.CurrentCultureIgnoreCase) != null)
+                    {
+                        var errorToken = response.GetValue("error", StringComparison.CurrentCultureIgnoreCase) as JObject;
+                        message = errorToken.GetValue("message", StringComparison.CurrentCultureIgnoreCase).ToString();
+                        code = errorToken.GetValue("code", StringComparison.CurrentCultureIgnoreCase).ToString();
+                    }
+                    else
+                    {
+                        message = response.GetValue("message", StringComparison.CurrentCultureIgnoreCase).ToString();
+                        code = response.GetValue("code", StringComparison.CurrentCultureIgnoreCase).ToString();
+                    }
                 }
                 catch
                 {
@@ -278,7 +243,7 @@ namespace Microsoft.WindowsAzure
                 }
             }
 
-            return Tuple.Create(code, message);
+            return new CloudError { Code = code, Message = message, OriginalMessage = content };
         }
     }
 }

--- a/src/Common/Internals/ParserHelper.cs
+++ b/src/Common/Internals/ParserHelper.cs
@@ -1,0 +1,119 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.WindowsAzure.Common.Internals
+{
+    /// <summary>
+    /// Parser helper.
+    /// </summary>
+    public static class ParserHelper
+    {
+        /// <summary>
+        /// Checks if content is possibly an XML.
+        /// </summary>
+        /// <param name="content">String to check.</param>
+        /// <param name="validate">If set to true will validate entire XML for validity otherwise will just check the first character.</param>
+        /// <returns>True is content is possibly an XML otherwise false.</returns>
+        public static bool IsXml(string content, bool validate = false)
+        {
+            var firstCharacter = FirstNonWhitespaceCharacter(content);
+            if (!validate)
+            {
+                return firstCharacter == '<';
+            }
+            else
+            {
+                if (firstCharacter != '<')
+                {
+                    return false;
+                }
+
+                try
+                {
+                    XDocument.Parse(content);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks if content is possibly a JSON.
+        /// </summary>
+        /// <param name="content">String to check.</param>
+        /// <param name="validate">If set to true will validate entire JSON for validity otherwise will just check the first character.</param>
+        /// <returns>True is content is possibly an JSON otherwise false.</returns>
+        public static bool IsJson(string content, bool validate = false)
+        {
+            var firstCharacter = FirstNonWhitespaceCharacter(content);
+            if (!validate)
+            {
+                return firstCharacter == '{';
+            }
+            else
+            {
+                if (firstCharacter != '{')
+                {
+                    return false;
+                }
+
+                try
+                {
+                    JObject.Parse(content);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns first non whitespace character
+        /// </summary>
+        /// <param name="content">Text to search in</param>
+        /// <returns>Non whitespace or default char</returns>
+        private static char FirstNonWhitespaceCharacter(string content)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return default(char);
+            }
+
+            for (int i = 0; i < content.Length; i++)
+            {
+                if (!char.IsWhiteSpace(content[i]))
+                {
+                    return content[i];
+                }
+            }
+
+            return default(char);
+        }
+    }
+}


### PR DESCRIPTION
- Changed logic for error parsing to detect XML or JSON based on the payload
- Added support for JSON errors nested inside an `error` object
- Exposed `ParseXXX` methods to be used in PowerShell
- Added unit tests
