### PR TITLE
Sql: Change in RecoverableDatabase and RecoverDatabaseOperation API URLs and parameters 

### DIFF
--- a/src/SqlManagement/Generated/IRecoverDatabaseOperations.cs
+++ b/src/SqlManagement/Generated/IRecoverDatabaseOperations.cs
@@ -36,9 +36,9 @@ namespace Microsoft.WindowsAzure.Management.Sql
         /// <summary>
         /// Issues a recovery request for an Azure SQL Database.
         /// </summary>
-        /// <param name='targetServerName'>
-        /// The name of the Azure SQL Database Server on which to recover the
-        /// source database.
+        /// <param name='sourceServerName'>
+        /// The name of the Azure SQL Database Server on which the database was
+        /// hosted.
         /// </param>
         /// <param name='parameters'>
         /// Additional parameters for the Create Recover Database Operation
@@ -51,6 +51,6 @@ namespace Microsoft.WindowsAzure.Management.Sql
         /// Contains the response to the Create Recover Database Operation
         /// request.
         /// </returns>
-        Task<RecoverDatabaseOperationCreateResponse> CreateAsync(string targetServerName, RecoverDatabaseOperationCreateParameters parameters, CancellationToken cancellationToken);
+        Task<RecoverDatabaseOperationCreateResponse> CreateAsync(string sourceServerName, RecoverDatabaseOperationCreateParameters parameters, CancellationToken cancellationToken);
     }
 }

--- a/src/SqlManagement/Generated/IRecoverableDatabaseOperations.cs
+++ b/src/SqlManagement/Generated/IRecoverableDatabaseOperations.cs
@@ -36,15 +36,11 @@ namespace Microsoft.WindowsAzure.Management.Sql
         /// <summary>
         /// Returns information about a recoverable Azure SQL Database.
         /// </summary>
-        /// <param name='targetServerName'>
-        /// The name of the Azure SQL Database Server on which to recover the
-        /// source database.
-        /// </param>
-        /// <param name='sourceServerName'>
+        /// <param name='serverName'>
         /// The name of the Azure SQL Database Server on which the database was
         /// hosted.
         /// </param>
-        /// <param name='sourceDatabaseName'>
+        /// <param name='databaseName'>
         /// The name of the recoverable Azure SQL Database to be obtained.
         /// </param>
         /// <param name='cancellationToken'>
@@ -53,17 +49,13 @@ namespace Microsoft.WindowsAzure.Management.Sql
         /// <returns>
         /// Contains the response to the Get Recoverable Database request.
         /// </returns>
-        Task<RecoverableDatabaseGetResponse> GetAsync(string targetServerName, string sourceServerName, string sourceDatabaseName, CancellationToken cancellationToken);
+        Task<RecoverableDatabaseGetResponse> GetAsync(string serverName, string databaseName, CancellationToken cancellationToken);
         
         /// <summary>
         /// Returns a collection of databases that can be recovered from a
         /// specified server.
         /// </summary>
-        /// <param name='targetServerName'>
-        /// The name of the Azure SQL Database Server on which to recover the
-        /// source database.
-        /// </param>
-        /// <param name='sourceServerName'>
+        /// <param name='serverName'>
         /// The name of the Azure SQL Database Server on which the databases
         /// were hosted.
         /// </param>
@@ -73,6 +65,6 @@ namespace Microsoft.WindowsAzure.Management.Sql
         /// <returns>
         /// Contains the response to the List Recoverable Databases request.
         /// </returns>
-        Task<RecoverableDatabaseListResponse> ListAsync(string targetServerName, string sourceServerName, CancellationToken cancellationToken);
+        Task<RecoverableDatabaseListResponse> ListAsync(string serverName, CancellationToken cancellationToken);
     }
 }

--- a/src/SqlManagement/Generated/Models/RecoverDatabaseOperation.cs
+++ b/src/SqlManagement/Generated/Models/RecoverDatabaseOperation.cs
@@ -52,17 +52,6 @@ namespace Microsoft.WindowsAzure.Management.Sql.Models
             set { this._sourceDatabaseName = value; }
         }
         
-        private string _sourceServerName;
-        
-        /// <summary>
-        /// Optional. Gets the name of the source Azure SQL Database Server.
-        /// </summary>
-        public string SourceServerName
-        {
-            get { return this._sourceServerName; }
-            set { this._sourceServerName = value; }
-        }
-        
         private string _targetDatabaseName;
         
         /// <summary>
@@ -72,6 +61,17 @@ namespace Microsoft.WindowsAzure.Management.Sql.Models
         {
             get { return this._targetDatabaseName; }
             set { this._targetDatabaseName = value; }
+        }
+        
+        private string _targetServerName;
+        
+        /// <summary>
+        /// Optional. Gets the name of the target Azure SQL Database Server.
+        /// </summary>
+        public string TargetServerName
+        {
+            get { return this._targetServerName; }
+            set { this._targetServerName = value; }
         }
         
         /// <summary>

--- a/src/SqlManagement/Generated/Models/RecoverDatabaseOperationCreateParameters.cs
+++ b/src/SqlManagement/Generated/Models/RecoverDatabaseOperationCreateParameters.cs
@@ -41,18 +41,6 @@ namespace Microsoft.WindowsAzure.Management.Sql.Models
             set { this._sourceDatabaseName = value; }
         }
         
-        private string _sourceServerName;
-        
-        /// <summary>
-        /// Optional. Gets or sets the name of the source Azure SQL Database
-        /// Server.
-        /// </summary>
-        public string SourceServerName
-        {
-            get { return this._sourceServerName; }
-            set { this._sourceServerName = value; }
-        }
-        
         private string _targetDatabaseName;
         
         /// <summary>
@@ -62,6 +50,18 @@ namespace Microsoft.WindowsAzure.Management.Sql.Models
         {
             get { return this._targetDatabaseName; }
             set { this._targetDatabaseName = value; }
+        }
+        
+        private string _targetServerName;
+        
+        /// <summary>
+        /// Optional. Gets or sets the name of the target Azure SQL Database
+        /// Server.
+        /// </summary>
+        public string TargetServerName
+        {
+            get { return this._targetServerName; }
+            set { this._targetServerName = value; }
         }
         
         /// <summary>

--- a/src/SqlManagement/Generated/Models/RestorableDroppedDatabase.cs
+++ b/src/SqlManagement/Generated/Models/RestorableDroppedDatabase.cs
@@ -26,7 +26,7 @@ using Microsoft.WindowsAzure.Management.Sql.Models;
 namespace Microsoft.WindowsAzure.Management.Sql.Models
 {
     /// <summary>
-    /// A dropped Azure SQL Database that can be restored.
+    /// Represents a dropped Azure SQL Database that can be restored.
     /// </summary>
     public partial class RestorableDroppedDatabase : SqlModelCommon
     {

--- a/src/SqlManagement/Generated/Models/RestorableDroppedDatabaseGetResponse.cs
+++ b/src/SqlManagement/Generated/Models/RestorableDroppedDatabaseGetResponse.cs
@@ -34,8 +34,8 @@ namespace Microsoft.WindowsAzure.Management.Sql.Models
         private RestorableDroppedDatabase _database;
         
         /// <summary>
-        /// Optional. Gets the restorable dropped database that has been
-        /// returned from a Get Restorable Dropped Database request.
+        /// Optional. Gets or sets the restorable dropped database that has
+        /// been returned from a Get Restorable Dropped Database request.
         /// </summary>
         public RestorableDroppedDatabase Database
         {

--- a/src/SqlManagement/Generated/Models/RestorableDroppedDatabaseListResponse.cs
+++ b/src/SqlManagement/Generated/Models/RestorableDroppedDatabaseListResponse.cs
@@ -35,8 +35,9 @@ namespace Microsoft.WindowsAzure.Management.Sql.Models
         private IList<RestorableDroppedDatabase> _databases;
         
         /// <summary>
-        /// Optional. Gets the collection of restorable dropped databases that
-        /// has been returned from a List Restorable Dropped Databases request.
+        /// Optional. Gets or sets the collection of restorable dropped
+        /// databases that has been returned from a List Restorable Dropped
+        /// Databases request.
         /// </summary>
         public IList<RestorableDroppedDatabase> Databases
         {

--- a/src/SqlManagement/Generated/RecoverDatabaseOperations.cs
+++ b/src/SqlManagement/Generated/RecoverDatabaseOperations.cs
@@ -68,9 +68,9 @@ namespace Microsoft.WindowsAzure.Management.Sql
         /// <summary>
         /// Issues a recovery request for an Azure SQL Database.
         /// </summary>
-        /// <param name='targetServerName'>
-        /// Required. The name of the Azure SQL Database Server on which to
-        /// recover the source database.
+        /// <param name='sourceServerName'>
+        /// Required. The name of the Azure SQL Database Server on which the
+        /// database was hosted.
         /// </param>
         /// <param name='parameters'>
         /// Required. Additional parameters for the Create Recover Database
@@ -83,12 +83,12 @@ namespace Microsoft.WindowsAzure.Management.Sql
         /// Contains the response to the Create Recover Database Operation
         /// request.
         /// </returns>
-        public async System.Threading.Tasks.Task<Microsoft.WindowsAzure.Management.Sql.Models.RecoverDatabaseOperationCreateResponse> CreateAsync(string targetServerName, RecoverDatabaseOperationCreateParameters parameters, CancellationToken cancellationToken)
+        public async System.Threading.Tasks.Task<Microsoft.WindowsAzure.Management.Sql.Models.RecoverDatabaseOperationCreateResponse> CreateAsync(string sourceServerName, RecoverDatabaseOperationCreateParameters parameters, CancellationToken cancellationToken)
         {
             // Validate
-            if (targetServerName == null)
+            if (sourceServerName == null)
             {
-                throw new ArgumentNullException("targetServerName");
+                throw new ArgumentNullException("sourceServerName");
             }
             if (parameters == null)
             {
@@ -106,13 +106,13 @@ namespace Microsoft.WindowsAzure.Management.Sql
             {
                 invocationId = Tracing.NextInvocationId.ToString();
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
-                tracingParameters.Add("targetServerName", targetServerName);
+                tracingParameters.Add("sourceServerName", sourceServerName);
                 tracingParameters.Add("parameters", parameters);
                 Tracing.Enter(invocationId, this, "CreateAsync", tracingParameters);
             }
             
             // Construct URL
-            string url = "/" + (this.Client.Credentials.SubscriptionId != null ? this.Client.Credentials.SubscriptionId.Trim() : "") + "/services/sqlservers/servers/" + targetServerName.Trim() + "/recoverdatabaseoperations";
+            string url = "/" + (this.Client.Credentials.SubscriptionId != null ? this.Client.Credentials.SubscriptionId.Trim() : "") + "/services/sqlservers/servers/" + sourceServerName.Trim() + "/recoverdatabaseoperations";
             string baseUrl = this.Client.BaseUri.AbsoluteUri;
             // Trim '/' character from the end of baseUrl and beginning of url.
             if (baseUrl[baseUrl.Length - 1] == '/')
@@ -152,11 +152,11 @@ namespace Microsoft.WindowsAzure.Management.Sql
                 sourceDatabaseNameElement.Value = parameters.SourceDatabaseName;
                 serviceResourceElement.Add(sourceDatabaseNameElement);
                 
-                if (parameters.SourceServerName != null)
+                if (parameters.TargetServerName != null)
                 {
-                    XElement sourceServerNameElement = new XElement(XName.Get("SourceServerName", "http://schemas.microsoft.com/windowsazure"));
-                    sourceServerNameElement.Value = parameters.SourceServerName;
-                    serviceResourceElement.Add(sourceServerNameElement);
+                    XElement targetServerNameElement = new XElement(XName.Get("TargetServerName", "http://schemas.microsoft.com/windowsazure"));
+                    targetServerNameElement.Value = parameters.TargetServerName;
+                    serviceResourceElement.Add(targetServerNameElement);
                 }
                 
                 if (parameters.TargetDatabaseName != null)
@@ -218,18 +218,18 @@ namespace Microsoft.WindowsAzure.Management.Sql
                             serviceResourceInstance.Id = requestIDInstance;
                         }
                         
-                        XElement sourceServerNameElement2 = serviceResourceElement2.Element(XName.Get("SourceServerName", "http://schemas.microsoft.com/windowsazure"));
-                        if (sourceServerNameElement2 != null)
-                        {
-                            string sourceServerNameInstance = sourceServerNameElement2.Value;
-                            serviceResourceInstance.SourceServerName = sourceServerNameInstance;
-                        }
-                        
                         XElement sourceDatabaseNameElement2 = serviceResourceElement2.Element(XName.Get("SourceDatabaseName", "http://schemas.microsoft.com/windowsazure"));
                         if (sourceDatabaseNameElement2 != null)
                         {
                             string sourceDatabaseNameInstance = sourceDatabaseNameElement2.Value;
                             serviceResourceInstance.SourceDatabaseName = sourceDatabaseNameInstance;
+                        }
+                        
+                        XElement targetServerNameElement2 = serviceResourceElement2.Element(XName.Get("TargetServerName", "http://schemas.microsoft.com/windowsazure"));
+                        if (targetServerNameElement2 != null)
+                        {
+                            string targetServerNameInstance = targetServerNameElement2.Value;
+                            serviceResourceInstance.TargetServerName = targetServerNameInstance;
                         }
                         
                         XElement targetDatabaseNameElement2 = serviceResourceElement2.Element(XName.Get("TargetDatabaseName", "http://schemas.microsoft.com/windowsazure"));

--- a/src/SqlManagement/Generated/RecoverDatabaseOperationsExtensions.cs
+++ b/src/SqlManagement/Generated/RecoverDatabaseOperationsExtensions.cs
@@ -41,9 +41,9 @@ namespace Microsoft.WindowsAzure
         /// Reference to the
         /// Microsoft.WindowsAzure.Management.Sql.IRecoverDatabaseOperations.
         /// </param>
-        /// <param name='targetServerName'>
-        /// Required. The name of the Azure SQL Database Server on which to
-        /// recover the source database.
+        /// <param name='sourceServerName'>
+        /// Required. The name of the Azure SQL Database Server on which the
+        /// database was hosted.
         /// </param>
         /// <param name='parameters'>
         /// Required. Additional parameters for the Create Recover Database
@@ -53,11 +53,11 @@ namespace Microsoft.WindowsAzure
         /// Contains the response to the Create Recover Database Operation
         /// request.
         /// </returns>
-        public static RecoverDatabaseOperationCreateResponse Create(this IRecoverDatabaseOperations operations, string targetServerName, RecoverDatabaseOperationCreateParameters parameters)
+        public static RecoverDatabaseOperationCreateResponse Create(this IRecoverDatabaseOperations operations, string sourceServerName, RecoverDatabaseOperationCreateParameters parameters)
         {
             return Task.Factory.StartNew((object s) => 
             {
-                return ((IRecoverDatabaseOperations)s).CreateAsync(targetServerName, parameters);
+                return ((IRecoverDatabaseOperations)s).CreateAsync(sourceServerName, parameters);
             }
             , operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
         }
@@ -69,9 +69,9 @@ namespace Microsoft.WindowsAzure
         /// Reference to the
         /// Microsoft.WindowsAzure.Management.Sql.IRecoverDatabaseOperations.
         /// </param>
-        /// <param name='targetServerName'>
-        /// Required. The name of the Azure SQL Database Server on which to
-        /// recover the source database.
+        /// <param name='sourceServerName'>
+        /// Required. The name of the Azure SQL Database Server on which the
+        /// database was hosted.
         /// </param>
         /// <param name='parameters'>
         /// Required. Additional parameters for the Create Recover Database
@@ -81,9 +81,9 @@ namespace Microsoft.WindowsAzure
         /// Contains the response to the Create Recover Database Operation
         /// request.
         /// </returns>
-        public static Task<RecoverDatabaseOperationCreateResponse> CreateAsync(this IRecoverDatabaseOperations operations, string targetServerName, RecoverDatabaseOperationCreateParameters parameters)
+        public static Task<RecoverDatabaseOperationCreateResponse> CreateAsync(this IRecoverDatabaseOperations operations, string sourceServerName, RecoverDatabaseOperationCreateParameters parameters)
         {
-            return operations.CreateAsync(targetServerName, parameters, CancellationToken.None);
+            return operations.CreateAsync(sourceServerName, parameters, CancellationToken.None);
         }
     }
 }

--- a/src/SqlManagement/Generated/RecoverableDatabaseOperations.cs
+++ b/src/SqlManagement/Generated/RecoverableDatabaseOperations.cs
@@ -68,15 +68,11 @@ namespace Microsoft.WindowsAzure.Management.Sql
         /// <summary>
         /// Returns information about a recoverable Azure SQL Database.
         /// </summary>
-        /// <param name='targetServerName'>
-        /// Required. The name of the Azure SQL Database Server on which to
-        /// recover the source database.
-        /// </param>
-        /// <param name='sourceServerName'>
+        /// <param name='serverName'>
         /// Required. The name of the Azure SQL Database Server on which the
         /// database was hosted.
         /// </param>
-        /// <param name='sourceDatabaseName'>
+        /// <param name='databaseName'>
         /// Required. The name of the recoverable Azure SQL Database to be
         /// obtained.
         /// </param>
@@ -86,20 +82,16 @@ namespace Microsoft.WindowsAzure.Management.Sql
         /// <returns>
         /// Contains the response to the Get Recoverable Database request.
         /// </returns>
-        public async System.Threading.Tasks.Task<Microsoft.WindowsAzure.Management.Sql.Models.RecoverableDatabaseGetResponse> GetAsync(string targetServerName, string sourceServerName, string sourceDatabaseName, CancellationToken cancellationToken)
+        public async System.Threading.Tasks.Task<Microsoft.WindowsAzure.Management.Sql.Models.RecoverableDatabaseGetResponse> GetAsync(string serverName, string databaseName, CancellationToken cancellationToken)
         {
             // Validate
-            if (targetServerName == null)
+            if (serverName == null)
             {
-                throw new ArgumentNullException("targetServerName");
+                throw new ArgumentNullException("serverName");
             }
-            if (sourceServerName == null)
+            if (databaseName == null)
             {
-                throw new ArgumentNullException("sourceServerName");
-            }
-            if (sourceDatabaseName == null)
-            {
-                throw new ArgumentNullException("sourceDatabaseName");
+                throw new ArgumentNullException("databaseName");
             }
             
             // Tracing
@@ -109,14 +101,13 @@ namespace Microsoft.WindowsAzure.Management.Sql
             {
                 invocationId = Tracing.NextInvocationId.ToString();
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
-                tracingParameters.Add("targetServerName", targetServerName);
-                tracingParameters.Add("sourceServerName", sourceServerName);
-                tracingParameters.Add("sourceDatabaseName", sourceDatabaseName);
+                tracingParameters.Add("serverName", serverName);
+                tracingParameters.Add("databaseName", databaseName);
                 Tracing.Enter(invocationId, this, "GetAsync", tracingParameters);
             }
             
             // Construct URL
-            string url = "/" + (this.Client.Credentials.SubscriptionId != null ? this.Client.Credentials.SubscriptionId.Trim() : "") + "/services/sqlservers/servers/" + targetServerName.Trim() + "/recoverabledatabases/" + sourceServerName.Trim() + "/" + sourceDatabaseName.Trim();
+            string url = "/" + (this.Client.Credentials.SubscriptionId != null ? this.Client.Credentials.SubscriptionId.Trim() : "") + "/services/sqlservers/servers/" + serverName.Trim() + "/recoverabledatabases/" + databaseName.Trim();
             string baseUrl = this.Client.BaseUri.AbsoluteUri;
             // Trim '/' character from the end of baseUrl and beginning of url.
             if (baseUrl[baseUrl.Length - 1] == '/')
@@ -268,11 +259,7 @@ namespace Microsoft.WindowsAzure.Management.Sql
         /// Returns a collection of databases that can be recovered from a
         /// specified server.
         /// </summary>
-        /// <param name='targetServerName'>
-        /// Required. The name of the Azure SQL Database Server on which to
-        /// recover the source database.
-        /// </param>
-        /// <param name='sourceServerName'>
+        /// <param name='serverName'>
         /// Required. The name of the Azure SQL Database Server on which the
         /// databases were hosted.
         /// </param>
@@ -282,16 +269,12 @@ namespace Microsoft.WindowsAzure.Management.Sql
         /// <returns>
         /// Contains the response to the List Recoverable Databases request.
         /// </returns>
-        public async System.Threading.Tasks.Task<Microsoft.WindowsAzure.Management.Sql.Models.RecoverableDatabaseListResponse> ListAsync(string targetServerName, string sourceServerName, CancellationToken cancellationToken)
+        public async System.Threading.Tasks.Task<Microsoft.WindowsAzure.Management.Sql.Models.RecoverableDatabaseListResponse> ListAsync(string serverName, CancellationToken cancellationToken)
         {
             // Validate
-            if (targetServerName == null)
+            if (serverName == null)
             {
-                throw new ArgumentNullException("targetServerName");
-            }
-            if (sourceServerName == null)
-            {
-                throw new ArgumentNullException("sourceServerName");
+                throw new ArgumentNullException("serverName");
             }
             
             // Tracing
@@ -301,13 +284,12 @@ namespace Microsoft.WindowsAzure.Management.Sql
             {
                 invocationId = Tracing.NextInvocationId.ToString();
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
-                tracingParameters.Add("targetServerName", targetServerName);
-                tracingParameters.Add("sourceServerName", sourceServerName);
+                tracingParameters.Add("serverName", serverName);
                 Tracing.Enter(invocationId, this, "ListAsync", tracingParameters);
             }
             
             // Construct URL
-            string url = "/" + (this.Client.Credentials.SubscriptionId != null ? this.Client.Credentials.SubscriptionId.Trim() : "") + "/services/sqlservers/servers/" + targetServerName.Trim() + "/recoverabledatabases/" + sourceServerName.Trim() + "?contentview=generic";
+            string url = "/" + (this.Client.Credentials.SubscriptionId != null ? this.Client.Credentials.SubscriptionId.Trim() : "") + "/services/sqlservers/servers/" + serverName.Trim() + "/recoverabledatabases?contentview=generic";
             string baseUrl = this.Client.BaseUri.AbsoluteUri;
             // Trim '/' character from the end of baseUrl and beginning of url.
             if (baseUrl[baseUrl.Length - 1] == '/')

--- a/src/SqlManagement/Generated/RecoverableDatabaseOperationsExtensions.cs
+++ b/src/SqlManagement/Generated/RecoverableDatabaseOperationsExtensions.cs
@@ -41,26 +41,22 @@ namespace Microsoft.WindowsAzure
         /// Reference to the
         /// Microsoft.WindowsAzure.Management.Sql.IRecoverableDatabaseOperations.
         /// </param>
-        /// <param name='targetServerName'>
-        /// Required. The name of the Azure SQL Database Server on which to
-        /// recover the source database.
-        /// </param>
-        /// <param name='sourceServerName'>
+        /// <param name='serverName'>
         /// Required. The name of the Azure SQL Database Server on which the
         /// database was hosted.
         /// </param>
-        /// <param name='sourceDatabaseName'>
+        /// <param name='databaseName'>
         /// Required. The name of the recoverable Azure SQL Database to be
         /// obtained.
         /// </param>
         /// <returns>
         /// Contains the response to the Get Recoverable Database request.
         /// </returns>
-        public static RecoverableDatabaseGetResponse Get(this IRecoverableDatabaseOperations operations, string targetServerName, string sourceServerName, string sourceDatabaseName)
+        public static RecoverableDatabaseGetResponse Get(this IRecoverableDatabaseOperations operations, string serverName, string databaseName)
         {
             return Task.Factory.StartNew((object s) => 
             {
-                return ((IRecoverableDatabaseOperations)s).GetAsync(targetServerName, sourceServerName, sourceDatabaseName);
+                return ((IRecoverableDatabaseOperations)s).GetAsync(serverName, databaseName);
             }
             , operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
         }
@@ -72,24 +68,20 @@ namespace Microsoft.WindowsAzure
         /// Reference to the
         /// Microsoft.WindowsAzure.Management.Sql.IRecoverableDatabaseOperations.
         /// </param>
-        /// <param name='targetServerName'>
-        /// Required. The name of the Azure SQL Database Server on which to
-        /// recover the source database.
-        /// </param>
-        /// <param name='sourceServerName'>
+        /// <param name='serverName'>
         /// Required. The name of the Azure SQL Database Server on which the
         /// database was hosted.
         /// </param>
-        /// <param name='sourceDatabaseName'>
+        /// <param name='databaseName'>
         /// Required. The name of the recoverable Azure SQL Database to be
         /// obtained.
         /// </param>
         /// <returns>
         /// Contains the response to the Get Recoverable Database request.
         /// </returns>
-        public static Task<RecoverableDatabaseGetResponse> GetAsync(this IRecoverableDatabaseOperations operations, string targetServerName, string sourceServerName, string sourceDatabaseName)
+        public static Task<RecoverableDatabaseGetResponse> GetAsync(this IRecoverableDatabaseOperations operations, string serverName, string databaseName)
         {
-            return operations.GetAsync(targetServerName, sourceServerName, sourceDatabaseName, CancellationToken.None);
+            return operations.GetAsync(serverName, databaseName, CancellationToken.None);
         }
         
         /// <summary>
@@ -100,22 +92,18 @@ namespace Microsoft.WindowsAzure
         /// Reference to the
         /// Microsoft.WindowsAzure.Management.Sql.IRecoverableDatabaseOperations.
         /// </param>
-        /// <param name='targetServerName'>
-        /// Required. The name of the Azure SQL Database Server on which to
-        /// recover the source database.
-        /// </param>
-        /// <param name='sourceServerName'>
+        /// <param name='serverName'>
         /// Required. The name of the Azure SQL Database Server on which the
         /// databases were hosted.
         /// </param>
         /// <returns>
         /// Contains the response to the List Recoverable Databases request.
         /// </returns>
-        public static RecoverableDatabaseListResponse List(this IRecoverableDatabaseOperations operations, string targetServerName, string sourceServerName)
+        public static RecoverableDatabaseListResponse List(this IRecoverableDatabaseOperations operations, string serverName)
         {
             return Task.Factory.StartNew((object s) => 
             {
-                return ((IRecoverableDatabaseOperations)s).ListAsync(targetServerName, sourceServerName);
+                return ((IRecoverableDatabaseOperations)s).ListAsync(serverName);
             }
             , operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
         }
@@ -128,20 +116,16 @@ namespace Microsoft.WindowsAzure
         /// Reference to the
         /// Microsoft.WindowsAzure.Management.Sql.IRecoverableDatabaseOperations.
         /// </param>
-        /// <param name='targetServerName'>
-        /// Required. The name of the Azure SQL Database Server on which to
-        /// recover the source database.
-        /// </param>
-        /// <param name='sourceServerName'>
+        /// <param name='serverName'>
         /// Required. The name of the Azure SQL Database Server on which the
         /// databases were hosted.
         /// </param>
         /// <returns>
         /// Contains the response to the List Recoverable Databases request.
         /// </returns>
-        public static Task<RecoverableDatabaseListResponse> ListAsync(this IRecoverableDatabaseOperations operations, string targetServerName, string sourceServerName)
+        public static Task<RecoverableDatabaseListResponse> ListAsync(this IRecoverableDatabaseOperations operations, string serverName)
         {
-            return operations.ListAsync(targetServerName, sourceServerName, CancellationToken.None);
+            return operations.ListAsync(serverName, CancellationToken.None);
         }
     }
 }

--- a/src/SqlManagement/Microsoft.WindowsAzure.Management.Sql.nuget.proj
+++ b/src/SqlManagement/Microsoft.WindowsAzure.Management.Sql.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.WindowsAzure.Management.Sql
     -->
     <SdkNuGetPackage Include="Microsoft.WindowsAzure.Management.Sql">
-      <PackageVersion>1.4.0</PackageVersion>
+      <PackageVersion>2.0.0</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/SqlManagement/Properties/AssemblyInfo.cs
+++ b/src/SqlManagement/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Azure SQL Server Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure SQL in the cloud.")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SqlManagement/SqlManagement.csproj
+++ b/src/SqlManagement/SqlManagement.csproj
@@ -144,7 +144,7 @@
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets') " />
   <Import Project="$(SolutionDir)\src\library.targets" />
   <Target Name="CopyMicrosoftWindowsAzureManagementSqlSpecification" BeforeTargets="GenerateCodeFromSpecs">
-    <Copy SourceFiles="..\..\packages\Microsoft.WindowsAzure.Management.Sql.Specification.1.0.5310.26145-prerelease\tools\Microsoft.WindowsAzure.Management.Sql.Specification.dll" DestinationFolder="." />
+    <Copy SourceFiles="..\..\packages\Microsoft.WindowsAzure.Management.Sql.Specification.1.0.5336.25609-prerelease\tools\Microsoft.WindowsAzure.Management.Sql.Specification.dll" DestinationFolder="." />
   </Target>
   <Import Project="GenerateCode.props" />
   <Import Project="..\..\packages\Hydra.Generator.1.0.5330.15854-prerelease\build\Hydra.Generator.targets" Condition="Exists('..\..\packages\Hydra.Generator.1.0.5330.15854-prerelease\build\Hydra.Generator.targets')" />

--- a/src/SqlManagement/packages.config
+++ b/src/SqlManagement/packages.config
@@ -7,6 +7,6 @@
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable-net45+sl50+wp80+win" />
   <package id="Microsoft.WindowsAzure.Common" version="1.3.0" targetFramework="portable-net45+sl50+win+wp80" />
   <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.1.0" targetFramework="portable-net45+sl50+win+wp80" />
-  <package id="Microsoft.WindowsAzure.Management.Sql.Specification" version="1.0.5310.26145-prerelease" targetFramework="portable-net45+sl50+win+wp80" />
+  <package id="Microsoft.WindowsAzure.Management.Sql.Specification" version="1.0.5336.25609-prerelease" targetFramework="portable-net45+sl50+win+wp80" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable-net45+sl50+win+wp80" />
 </packages>


### PR DESCRIPTION
Before this change, the RecoverableDatabase GET URL required both a target server name and a source server name. Now it requires only a source server name.

Before this change, the RecoverDatabaseOperations POST URL had the target server name in the URL and the source server name in the request body. Now it has the source server name in the URL and the target server name in the request body.

These are intentionally backward-incompatible breaking changes as the Geo-Restore service is not in GA yet.

I've bumped the package version to 1.5.0
