### PR TITLE
Test case for #1206.  Fails in the current build, but is fixed by proposed fix for #987

### DIFF
--- a/src/HDInsight/Microsoft.Hadoop.Avro.Tests/SchemaTests/JsonSchemaBuilderTests.cs
+++ b/src/HDInsight/Microsoft.Hadoop.Avro.Tests/SchemaTests/JsonSchemaBuilderTests.cs
@@ -634,6 +634,30 @@ namespace Microsoft.Hadoop.Avro.Tests
             Assert.AreEqual(schema1.ToString(), schema2.ToString());
         }
 
+        // Test for https://github.com/Azure/azure-sdk-for-net/issues/1206
+        [TestMethod]
+        [TestCategory("CheckIn")]
+        public void JsonSchemaBuilder_FixedTypeReferences()
+        {
+            var guidSchemaJson = "{ \"type\": \"fixed\", \"name\": \"System.Guid\", \"size\": 16 }";
+
+            var schemaWithFixedType = @"{
+                ""type"":""record"",
+                ""name"":""Config"",
+                ""fields"":
+                [
+                    {
+                        ""name"":""ID1"",
+                        ""type"": " + guidSchemaJson + @"
+                    },
+                    {
+                        ""name"":""ID2"",
+                        ""type"":""System.Guid""
+                    }
+                ]}";
+            var schema = this.builder.BuildSchema(schemaWithFixedType);
+        }
+
         [TestInitialize]
         public void TestSetup()
         {


### PR DESCRIPTION
The fix in the hdinsight fork is here:
https://github.com/hdinsight/azure-sdk-for-net/commit/27d1ba62479f7dc3bfcd2a61a63144918489a9a9

I'm not including the fix b/c I assume a merge from the hdinsight fork is forthcoming.  I'm happy to provide it if it's helpful.  The diff for the fix is linked here (originally submitted to codeplex b/c I didn't know this project had moved):
https://hadoopsdk.codeplex.com/SourceControl/network/forks/johncrim/bug76/changeset/92f1ca56a6be94f5a9c04dd70b441970606d7876
