### PR TITLE
GetHistoricalUsageMetrics time parameters sortable datetime format

### DIFF
--- a/src/WebSiteManagement/Generated/WebSiteOperations.cs
+++ b/src/WebSiteManagement/Generated/WebSiteOperations.cs
@@ -2689,11 +2689,11 @@ namespace Microsoft.WindowsAzure.Management.WebSites
             }
             if (parameters.StartTime != null)
             {
-                url = url + "&StartTime=" + Uri.EscapeUriString(parameters.StartTime.Value.ToString());
+                url = url + "&StartTime=" + Uri.EscapeUriString(parameters.StartTime.Value.ToString("s"));
             }
             if (parameters.EndTime != null)
             {
-                url = url + "&EndTime=" + Uri.EscapeUriString(parameters.EndTime.Value.ToString());
+                url = url + "&EndTime=" + Uri.EscapeUriString(parameters.EndTime.Value.ToString("s"));
             }
             // Trim '/' character from the end of baseUrl and beginning of url.
             if (baseUrl[baseUrl.Length - 1] == '/')


### PR DESCRIPTION
Added sortable datetime pattern to StartTime and EndTime to support different cultures.<p><a href="https://github.com/Azure/azure-sdk-for-net/pull/601">https://github.com/Azure/azure-sdk-for-net/pull/601</a></p>

<!---@tfsbridge:{"tfsId":2115032}-->
