### PR TITLE
[BUG] SDK creates a lot of HttpClient causing connection starvation

### DIFF
--- a/AzureManagementLibraries.sln
+++ b/AzureManagementLibraries.sln
@@ -456,9 +456,7 @@ Global
 		{B419782D-CA57-40F9-9322-340A4E852E82}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
 		{B419782D-CA57-40F9-9322-340A4E852E82}.Net45-Release|Any CPU.Build.0 = Net45-Release|Any CPU
 		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net40-Debug|Any CPU.ActiveCfg = Net40-Debug|Any CPU
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net40-Debug|Any CPU.Build.0 = Net40-Debug|Any CPU
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net40-Release|Any CPU.ActiveCfg = Net40-Release|Any CPU
@@ -468,9 +466,7 @@ Global
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net45-Release|Any CPU.Build.0 = Net45-Release|Any CPU
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AzureManagementLibraries.sln
+++ b/AzureManagementLibraries.sln
@@ -77,6 +77,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiManagementManagement", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeyVault", "src\KeyVault\Microsoft.Azure.KeyVault\KeyVault.csproj", "{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeyVault.Core", "src\KeyVault\Microsoft.Azure.KeyVault.Core\KeyVault.Core.csproj", "{B419782D-CA57-40F9-9322-340A4E852E82}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeyVault.Extensions", "src\KeyVault\Microsoft.Azure.KeyVault.Extensions\KeyVault.Extensions.csproj", "{937E445A-5604-4998-A9F5-9BE1E39001A4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Net40-Debug|Any CPU = Net40-Debug|Any CPU
@@ -443,6 +447,30 @@ Global
 		{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56}.Net45-Release|Any CPU.Build.0 = Net45-Release|Any CPU
 		{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56}.Portable-Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
 		{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Net40-Debug|Any CPU.ActiveCfg = Net40-Debug|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Net40-Debug|Any CPU.Build.0 = Net40-Debug|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Net40-Release|Any CPU.ActiveCfg = Net40-Release|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Net40-Release|Any CPU.Build.0 = Net40-Release|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Net45-Release|Any CPU.Build.0 = Net45-Release|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net40-Debug|Any CPU.ActiveCfg = Net40-Debug|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net40-Debug|Any CPU.Build.0 = Net40-Debug|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net40-Release|Any CPU.ActiveCfg = Net40-Release|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net40-Release|Any CPU.Build.0 = Net40-Release|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net45-Release|Any CPU.Build.0 = Net45-Release|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -478,6 +506,8 @@ Global
 		{2C21CBE7-5D68-434A-BB20-463886BE5551} = {868850B4-1073-41A1-ABA8-A3B465880148}
 		{C85D57A0-BFC7-4483-AAEF-9ABB9313873B} = {868850B4-1073-41A1-ABA8-A3B465880148}
 		{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56} = {868850B4-1073-41A1-ABA8-A3B465880148}
+		{B419782D-CA57-40F9-9322-340A4E852E82} = {868850B4-1073-41A1-ABA8-A3B465880148}
+		{937E445A-5604-4998-A9F5-9BE1E39001A4} = {868850B4-1073-41A1-ABA8-A3B465880148}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = WindowsAzureLibraries.vsmdi

--- a/AzureManagementLibraries.sln
+++ b/AzureManagementLibraries.sln
@@ -456,7 +456,9 @@ Global
 		{B419782D-CA57-40F9-9322-340A4E852E82}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
 		{B419782D-CA57-40F9-9322-340A4E852E82}.Net45-Release|Any CPU.Build.0 = Net45-Release|Any CPU
 		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
 		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
+		{B419782D-CA57-40F9-9322-340A4E852E82}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net40-Debug|Any CPU.ActiveCfg = Net40-Debug|Any CPU
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net40-Debug|Any CPU.Build.0 = Net40-Debug|Any CPU
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net40-Release|Any CPU.ActiveCfg = Net40-Release|Any CPU

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -17,6 +17,8 @@
   <repository path="..\src\ExpressRouteManagement\packages.config" />
   <repository path="..\src\Gallery\packages.config" />
   <repository path="..\src\Insights\packages.config" />
+  <repository path="..\src\KeyVault\Microsoft.Azure.KeyVault.Core\packages.config" />
+  <repository path="..\src\KeyVault\Microsoft.Azure.KeyVault.Extensions\packages.config" />
   <repository path="..\src\KeyVault\Microsoft.Azure.KeyVault\packages.config" />
   <repository path="..\src\Management\packages.config" />
   <repository path="..\src\MediaServicesManagement\packages.config" />

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Core/IKey.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Core/IKey.cs
@@ -1,0 +1,115 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.KeyVault.Core
+{
+    /// <summary>
+    /// Interface for Keys
+    /// </summary>
+    public interface IKey
+    {
+        /// <summary>
+        /// The default encryption algorithm for this key
+        /// </summary>
+        string DefaultEncryptionAlgorithm { get; }
+
+        /// <summary>
+        /// The default key wrap algorithm for this key
+        /// </summary>
+        string DefaultKeyWrapAlgorithm { get; }
+
+        /// <summary>
+        /// The default signature algorithm for this key
+        /// </summary>
+        string DefaultSignatureAlgorithm { get; }
+
+        /// <summary>
+        /// The key identifier
+        /// </summary>
+        string Kid { get; }
+
+        /// <summary>
+        /// Decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="ciphertext">The cipher text to decrypt</param>
+        /// <param name="iv">The initialization vector</param>
+        /// <param name="authenticationData">The authentication data</param>
+        /// <param name="algorithm">The algorithm to use</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The plain text</returns>
+        /// <remarks>If algorithm is not specified, an implementation should use its default algorithm.
+        /// Not all algorithms require, or support, all parameters.</remarks>
+        Task<byte[]> DecryptAsync( byte[] ciphertext, byte[] iv, byte[] authenticationData, byte[] authenticationTag, string algorithm, CancellationToken token );
+
+        /// <summary>
+        /// Encrypts the specified plain text.
+        /// </summary>
+        /// <param name="plaintext">The plain text to encrypt</param>
+        /// <param name="iv">The initialization vector</param>
+        /// <param name="authenticationData">The authentication data</param>
+        /// <param name="algorithm">The algorithm to use</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>A Tuple consisting of the cipher text, the authentication tag (if applicable), the algorithm used</returns>
+        /// <remarks>If the algorithm is not specified, an implementation should use its default algorithm.
+        /// Not all algorithyms require, or support, all parameters.</remarks>
+        Task<Tuple<byte[], byte[], string>> EncryptAsync( byte[] plaintext, byte[] iv, byte[] authenticationData, string algorithm, CancellationToken token );
+
+        /// <summary>
+        /// Encrypts the specified key material.
+        /// </summary>
+        /// <param name="key">The key material to encrypt</param>
+        /// <param name="algorithm">The algorithm to use</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>A Tuple consisting of the encrypted key and the algorithm used</returns>
+        /// <remarks>If the algorithm is not specified, an implementation should use its default algorithm</remarks>
+        Task<Tuple<byte[], string>> WrapKeyAsync( byte[] key, string algorithm, CancellationToken token );
+
+        /// <summary>
+        /// Decrypts the specified key material.
+        /// </summary>
+        /// <param name="encryptedKey">The encrypted key material</param>
+        /// <param name="algorithm">The algorithm to use</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The decrypted key material</returns>
+        /// <remarks>If the algorithm is not specified, an implementation should use its default algorithm</remarks>
+        Task<byte[]> UnwrapKeyAsync( byte[] encryptedKey, string algorithm, CancellationToken token );
+
+        /// <summary>
+        /// Signs the specified digest.
+        /// </summary>
+        /// <param name="digest">The digest to sign</param>
+        /// <param name="algorithm">The algorithm to use</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>A Tuple consisting of the signature and the algorithm used</returns>
+        /// <remarks>If the algorithm is not specified, an implementation should use its default algorithm</remarks>
+        Task<Tuple<byte[], string>> SignAsync( byte[] digest, string algorithm, CancellationToken token );
+
+        /// <summary>
+        /// Verifies the specified signature value
+        /// </summary>
+        /// <param name="digest">The digest</param>
+        /// <param name="signature">The signature value</param>
+        /// <param name="algorithm">The algorithm to use</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>A bool indicating whether the signature was successfully verified</returns>
+        Task<bool> VerifyAsync( byte[] digest, byte[] signature, string algorithm, CancellationToken token );
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Core/IKey.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Core/IKey.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.KeyVault.Core
     /// <summary>
     /// Interface for Keys
     /// </summary>
-    public interface IKey
+    public interface IKey : IDisposable
     {
         /// <summary>
         /// The default encryption algorithm for this key

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Core/IKeyResolver.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Core/IKeyResolver.cs
@@ -1,0 +1,38 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.KeyVault.Core
+{
+    /// <summary>
+    /// Interface for key resolvers.
+    /// </summary>
+    public interface IKeyResolver
+    {
+        /// <summary>
+        /// Provides an IKey implementation for the specified key identifier.
+        /// </summary>
+        /// <param name="kid">The key identifier to resolve</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The resolved IKey implementation or null</returns>
+        /// <remarks>Implementations should check the format of the kid to ensure that it is recognized. Null, rather than 
+        /// an exception, should be returned for unrecognized key identifiers to enable chaining of key resolvers.</remarks>
+        Task<IKey> ResolveKeyAsync( string kid, CancellationToken token );
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Core/KeyVault.Core.csproj
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Core/KeyVault.Core.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B419782D-CA57-40F9-9322-340A4E852E82}</ProjectGuid>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Azure.KeyVault.Core</RootNamespace>
+    <AssemblyName>Microsoft.Azure.KeyVault.Core</AssemblyName>
+    <OutputType>Library</OutputType>
+    <RestorePackages>true</RestorePackages>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)\tools\Library.Settings.targets" />
+  <ItemGroup>
+    <Compile Include="Generated\**\*.cs" />
+    <Compile Include="IKey.cs" />
+    <Compile Include="IKeyResolver.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Microsoft.Azure.KeyVault.Core.nuspec" />
+    <None Include="Microsoft.Azure.KeyVault.Core.nuget.proj">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
+</Project>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Core/KeyVault.Core.csproj
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Core/KeyVault.Core.csproj
@@ -26,7 +26,7 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(LibraryFxTarget)' == 'net40'">
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
@@ -35,12 +35,12 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System.Net" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" Condition=" '$(LibraryFxTarget)' == 'portable' " />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition=" '$(LibraryFxTarget)' != 'portable' " />
   <Import Project="..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.nuget.proj
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.nuget.proj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <!--
+    Microsoft.Azure.KeyVault.Core
+    -->
+    <SdkNuGetPackage Include="Microsoft.Azure.KeyVault.Core">
+      <PackageVersion>0.9.0-preview</PackageVersion>
+      <Folder>$(MSBuildThisFileDirectory)</Folder>
+    </SdkNuGetPackage>
+  </ItemGroup>
+</Project>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.nuspec
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.nuspec
@@ -24,9 +24,6 @@
         <reference file="Microsoft.Azure.KeyVault.Core.dll" />
       </group>
     </references>
-    <dependencies>
-      <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
-    </dependencies>
   </metadata>
   <files>
     <file src="KeyVault\Microsoft.Azure.KeyVault.Core\**\*.cs" target="src" />

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.nuspec
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.nuspec
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata minClientVersion="2.5">
+    <id>Microsoft.Azure.KeyVault.Core</id>
+    <title>Microsoft Azure Key Vault Core Library</title>
+    <releaseNotes>Initial release</releaseNotes>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>azure-sdk, Microsoft</owners>
+    <licenseUrl>http://aka.ms/windowsazureapache2</licenseUrl>
+    <projectUrl>https://github.com/Azure/azure-sdk-for-net</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>IKey and IKeyResolver interfaces.</summary>
+    <description>Provides IKey and IKeyResolver interfaces for locating keys from identifiers
+    and performing operations with keys.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags>Microsoft Azure key vault "key vault" azureofficial windowsazureofficial</tags>
+    <references>
+      <group targetFramework="net45">
+        <reference file="Microsoft.Azure.KeyVault.Core.dll" />
+      </group>
+      <group targetFramework="net40">
+        <reference file="Microsoft.Azure.KeyVault.Core.dll" />
+      </group>
+    </references>
+    <dependencies>
+      <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="KeyVault\Microsoft.Azure.KeyVault.Core\**\*.cs" target="src" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.dll" target="lib\net45" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.pdb" target="lib\net45" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.xml" target="lib\net45" />
+    <file src="..\binaries\net40\Microsoft.Azure.KeyVault.Core.dll" target="lib\net40" />
+    <file src="..\binaries\net40\Microsoft.Azure.KeyVault.Core.pdb" target="lib\net40" />
+    <file src="..\binaries\net40\Microsoft.Azure.KeyVault.Core.xml" target="lib\net40" />
+  </files>
+</package>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.nuspec
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.nuspec
@@ -23,15 +23,21 @@
       <group targetFramework="net40">
         <reference file="Microsoft.Azure.KeyVault.Core.dll" />
       </group>
+      <group targetFramework="portable-net45+wp8+wpa81+win">
+        <reference file="Microsoft.Azure.KeyVault.Core.dll" />
+      </group>
     </references>
   </metadata>
   <files>
     <file src="KeyVault\Microsoft.Azure.KeyVault.Core\**\*.cs" target="src" />
-    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.dll" target="lib\net45" />
-    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.pdb" target="lib\net45" />
-    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.xml" target="lib\net45" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.dll" target="lib\portable-net45+wp8+wpa81+win" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.pdb" target="lib\portable-net45+wp8+wpa81+win" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.xml" target="lib\portable-net45+wp8+wpa81+win" />
     <file src="..\binaries\net40\Microsoft.Azure.KeyVault.Core.dll" target="lib\net40" />
     <file src="..\binaries\net40\Microsoft.Azure.KeyVault.Core.pdb" target="lib\net40" />
     <file src="..\binaries\net40\Microsoft.Azure.KeyVault.Core.xml" target="lib\net40" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.dll" target="lib\net45" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.pdb" target="lib\net45" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Core.xml" target="lib\net45" />
   </files>
 </package>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Core/packages.config
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Core/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
+</packages>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/AggregateKeyResolver.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/AggregateKeyResolver.cs
@@ -1,0 +1,59 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.KeyVault.Core;
+
+namespace Microsoft.Azure.KeyVault
+{
+    public class AggregateKeyResolver : IKeyResolver
+    {
+        private readonly ConcurrentBag<IKeyResolver> _resolvers = new ConcurrentBag<IKeyResolver>();
+
+        public AggregateKeyResolver Add( IKeyResolver resolver )
+        {
+            if ( resolver == null )
+                throw new ArgumentNullException( "resolver" );
+
+            _resolvers.Add( resolver );
+
+            return this;
+        }
+
+        #region IKeyResolver
+
+        public async Task<IKey> ResolveKeyAsync( string kid, CancellationToken token )
+        {
+            foreach ( var resolver in _resolvers )
+            {
+                IKey resolved = await resolver.ResolveKeyAsync( kid, token );
+
+                if ( resolved != null )
+                {
+                    return resolved;
+                }
+            }
+
+            return null;
+        }
+
+        #endregion
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/AggregateKeyResolver.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/AggregateKeyResolver.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.KeyVault
 
         #region IKeyResolver
 
-        public async Task<IKey> ResolveKeyAsync( string kid, CancellationToken token = default( CancellationToken ) )
+        public async Task<IKey> ResolveKeyAsync( string kid, CancellationToken token )
         {
             foreach ( var resolver in _resolvers )
             {

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/AesExtensions.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/AesExtensions.cs
@@ -1,0 +1,43 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Security.Cryptography;
+using Microsoft.Azure.KeyVault.WebKey;
+
+namespace Microsoft.Azure.KeyVault.Cryptography
+{
+    public static class AesExtensions
+    {
+        /// <summary>
+        /// Converts an AES object to a JsonWebKey of type Octet
+        /// </summary>
+        /// <param name="self"></param>
+        /// <returns></returns>
+        public static JsonWebKey ToJsonWebKey( this Aes self )
+        {
+            if ( self == null )
+                throw new ArgumentNullException( "self" );
+
+            return new JsonWebKey()
+            {
+                Kty = JsonWebKeyType.Octet,
+                K   = self.Key,
+            };
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithm.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithm.cs
@@ -1,0 +1,45 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+
+namespace Microsoft.Azure.KeyVault.Cryptography
+{
+    /// <summary>
+    /// Abstract Algorithm.
+    /// </summary>
+    public abstract class Algorithm 
+    {
+        private readonly string _name;
+
+        protected Algorithm( string name )
+        {
+            if ( string.IsNullOrEmpty( name ) )
+                throw new ArgumentNullException( "name" );
+
+            _name = name;
+        }
+
+        /// <summary>
+        /// The name of the algorithm
+        /// </summary>
+        public string Name
+        {
+            get { return _name; }
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/AlgorithmResolver.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/AlgorithmResolver.cs
@@ -1,0 +1,92 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Azure.KeyVault.Cryptography.Algorithms;
+
+namespace Microsoft.Azure.KeyVault.Cryptography
+{
+    /// <summary>
+    /// Resolves algorithm name to implementations.
+    /// </summary>
+    public class AlgorithmResolver
+    {
+        static AlgorithmResolver()
+        {
+            Default.AddAlgorithm( Aes128CbcHmacSha256.AlgorithmName, new Aes128CbcHmacSha256() );
+            Default.AddAlgorithm( Aes192CbcHmacSha384.AlgorithmName, new Aes192CbcHmacSha384() );
+            Default.AddAlgorithm( Aes256CbcHmacSha512.AlgorithmName, new Aes256CbcHmacSha512() );
+
+            Default.AddAlgorithm( Aes128Cbc.AlgorithmName, new Aes128Cbc() );
+            Default.AddAlgorithm( Aes192Cbc.AlgorithmName, new Aes192Cbc() );
+            Default.AddAlgorithm( Aes256Cbc.AlgorithmName, new Aes256Cbc() );
+
+            Default.AddAlgorithm( AesKw128.AlgorithmName, new AesKw128() );
+            Default.AddAlgorithm( AesKw192.AlgorithmName, new AesKw192() );
+            Default.AddAlgorithm( AesKw256.AlgorithmName, new AesKw256() );
+
+            Default.AddAlgorithm( Rsa15.AlgorithmName, new Rsa15() );
+            Default.AddAlgorithm( RsaOaep.AlgorithmName, new RsaOaep() );
+
+            Default.AddAlgorithm( Rs256.AlgorithmName, new Rs256() );
+            Default.AddAlgorithm( RsNull.AlgorithmName, new RsNull() );
+        }
+
+        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+        public static readonly AlgorithmResolver Default = new AlgorithmResolver();
+
+        private readonly Dictionary<string, Algorithm> _algorithms = new Dictionary<string, Algorithm>();
+
+        /// <summary>
+        /// Returns the implementation for an algorithm name
+        /// </summary>
+        /// <param name="algorithmName">The algorithm name</param>
+        /// <returns></returns>
+        public Algorithm this[ string algorithmName ]
+        {
+            get { return _algorithms[algorithmName]; }
+            set { _algorithms[algorithmName] = value;  }
+        }
+
+        /// <summary>
+        /// Adds an algorithm to the resolver
+        /// </summary>
+        /// <param name="algorithmName">The algorithm name</param>
+        /// <param name="provider">The provider for the algorithm</param>
+        public void AddAlgorithm( string algorithmName, Algorithm provider )
+        {
+            if ( string.IsNullOrWhiteSpace( algorithmName ) )
+                throw new ArgumentNullException( "algorithm" );
+
+            if ( provider == null )
+                throw new ArgumentNullException( "provider" );
+
+            _algorithms[algorithmName] = provider;
+        }
+
+        /// <summary>
+        /// Removes an algorithm from the resolver
+        /// </summary>
+        /// <param name="algorithmName">The algorithm name</param>
+        public void RemoveAlgorithm( string algorithmName )
+        {
+            _algorithms.Remove( algorithmName );
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/AlgorithmResolver.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/AlgorithmResolver.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography
         public void AddAlgorithm( string algorithmName, Algorithm provider )
         {
             if ( string.IsNullOrWhiteSpace( algorithmName ) )
-                throw new ArgumentNullException( "algorithm" );
+                throw new ArgumentNullException( "algorithmName" );
 
             if ( provider == null )
                 throw new ArgumentNullException( "provider" );

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/Aes128CbcHmacSha256.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/Aes128CbcHmacSha256.cs
@@ -1,0 +1,28 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public class Aes128CbcHmacSha256 : AesCbcHmacSha2
+    {
+        public const string AlgorithmName = "A128CBC-HS256";
+
+        public Aes128CbcHmacSha256() : base( AlgorithmName )
+        {
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/Aes192CbcHmacSha384.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/Aes192CbcHmacSha384.cs
@@ -1,0 +1,28 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public class Aes192CbcHmacSha384 : AesCbcHmacSha2
+    {
+        public const string AlgorithmName = "A192CBC-HS384";
+
+        public Aes192CbcHmacSha384() : base( AlgorithmName )
+        {
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/Aes256CbcHmacSha512.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/Aes256CbcHmacSha512.cs
@@ -1,0 +1,28 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public class Aes256CbcHmacSha512 : AesCbcHmacSha2
+    {
+        public const string AlgorithmName = "A256CBC-HS512";
+
+        public Aes256CbcHmacSha512() : base( AlgorithmName )
+        {
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesCbc.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesCbc.cs
@@ -35,9 +35,10 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 throw new CryptographicException( "No initialization vector" );
 
             // Create the AES provider
-            var aes = new RijndaelManaged { Mode = CipherMode.CBC, Padding = PaddingMode.PKCS7, KeySize = key.Length*8, Key = key, IV = iv };
-
-            return aes.CreateDecryptor();
+            using ( var aes = new RijndaelManaged { Mode = CipherMode.CBC, Padding = PaddingMode.PKCS7, KeySize = key.Length*8, Key = key, IV = iv } )
+            {
+                return aes.CreateDecryptor();
+            }
         }
 
         public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv, byte[] authenticationData )
@@ -49,9 +50,10 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 throw new CryptographicException( "No initialization vector" );
 
             // Create the AES provider
-            var aes = new RijndaelManaged { Mode = CipherMode.CBC, Padding = PaddingMode.PKCS7, KeySize = key.Length*8, Key = key, IV = iv };
-
-            return aes.CreateEncryptor();
+            using ( var aes = new RijndaelManaged { Mode = CipherMode.CBC, Padding = PaddingMode.PKCS7, KeySize = key.Length*8, Key = key, IV = iv } )
+            {
+                return aes.CreateEncryptor();
+            }
         }
     }
 

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesCbc.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesCbc.cs
@@ -1,0 +1,90 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public abstract class AesCbc : SymmetricEncryptionAlgorithm
+    {
+        protected AesCbc( string name )
+            : base( name )
+        {
+        }
+
+        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv, byte[] authenticationData )
+        {
+            if ( key == null )
+                throw new CryptographicException( "No key material" );
+
+            if ( iv == null )
+                throw new CryptographicException( "No initialization vector" );
+
+            // Create the AES provider
+            var aes = new RijndaelManaged { Mode = CipherMode.CBC, Padding = PaddingMode.PKCS7, KeySize = key.Length*8, Key = key, IV = iv };
+
+            return aes.CreateDecryptor();
+        }
+
+        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv, byte[] authenticationData )
+        {
+            if ( key == null )
+                throw new CryptographicException( "No key material" );
+
+            if ( iv == null )
+                throw new CryptographicException( "No initialization vector" );
+
+            // Create the AES provider
+            var aes = new RijndaelManaged { Mode = CipherMode.CBC, Padding = PaddingMode.PKCS7, KeySize = key.Length*8, Key = key, IV = iv };
+
+            return aes.CreateEncryptor();
+        }
+    }
+
+    public class Aes128Cbc : AesCbc
+    {
+        public const string AlgorithmName = "A128CBC";
+
+        public Aes128Cbc()
+            : base( AlgorithmName )
+        {
+        }
+
+    }
+
+    public class Aes192Cbc : AesCbc
+    {
+        public const string AlgorithmName = "A192CBC";
+
+        public Aes192Cbc()
+            : base( AlgorithmName )
+        {
+        }
+
+    }
+
+    public class Aes256Cbc : AesCbc
+    {
+        public const string AlgorithmName = "A256CBC";
+
+        public Aes256Cbc()
+            : base( AlgorithmName )
+        {
+        }
+
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesCbcHmacSha2.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesCbcHmacSha2.cs
@@ -1,0 +1,356 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Globalization;
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public abstract class AesCbcHmacSha2 : SymmetricEncryptionAlgorithm
+    {
+        protected AesCbcHmacSha2( string name )
+            : base( name )
+        {
+        }
+
+        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv, byte[] authenticationData )
+        {
+            if ( key == null )
+                throw new CryptographicException( "No key material" );
+
+            if ( iv == null )
+                throw new CryptographicException( "No initialization vector" );
+
+            if ( authenticationData == null )
+                throw new CryptographicException( "No associated data" );
+
+            // Create the Decryptor
+            return new AesCbcHmacSha2Decryptor( Name, key, iv, authenticationData );
+        }
+
+        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv, byte[] authenticationData )
+        {
+            if ( key == null )
+                throw new CryptographicException( "No key material" );
+
+            if ( iv == null )
+                throw new CryptographicException( "No initialization vector" );
+
+            if ( authenticationData == null )
+                throw new CryptographicException( "No associated data" );
+
+            // Create the Encryptor
+            return new AesCbcHmacSha2Encryptor( Name, key, iv, authenticationData );
+        }
+
+        private static void GetAlgorithmParameters( string algorithm, byte[] key, out byte[] aes_key, out byte[] hmac_key, out HMAC hmac )
+        {
+            switch ( algorithm )
+            {
+                case Aes128CbcHmacSha256.AlgorithmName:
+                    {
+                        if ( ( key.Length << 3 ) < 256 )
+                            throw new CryptographicException( string.Format( CultureInfo.CurrentCulture, "{0} key length in bits {1} < 256", algorithm, key.Length << 3 ) );
+
+                        hmac_key = new byte[128 >> 3];
+                        aes_key  = new byte[128 >> 3];
+                        Array.Copy( key, hmac_key, 128 >> 3 );
+                        Array.Copy( key, 128 >> 3, aes_key, 0, 128 >> 3 );
+
+                        hmac = new HMACSHA256( hmac_key );
+
+                        break;
+                    }
+
+                case Aes192CbcHmacSha384.AlgorithmName:
+                    {
+                        if ( ( key.Length << 3 ) < 384 )
+                            throw new CryptographicException( string.Format( CultureInfo.CurrentCulture, "{0} key length in bits {1} < 384", algorithm, key.Length << 3 ) );
+
+                        hmac_key = new byte[192 >> 3];
+                        aes_key  = new byte[192 >> 3];
+                        Array.Copy( key, hmac_key, 192 >> 3 );
+                        Array.Copy( key, 192 >> 3, aes_key, 0, 192 >> 3 );
+
+                        hmac = new HMACSHA384( hmac_key );
+
+                        break;
+                    }
+
+                case Aes256CbcHmacSha512.AlgorithmName:
+                    {
+                        if ( ( key.Length << 3 ) < 512 )
+                            throw new CryptographicException( string.Format( CultureInfo.CurrentCulture, "{0} key length in bits {1} < 512", algorithm, key.Length << 3 ) );
+
+                        hmac_key = new byte[256 >> 3];
+                        aes_key  = new byte[256 >> 3];
+                        Array.Copy( key, hmac_key, 256 >> 3 );
+                        Array.Copy( key, 256 >> 3, aes_key, 0, 256 >> 3 );
+
+                        hmac = new HMACSHA512( hmac_key );
+
+                        break;
+                    }
+
+                default:
+                    {
+                        throw new CryptographicException( string.Format( CultureInfo.CurrentCulture, "Unsupported algorithm: {0}", algorithm ) );
+                    }
+            }
+        }
+
+        protected class AesCbcHmacSha2Encryptor : IAuthenticatedCryptoTransform
+        {
+            readonly byte[]  _hmac_key;
+
+            readonly byte[]  _associated_data_length;
+
+            RijndaelManaged  _aes;
+            HMAC             _hmac;
+
+            ICryptoTransform _inner;
+            byte[]           _tag;
+
+            public AesCbcHmacSha2Encryptor( string name, byte[] key, byte[] iv, byte[] associatedData )
+            {
+                // Split the key to get the AES key, the HMAC key and the HMAC object
+                byte[] aesKey;
+
+                GetAlgorithmParameters( name, key, out aesKey, out _hmac_key, out _hmac );
+
+                // Create the AES provider
+                _aes = new RijndaelManaged { Mode = CipherMode.CBC, Padding = PaddingMode.PKCS7, KeySize = aesKey.Length*8, Key = aesKey, IV = iv };
+
+                _inner = _aes.CreateEncryptor();
+
+                _associated_data_length = ConvertToBigEndian( associatedData.Length * 8 );
+
+                // Prime the hash.
+                _hmac.TransformBlock( associatedData, 0, associatedData.Length, associatedData, 0 );
+                _hmac.TransformBlock( iv, 0, iv.Length, iv, 0 );
+            }
+
+            public byte[] Tag
+            {
+                get { return _tag; }
+            }
+
+            public bool CanReuseTransform
+            {
+	            get { return _inner.CanReuseTransform; }
+            }
+
+            public bool CanTransformMultipleBlocks
+            {
+	            get { return _inner.CanTransformMultipleBlocks; }
+            }
+
+            public int InputBlockSize
+            {
+	            get { return _inner.InputBlockSize; }
+            }
+
+            public int OutputBlockSize
+            {
+	            get { return _inner.OutputBlockSize; }
+            }
+
+            public int TransformBlock( byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset )
+            {
+                // Encrypt the block
+                var result = _inner.TransformBlock( inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset );
+
+                // Add it to the running hash
+                _hmac.TransformBlock( outputBuffer, outputOffset, result, outputBuffer, outputOffset );
+
+                return result;
+            }
+
+            public byte[] TransformFinalBlock( byte[] inputBuffer, int inputOffset, int inputCount )
+            {
+                // Encrypt the block
+                var result = _inner.TransformFinalBlock( inputBuffer, inputOffset, inputCount );
+
+                // Add it to the running hash
+                _hmac.TransformBlock( result, 0, result.Length, result, 0 );
+
+                // Add the associated_data_length bytes to the hash
+                _hmac.TransformFinalBlock( _associated_data_length, 0, _associated_data_length.Length );
+
+                // Compute the tag
+                _tag = new byte[_hmac_key.Length];
+                Array.Copy( _hmac.Hash, _tag, _hmac_key.Length );
+
+                return result;
+            }
+
+            public void Dispose()
+            {
+ 	           Dispose( true );
+               GC.SuppressFinalize( this );
+            }
+
+            protected virtual void Dispose( bool disposing )
+            {
+                if ( disposing )
+                {
+                    if ( _inner != null )
+                    {
+                        _inner.Dispose();
+                        _inner = null;
+                    }
+
+                    if ( _hmac != null )
+                    {
+                        _hmac.Dispose();
+                        _hmac = null;
+                    }
+
+                    if ( _aes != null )
+                    {
+                        _aes.Dispose();
+                        _aes = null;
+                    }
+                }
+            }
+        }
+
+        protected class AesCbcHmacSha2Decryptor : IAuthenticatedCryptoTransform
+        {
+            readonly byte[]  _hmac_key;
+
+            readonly byte[]  _associated_data_length;
+
+            RijndaelManaged  _aes;
+            HMAC             _hmac;
+
+            ICryptoTransform _inner;
+            byte[]           _tag;
+
+            public AesCbcHmacSha2Decryptor( string name, byte[] key, byte[] iv, byte[] associatedData )
+            {
+                // Split the key to get the AES key, the HMAC key and the HMAC object
+                byte[] aesKey;
+
+                GetAlgorithmParameters( name, key, out aesKey, out _hmac_key, out _hmac );
+
+                // Create the AES provider
+                _aes = new RijndaelManaged { Mode = CipherMode.CBC, Padding = PaddingMode.PKCS7, KeySize = aesKey.Length*8, Key = aesKey, IV = iv };
+
+                _inner = _aes.CreateDecryptor();
+
+                _associated_data_length = ConvertToBigEndian( associatedData.Length * 8 );
+
+                // Prime the hash.
+                _hmac.TransformBlock( associatedData, 0, associatedData.Length, associatedData, 0 );
+                _hmac.TransformBlock( iv, 0, iv.Length, iv, 0 );
+            }
+
+            public byte[] Tag
+            {
+                get { return _tag; }
+            }
+
+            public bool CanReuseTransform
+            {
+	            get { return _inner.CanReuseTransform; }
+            }
+
+            public bool CanTransformMultipleBlocks
+            {
+	            get { return _inner.CanTransformMultipleBlocks; }
+            }
+
+            public int InputBlockSize
+            {
+	            get { return _inner.InputBlockSize; }
+            }
+
+            public int OutputBlockSize
+            {
+	            get { return _inner.OutputBlockSize; }
+            }
+
+            public int TransformBlock( byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset )
+            {
+                // Add the cipher text to the running hash
+                _hmac.TransformBlock( inputBuffer, inputOffset, inputCount, inputBuffer, inputOffset );
+
+                // Decrypt the cipher text
+                return _inner.TransformBlock( inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset );
+            }
+
+            public byte[] TransformFinalBlock( byte[] inputBuffer, int inputOffset, int inputCount )
+            {
+                // Add the cipher text to the running hash
+                _hmac.TransformBlock( inputBuffer, inputOffset, inputCount, inputBuffer, inputOffset );
+
+                // Add the associated_data_length bytes to the hash
+                _hmac.TransformFinalBlock( _associated_data_length, 0, _associated_data_length.Length );
+
+                // Compute the tag
+                _tag = new byte[_hmac_key.Length];
+                Array.Copy( _hmac.Hash, _tag, _hmac_key.Length );
+
+                return _inner.TransformFinalBlock( inputBuffer, inputOffset, inputCount );
+            }
+
+            public void Dispose()
+            {
+                Dispose( true );
+                GC.SuppressFinalize( this );
+            }
+
+            protected virtual void Dispose( bool disposing )
+            {
+                if ( disposing )
+                {
+                    if ( _inner != null )
+                    {
+                        _inner.Dispose();
+                        _inner = null;
+                    }
+
+                    if ( _hmac != null )
+                    {
+                        _hmac.Dispose();
+                        _hmac = null;
+                    }
+
+                    if ( _aes != null )
+                    {
+                        _aes.Dispose();
+                        _aes = null;
+                    }
+                }
+            }
+        }
+
+        static byte[] ConvertToBigEndian( Int64 i )
+        {
+            byte[] temp = BitConverter.GetBytes( i );
+
+            if ( BitConverter.IsLittleEndian )
+            {
+                Array.Reverse( temp );
+            }
+
+            return temp;
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesCbcHmacSha2.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesCbcHmacSha2.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
             }
         }
 
-        protected class AesCbcHmacSha2Encryptor : IAuthenticatedCryptoTransform
+        class AesCbcHmacSha2Encryptor : IAuthenticatedCryptoTransform
         {
             readonly byte[]  _hmac_key;
 
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
             ICryptoTransform _inner;
             byte[]           _tag;
 
-            public AesCbcHmacSha2Encryptor( string name, byte[] key, byte[] iv, byte[] associatedData )
+            internal AesCbcHmacSha2Encryptor( string name, byte[] key, byte[] iv, byte[] associatedData )
             {
                 // Split the key to get the AES key, the HMAC key and the HMAC object
                 byte[] aesKey;
@@ -230,7 +230,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
             }
         }
 
-        protected class AesCbcHmacSha2Decryptor : IAuthenticatedCryptoTransform
+        class AesCbcHmacSha2Decryptor : IAuthenticatedCryptoTransform
         {
             readonly byte[]  _hmac_key;
 
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
             ICryptoTransform _inner;
             byte[]           _tag;
 
-            public AesCbcHmacSha2Decryptor( string name, byte[] key, byte[] iv, byte[] associatedData )
+            internal AesCbcHmacSha2Decryptor( string name, byte[] key, byte[] iv, byte[] associatedData )
             {
                 // Split the key to get the AES key, the HMAC key and the HMAC object
                 byte[] aesKey;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw.cs
@@ -1,0 +1,395 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public abstract class AesKw : KeyWrapAlgorithm
+    {
+        const int BlockSizeInBits  = 64;
+        const int BlockSizeInBytes = BlockSizeInBits >> 3;
+
+        protected static readonly byte[]                   DefaultIv = new byte[] { 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6 };
+        protected static readonly RNGCryptoServiceProvider Rng       = new RNGCryptoServiceProvider();
+
+        protected AesKw( string name ) : base( name )
+        {
+            
+        }
+
+        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv = null )
+        {
+            return new AesKwEncryptor( key, iv ?? DefaultIv );
+        }
+
+        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv = null )
+        {
+            return new AesKwDecryptor( key, iv ?? DefaultIv );
+        }
+
+        static byte[] GetBytes( UInt64 i )
+        {
+            byte[] temp = BitConverter.GetBytes( i );
+
+            if ( BitConverter.IsLittleEndian )
+            {
+                Array.Reverse( temp );
+            }
+
+            return temp;
+        }
+
+        public class AesKwEncryptor : ICryptoTransform
+        {
+            private RijndaelManaged _aes;
+            private byte[]          _iv;
+
+            internal AesKwEncryptor( byte[] keyBytes, byte[] iv )
+            {
+                // Create the AES provider
+                _aes = new RijndaelManaged { Mode = CipherMode.ECB, Padding = PaddingMode.None, KeySize = keyBytes.Length*8, Key = keyBytes };
+
+                // Set the AES IV to Zeroes
+                var aesIv = new byte[_aes.BlockSize >> 3];
+
+                aesIv.Zero();
+
+                _aes.IV = aesIv;
+
+                // Remember the real IV
+                _iv = iv.Clone() as byte[];
+            }
+
+            public bool CanReuseTransform
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public bool CanTransformMultipleBlocks
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int InputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int OutputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int TransformBlock( byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset )
+            {
+                // No support for block-by-block transformation
+                throw new NotImplementedException();
+            }
+
+            public byte[] TransformFinalBlock( byte[] inputBuffer, int inputOffset, int inputCount )
+            {
+                if ( inputBuffer == null )
+                    throw new ArgumentNullException( "inputBuffer" );
+
+                if ( inputBuffer.Length == 0 )
+                    throw new ArgumentNullException( "inputBuffer", "The length of the inputBuffer parameter cannot be zero" );
+
+                if ( inputCount <= 0 )
+                    throw new ArgumentOutOfRangeException( "inputCount", "The inputCount parameter must not be zero or negative" );
+
+                if ( inputCount % 8 != 0 )
+                    throw new ArgumentOutOfRangeException( "inputCount", "The inputCount parameter must be a multiple of 64 bits" );
+
+                if ( inputOffset < 0 )
+                    throw new ArgumentOutOfRangeException( "inputOffset", "The inputOffset parameter must not be negative" );
+
+                if ( inputOffset + inputCount > inputBuffer.Length )
+                    throw new ArgumentOutOfRangeException( "inputCount", "The sum of inputCount and inputOffset parameters must not be larger than the length of inputBuffer" );
+
+
+                /*
+                   1) Initialize variables.
+
+                       Set A = IV, an initial value (see 2.2.3)
+                       For i = 1 to n
+                           R[i] = P[i]
+
+                   2) Calculate intermediate values.
+
+                       For j = 0 to 5
+                           For i=1 to n
+                               B = AES(K, A | R[i])
+                               A = MSB(64, B) ^ t where t = (n*j)+i
+                               R[i] = LSB(64, B)
+
+                   3) Output the results.
+
+                       Set C[0] = A
+                       For i = 1 to n
+                           C[i] = R[i]
+                */
+
+                // The default initialization vector from RFC3394
+                byte[]   a  = _iv;
+
+                // The number of input blocks
+                var      n  = inputCount >> 3;
+
+                // The set of input blocks
+                byte[]  r  = new byte[n << 3];
+
+                Array.Copy( inputBuffer, inputOffset, r, 0, inputCount );
+
+                var    encryptor = _aes.CreateEncryptor();
+                byte[] block     = new byte[16];
+
+                // Calculate intermediate values
+                for ( var j = 0; j < 6; j++ )
+                {
+                    for ( var i = 0; i < n; i++ )
+                    {
+                        // T = ( n * j ) + i
+                        var t = (ulong)( ( n * j ) + i + 1 );
+
+                        // B = AES( K, A | R[i] )
+
+                        // First, block = A | R[i]
+                        Array.Copy( a, block, a.Length );
+                        Array.Copy( r, i << 3, block, 64 >> 3, 64 >> 3 );
+
+                        // Second, AES( K, block )
+                        var b = encryptor.TransformFinalBlock( block, 0, 16 );
+
+                        // A = MSB( 64, B )
+                        Array.Copy( b, a, 64 >> 3 );
+                        
+                        // A = A ^ t
+                        a.Xor( GetBytes( t ), true );
+                        
+                        // R[i] = LSB( 64, B )
+                        Array.Copy( b, 64 >> 3, r, i << 3, 64 >> 3 );
+                    }
+                }
+
+                var c = new byte[( n + 1 ) << 3];
+
+                Array.Copy( a, c, a.Length );
+
+                for ( var i = 0; i < n; i++ )
+                {
+                    Array.Copy( r, i << 3, c, ( i + 1 ) << 3, 8 );
+                }
+
+                return c;
+            }
+
+            public void Dispose()
+            {
+                Dispose( true );
+                GC.SuppressFinalize( this );
+            }
+
+            protected virtual void Dispose( bool disposing )
+            {
+                if ( disposing )
+                {
+                    if ( _aes != null )
+                    {
+                        _aes.Dispose();
+                        _aes = null;
+                    }
+                }
+            }
+        }
+
+        public class AesKwDecryptor : ICryptoTransform
+        {
+            private RijndaelManaged _aes;
+            private byte[]          _iv;
+
+            internal AesKwDecryptor( byte[] keyBytes, byte[] iv )
+            {
+                // Create the AES provider
+                _aes = new RijndaelManaged { Mode = CipherMode.ECB, Padding = PaddingMode.None, KeySize = keyBytes.Length*8, Key = keyBytes };
+
+                // Set the AES IV to Zeroes
+                var aesIv = new byte[_aes.BlockSize >> 3];
+
+                aesIv.Zero();
+
+                _aes.IV = aesIv;
+
+                // Remember the real IV
+                _iv = iv.Clone() as byte[];
+            }
+
+            public bool CanReuseTransform
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public bool CanTransformMultipleBlocks
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int InputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int OutputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int TransformBlock( byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset )
+            {
+                // No support for block-by-block transformation
+                throw new NotImplementedException();
+            }
+
+            public byte[] TransformFinalBlock( byte[] inputBuffer, int inputOffset, int inputCount )
+            {
+                if ( inputBuffer == null )
+                    throw new ArgumentNullException( "inputBuffer" );
+
+                if ( inputBuffer.Length == 0 )
+                    throw new ArgumentNullException( "inputBuffer", "The length of the inputBuffer parameter cannot be zero" );
+
+                if ( inputCount <= 0 )
+                    throw new ArgumentOutOfRangeException( "inputCount", "The inputCount parameter must not be zero or negative" );
+
+                if ( inputCount % 8 != 0 )
+                    throw new ArgumentOutOfRangeException( "inputCount", "The inputCount parameter must be a multiple of 64 bits" );
+
+                if ( inputOffset < 0 )
+                    throw new ArgumentOutOfRangeException( "inputOffset", "The inputOffset parameter must not be negative" );
+
+                if ( inputOffset + inputCount > inputBuffer.Length )
+                    throw new ArgumentOutOfRangeException( "inputCount", "The sum of inputCount and inputOffset parameters must not be larger than the length of inputBuffer" );
+
+
+                /*
+                    1) Initialize variables.
+
+                        Set A = C[0]
+                        For i = 1 to n
+                            R[i] = C[i]
+
+                    2) Compute intermediate values.
+
+                        For j = 5 to 0
+                            For i = n to 1
+                                B = AES-1(K, (A ^ t) | R[i]) where t = n*j+i
+                                A = MSB(64, B)
+                                R[i] = LSB(64, B)
+
+                    3) Output results.
+
+                    If A is an appropriate initial value (see 2.2.3),
+                    Then
+                        For i = 1 to n
+                            P[i] = R[i]
+                    Else
+                        Return an error
+                */
+
+                // A = C[0]
+                byte[]   a  = new byte[BlockSizeInBytes];
+
+                Array.Copy( inputBuffer, inputOffset, a, 0, BlockSizeInBytes );
+
+                // The number of input blocks
+                var      n  = ( inputCount - BlockSizeInBytes ) >> 3;
+
+                // The set of input blocks
+                byte[]   r  = new byte[n << 3];
+
+                Array.Copy( inputBuffer, inputOffset + BlockSizeInBytes, r, 0, inputCount - BlockSizeInBytes );
+
+                var    encryptor = _aes.CreateDecryptor();
+                byte[] block     = new byte[16];
+
+                // Calculate intermediate values
+                for ( var j = 5; j >= 0; j-- )
+                {
+                    for ( var i = n; i > 0; i-- )
+                    {
+                        // T = ( n * j ) + i
+                        var t = (ulong)( ( n * j ) + i );
+
+                        // B = AES-1(K, (A ^ t) | R[i] )
+
+                        // First, A = ( A ^ t )
+                        a.Xor( GetBytes( t ), true );
+
+                        // Second, block = ( A | R[i] )
+                        Array.Copy( a, block, BlockSizeInBytes );
+                        Array.Copy( r, ( i - 1 ) << 3, block, BlockSizeInBytes, BlockSizeInBytes );
+
+                        // Third, b = AES-1( block )
+                        var b = encryptor.TransformFinalBlock( block, 0, 16 );
+
+                        // A = MSB(64, B)
+                        Array.Copy( b, a, BlockSizeInBytes );
+
+                        // R[i] = LSB(64, B)
+                        Array.Copy( b, BlockSizeInBytes, r, ( i - 1 ) << 3, BlockSizeInBytes );
+                    }
+                }
+
+                if ( a.SequenceEqual( DefaultIv ) )
+                {
+                    var c = new byte[n << 3];
+
+                    for ( var i = 0; i < n; i++ )
+                    {
+                        Array.Copy( r, i << 3, c, i << 3, 8 );
+                    }
+
+                    return c;
+                }
+                else
+                {
+                    throw new CryptographicException( "Data is not authentic" );
+                }
+            }
+
+            public void Dispose()
+            {
+                Dispose( true );
+                GC.SuppressFinalize( this );
+            }
+
+            protected virtual void Dispose( bool disposing )
+            {
+                if ( disposing )
+                {
+                    if ( _aes != null )
+                    {
+                        _aes.Dispose();
+                        _aes = null;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw128.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw128.cs
@@ -1,0 +1,54 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public class AesKw128 : AesKw
+    {
+        public const string AlgorithmName = "A128KW";
+
+        public AesKw128()
+            : base( AlgorithmName )
+        {
+        }
+
+        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv = null )
+        {
+            if ( key == null )
+                throw new ArgumentNullException( "key" );
+
+            if ( key.Length << 3 != 128 )
+                throw new ArgumentOutOfRangeException( "key", "key must be 128 bits long" );
+
+            return base.CreateDecryptor( key, iv );
+        }
+
+        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv = null )
+        {
+            if ( key == null )
+                throw new ArgumentNullException( "key" );
+
+            if ( key.Length << 3 != 128 )
+                throw new ArgumentOutOfRangeException( "key", "key must be 128 bits long" );
+
+            return base.CreateEncryptor( key, iv );
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw128.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw128.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
         {
         }
 
-        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv = null )
+        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv )
         {
             if ( key == null )
                 throw new ArgumentNullException( "key" );
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
             return base.CreateDecryptor( key, iv );
         }
 
-        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv = null )
+        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv )
         {
             if ( key == null )
                 throw new ArgumentNullException( "key" );

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw192.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw192.cs
@@ -1,0 +1,54 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public class AesKw192 : AesKw
+    {
+        public const string AlgorithmName = "A192KW";
+
+        public AesKw192()
+            : base( AlgorithmName )
+        {
+        }
+
+        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv = null )
+        {
+            if ( key == null )
+                throw new ArgumentNullException( "key" );
+
+            if ( key.Length << 3 != 192 )
+                throw new ArgumentOutOfRangeException( "key", "key must be 192 bits long" );
+
+            return base.CreateDecryptor( key, iv );
+        }
+
+        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv = null )
+        {
+            if ( key == null )
+                throw new ArgumentNullException( "key" );
+
+            if ( key.Length << 3 != 192 )
+                throw new ArgumentOutOfRangeException( "key", "key must be 192 bits long" );
+
+            return base.CreateEncryptor( key, iv );
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw192.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw192.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
         {
         }
 
-        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv = null )
+        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv )
         {
             if ( key == null )
                 throw new ArgumentNullException( "key" );
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
             return base.CreateDecryptor( key, iv );
         }
 
-        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv = null )
+        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv )
         {
             if ( key == null )
                 throw new ArgumentNullException( "key" );

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw256.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw256.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
         {
         }
 
-        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv = null )
+        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv )
         {
             if ( key == null )
                 throw new ArgumentNullException( "key" );
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
             return base.CreateDecryptor( key, iv );
         }
 
-        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv = null )
+        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv )
         {
             if ( key == null )
                 throw new ArgumentNullException( "key" );

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw256.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/AesKw256.cs
@@ -1,0 +1,54 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public class AesKw256 : AesKw
+    {
+        public const string AlgorithmName = "A256KW";
+
+        public AesKw256()
+            : base( AlgorithmName )
+        {
+        }
+
+        public override ICryptoTransform CreateDecryptor( byte[] key, byte[] iv = null )
+        {
+            if ( key == null )
+                throw new ArgumentNullException( "key" );
+
+            if ( key.Length << 3 != 256 )
+                throw new ArgumentOutOfRangeException( "key", "key must be 256 bits long" );
+
+            return base.CreateDecryptor( key, iv );
+        }
+
+        public override ICryptoTransform CreateEncryptor( byte[] key, byte[] iv = null )
+        {
+            if ( key == null )
+                throw new ArgumentNullException( "key" );
+
+            if ( key.Length << 3 != 256 )
+                throw new ArgumentOutOfRangeException( "key", "key must be 256 bits long" );
+
+            return base.CreateEncryptor( key, iv );
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/NativeMethods.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/NativeMethods.cs
@@ -1,0 +1,128 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    internal static class NativeMethods
+    {
+        internal const int Success = 0x00000000;                              // ERROR_SUCCESS
+        internal const int BadSignature = unchecked( (int)0x80090006 );        // NTE_BAD_SIGNATURE
+        internal const int InvalidParameter = unchecked( (int)0x80090027 );    // NTE_INVALID_PARAMETER
+
+        internal const int BCRYPT_RSAPUBLIC_MAGIC      = 0x31415352;
+        internal const int BCRYPT_RSAPRIVATE_MAGIC     = 0x32415352;
+        internal const int BCRYPT_RSAFULLPRIVATE_MAGIC = 0x33415352;
+
+        [StructLayout( LayoutKind.Sequential )]
+        internal struct NCRYPT_PKCS1_PADDING_INFO
+        {
+            [MarshalAs( UnmanagedType.LPWStr )]
+            public string pszAlgId;
+        }
+
+        /// <summary>
+        ///     Padding modes 
+        /// </summary>
+        internal enum AsymmetricPaddingMode
+        {
+            None = 1,                       // BCRYPT_PAD_NONE
+            Pkcs1 = 2,                      // BCRYPT_PAD_PKCS1
+            Oaep = 4,                       // BCRYPT_PAD_OAEP
+            Pss = 8                         // BCRYPT_PAD_PSS
+        }
+
+        [DllImport( "ncrypt.dll" )]
+        internal static extern int NCryptOpenStorageProvider( [Out] out SafeNCryptProviderHandle phProvider,
+                                                            [MarshalAs( UnmanagedType.LPWStr )] string pszProviderName,
+                                                            int dwFlags );
+
+        [DllImport( "ncrypt.dll" )]
+        internal static extern int NCryptImportKey( SafeNCryptProviderHandle hProvider,
+                                                            IntPtr hImportKey,
+                                                            [MarshalAs( UnmanagedType.LPWStr )] string pszBlobType,
+                                                            [In, MarshalAs( UnmanagedType.LPArray )] byte[] pParameterList,
+                                                            out SafeNCryptKeyHandle phKey,
+                                                            [In, MarshalAs( UnmanagedType.LPArray )] byte[] pbData,
+                                                            int cbData,
+                                                            int dwFlags );
+
+        [DllImport( "ncrypt.dll" )]
+        internal static extern int NCryptSignHash(
+            SafeNCryptKeyHandle hKey,
+            [In] ref NCRYPT_PKCS1_PADDING_INFO pPaddingInfo,
+            [In, MarshalAs( UnmanagedType.LPArray )] byte[] pbHashValue,
+            int cbHashValue,
+            [In, MarshalAs( UnmanagedType.LPArray )] byte[] pbSignature,
+            int cbSignature,
+            [Out] out int pcbResult,
+            AsymmetricPaddingMode dwFlags );
+
+        [DllImport( "ncrypt.dll" )]
+        internal static extern int NCryptVerifySignature( SafeNCryptKeyHandle hKey,
+                                                               [In] ref NCRYPT_PKCS1_PADDING_INFO pPaddingInfo,
+                                                               [In, MarshalAs( UnmanagedType.LPArray )] byte[] pbHashValue,
+                                                               int cbHashValue,
+                                                               [In, MarshalAs( UnmanagedType.LPArray )] byte[] pbSignature,
+                                                               int cbSignature,
+                                                               AsymmetricPaddingMode dwFlags );
+
+        internal static byte[] NewNCryptPublicBlob( RSAParameters rsaParams )
+        {
+            // Builds a BCRYPT_RSAKEY_BLOB strucutre ( http://msdn.microsoft.com/en-us/library/windows/desktop/aa375531(v=vs.85).aspx ).
+            var size = 6 * 4 + rsaParams.Exponent.Length + rsaParams.Modulus.Length;
+            var data = new byte[size];
+            var stream = new MemoryStream( data );
+            var writer = new BinaryWriter( stream );
+            writer.Write( (int)0x31415352 );
+            writer.Write( (int)rsaParams.Modulus.Length * 8 );
+            writer.Write( (int)rsaParams.Exponent.Length );
+            writer.Write( (int)rsaParams.Modulus.Length );
+            writer.Write( (int)0 );
+            writer.Write( (int)0 );
+            writer.Write( rsaParams.Exponent );
+            writer.Write( rsaParams.Modulus );
+            return data;
+        }
+
+        internal static byte[] NewNCryptPrivateBlob( RSAParameters rsaParams )
+        {
+            // Builds a BCRYPT_RSAKEY_BLOB strucutre ( http://msdn.microsoft.com/en-us/library/windows/desktop/aa375531(v=vs.85).aspx ).
+            var size = 6 * 4 + rsaParams.Exponent.Length + rsaParams.Modulus.Length + rsaParams.P.Length + rsaParams.Q.Length;
+            var data = new byte[size];
+            var stream = new MemoryStream( data );
+            var writer = new BinaryWriter( stream );
+            writer.Write( BCRYPT_RSAPRIVATE_MAGIC );
+            writer.Write( rsaParams.Modulus.Length * 8 ); // BitLength
+            writer.Write( rsaParams.Exponent.Length ); // cbPublicExp
+            writer.Write( rsaParams.Modulus.Length ); // cbModulus
+            writer.Write( rsaParams.P.Length ); // cbPrime1
+            writer.Write( rsaParams.Q.Length ); // cbPrime2
+            writer.Write( rsaParams.Exponent );
+            writer.Write( rsaParams.Modulus );
+            writer.Write( rsaParams.P );
+            writer.Write( rsaParams.Q );
+            return data;
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/Rs256.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/Rs256.cs
@@ -1,0 +1,66 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public class Rs256 : AsymmetricSignatureAlgorithm
+    {
+        public const string AlgorithmName = "RS256";
+
+        public Rs256()
+            : base( AlgorithmName )
+        {
+        }
+
+        public override byte[] SignHash( AsymmetricAlgorithm key, byte[] digest )
+        {
+            if ( key == null )
+                throw new ArgumentNullException( "key" );
+
+            if ( digest == null )
+                throw new ArgumentNullException( "digest" );
+
+            var rsa = key as RSACryptoServiceProvider;
+
+            if ( rsa == null )
+                throw new ArgumentException( "key must be an instance of RSACryptoServiceProvider", "key" );
+
+            return rsa.SignHash( digest, CryptoConfig.MapNameToOID( "SHA256" ) );
+        }
+
+
+        public override bool VerifyHash( AsymmetricAlgorithm key, byte[] digest, byte[] signature )
+        {
+            if ( key == null )
+                throw new ArgumentNullException( "key" );
+
+            if ( digest == null )
+                throw new ArgumentNullException( "digest" );
+
+            var rsa = key as RSACryptoServiceProvider;
+
+            if ( rsa == null )
+                throw new ArgumentException( "key must be an instance of RSACryptoServiceProvider", "key" );
+
+            return rsa.VerifyHash( digest, CryptoConfig.MapNameToOID( "SHA256" ), signature );
+        }
+
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/RsNull.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/RsNull.cs
@@ -1,0 +1,94 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public class RsNull : AsymmetricSignatureAlgorithm
+    {
+        public const string AlgorithmName = "RSNULL";
+
+        public RsNull()
+            : base( AlgorithmName )
+        {
+        }
+
+        public override byte[] SignHash( AsymmetricAlgorithm key, byte[] digest )
+        {
+            var csp = key as RSACryptoServiceProvider;
+
+            SafeNCryptProviderHandle hProvider;
+            var errorCode = NativeMethods.NCryptOpenStorageProvider( out hProvider, "Microsoft Software Key Storage Provider", 0 );
+            if ( errorCode != NativeMethods.Success )
+                throw new CryptographicException( errorCode );
+
+            var blob = NativeMethods.NewNCryptPrivateBlob( csp.ExportParameters( true ) );
+            SafeNCryptKeyHandle hKey;
+            errorCode = NativeMethods.NCryptImportKey( hProvider, IntPtr.Zero, "RSAPRIVATEBLOB", null, out hKey, blob, blob.Length, 0 );
+            if ( errorCode != NativeMethods.Success )
+                throw new CryptographicException( errorCode );
+
+            var pkcs1Info = new NativeMethods.NCRYPT_PKCS1_PADDING_INFO { pszAlgId = null };
+
+            int cbResult;
+            errorCode = NativeMethods.NCryptSignHash( hKey, ref pkcs1Info, digest, digest.Length, null, 0, out cbResult, NativeMethods.AsymmetricPaddingMode.Pkcs1 );
+            if ( errorCode != NativeMethods.Success )
+                throw new CryptographicException( errorCode );
+
+            var signature = new byte[cbResult];
+            errorCode = NativeMethods.NCryptSignHash( hKey, ref pkcs1Info, digest, digest.Length, signature, signature.Length, out cbResult, NativeMethods.AsymmetricPaddingMode.Pkcs1 );
+            if ( errorCode != NativeMethods.Success )
+                throw new CryptographicException( errorCode );
+
+            if ( cbResult != signature.Length )
+            {
+                var temp = new byte[cbResult];
+                Array.Copy( signature, temp, cbResult );
+                signature = temp;
+            }
+
+            return signature;
+        }
+
+        public override bool VerifyHash( AsymmetricAlgorithm key, byte[] digest, byte[] signature )
+        {
+            var csp = key as RSACryptoServiceProvider;
+
+            SafeNCryptProviderHandle hProvider;
+            var errorCode = NativeMethods.NCryptOpenStorageProvider( out hProvider, "Microsoft Software Key Storage Provider", 0 );
+            if ( errorCode != NativeMethods.Success )
+                throw new CryptographicException( errorCode );
+
+            var blob = NativeMethods.NewNCryptPublicBlob( csp.ExportParameters( false ) );
+            SafeNCryptKeyHandle hKey;
+            errorCode = NativeMethods.NCryptImportKey( hProvider, IntPtr.Zero, "RSAPUBLICBLOB", null, out hKey, blob, blob.Length, 0 );
+            if ( errorCode != NativeMethods.Success )
+                throw new CryptographicException( errorCode );
+
+            var pkcs1Info = new NativeMethods.NCRYPT_PKCS1_PADDING_INFO { pszAlgId = null };
+
+            errorCode = NativeMethods.NCryptVerifySignature( hKey, ref pkcs1Info, digest, digest.Length, signature, signature.Length, NativeMethods.AsymmetricPaddingMode.Pkcs1 );
+            if ( errorCode != NativeMethods.Success && errorCode != NativeMethods.BadSignature && errorCode != NativeMethods.InvalidParameter )
+                throw new CryptographicException( errorCode );
+
+            return ( errorCode == NativeMethods.Success );
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/Rsa15.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/Rsa15.cs
@@ -1,0 +1,145 @@
+﻿
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public class Rsa15 : RsaEncryption
+    {
+        public const string AlgorithmName = "RSA_15";
+
+        public Rsa15()
+            : base( AlgorithmName )
+        {
+        }
+
+        public override ICryptoTransform CreateEncryptor( AsymmetricAlgorithm key )
+        {
+            RSACryptoServiceProvider csp = key as RSACryptoServiceProvider;
+
+            if ( csp == null )
+                throw new ArgumentException( "key must be an instance of RSACryptoServiceProvider", "key" );
+
+            return new Rsa15Encryptor( csp );
+        }
+
+        public override ICryptoTransform CreateDecryptor( AsymmetricAlgorithm key )
+        {
+            RSACryptoServiceProvider csp = key as RSACryptoServiceProvider;
+
+            if ( csp == null )
+                throw new ArgumentException( "key must be an instance of RSACryptoServiceProvider", "key" );
+
+            return new Rsa15Decryptor( csp );
+        }
+
+        /// <summary>
+        /// RSA 15 Decryptor
+        /// </summary>
+        /// <remarks>
+        /// While this class has a reference to an IDisposable object,
+        /// it is not the owner of the object and will not Dispose it.
+        /// </remarks>
+        class Rsa15Decryptor : ICryptoTransform
+        {
+            private readonly RSACryptoServiceProvider _csp;
+
+            internal Rsa15Decryptor( RSACryptoServiceProvider csp )
+            {
+                _csp = csp;
+            }
+
+            public bool CanReuseTransform
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public bool CanTransformMultipleBlocks
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int InputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int OutputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int TransformBlock( byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset )
+            {
+                throw new NotImplementedException();
+            }
+
+            public byte[] TransformFinalBlock( byte[] inputBuffer, int inputOffset, int inputCount )
+            {
+                byte[] block = inputBuffer.Skip( inputOffset ).Take( inputCount ).ToArray();
+
+                return _csp.Decrypt( block, false );
+            }
+
+            public void Dispose()
+            {
+                // Intentionally empty
+            }
+        }
+
+        /// <summary>
+        /// RSA 15 Encryptor
+        /// </summary>
+        /// <remarks>
+        /// While this class has a reference to an IDisposable object,
+        /// it is not the owner of the object and will not Dispose it.
+        /// </remarks>
+        class Rsa15Encryptor : ICryptoTransform
+        {
+            private readonly RSACryptoServiceProvider _csp;
+
+            internal Rsa15Encryptor( RSACryptoServiceProvider csp )
+            {
+                _csp = csp;
+            }
+
+            public bool CanReuseTransform
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public bool CanTransformMultipleBlocks
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int InputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int OutputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int TransformBlock( byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset )
+            {
+                throw new NotImplementedException();
+            }
+
+            public byte[] TransformFinalBlock( byte[] inputBuffer, int inputOffset, int inputCount )
+            {
+                byte[] block = inputBuffer.Skip( inputOffset ).Take( inputCount ).ToArray();
+
+                return _csp.Encrypt( block , false );
+            }
+
+            public void Dispose()
+            {
+                // Intentionally empty
+            }
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/RsaEncryption.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/RsaEncryption.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public abstract class RsaEncryption : AsymmetricEncryptionAlgorithm
+    {
+        protected RsaEncryption( string name ) : base( name )
+        {
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/RsaOaep.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/Algorithms/RsaOaep.cs
@@ -1,0 +1,145 @@
+﻿
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    public class RsaOaep : RsaEncryption
+    {
+        public const string AlgorithmName = "RSA-OAEP";
+
+        public RsaOaep()
+            : base( AlgorithmName )
+        {
+        }
+
+        public override ICryptoTransform CreateEncryptor( AsymmetricAlgorithm key )
+        {
+            RSACryptoServiceProvider csp = key as RSACryptoServiceProvider;
+
+            if ( csp == null )
+                throw new ArgumentException( "key must be an instance of RSACryptoServiceProvider", "key" );
+
+            return new RsaOaepEncryptor( csp );
+        }
+
+        public override ICryptoTransform CreateDecryptor( AsymmetricAlgorithm key )
+        {
+            RSACryptoServiceProvider csp = key as RSACryptoServiceProvider;
+
+            if ( csp == null )
+                throw new ArgumentException( "key must be an instance of RSACryptoServiceProvider", "key" );
+
+            return new RsaOaepDecryptor( csp );
+        }
+
+        /// <summary>
+        /// RSA 15 Decryptor
+        /// </summary>
+        /// <remarks>
+        /// While this class has a reference to an IDisposable object,
+        /// it is not the owner of the object and will not Dispose it.
+        /// </remarks>
+        class RsaOaepDecryptor : ICryptoTransform
+        {
+            private readonly RSACryptoServiceProvider _csp;
+
+            internal RsaOaepDecryptor( RSACryptoServiceProvider csp )
+            {
+                _csp = csp;
+            }
+
+            public bool CanReuseTransform
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public bool CanTransformMultipleBlocks
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int InputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int OutputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int TransformBlock( byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset )
+            {
+                throw new NotImplementedException();
+            }
+
+            public byte[] TransformFinalBlock( byte[] inputBuffer, int inputOffset, int inputCount )
+            {
+                byte[] block = inputBuffer.Skip( inputOffset ).Take( inputCount ).ToArray();
+
+                return _csp.Decrypt( block, true );
+            }
+
+            public void Dispose()
+            {
+                // Intentionally empty
+            }
+        }
+
+        /// <summary>
+        /// RSA 15 Encryptor
+        /// </summary>
+        /// <remarks>
+        /// While this class has a reference to an IDisposable object,
+        /// it is not the owner of the object and will not Dispose it.
+        /// </remarks>
+        class RsaOaepEncryptor : ICryptoTransform
+        {
+            private readonly RSACryptoServiceProvider _csp;
+
+            internal RsaOaepEncryptor( RSACryptoServiceProvider csp )
+            {
+                _csp = csp;
+            }
+
+            public bool CanReuseTransform
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public bool CanTransformMultipleBlocks
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int InputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int OutputBlockSize
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public int TransformBlock( byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset )
+            {
+                throw new NotImplementedException();
+            }
+
+            public byte[] TransformFinalBlock( byte[] inputBuffer, int inputOffset, int inputCount )
+            {
+                byte[] block = inputBuffer.Skip( inputOffset ).Take( inputCount ).ToArray();
+
+                return _csp.Encrypt( block , true );
+            }
+
+            public void Dispose()
+            {
+                // Intentionally empty
+            }
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/ByteExtensions.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/ByteExtensions.cs
@@ -1,0 +1,96 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+
+namespace Microsoft.Azure.KeyVault.Cryptography
+{
+    internal static class ByteExtensions
+    {
+        internal static byte[] Or( this byte[] self, byte[] other )
+        {
+            return Or( self, other, 0 );
+        }
+
+        internal static byte[] Or( this byte[] self, byte[] other, int offset )
+        {
+            if ( self == null )
+                throw new ArgumentNullException( "self" );
+
+            if ( other == null )
+                throw new ArgumentNullException( "other" );
+
+            if ( self.Length > other.Length - offset )
+                throw new ArgumentException( "self and other lengths do not match" );
+
+            var result = new byte[self.Length];
+
+            for ( var i = 0; i < self.Length; i++ )
+            {
+                result[i] = (byte)( self[i] | other[offset + i] );
+            }
+
+            return result;
+        }
+
+        internal static byte[] Xor( this byte[] self, byte[] other, bool inPlace = false )
+        {
+            return Xor( self, other, 0, inPlace );
+        }
+
+        internal static byte[] Xor( this byte[] self, byte[] other, int offset, bool inPlace = false )
+        {
+            if ( self == null )
+                throw new ArgumentNullException( "self" );
+
+            if ( other == null )
+                throw new ArgumentNullException( "other" );
+
+            if ( self.Length > other.Length - offset )
+                throw new ArgumentException( "self and other lengths do not match" );
+
+            if ( inPlace )
+            {
+                for ( var i = 0; i < self.Length; i++ )
+                {
+                    self[i] = (byte)( self[i] ^ other[offset + i] );
+                }
+
+                return self;
+            }
+            else
+            {
+                var result = new byte[self.Length];
+
+                for ( var i = 0; i < self.Length; i++ )
+                {
+                    result[i] = (byte)( self[i] ^ other[offset + i] );
+                }
+
+                return result;
+            }
+        }
+
+        internal static void Zero( this byte[] self )
+        {
+            for ( var i = 0; i < self.Length; i++ )
+            {
+                self[i] = 0;
+            }
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/EncryptionAlgorithm.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/EncryptionAlgorithm.cs
@@ -1,0 +1,85 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography
+{
+    /// <summary>
+    /// Abstract Encryption Algorithm
+    /// </summary>
+    public abstract class EncryptionAlgorithm : Algorithm
+    {
+        protected EncryptionAlgorithm( string name ) : base( name )
+        {
+        }
+    }
+
+    /// <summary>
+    /// Abstract Asymmetric Algorithm
+    /// </summary>
+    public abstract class AsymmetricEncryptionAlgorithm : EncryptionAlgorithm
+    {
+        protected AsymmetricEncryptionAlgorithm( string name )
+            : base( name )
+        {
+        }
+
+        /// <summary>
+        /// Create an encryptor for the specified key
+        /// </summary>
+        /// <param name="key">The key used to create the encryptor</param>
+        /// <returns>An ICryptoTransform for encrypting data</returns>
+        public abstract ICryptoTransform CreateEncryptor( AsymmetricAlgorithm key );
+
+        /// <summary>
+        /// Create a decryptor for the specified key
+        /// </summary>
+        /// <param name="key">The key used to create decryptor</param>
+        /// <returns>An ICryptoTransform for encrypting data</returns>
+        public abstract ICryptoTransform CreateDecryptor( AsymmetricAlgorithm key );
+    }
+
+    /// <summary>
+    /// Abstract Symmetric Algorithm
+    /// </summary>
+    public abstract class SymmetricEncryptionAlgorithm : EncryptionAlgorithm
+    {
+        protected SymmetricEncryptionAlgorithm( string name )
+            : base( name )
+        {
+        }
+
+        /// <summary>
+        /// Create an encryptor for the specified key
+        /// </summary>
+        /// <param name="key">The key</param>
+        /// <param name="iv">The initialization vector</param>
+        /// <param name="authenticationData">Authentication data</param>
+        /// <returns>An ICryptoTranform for encrypting data</returns>
+        public abstract ICryptoTransform CreateEncryptor( byte[] key, byte[] iv, byte[] authenticationData = null );
+
+        /// <summary>
+        /// Crea a decryptor for the specified key
+        /// </summary>
+        /// <param name="key">The key</param>
+        /// <param name="iv">The initialization vector</param>
+        /// <param name="authenticationData">Authentication data</param>
+        /// <returns>An ICryptoTransform for decrypting data</returns>
+        public abstract ICryptoTransform CreateDecryptor( byte[] key, byte[] iv, byte[] authenticationData = null );
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/EncryptionAlgorithm.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/EncryptionAlgorithm.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography
         /// <param name="iv">The initialization vector</param>
         /// <param name="authenticationData">Authentication data</param>
         /// <returns>An ICryptoTranform for encrypting data</returns>
-        public abstract ICryptoTransform CreateEncryptor( byte[] key, byte[] iv, byte[] authenticationData = null );
+        public abstract ICryptoTransform CreateEncryptor( byte[] key, byte[] iv, byte[] authenticationData );
 
         /// <summary>
         /// Crea a decryptor for the specified key
@@ -80,6 +80,6 @@ namespace Microsoft.Azure.KeyVault.Cryptography
         /// <param name="iv">The initialization vector</param>
         /// <param name="authenticationData">Authentication data</param>
         /// <returns>An ICryptoTransform for decrypting data</returns>
-        public abstract ICryptoTransform CreateDecryptor( byte[] key, byte[] iv, byte[] authenticationData = null );
+        public abstract ICryptoTransform CreateDecryptor( byte[] key, byte[] iv, byte[] authenticationData );
     }
 }

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/IAuthenticatedCryptoTransform.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/IAuthenticatedCryptoTransform.cs
@@ -1,0 +1,26 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography
+{
+    public interface IAuthenticatedCryptoTransform : ICryptoTransform
+    {
+        byte[] Tag { get; }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/KeyWrapAlgorithm.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/KeyWrapAlgorithm.cs
@@ -1,0 +1,48 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography
+{
+    /// <summary>
+    /// An abstract Key Wrap Algorithm
+    /// </summary>
+    public abstract class KeyWrapAlgorithm : Algorithm
+    {
+        protected KeyWrapAlgorithm( string name )
+            : base( name )
+        {
+        }
+
+        /// <summary>
+        /// Create an encryptor for the specified key
+        /// </summary>
+        /// <param name="key">The key</param>
+        /// <param name="iv">The initialization vector</param>
+        /// <returns>An ICryptoTranform for encrypting data</returns>
+        public abstract ICryptoTransform CreateEncryptor( byte[] key, byte[] iv = null );
+
+        /// <summary>
+        /// Crea a decryptor for the specified key
+        /// </summary>
+        /// <param name="key">The key</param>
+        /// <param name="iv">The initialization vector</param>
+        /// <returns>An ICryptoTransform for decrypting data</returns>
+        public abstract ICryptoTransform CreateDecryptor( byte[] key, byte[] iv = null );
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/KeyWrapAlgorithm.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/KeyWrapAlgorithm.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography
         /// <param name="key">The key</param>
         /// <param name="iv">The initialization vector</param>
         /// <returns>An ICryptoTranform for encrypting data</returns>
-        public abstract ICryptoTransform CreateEncryptor( byte[] key, byte[] iv = null );
+        public abstract ICryptoTransform CreateEncryptor( byte[] key, byte[] iv );
 
         /// <summary>
         /// Crea a decryptor for the specified key
@@ -43,6 +43,6 @@ namespace Microsoft.Azure.KeyVault.Cryptography
         /// <param name="key">The key</param>
         /// <param name="iv">The initialization vector</param>
         /// <returns>An ICryptoTransform for decrypting data</returns>
-        public abstract ICryptoTransform CreateDecryptor( byte[] key, byte[] iv = null );
+        public abstract ICryptoTransform CreateDecryptor( byte[] key, byte[] iv );
     }
 }

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/RsaExtensions.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/RsaExtensions.cs
@@ -15,6 +15,7 @@
 // See the Apache License, Version 2.0 for the specific language
 // governing permissions and limitations under the License.
 
+using System;
 using System.Security.Cryptography;
 using Microsoft.Azure.KeyVault.WebKey;
 
@@ -30,6 +31,9 @@ namespace Microsoft.Azure.KeyVault.Cryptography
         /// <returns>A WebKey representing the RSA object</returns>
         public static JsonWebKey ToJsonWebKey( this RSA self, bool includePrivateParameters = false )
         {
+            if ( self == null )
+                throw new ArgumentNullException( "self" );
+
             return ToJsonWebKey( self.ExportParameters( includePrivateParameters ) );
         }
 

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/RsaExtensions.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/RsaExtensions.cs
@@ -1,0 +1,59 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System.Security.Cryptography;
+using Microsoft.Azure.KeyVault.WebKey;
+
+namespace Microsoft.Azure.KeyVault.Cryptography
+{
+    public static class RsaExtensions
+    {
+        /// <summary>
+        /// Converts a RSA object to a JsonWebKey of type RSA.
+        /// </summary>
+        /// <param name="self">The RSA object to convert</param>
+        /// <param name="includePrivateParameters">True to include the RSA private key parameters</param>
+        /// <returns>A WebKey representing the RSA object</returns>
+        public static JsonWebKey ToJsonWebKey( this RSA self, bool includePrivateParameters = false )
+        {
+            return ToJsonWebKey( self.ExportParameters( includePrivateParameters ) );
+        }
+
+        /// <summary>
+        /// Converts a RSAParameters object to a WebKey of type RSA.
+        /// </summary>
+        /// <param name="self">The RSA parameters object to convert</param>
+        /// <returns>A WebKey representing the RSA object</returns>
+        public static JsonWebKey ToJsonWebKey( this RSAParameters self )
+        {
+            return new JsonWebKey()
+            {
+                Kty = JsonWebKeyType.Rsa,
+
+                E  = self.Exponent,
+                N  = self.Modulus,
+
+                D  = self.D,
+                DP = self.DP,
+                DQ = self.DQ,
+                QI = self.InverseQ,
+                P  = self.P,
+                Q  = self.Q,
+            };
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/SignatureAlgorithm.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/SignatureAlgorithm.cs
@@ -1,0 +1,60 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography
+{
+    /// <summary>
+    /// Abstract SignatureAlgorithm
+    /// </summary>
+    public abstract class SignatureAlgorithm : Algorithm
+    {
+        protected SignatureAlgorithm( string name )
+            : base( name )
+        {
+        }
+    }
+
+    /// <summary>
+    /// Abstract Asymmetric Signature algorithm
+    /// </summary>
+    public abstract class AsymmetricSignatureAlgorithm : SignatureAlgorithm
+    {
+        protected AsymmetricSignatureAlgorithm( string name )
+            : base( name )
+        {
+        }
+
+        /// <summary>
+        /// Sign a digest using the specified key
+        /// </summary>
+        /// <param name="key">The key to use</param>
+        /// <param name="digest">The digest to sign</param>
+        /// <returns>The signature</returns>
+        public abstract byte[] SignHash( AsymmetricAlgorithm key, byte[] digest );
+
+        /// <summary>
+        /// Verify a signature of a digest using the specified key
+        /// </summary>
+        /// <param name="key">The key to use</param>
+        /// <param name="digest">The digest that was signed</param>
+        /// <param name="signature">The signature value</param>
+        /// <returns>True if the computed signature matches the supplied signature</returns>
+        public abstract bool VerifyHash( AsymmetricAlgorithm key, byte[] digest, byte[] signature );
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/KeyVault.Extensions.csproj
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/KeyVault.Extensions.csproj
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{937E445A-5604-4998-A9F5-9BE1E39001A4}</ProjectGuid>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Azure.KeyVault</RootNamespace>
+    <AssemblyName>Microsoft.Azure.KeyVault.Extensions</AssemblyName>
+    <OutputType>Library</OutputType>
+    <RestorePackages>true</RestorePackages>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)\tools\Library.Settings.targets" />
+  <ItemGroup>
+    <None Include="Microsoft.Azure.KeyVault.Extensions.nuspec" />
+    <None Include="Microsoft.Azure.KeyVault.Extensions.nuget.proj">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Azure.KeyVault.Core\KeyVault.Core.csproj">
+      <Project>{b419782d-ca57-40f9-9322-340a4e852e82}</Project>
+      <Name>KeyVault.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.Azure.KeyVault\KeyVault.csproj">
+      <Project>{bec7dbf7-a3b1-4088-bdff-c1c2a0fd6f56}</Project>
+      <Name>KeyVault</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AggregateKeyResolver.cs" />
+    <Compile Include="KeyVaultKey.cs" />
+    <Compile Include="KeyVaultKeyResolver.cs" />
+    <Compile Include="Cryptography\RsaExtensions.cs" />
+    <Compile Include="Cryptography\AesExtensions.cs" />
+    <Compile Include="Cryptography\Algorithm.cs" />
+    <Compile Include="Cryptography\AlgorithmResolver.cs" />
+    <Compile Include="Cryptography\Algorithms\Aes128CbcHmacSha256.cs" />
+    <Compile Include="Cryptography\Algorithms\Aes192CbcHmacSha384.cs" />
+    <Compile Include="Cryptography\Algorithms\Aes256CbcHmacSha512.cs" />
+    <Compile Include="Cryptography\Algorithms\AesCbc.cs" />
+    <Compile Include="Cryptography\Algorithms\AesCbcHmacSha2.cs" />
+    <Compile Include="Cryptography\Algorithms\AesKw.cs" />
+    <Compile Include="Cryptography\Algorithms\AesKw128.cs" />
+    <Compile Include="Cryptography\Algorithms\AesKw192.cs" />
+    <Compile Include="Cryptography\Algorithms\AesKw256.cs" />
+    <Compile Include="Cryptography\Algorithms\NativeMethods.cs" />
+    <Compile Include="Cryptography\Algorithms\Rs256.cs" />
+    <Compile Include="Cryptography\Algorithms\Rsa15.cs" />
+    <Compile Include="Cryptography\Algorithms\RsaEncryption.cs" />
+    <Compile Include="Cryptography\Algorithms\RsaOaep.cs" />
+    <Compile Include="Cryptography\Algorithms\RsNull.cs" />
+    <Compile Include="Cryptography\ByteExtensions.cs" />
+    <Compile Include="Cryptography\EncryptionAlgorithm.cs" />
+    <Compile Include="Cryptography\IAuthenticatedCryptoTransform.cs" />
+    <Compile Include="Cryptography\KeyWrapAlgorithm.cs" />
+    <Compile Include="Cryptography\SignatureAlgorithm.cs" />
+    <Compile Include="RsaKey.cs" />
+    <Compile Include="SymmetricKey.cs" />
+    <Compile Include="WebKey\JsonWebKey.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
+</Project>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/KeyVault.Extensions.csproj
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/KeyVault.Extensions.csproj
@@ -12,6 +12,7 @@
     <OutputType>Library</OutputType>
     <RestorePackages>true</RestorePackages>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NuGetPackageImportStamp>b90ee2a1</NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\tools\Library.Settings.targets" />
   <ItemGroup>
@@ -32,6 +33,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CachingKeyResolver.cs" />
     <Compile Include="AggregateKeyResolver.cs" />
     <Compile Include="KeyVaultKey.cs" />
     <Compile Include="KeyVaultKeyResolver.cs" />
@@ -59,6 +61,7 @@
     <Compile Include="Cryptography\IAuthenticatedCryptoTransform.cs" />
     <Compile Include="Cryptography\KeyWrapAlgorithm.cs" />
     <Compile Include="Cryptography\SignatureAlgorithm.cs" />
+    <Compile Include="LRUCache.cs" />
     <Compile Include="RsaKey.cs" />
     <Compile Include="SymmetricKey.cs" />
     <Compile Include="WebKey\JsonWebKey.cs" />
@@ -78,9 +81,11 @@
     <Reference Include="System" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  <Import Project="..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
 </Project>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/KeyVaultKey.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/KeyVaultKey.cs
@@ -1,0 +1,115 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.KeyVault.Core;
+using Microsoft.Azure.KeyVault.WebKey;
+
+namespace Microsoft.Azure.KeyVault
+{
+    internal class KeyVaultKey : IKey
+    {
+        private readonly KeyVaultClient _client;
+        private readonly IKey           _implementation;
+
+        internal KeyVaultKey( KeyVaultClient client, KeyBundle keyBundle )
+        {
+            switch ( keyBundle.Key.Kty )
+            {
+                case JsonWebKeyType.Rsa:
+                    _implementation = new RsaKey( keyBundle.Key.Kid, keyBundle.Key.ToRSA() );
+                    break;
+
+                case JsonWebKeyType.RsaHsm:
+                    _implementation = new RsaKey( keyBundle.Key.Kid, keyBundle.Key.ToRSA() );
+                    break;
+            }
+
+            if ( _implementation == null )
+                throw new ArgumentException( string.Format( "The key type \"{0}\" is not supported", keyBundle.Key.Kty ) );
+
+            _client = client;
+        }
+
+        public string DefaultEncryptionAlgorithm
+        {
+            get { return _implementation.DefaultEncryptionAlgorithm; }
+        }
+
+        public string DefaultKeyWrapAlgorithm
+        {
+            get { return _implementation.DefaultKeyWrapAlgorithm; }
+        }
+
+        public string DefaultSignatureAlgorithm
+        {
+            get { return _implementation.DefaultSignatureAlgorithm; }
+        }
+
+        public string Kid
+        {
+            get { return _implementation.Kid; }
+        }
+
+        public Task<byte[]> DecryptAsync( byte[] ciphertext, byte[] iv, byte[] authenticationData, byte[] authenticationTag, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            if ( string.IsNullOrWhiteSpace( algorithm ) )
+                algorithm = DefaultEncryptionAlgorithm;
+
+            // Never local
+            return _client.DecryptAsync( _implementation.Kid, algorithm, ciphertext, token )
+                    .ContinueWith( result => result.Result.Result, token );
+        }
+
+        public Task<Tuple<byte[], byte[], string>> EncryptAsync( byte[] plaintext, byte[] iv, byte[] authenticationData, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            return _implementation.EncryptAsync( plaintext, iv, authenticationData, algorithm, token );
+        }
+
+        public Task<Tuple<byte[], string>> WrapKeyAsync( byte[] plaintext, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            return _implementation.WrapKeyAsync( plaintext, algorithm, token );
+        }
+
+        public Task<byte[]> UnwrapKeyAsync( byte[] ciphertext, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            if ( string.IsNullOrWhiteSpace( algorithm ) )
+                algorithm = DefaultKeyWrapAlgorithm;
+
+            // Never local
+            return _client.UnwrapKeyAsync( _implementation.Kid, algorithm, ciphertext, token )
+                    .ContinueWith( result => result.Result.Result, token );
+        }
+
+        public Task<Tuple<byte[], string>> SignAsync( byte[] digest, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            if ( string.IsNullOrWhiteSpace( algorithm ) )
+                algorithm = DefaultSignatureAlgorithm;
+
+            // Never local
+            return _client.SignAsync( _implementation.Kid, algorithm, digest, token )
+                .ContinueWith( result => new Tuple<byte[], string>( result.Result.Result, algorithm ), token );
+        }
+
+        public Task<bool> VerifyAsync( byte[] digest, byte[] signature, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            return _implementation.VerifyAsync( digest, signature, algorithm, token );
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/KeyVaultKeyResolver.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/KeyVaultKeyResolver.cs
@@ -1,0 +1,149 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.KeyVault.Core;
+
+namespace Microsoft.Azure.KeyVault
+{
+    public class KeyVaultKeyResolver : IKeyResolver
+    {
+        private readonly KeyVaultClient _client;
+        private readonly string         _name;
+
+        public KeyVaultKeyResolver( KeyVaultClient.AuthenticationCallback cb )
+            : this( new KeyVaultClient( cb ) )
+        {
+        }
+
+        public KeyVaultKeyResolver( KeyVaultClient client )
+            : this( string.Empty, client )
+        {
+        }
+
+        public KeyVaultKeyResolver( string vaultName, KeyVaultClient client )
+        {
+            if ( client == null )
+                throw new ArgumentNullException( "client" );
+
+            _name   = vaultName;
+            _client = client;
+        }
+
+        public async Task<IKey> ResolveKeyAsync( string kid, CancellationToken token = default(CancellationToken) )
+        {
+            if ( string.IsNullOrWhiteSpace( kid ) )
+                throw new ArgumentNullException( "kid" );
+
+            // If the resolver has a name prefix, only handle kid that have that prefix
+            if ( !string.IsNullOrEmpty( _name ) && !kid.StartsWith( _name, StringComparison.OrdinalIgnoreCase ) )
+                return null;
+
+            if ( KeyIdentifier.IsKeyIdentifier( kid ) )
+                return await ResolveKeyFromKeyAsync( kid, token );
+
+            if ( SecretIdentifier.IsSecretIdentifier( kid ) )
+                return await ResolveKeyFromSecretAsync( kid, token );
+
+            // Return null rather than throw an exception here
+            return null;
+        }
+
+        private Task<IKey> ResolveKeyFromKeyAsync( string kid, CancellationToken token )
+        {
+            return _client.GetKeyAsync( kid, token )
+                .ContinueWith<IKey>( task =>
+                {
+                    var keyBundle = task.Result;
+
+                    if ( keyBundle != null )
+                    {
+                        return new KeyVaultKey( _client, keyBundle );
+                    }
+
+                    return null;
+                }, token );
+        }
+
+        private Task<IKey> ResolveKeyFromSecretAsync( string sid, CancellationToken token )
+        {
+            return _client.GetSecretAsync( sid, token )
+                .ContinueWith<IKey>( task =>
+                {
+                    var secret = task.Result;
+
+                    if ( secret != null && string.Equals( secret.ContentType, "application/octet-stream", StringComparison.OrdinalIgnoreCase ) )
+                    {
+                        var keyBytes = FromBase64UrlString( secret.Value );
+
+                        if ( keyBytes != null )
+                        {
+                            return new SymmetricKey( sid, keyBytes );
+                        }
+                    }
+
+                    return null;
+                }, token );
+        }
+
+        /// <summary>
+        /// Converts a byte array to a Base64Url encoded string
+        /// </summary>
+        /// <param name="input">The byte array to convert</param>
+        /// <returns>The Base64Url encoded form of the input</returns>
+        private static string ToBase64UrlString( byte[] input )
+        {
+            if ( input == null )
+                throw new ArgumentNullException( "input" );
+
+            return Convert.ToBase64String( input ).TrimEnd( '=' ).Replace( '+', '-' ).Replace( '/', '_' );
+        }
+
+        /// <summary>
+        /// Converts a Base64Url encoded string to a byte array
+        /// </summary>
+        /// <param name="input">The Base64Url encoded string</param>
+        /// <returns>The byte array represented by the enconded string</returns>
+        private static byte[] FromBase64UrlString( string input )
+        {
+            if ( string.IsNullOrEmpty( input ) )
+                throw new ArgumentNullException( "input" );
+
+            return Convert.FromBase64String( Pad( input.Replace( '-', '+' ).Replace( '_', '/' ) ) );
+        }
+
+        /// <summary>
+        /// Adds padding to the input
+        /// </summary>
+        /// <param name="input"> the input string </param>
+        /// <returns> the padded string </returns>
+        private static string Pad( string input )
+        {
+            var count = 3 - ( ( input.Length + 3 ) % 4 );
+
+            if ( count == 0 )
+            {
+                return input;
+            }
+
+            return input + new string( '=', count );
+        }
+
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/LRUCache.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/LRUCache.cs
@@ -1,0 +1,167 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Microsoft.Azure.KeyVault
+{
+    /// <summary>
+    /// A simple Least Recently Used Cache
+    /// </summary>
+    /// <typeparam name="K">The type of the key</typeparam>
+    /// <typeparam name="V">The type of the value</typeparam>
+    internal class LRUCache<K, V> where K : class where V : class
+    {
+        private int                  _capacity;
+        private Dictionary<K, V>     _cache = new Dictionary<K, V>();
+        private LinkedList<K>        _list  = new LinkedList<K>();
+        private ReaderWriterLockSlim _lock  = new ReaderWriterLockSlim();
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="capacity">The maximum capacity of the cache</param>
+        public LRUCache( int capacity )
+        {
+            if ( capacity <= 0 )
+                throw new ArgumentException( "Capacity must be a positive non-zero value" );
+
+            _capacity = capacity;
+        }
+
+        /// <summary>
+        /// Adds a key and value to the cache.
+        /// </summary>
+        /// <param name="key">The key</param>
+        /// <param name="value">The value</param>
+        public void Add( K key, V value )
+        {
+            if ( key == null )
+                throw new ArgumentNullException( "key" );
+
+            if ( value == null )
+                throw new ArgumentNullException( "value" );
+
+            try
+            {
+                _lock.EnterWriteLock();
+
+                // Cache before List as the cache may throw an exception
+                _cache.Add( key, value );
+                _list.AddLast( key );
+
+                if ( _list.Count > _capacity )
+                {
+                    LinkedListNode<K> lruKey = _list.First;
+
+                    _cache.Remove( lruKey.Value );
+                    _list.RemoveFirst();
+                }
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// Gets a value from the cache.
+        /// </summary>
+        /// <param name="key">The key</param>
+        /// <returns>The value for the key or null</returns>
+        public V Get( K key )
+        {
+            if ( key == null )
+                throw new ArgumentNullException( "key" );
+
+            V value = null;
+
+            try
+            {
+                _lock.EnterUpgradeableReadLock();
+
+                if ( _cache.TryGetValue( key, out value ) )
+                {
+                    try
+                    {
+                        _lock.EnterWriteLock();
+
+                        // Move the key to the tail of the LRU list
+                        _list.Remove( key );
+                        _list.AddLast( key );
+                    }
+                    finally
+                    {
+                        _lock.ExitWriteLock();
+                    }
+                }
+            }
+            finally
+            {
+                _lock.ExitUpgradeableReadLock();
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Removes a key and its value from the cache
+        /// </summary>
+        /// <param name="key">The key to remove</param>
+        public void Remove( K key )
+        {
+            if ( key == null )
+                throw new ArgumentNullException( "key" );
+
+            try
+            {
+                _lock.EnterUpgradeableReadLock();
+
+                if ( _cache.ContainsKey( key ) )
+                {
+                    _cache.Remove( key );
+                    _list.Remove( key );
+                }
+            }
+            finally
+            {
+                _lock.ExitUpgradeableReadLock();
+            }
+        }
+
+        /// <summary>
+        /// Resets the content of the cache.
+        /// </summary>
+        public void Reset()
+        {
+            try
+            {
+                _lock.EnterWriteLock();
+
+                _cache.Clear();
+                _list.Clear();
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/LRUCache.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/LRUCache.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.KeyVault
     /// </summary>
     /// <typeparam name="K">The type of the key</typeparam>
     /// <typeparam name="V">The type of the value</typeparam>
-    internal class LRUCache<K, V> where K : class where V : class
+    internal class LRUCache<K, V> : IDisposable where K : class where V : class
     {
         private int                  _capacity;
         private Dictionary<K, V>     _cache = new Dictionary<K, V>();
@@ -53,6 +53,9 @@ namespace Microsoft.Azure.KeyVault
         /// <param name="value">The value</param>
         public void Add( K key, V value )
         {
+            if ( _lock == null )
+                throw new ObjectDisposedException( "LRUCache" );
+
             if ( key == null )
                 throw new ArgumentNullException( "key" );
 
@@ -88,6 +91,9 @@ namespace Microsoft.Azure.KeyVault
         /// <returns>The value for the key or null</returns>
         public V Get( K key )
         {
+            if ( _lock == null )
+                throw new ObjectDisposedException( "LRUCache" );
+
             if ( key == null )
                 throw new ArgumentNullException( "key" );
 
@@ -127,6 +133,9 @@ namespace Microsoft.Azure.KeyVault
         /// <param name="key">The key to remove</param>
         public void Remove( K key )
         {
+            if ( _lock == null )
+                throw new ObjectDisposedException( "LRUCache" );
+
             if ( key == null )
                 throw new ArgumentNullException( "key" );
 
@@ -151,6 +160,9 @@ namespace Microsoft.Azure.KeyVault
         /// </summary>
         public void Reset()
         {
+            if ( _lock == null )
+                throw new ObjectDisposedException( "LRUCache" );
+
             try
             {
                 _lock.EnterWriteLock();
@@ -161,6 +173,24 @@ namespace Microsoft.Azure.KeyVault
             finally
             {
                 _lock.ExitWriteLock();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose( true );
+            GC.SuppressFinalize( this );
+        }
+
+        protected virtual void Dispose( bool disposing )
+        {
+            if ( disposing )
+            {
+                if ( _lock != null )
+                {
+                    _lock.Dispose();
+                    _lock = null;
+                }
             }
         }
     }

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.nuget.proj
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.nuget.proj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <!--
+    Microsoft.Azure.KeyVault.Extensions
+    -->
+    <SdkNuGetPackage Include="Microsoft.Azure.KeyVault.Extensions">
+      <PackageVersion>0.9.0-preview</PackageVersion>
+      <Folder>$(MSBuildThisFileDirectory)</Folder>
+    </SdkNuGetPackage>
+  </ItemGroup>
+</Project>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.nuspec
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.nuspec
@@ -24,9 +24,17 @@
       </group>
     </references>
     <dependencies>
-      <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
-      <dependency id="Microsoft.Azure.KeyVault" version="0.9.0-preview" />
-      <dependency id="Microsoft.Azure.KeyVault.Core" version="0.1.0-preview" />
+      <group targetFramework="net40">
+        <dependency id="Microsoft.Bcl" version="1.1.9" />
+        <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
+        <dependency id="Microsoft.Bcl.Build" version="1.0.14" />
+        <dependency id="Microsoft.Azure.KeyVault" version="0.9.0-preview" />
+        <dependency id="Microsoft.Azure.KeyVault.Core" version="0.9.0-preview" />
+      </group>
+      <group targetFramework="net45">
+        <dependency id="Microsoft.Azure.KeyVault" version="0.9.0-preview" />
+        <dependency id="Microsoft.Azure.KeyVault.Core" version="0.9.0-preview" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.nuspec
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.nuspec
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata minClientVersion="2.5">
+    <id>Microsoft.Azure.KeyVault.Extensions</id>
+    <title>Microsoft Azure Key Vault Extensions Library</title>
+    <releaseNotes>Initial release</releaseNotes>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>azure-sdk, Microsoft</owners>
+    <licenseUrl>http://aka.ms/windowsazureapache2</licenseUrl>
+    <projectUrl>https://github.com/Azure/azure-sdk-for-net</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>Provides extended capabilities for Azure Key Vault.</summary>
+    <description>Provides extended capabilities for Azure Key Vault.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags>Microsoft Azure key vault "key vault" azureofficial windowsazureofficial</tags>
+    <references>
+      <group targetFramework="net45">
+        <reference file="Microsoft.Azure.KeyVault.Extensions.dll" />
+      </group>
+      <group targetFramework="net40">
+        <reference file="Microsoft.Azure.KeyVault.Extensions.dll" />
+      </group>
+    </references>
+    <dependencies>
+      <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
+      <dependency id="Microsoft.Azure.KeyVault" version="0.9.0-preview" />
+      <dependency id="Microsoft.Azure.KeyVault.Core" version="0.1.0-preview" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="KeyVault\Microsoft.Azure.KeyVault.Extensions\**\*.cs" target="src" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Extensions.dll" target="lib\net45" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Extensions.pdb" target="lib\net45" />
+    <file src="..\binaries\net45\Microsoft.Azure.KeyVault.Extensions.xml" target="lib\net45" />
+    <file src="..\binaries\net40\Microsoft.Azure.KeyVault.Extensions.dll" target="lib\net40" />
+    <file src="..\binaries\net40\Microsoft.Azure.KeyVault.Extensions.pdb" target="lib\net40" />
+    <file src="..\binaries\net40\Microsoft.Azure.KeyVault.Extensions.xml" target="lib\net40" />
+  </files>
+</package>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/RsaKey.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/RsaKey.cs
@@ -1,0 +1,325 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.KeyVault.Core;
+using Microsoft.Azure.KeyVault.Cryptography;
+using Microsoft.Azure.KeyVault.Cryptography.Algorithms;
+
+namespace Microsoft.Azure.KeyVault
+{
+    /// <summary>
+    /// An RSA key.
+    /// </summary>
+    public class RsaKey : IKey, IDisposable
+    {
+        public const int KeySize1024 = 1024;
+        public const int KeySize2048 = 2048;
+
+        private static readonly int DefaultKeySize = KeySize2048;
+
+        private RSACryptoServiceProvider _csp;
+
+        /// <summary>
+        /// Key Identifier
+        /// </summary>
+        public string Kid { get; private set; }
+
+        /// <summary>
+        /// Constructor, creates a 2048 bit key with a GUID identifier.
+        /// </summary>
+        public RsaKey() : this( Guid.NewGuid().ToString( "D" ), DefaultKeySize )
+        {
+        }
+
+        /// <summary>
+        /// Constructor, creates a 2048 bit RSA key.
+        /// </summary>
+        /// <param name="kid">The key identifier to use</param>
+        public RsaKey( string kid ) : this( kid, DefaultKeySize )
+        {
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="kid">The key identifier to use</param>
+        /// <param name="keySize">The size of the key</param>
+        public RsaKey( string kid, int keySize )
+        {
+            if ( string.IsNullOrWhiteSpace( kid ) )
+                throw new ArgumentNullException( "kid" );
+
+            Kid = kid;
+
+            _csp = new RSACryptoServiceProvider( keySize );
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="kid">The key identifier to use</param>
+        /// <param name="keyParameters">The RSA parameters for the key</param>
+        public RsaKey( string kid, RSAParameters keyParameters )
+        {
+            if ( string.IsNullOrWhiteSpace( kid ) )
+                throw new ArgumentNullException( "kid" );
+
+            Kid = kid;
+
+            _csp = new RSACryptoServiceProvider();
+            _csp.ImportParameters( keyParameters );
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="kid">The key identifier to use</param>
+        /// <param name="csp">The RSA CSP object for the key</param>
+        /// <remarks>A new CSP is created using the parameters from the parameter CSP</remarks>
+        public RsaKey( string kid, RSACryptoServiceProvider csp )
+        {
+            if ( string.IsNullOrWhiteSpace( kid ) )
+                throw new ArgumentNullException( "kid" );
+
+            if ( csp == null )
+                throw new ArgumentNullException( "csp" );
+
+            Kid = kid;
+
+            _csp = new RSACryptoServiceProvider();
+            _csp.ImportParameters( csp.PublicOnly ? csp.ExportParameters( false ) : csp.ExportParameters( true ) );
+        }
+
+        // Intentionally excluded.
+        //~RsaKey()
+        //{
+        //    Dispose( false );
+        //}
+
+        public void Dispose()
+        {
+            Dispose( true );
+            GC.SuppressFinalize( this );
+        }
+
+        protected virtual void Dispose( bool disposing )
+        {
+            // Clean up managed resources if Dispose was called
+            if ( disposing )
+            {
+                if ( _csp != null )
+                {
+                    _csp.Dispose();
+                    _csp = null;
+                }
+            }
+
+            // Clean up native resources always
+        }
+
+        /// <summary>
+        /// Indicates whether the RSA key has only public key material.
+        /// </summary>
+        public bool PublicOnly
+        {
+            get
+            {
+                if ( _csp == null )
+                    throw new ObjectDisposedException( string.Format( "RsaKey {0} is disposed", Kid ) );
+
+                return _csp.PublicOnly; }
+        }
+
+        #region IKey implementation
+
+        public string DefaultEncryptionAlgorithm
+        {
+            get { return RsaOaep.AlgorithmName; }
+        }
+
+        public string DefaultKeyWrapAlgorithm
+        {
+            get { return RsaOaep.AlgorithmName; }
+        }
+
+        public string DefaultSignatureAlgorithm
+        {
+            get { return Rs256.AlgorithmName; }
+        }
+        
+// Warning 1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+#pragma warning disable 1998
+
+        public async Task<byte[]> DecryptAsync( byte[] ciphertext, byte[] iv, byte[] authenticationData = null, byte[] authenticationTag = null, string algorithm = RsaOaep.AlgorithmName, CancellationToken token = default(CancellationToken) )
+        {
+            if ( _csp == null )
+                throw new ObjectDisposedException( string.Format( "RsaKey {0} is disposed", Kid ) );
+
+            if ( string.IsNullOrWhiteSpace( algorithm ) )
+                algorithm = DefaultEncryptionAlgorithm;
+
+            if ( ciphertext == null || ciphertext.Length == 0 )
+                throw new ArgumentNullException( "ciphertext" );
+
+            if ( iv != null )
+                throw new ArgumentException( "Initialization vector must be null", "iv" );
+
+            if ( authenticationData != null )
+                throw new ArgumentException( "Authentication data must be null", "authenticationData" );
+
+            if ( _csp.PublicOnly )
+                throw new NotSupportedException( "Decrypt is not supported because no private key is available" );
+
+            AsymmetricEncryptionAlgorithm algo = AlgorithmResolver.Default[algorithm] as AsymmetricEncryptionAlgorithm;
+
+            if ( algo == null )
+                throw new NotSupportedException( "algorithm is not supported" );
+
+            using ( var encryptor = algo.CreateDecryptor( _csp ) )
+            {
+                return encryptor.TransformFinalBlock( ciphertext, 0, ciphertext.Length );
+            }
+        }
+
+        public async Task<Tuple<byte[], byte[], string>> EncryptAsync( byte[] plaintext, byte[] iv = null, byte[] authenticationData = null, string algorithm = RsaOaep.AlgorithmName, CancellationToken token = default(CancellationToken) )
+        {
+            if ( _csp == null )
+                throw new ObjectDisposedException( string.Format( "RsaKey {0} is disposed", Kid ) );
+
+            if ( string.IsNullOrWhiteSpace( algorithm ) )
+                algorithm = DefaultEncryptionAlgorithm;
+
+            if ( plaintext == null || plaintext.Length == 0 )
+                throw new ArgumentNullException( "plaintext" );
+
+            if ( iv != null )
+                throw new ArgumentException( "Initialization vector must be null", "iv" );
+
+            if ( authenticationData != null )
+                throw new ArgumentException( "Authentication data must be null", "authenticationData" );
+
+            AsymmetricEncryptionAlgorithm algo = AlgorithmResolver.Default[algorithm] as AsymmetricEncryptionAlgorithm;
+
+            if ( algo == null )
+                throw new NotSupportedException( "algorithm is not supported" );
+
+            using ( var encryptor = algo.CreateEncryptor( _csp ) )
+            {
+                return new Tuple<byte[], byte[], string>( encryptor.TransformFinalBlock( plaintext, 0, plaintext.Length ), null, algorithm );
+            }
+        }
+
+        public async Task<Tuple<byte[], string>> WrapKeyAsync( byte[] key, string algorithm = RsaOaep.AlgorithmName, CancellationToken token = default(CancellationToken) )
+        {
+            if ( _csp == null )
+                throw new ObjectDisposedException( string.Format( "RsaKey {0} is disposed", Kid ) );
+
+            if ( string.IsNullOrWhiteSpace( algorithm ) )
+                algorithm = DefaultKeyWrapAlgorithm;
+
+            if ( key == null || key.Length == 0 )
+                throw new ArgumentNullException( "key" );
+
+            AsymmetricEncryptionAlgorithm algo = AlgorithmResolver.Default[algorithm] as AsymmetricEncryptionAlgorithm;
+
+            if ( algo == null )
+                throw new NotSupportedException( "algorithm is not supported" );
+
+            using ( var encryptor = algo.CreateEncryptor( _csp ) )
+            {
+                return new Tuple<byte[], string>( encryptor.TransformFinalBlock( key, 0, key.Length ), algorithm );
+            }
+        }
+
+        public async Task<byte[]> UnwrapKeyAsync( byte[] wrappedKey, string algorithm = RsaOaep.AlgorithmName, CancellationToken token = default(CancellationToken) )
+        {
+            if ( _csp == null )
+                throw new ObjectDisposedException( string.Format( "RsaKey {0} is disposed", Kid ) );
+
+            if ( string.IsNullOrWhiteSpace( algorithm ) )
+                algorithm = DefaultKeyWrapAlgorithm;
+
+            if ( wrappedKey == null || wrappedKey.Length == 0 )
+                throw new ArgumentNullException( "wrappedKey" );
+
+            if ( _csp.PublicOnly )
+                throw new NotSupportedException( "UnwrapKey is not supported because no private key is available" );
+
+            AsymmetricEncryptionAlgorithm algo = AlgorithmResolver.Default[algorithm] as AsymmetricEncryptionAlgorithm;
+
+            if ( algo == null )
+                throw new NotSupportedException( "algorithm is not supported" );
+
+            using ( var encryptor = algo.CreateDecryptor( _csp ) )
+            {
+                return encryptor.TransformFinalBlock( wrappedKey, 0, wrappedKey.Length );
+            }
+        }
+
+        public async Task<Tuple<byte[], string>> SignAsync( byte[] digest, string algorithm, CancellationToken token = default(CancellationToken) )
+        {
+            if ( _csp == null )
+                throw new ObjectDisposedException( string.Format( "RsaKey {0} is disposed", Kid ) );
+
+            if ( algorithm == null )
+                algorithm = DefaultSignatureAlgorithm;
+
+            if ( digest == null )
+                throw new ArgumentNullException( "digest" );
+
+            if ( _csp.PublicOnly )
+                throw new NotSupportedException( "Sign is not supported because no private key is available" );
+
+            AsymmetricSignatureAlgorithm algo = AlgorithmResolver.Default[algorithm] as AsymmetricSignatureAlgorithm;
+
+            if ( algo == null )
+                throw new NotSupportedException( "algorithm is not supported" );
+
+            return new Tuple<byte[], string>( algo.SignHash( _csp, digest ), algorithm );
+        }
+
+        public async Task<bool> VerifyAsync( byte[] digest, byte[] signature, string algorithm, CancellationToken token = default(CancellationToken) )
+        {
+            if ( _csp == null )
+                throw new ObjectDisposedException( string.Format( "RsaKey {0} is disposed", Kid ) );
+
+            if ( digest == null )
+                throw new ArgumentNullException( "digest" );
+
+            if ( signature == null )
+                throw new ArgumentNullException( "signature" );
+
+            if ( algorithm == null )
+                algorithm = DefaultSignatureAlgorithm;
+
+            AsymmetricSignatureAlgorithm algo = AlgorithmResolver.Default[algorithm] as AsymmetricSignatureAlgorithm;
+
+            if ( algo == null )
+                throw new NotSupportedException( "algorithm is not supported" );
+
+            return algo.VerifyHash( _csp, digest, signature );
+        }
+
+#pragma warning restore 1998
+
+        #endregion
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/RsaKey.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/RsaKey.cs
@@ -16,6 +16,7 @@
 // governing permissions and limitations under the License.
 
 using System;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -143,7 +144,7 @@ namespace Microsoft.Azure.KeyVault
             get
             {
                 if ( _csp == null )
-                    throw new ObjectDisposedException( string.Format( "RsaKey {0} is disposed", Kid ) );
+                    throw new ObjectDisposedException( string.Format( CultureInfo.InvariantCulture, "RsaKey {0} is disposed", Kid ) );
 
                 return _csp.PublicOnly; }
         }
@@ -249,7 +250,7 @@ namespace Microsoft.Azure.KeyVault
             }
         }
 
-        public async Task<byte[]> UnwrapKeyAsync( byte[] wrappedKey, string algorithm = RsaOaep.AlgorithmName, CancellationToken token = default(CancellationToken) )
+        public async Task<byte[]> UnwrapKeyAsync( byte[] encryptedKey, string algorithm = RsaOaep.AlgorithmName, CancellationToken token = default(CancellationToken) )
         {
             if ( _csp == null )
                 throw new ObjectDisposedException( string.Format( "RsaKey {0} is disposed", Kid ) );
@@ -257,7 +258,7 @@ namespace Microsoft.Azure.KeyVault
             if ( string.IsNullOrWhiteSpace( algorithm ) )
                 algorithm = DefaultKeyWrapAlgorithm;
 
-            if ( wrappedKey == null || wrappedKey.Length == 0 )
+            if ( encryptedKey == null || encryptedKey.Length == 0 )
                 throw new ArgumentNullException( "wrappedKey" );
 
             if ( _csp.PublicOnly )
@@ -270,7 +271,7 @@ namespace Microsoft.Azure.KeyVault
 
             using ( var encryptor = algo.CreateDecryptor( _csp ) )
             {
-                return encryptor.TransformFinalBlock( wrappedKey, 0, wrappedKey.Length );
+                return encryptor.TransformFinalBlock( encryptedKey, 0, encryptedKey.Length );
             }
         }
 

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/SymmetricKey.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/SymmetricKey.cs
@@ -1,0 +1,283 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.KeyVault.Core;
+using Microsoft.Azure.KeyVault.Cryptography;
+using Microsoft.Azure.KeyVault.Cryptography.Algorithms;
+
+namespace Microsoft.Azure.KeyVault
+{
+    /// <summary>
+    /// A simple Symmetric Key
+    /// </summary>
+    public class SymmetricKey : IKey
+    {
+        public const int KeySize128 = 128 >> 3;
+        public const int KeySize192 = 192 >> 3;
+        public const int KeySize256 = 256 >> 3;
+        public const int KeySize384 = 384 >> 3;
+        public const int KeySize512 = 512 >> 3;
+
+        private static readonly int                      DefaultKeySize = KeySize256;
+        private static readonly RNGCryptoServiceProvider Rng            = new RNGCryptoServiceProvider();
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public SymmetricKey()
+            : this( Guid.NewGuid().ToString( "N" ), DefaultKeySize )
+        {
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="kid">The key identifier to use</param>
+        public SymmetricKey( string kid )
+            : this( kid, DefaultKeySize )
+        {
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="kid">The key identifier to use</param>
+        /// <param name="keySize">The key size</param>
+        public SymmetricKey( string kid, int keySize )
+        {
+            if ( string.IsNullOrWhiteSpace( kid ) )
+                throw new ArgumentNullException( "kid" );
+
+            if ( keySize != KeySize128 && keySize != KeySize192 && keySize != KeySize256 && keySize != KeySize384 && keySize != KeySize512 )
+                throw new ArgumentOutOfRangeException( "keySize", "The key size must be 128, 192, 256, 384 or 512 bits of data" );
+
+            Kid = kid;
+            Key = new byte[keySize];
+
+            Rng.GetNonZeroBytes( Key );
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="kid">The key identifier</param>
+        /// <param name="keyBytes">The key material</param>
+        public SymmetricKey( string kid, byte[] keyBytes )
+        {
+            if ( string.IsNullOrWhiteSpace( kid ) )
+                throw new ArgumentNullException( "kid" );
+
+            if ( keyBytes == null )
+                throw new ArgumentNullException( "keyBytes" );
+
+            if ( keyBytes.Length != KeySize128 && keyBytes.Length != KeySize192 && keyBytes.Length != KeySize256 && keyBytes.Length != KeySize384 && keyBytes.Length != KeySize512 )
+                throw new ArgumentOutOfRangeException( "keyBytes", "The key material must be 128, 192, 256, 384 or 512 bits of data" );
+
+            Kid = kid;
+            Key = keyBytes;
+        }
+
+        public byte[] Key { get; private set; }
+
+        #region IKey Implementation
+
+        public string Kid { get; protected set; }
+
+        public string DefaultEncryptionAlgorithm
+        {
+            get
+            {
+                switch ( Key.Length )
+                {
+                    case KeySize128:
+                        return Aes128Cbc.AlgorithmName;
+
+                    case KeySize192:
+                        return Aes192Cbc.AlgorithmName;
+
+                    case KeySize256:
+                        return Aes128CbcHmacSha256.AlgorithmName;
+
+                    case KeySize384:
+                        return Aes192CbcHmacSha384.AlgorithmName;
+
+                    case KeySize512:
+                        return Aes256CbcHmacSha512.AlgorithmName;
+                }
+
+                return null;
+            }
+        }
+
+        public string DefaultKeyWrapAlgorithm
+        {
+            get
+            {
+                switch ( Key.Length )
+                {
+                    case KeySize128:
+                        return AesKw128.AlgorithmName;
+
+                    case KeySize192:
+                        return AesKw192.AlgorithmName;
+
+                    case KeySize256:
+                        return AesKw256.AlgorithmName;
+
+                    case KeySize384:
+                        // TODO
+                        return AesKw256.AlgorithmName;
+
+                    case KeySize512:
+                        return AesKw256.AlgorithmName;
+                }
+
+                return null;
+            }
+        }
+
+        public string DefaultSignatureAlgorithm
+        {
+            get { return null; }
+        }
+
+        // Warning 1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+#pragma warning disable 1998
+
+        public async Task<byte[]> DecryptAsync( byte[] ciphertext, byte[] iv, byte[] authenticationData = null, byte[] authenticationTag = null, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            if ( string.IsNullOrWhiteSpace( algorithm ) )
+                algorithm = DefaultEncryptionAlgorithm;
+
+            if ( ciphertext == null )
+                throw new ArgumentNullException( "ciphertext" );
+
+            if ( iv == null )
+                throw new ArgumentNullException( "iv" );
+
+            var algo = AlgorithmResolver.Default[algorithm] as SymmetricEncryptionAlgorithm;
+
+            if ( algo == null )
+                throw new NotSupportedException( algorithm );
+
+            using ( var encryptor = algo.CreateDecryptor( Key, iv, authenticationData ) )
+            {
+                var result    = encryptor.TransformFinalBlock( ciphertext, 0, ciphertext.Length );
+                var transform = encryptor as IAuthenticatedCryptoTransform;
+
+                if ( transform == null )
+                    return result;
+
+                if ( authenticationData == null || authenticationTag == null )
+                    throw new CryptographicException( "AuthenticatingCryptoTransform requires authenticationData and authenticationTag" );
+
+                if ( !authenticationTag.SequenceEqual( transform.Tag ) )
+                    throw new CryptographicException( "Data is not authentic" );
+
+                return result;
+            }
+        }
+
+        public async Task<Tuple<byte[], byte[], string>> EncryptAsync( byte[] plaintext, byte[] iv, byte[] authenticationData = null, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            if ( string.IsNullOrWhiteSpace( algorithm ) )
+                algorithm = DefaultEncryptionAlgorithm;
+
+            if ( plaintext == null )
+                throw new ArgumentNullException( "plaintext" );
+
+            if ( iv == null )
+                throw new ArgumentNullException( "iv" );
+
+            var algo = AlgorithmResolver.Default[algorithm] as SymmetricEncryptionAlgorithm;
+
+            if ( algo == null )
+                throw new NotSupportedException( algorithm );
+
+            using ( var encryptor = algo.CreateEncryptor( Key, iv, authenticationData ) )
+            {
+                var    cipherText        = encryptor.TransformFinalBlock( plaintext, 0, plaintext.Length );
+                byte[] authenticationTag = null;
+                var    transform         = encryptor as IAuthenticatedCryptoTransform;
+
+                if ( transform != null )
+                {
+                    authenticationTag = transform.Tag.Clone() as byte[];
+                }
+
+                return new Tuple<byte[],byte[], string>( cipherText, authenticationTag, algorithm );
+            }
+        }
+
+        public async Task<Tuple<byte[], string>> WrapKeyAsync( byte[] key, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            if ( string.IsNullOrWhiteSpace( algorithm ) )
+                algorithm = DefaultKeyWrapAlgorithm;
+
+            if ( key == null || key.Length == 0 )
+                throw new ArgumentNullException( "key" );
+
+            var algo = AlgorithmResolver.Default[algorithm] as KeyWrapAlgorithm;
+
+            if ( algo == null )
+                throw new NotSupportedException( algorithm );
+
+            using ( var encryptor = algo.CreateEncryptor( Key ) )
+            {
+                return new Tuple<byte[], string>( encryptor.TransformFinalBlock( key, 0, key.Length ), algorithm );
+            }
+        }
+
+        public async Task<byte[]> UnwrapKeyAsync( byte[] wrappedKey, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            if ( string.IsNullOrWhiteSpace( algorithm ) )
+                algorithm = DefaultKeyWrapAlgorithm;
+
+            if ( wrappedKey == null || wrappedKey.Length == 0 )
+                throw new ArgumentNullException( "wrappedKey" );
+
+            var algo = AlgorithmResolver.Default[algorithm] as KeyWrapAlgorithm;
+
+            if ( algo == null )
+                throw new NotSupportedException( algorithm );
+
+            using ( var encryptor = algo.CreateDecryptor( Key ) )
+            {
+                return encryptor.TransformFinalBlock( wrappedKey, 0, wrappedKey.Length );
+            }
+        }
+
+        public async Task<Tuple<byte[], string>> SignAsync( byte[] digest, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<bool> VerifyAsync( byte[] digest, byte[] signature, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        {
+            throw new NotImplementedException();
+        }
+
+#pragma warning restore 1998
+
+        #endregion
+    }
+}

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/SymmetricKey.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/SymmetricKey.cs
@@ -144,10 +144,11 @@ namespace Microsoft.Azure.KeyVault
                         return AesKw256.AlgorithmName;
 
                     case KeySize384:
-                        // TODO
+                        // Default to longest allowed key length for wrap
                         return AesKw256.AlgorithmName;
 
                     case KeySize512:
+                        // Default to longest allowed key length for wrap
                         return AesKw256.AlgorithmName;
                 }
 
@@ -241,18 +242,18 @@ namespace Microsoft.Azure.KeyVault
             if ( algo == null )
                 throw new NotSupportedException( algorithm );
 
-            using ( var encryptor = algo.CreateEncryptor( Key ) )
+            using ( var encryptor = algo.CreateEncryptor( Key, null ) )
             {
                 return new Tuple<byte[], string>( encryptor.TransformFinalBlock( key, 0, key.Length ), algorithm );
             }
         }
 
-        public async Task<byte[]> UnwrapKeyAsync( byte[] wrappedKey, string algorithm = null, CancellationToken token = default(CancellationToken) )
+        public async Task<byte[]> UnwrapKeyAsync( byte[] encryptedKey, string algorithm = null, CancellationToken token = default(CancellationToken) )
         {
             if ( string.IsNullOrWhiteSpace( algorithm ) )
                 algorithm = DefaultKeyWrapAlgorithm;
 
-            if ( wrappedKey == null || wrappedKey.Length == 0 )
+            if ( encryptedKey == null || encryptedKey.Length == 0 )
                 throw new ArgumentNullException( "wrappedKey" );
 
             var algo = AlgorithmResolver.Default[algorithm] as KeyWrapAlgorithm;
@@ -260,9 +261,9 @@ namespace Microsoft.Azure.KeyVault
             if ( algo == null )
                 throw new NotSupportedException( algorithm );
 
-            using ( var encryptor = algo.CreateDecryptor( Key ) )
+            using ( var encryptor = algo.CreateDecryptor( Key, null ) )
             {
-                return encryptor.TransformFinalBlock( wrappedKey, 0, wrappedKey.Length );
+                return encryptor.TransformFinalBlock( encryptedKey, 0, encryptedKey.Length );
             }
         }
 
@@ -279,5 +280,16 @@ namespace Microsoft.Azure.KeyVault
 #pragma warning restore 1998
 
         #endregion
+
+        public void Dispose()
+        {
+            Dispose( true );
+            GC.SuppressFinalize( this );
+        }
+
+        protected virtual void Dispose( bool disposing )
+        {
+            // Intentionally empty: IDisposable is the base for IKey
+        }
     }
 }

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/WebKey/JsonWebKey.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/WebKey/JsonWebKey.cs
@@ -1,0 +1,93 @@
+﻿//
+// Copyright © Microsoft Corporation, All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.WebKey
+{
+    public static class JsonWebKeyExtensions
+    {
+        /// <summary>
+        /// Converts a WebKey of type Octet to an AES object.
+        /// </summary>        
+        /// <returns>An initialize AES provider</returns>
+        /// <remarks>Throws InvalidOperationException if the JsonWebKey is not an Octet key</remarks>
+        public static Aes ToAes( this JsonWebKey self )
+        {
+            if ( !self.Kty.Equals( JsonWebKeyType.Octet ) )
+                throw new InvalidOperationException( "key is not an octet key" );
+
+            if ( self.K == null )
+                throw new InvalidOperationException( "key does not contain a value" );
+
+            Aes aesProvider = Aes.Create();
+
+            if ( aesProvider != null )
+                aesProvider.Key = self.K;
+
+            return aesProvider;
+        }
+
+        /// <summary>
+        /// Converts a WebKey of type RSA or RSA-HSM to a RSA provider
+        /// </summary>
+        /// <param name="includePrivateParameters">Determines whether private key material, if available, is included</param>
+        /// <returns>An initialized RSACryptoServiceProvider instance</returns>
+        /// <remarks>Throws InvalidOperationException if the JsonWebKey is not RSA key</remarks>
+        public static RSACryptoServiceProvider ToRSA( this JsonWebKey self, bool includePrivateParameters = false )
+        {
+            var rsaParameters = self.ToRSAParameters( includePrivateParameters );
+            var rsaProvider   = new RSACryptoServiceProvider();
+
+            rsaProvider.ImportParameters( rsaParameters );
+
+            return rsaProvider;
+        }
+
+
+        /// <summary>
+        /// Converts a WebKey of type RSA or RSA-HSM to a RSA provider
+        /// </summary>
+        /// <param name="includePrivateParameters">Determines whether private key material, if available, is included</param>
+        /// <returns>An initialized RSACryptoServiceProvider instance</returns>
+        /// <remarks>Throws InvalidOperationException if the JsonWebKey is not a RSA key</remarks>
+        public static RSAParameters ToRSAParameters( this JsonWebKey self, bool includePrivateParameters = false )
+        {
+            if ( !string.Equals( JsonWebKeyType.Rsa, self.Kty ) && !string.Equals( JsonWebKeyType.RsaHsm, self.Kty ) )
+                throw new InvalidOperationException( "Key is not a RSA key" );
+
+            var result = new RSAParameters()
+            {
+                Modulus  = self.N,
+                Exponent = self.E,
+            };
+
+            if ( includePrivateParameters )
+            {
+                result.D        = self.D;
+                result.DP       = self.DP;
+                result.DQ       = self.DQ;
+                result.InverseQ = self.QI;
+                result.P        = self.P;
+                result.Q        = self.Q;
+            }
+
+            return result;
+        }
+    }
+ }

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/WebKey/JsonWebKey.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/WebKey/JsonWebKey.cs
@@ -27,8 +27,12 @@ namespace Microsoft.Azure.KeyVault.WebKey
         /// </summary>        
         /// <returns>An initialize AES provider</returns>
         /// <remarks>Throws InvalidOperationException if the JsonWebKey is not an Octet key</remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage( "Microsoft.Reliability", "CA2000:Dispose objects before losing scope" )]
         public static Aes ToAes( this JsonWebKey self )
         {
+            if ( self == null )
+                throw new ArgumentNullException( "self" );
+
             if ( !self.Kty.Equals( JsonWebKeyType.Octet ) )
                 throw new InvalidOperationException( "key is not an octet key" );
 
@@ -51,6 +55,9 @@ namespace Microsoft.Azure.KeyVault.WebKey
         /// <remarks>Throws InvalidOperationException if the JsonWebKey is not RSA key</remarks>
         public static RSACryptoServiceProvider ToRSA( this JsonWebKey self, bool includePrivateParameters = false )
         {
+            if ( self == null )
+                throw new ArgumentNullException( "self" );
+
             var rsaParameters = self.ToRSAParameters( includePrivateParameters );
             var rsaProvider   = new RSACryptoServiceProvider();
 
@@ -68,6 +75,9 @@ namespace Microsoft.Azure.KeyVault.WebKey
         /// <remarks>Throws InvalidOperationException if the JsonWebKey is not a RSA key</remarks>
         public static RSAParameters ToRSAParameters( this JsonWebKey self, bool includePrivateParameters = false )
         {
+            if ( self == null )
+                throw new ArgumentNullException( "self" );
+
             if ( !string.Equals( JsonWebKeyType.Rsa, self.Kty ) && !string.Equals( JsonWebKeyType.RsaHsm, self.Kty ) )
                 throw new InvalidOperationException( "Key is not a RSA key" );
 

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/packages.config
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
+</packages>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/packages.config
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.1.8" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
**Describe the bug**
When using the SDK for long-running processes, we've noticed that it's causing Linux workloads to run out of connections (https://github.com/tomkerkhove/promitor/issues/798).

After digging deeper, we thought we were not using the SDK correctly so we've POCed a refactoring where we only authenticate once and re-use it for the rest of the processing (https://github.com/tomkerkhove/promitor/pull/844).

After digging deeper, [@maartenba found that the SDK is creating a lot of HttpClients ](https://github.com/tomkerkhove/promitor/pull/844#issuecomment-577135547) and not re-using them.

Is this on purpose or is this a bug?

***Exception or Stack Trace***
```
System.Net.Http.HttpRequestException: Too many open files in system ---> System.Net.Sockets.SocketException: Too many open files in system
   at System.Net.Sockets.Socket..ctor(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
   at System.Net.Sockets.DualSocketMultipleConnectAsync..ctor(SocketType socketType, ProtocolType protocolType)
   at System.Net.Sockets.Socket.ConnectAsync(SocketType socketType, ProtocolType protocolType, SocketAsyncEventArgs e)
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
```

**To Reproduce**
Steps to reproduce the behavior:
- Authenticate client
- Have look how many clients are created

**Expected behavior**
Re-use of one HttpClient rather than 70+

**Setup (please complete the following information):**
 - OS: Linux
 - IDE : Visual Studio
 - Version of the Library used: 1.30.0

**Information Checklist**
Kindly make sure that you have added all the following information above and checkoff the required fields otherwise we will treat the issuer as an incomplete report
- [X] Bug Description Added
- [X] Repro Steps Added
- [X] Setup information Added
