### PR TITLE
Update build script to handle projects with non default target list

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -156,7 +156,8 @@
         Assembly="%(DelaySignedAssembliesToValidate.Identity)"
         ExpectedTokenSignature="$(StrongNameToken)"
         ExpectedDelaySigned="true"
-        ContinueOnError="false" />
+        ContinueOnError="false" 
+        Condition="'@(DelaySignedAssembliesToValidate)' != ''"/>
 
     <CodeSigningTask
         Description="Microsoft Azure SDK"
@@ -165,7 +166,7 @@
         DestinationPath="binaries\$(LibraryFxTarget)"
         SigningLogPath="binaries\$(LibraryFxTarget)\signing.log"
         ToolsPath="$(CIToolsPath)"
-        Condition="!$(DelaySign)"/>
+        Condition="!$(DelaySign) and '@(DelaySignedAssembliesToValidate)' != ''"/>
     <!--If we are testing locally then we copy the binaries and do not submit to the code sign server-->
     <Copy SourceFiles="@(DelaySignedAssembliesToValidate)" DestinationFolder="binaries\$(LibraryFxTarget)" Condition="$(DelaySign)" />
     
@@ -178,7 +179,7 @@
         ExpectedTokenSignature="$(StrongNameToken)"
         ExpectedDelaySigned="false"
         ContinueOnError="false" 
-        Condition="!$(DelaySign)"/>
+        Condition="!$(DelaySign) and '@(DelaySignedAssembliesToValidate)' != ''"/>
     
     <RemoveDir Directories="binaries\$(LibraryFxTarget)\unsigned;" ContinueOnError="true" />
   </Target>

--- a/build.proj
+++ b/build.proj
@@ -151,6 +151,10 @@
     <ItemGroup>
       <DelaySignedAssembliesToValidate Include="binaries\$(LibraryFxTarget)\unsigned\*.dll" />
     </ItemGroup>
+    
+    <Message Importance="high" Text="Binaries\$(LibraryFxTarget)\unsigned contains no files. Code sign will skip." 
+             Condition="'@(DelaySignedAssembliesToValidate)' == ''" />
+    
     <ValidateStrongNameSignatureTask
         WindowsSdkPath="$(WindowsSdkPath)"
         Assembly="%(DelaySignedAssembliesToValidate.Identity)"


### PR DESCRIPTION
2 teams confirmed they still have packages which use non default target list say 'net40' only. 
This PR handles that, particularly, we no longer error out when the 'portable\unsigned' folder contains nothing. There is another option that we can make the 'fxtargetlist' to be configurable, but that means we will need to configure 4 CI projects to expose this parameter, which is a little complicate to the partner teams.
I am also making similar change to the azure-sdk-for-net-pr repo.
