### PR TITLE
Fix summary comment for StartAsync

### DIFF
--- a/src/AutomationManagement/Generated/RunbookOperations.cs
+++ b/src/AutomationManagement/Generated/RunbookOperations.cs
@@ -3439,7 +3439,7 @@ namespace Microsoft.Azure.Management.Automation
         }
         
         /// <summary>
-        /// Delete the runbook identified by runbookId.  (see
+        /// Start the runbook identified by runbookId.  (see
         /// http://msdn.microsoft.com/en-us/library/windowsazure/XXXXXXX.aspx
         /// for more information)
         /// </summary>


### PR DESCRIPTION
- The "StartAsync" method's summary comment erroneously talked about "deleting" a runbook instead of "starting" a runbook.
