### PR TITLE
Prevent logging of configuration setting values

### DIFF
--- a/src/Configuration/AzureApplicationSettings.cs
+++ b/src/Configuration/AzureApplicationSettings.cs
@@ -144,7 +144,7 @@ namespace Microsoft.WindowsAzure
 
             if (value != null)
             {
-                message = string.Format(CultureInfo.InvariantCulture, "PASS ({0})", value);
+                message = "PASS";
             }
             else
             {


### PR DESCRIPTION
CloudConfigurationManager.GetSetting should not cause logging of actual values of configuration settings as discussed in #653 .<p><a href="https://github.com/Azure/azure-sdk-for-net/pull/654">https://github.com/Azure/azure-sdk-for-net/pull/654</a></p>

<!---@tfsbridge:{"tfsId":2115029}-->
