### PR TITLE
Local

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -36,8 +36,8 @@
   
   /p:NuGetKey=NUGET_PUBLISHING_KEY
     Provides the key used to publish to a NuGet or MyGet server.
-
     This key should never be committed to source control.
+    
   /p:NuGetPublishingSource=Uri
     The NuGet Server to push packages to.
   -->  

--- a/build.proj
+++ b/build.proj
@@ -38,17 +38,8 @@
     Provides the key used to publish to a NuGet or MyGet server.
 
     This key should never be committed to source control.
-
-  /p:PublishSymbolSourcePackages
-    A true/false value indicating whether to push the symbol + source
-    packages to a symbol server.
-
   /p:NuGetPublishingSource=Uri
     The NuGet Server to push packages to.
-
-  /p:NuGetSymbolPublishingSource=Uri
-    The NuGet Server to push symbol + source packages to.
-
   -->  
   
   <PropertyGroup>

--- a/tools/Library.Settings.targets
+++ b/tools/Library.Settings.targets
@@ -131,6 +131,6 @@
     </PropertyGroup>
 
     <!-- Update all explicit references to dependent versions. -->
-    <Exec Command="$(PowerShellExe) -NonInteractive -ExecutionPolicy bypass -Command &quot;&amp; { &amp;&apos;$(NuSpecSyncScript)&apos; &apos;$(MSBuildProjectDirectory)&apos; -BasePath &apos;$(LibrarySourceFolder)&apos; }&quot;" />
+    <Exec Command="$(PowerShellExe) -NonInteractive -ExecutionPolicy bypass -Command &quot;&amp; { &amp;&apos;$(NuSpecSyncScript)&apos; &apos;$(MSBuildProjectDirectory)&apos; }&quot;" />
   </Target>
 </Project>

--- a/tools/Sync-NuspecDependencies.ps1
+++ b/tools/Sync-NuspecDependencies.ps1
@@ -1,13 +1,9 @@
 [CmdletBinding()]
 Param(
 [Parameter(Mandatory=$False, Position=0)]
-[string]$Folder,
-[Parameter(Mandatory=$False)]
-[string]$BasePath
+[string]$Folder
 )
 
-if ($BasePath -eq '' -or $BasePath -eq $null) { $BasePath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)\..\src" }
-echo "Base path: $BasePath" 
 $ErrorActionPreference = "Stop"
 
 # Function to update nuspec file
@@ -130,12 +126,4 @@ function SyncNuspecFile([string]$FolderPath)
     }
 }
 
-if ($Folder -eq '' -or $Folder -eq $null) {
-    $subFolders = Get-ChildItem -Directory -Path $BasePath
-    ForEach ($subFolder in $subFolders) {
-        SyncNuspecFile $subFolder.FullName
-    }
-} else {
-    SyncNuspecFile $Folder
-}
-
+SyncNuspecFile $Folder

--- a/tools/nuget.targets
+++ b/tools/nuget.targets
@@ -19,7 +19,6 @@
   
   <PropertyGroup>
     <NuGetVerbosity>normal</NuGetVerbosity>
-    <PublishSymbolSourcePackages>true</PublishSymbolSourcePackages>
   </PropertyGroup>
 
   <ItemGroup>
@@ -99,23 +98,14 @@
       <ActualSource Condition=" '$(NuGetPublishingSource)' != '' "> -Source $(NuGetPublishingSource)</ActualSource>
     </PropertyGroup>
 
-    <Message Importance="high" Text="Publishing NuGet packages to the cloud at $(NuGetPublishingSource)" />
+    <!--Ran 'nuget push' on the main package, will automatically push the symbol package at the same time-->
+    <Message Importance="high" Text="Publishing main and symbols packages to the cloud at $(NuGetPublishingSource)" />
     <Exec Command="$(NuGetCommand) push &quot;$(PackageOutputDir)\%(SdkNuGetPackage.Identity).%(SdkNuGetPackage.PackageVersion).nupkg&quot; $(NuGetKey)$(ActualSource)"
           IgnoreExitCode="true"
           Condition=" '%(SdkNuGetPackage.Publish)' != 'false' " />
 
-    <Message Importance="high" Text="Publishing NuGet symbol &amp; source packages to the cloud at $(NuGetSymbolPublishingSource)"
-             Condition=" $(NuGetSymbolPublishingSource) != '' "/>
-    <Exec Command="$(NuGetCommand) push &quot;$(PackageOutputDir)\%(SdkNuGetPackage.Identity).%(SdkNuGetPackage.PackageVersion).Symbols.nupkg&quot; $(NuGetKey) -Source $(NuGetSymbolPublishingSource)"
-          Condition=" $(NuGetSymbolPublishingSource) != '' And '%(SdkNuGetPackage.Publish)' != 'false' And '%(SdkNuGetPackage.SkipSymbolSourcePackage)' != 'true' And '$(PublishSymbolSourcePackages)' == 'true' "
-          IgnoreExitCode="true"
-          ContinueOnError="true" />
-
     <Message Text="Not publishing package %(SdkNuGetPackage.Identity) as Publish is set to 'false' for the component."
              Condition=" '%(SdkNuGetPackage.Publish)' == 'false' " />
-
-    <Warning Text="Symbol/source packages are not being pushed. The PublishSymbolSourcePackages property is not set to true."
-             Condition=" '$(PublishSymbolSourcePackages)' != 'true' " />
   </Target>
 
 </Project>

--- a/tools/nuget.targets
+++ b/tools/nuget.targets
@@ -59,7 +59,7 @@
                           LogReplacement="false" />
 
     <!-- Update all explicit references to dependent versions. -->
-    <Exec Command="$(PowerShellExe) -NonInteractive -ExecutionPolicy bypass -Command &quot;&amp; { &amp;&apos;$(NuSpecSyncScript)&apos; -BasePath &apos;$(LibrarySourceFolder)&apos; }&quot;" />
+    <Exec Command="$(PowerShellExe) -NonInteractive -ExecutionPolicy bypass -Command &quot;&amp; { &amp;&apos;$(NuSpecSyncScript)&apos; &apos;%(NuspecFilesToUpdate.RootDir)%(NuspecFilesToUpdate.Directory)&apos; }&quot;" />
 
     <!-- Second, use the new files as destructive replacement targets. -->
     <ItemGroup>


### PR DESCRIPTION
1. The flags which controls symbol packages is unnecessary, because nuget will automatically publish symbols package
2. The global refresh all nuspec file is unnecessary and we should only do it for the package being built
