### PR TITLE
add LibraryCustomConstants for net40 and portable build configurations

### DIFF
--- a/tools/Library.Settings.targets
+++ b/tools/Library.Settings.targets
@@ -46,6 +46,14 @@
     <LibraryCustomConstants>NET45</LibraryCustomConstants>
   </PropertyGroup>
   
+  <PropertyGroup Condition=" '$(LibraryFxTarget)' == 'net40'" >
+    <LibraryCustomConstants>NET40</LibraryCustomConstants>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(LibraryFxTarget)' == 'portable'" >
+    <LibraryCustomConstants>PORTABLE</LibraryCustomConstants>
+  </PropertyGroup>
+  
   <PropertyGroup Condition=" '$(CodeSign)' == 'true' " >
     <LibraryCustomConstants>$(LibraryCustomConstants);CODESIGN</LibraryCustomConstants>
   </PropertyGroup>


### PR DESCRIPTION
These constants are needed for the new Data Factory SDK which is being developed in the DataFactoriesDev branch. 
