### PR TITLE
Fix documentation on InputEndpoint port fields.

### DIFF
--- a/src/ComputeManagement/Generated/Models/InputEndpoint.cs
+++ b/src/ComputeManagement/Generated/Models/InputEndpoint.cs
@@ -117,7 +117,7 @@ namespace Microsoft.WindowsAzure.Management.Compute.Models
         private int? _localPort;
         
         /// <summary>
-        /// Optional. Specifies the internal port on which the virtual machine
+        /// Optional. Specifies the private port on which the virtual machine
         /// is listening to serve the endpoint. This element is only listed
         /// for Virtual Machine deployments.
         /// </summary>
@@ -142,7 +142,8 @@ namespace Microsoft.WindowsAzure.Management.Compute.Models
         private int? _port;
         
         /// <summary>
-        /// Optional. The size of the role instance.
+        /// Optional. Specifies the public port which will listen for inbound
+        /// requests to the endpoint.
         /// </summary>
         public int? Port
         {


### PR DESCRIPTION
Update XML documentation on InputEndoint LocalPort and Port fields to
match the Portal names and to accurately describe use of the Port.
