### PR TITLE
ADF Runtime integration into Sdk (on behalf of alextolp)

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/DataFactory.Tests.csproj
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/DataFactory.Tests.csproj
@@ -33,6 +33,7 @@
     <Compile Include="ScenarioTests\TestHelper.cs" />
     <Compile Include="UnitTests\ActivityTypeTests.cs" />
     <Compile Include="UnitTests\ComputeTypeTests.cs" />
+    <Compile Include="UnitTests\DataSetTests.cs" />
     <Compile Include="UnitTests\LinkedServiceTests.cs" />
     <Compile Include="UnitTests\LinkedServiceTypeRegistrationTests.cs" />
     <Compile Include="UnitTests\PipelineTests.cs" />

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/Common.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/Common.cs
@@ -172,7 +172,7 @@ namespace DataFactory.Tests.Framework
 
             Assert.Equal(itemType, actualType);
 
-            if ((itemType.IsValueType && !itemType.IsConstructedGenericType) || itemType == typeof(string))
+            if ((itemType.IsValueType && !itemType.IsConstructedGenericType) || itemType == typeof(string) || itemType == typeof(JValue))
             {
                 Assert.Equal(expected, actual);
             }

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/DataSetTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/DataSetTests.cs
@@ -1,0 +1,98 @@
+﻿// 
+// Copyright (c) Microsoft and contributors.  All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// 
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+using DataFactory.Tests.Framework;
+using DataFactory.Tests.Framework.JsonSamples;
+using Microsoft.Azure.Management.DataFactories.Conversion;
+using Microsoft.Azure.Management.DataFactories.Runtime;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Core = Microsoft.Azure.Management.DataFactories.Core;
+
+namespace DataFactory.Tests.UnitTests
+{
+    public class DataSetTests : UnitTestBase
+    {
+        private TableConverter tableConverter = new TableConverter();
+        private LinkedServiceConverter linkedServiceConverter = new LinkedServiceConverter();
+
+        [Fact]
+        [Trait(TraitName.TestType, TestType.Unit)]
+        [Trait(TraitName.Function, TestType.Conversion)]
+        public void DataSetLinkedServiceJsonConstsTest()
+        {
+            IEnumerable<JsonSampleInfo> samples = JsonSampleCommon.GetJsonSamplesFromType<LinkedServiceJsonSamples>();
+            this.TestLinkedServiceJsonSamples(samples);
+        }
+
+        [Fact]
+        [Trait(TraitName.TestType, TestType.Unit)]
+        [Trait(TraitName.Function, TestType.Conversion)]
+        public void DataSetCustomLinkedServiceJsonConstsTest()
+        {
+            IEnumerable<JsonSampleInfo> samples = JsonSampleCommon.GetJsonSamplesFromType<CustomLinkedServiceJsonSamples>();
+            this.TestLinkedServiceJsonSamples(samples);
+        }
+
+        [Fact]
+        [Trait(TraitName.TestType, TestType.Unit)]
+        [Trait(TraitName.Function, TestType.Conversion)]
+        public void DataSetTableJsonConstsTest()
+        {
+            IEnumerable<JsonSampleInfo> samples = JsonSampleCommon.GetJsonSamplesFromType<TableJsonSamples>();
+            this.TestTableJsonSamples(samples);
+        }
+
+        private void TestTableJsonSamples(IEnumerable<JsonSampleInfo> samples)
+        {
+            TestJsonSamples(samples, "table", json =>
+            {
+                Core.Models.Table table = Core.DataFactoryManagementClient.DeserializeInternalTableJson(json);
+
+                return new DataSet()
+                {
+                    Table = this.tableConverter.ToWrapperType(table)
+                };
+            });
+        }
+
+        private void TestLinkedServiceJsonSamples(IEnumerable<JsonSampleInfo> samples)
+        {
+            TestJsonSamples(samples, "linkedService", json =>
+            {
+                Core.Models.LinkedService linkedService = Core.DataFactoryManagementClient.DeserializeInternalLinkedServiceJson(json);
+
+                return new DataSet()
+                {
+                    LinkedService = this.linkedServiceConverter.ToWrapperType(linkedService)
+                };
+            });
+        }
+
+        private void TestJsonSamples(IEnumerable<JsonSampleInfo> samples, string token, Func<string, DataSet> getDataSet)
+        {
+            foreach (JsonSampleInfo sample in samples)
+            {
+                DataSet expectedDataSet = getDataSet(sample.Json);
+                DataSet actualDataSet = JsonConvert.DeserializeObject<DataSet>(string.Concat("{ \"", token, "\" : ", sample.Json, "}"));
+
+                Common.ValidateAreSame(expectedDataSet, actualDataSet);
+            }
+        }
+    }
+}

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/ActivityConfiguration.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/ActivityConfiguration.cs
@@ -1,0 +1,26 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Management.DataFactories.Runtime
+{
+    internal class ActivityConfiguration
+    {
+        public IEnumerable<DataSet> InputDataSets { get; set; }
+        public IEnumerable<DataSet> OutputDataSets { get; set; }
+        public IDictionary<string, string> ExtendedProperties { get; set; }
+    }
+}

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/ActivityExecutor.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/ActivityExecutor.cs
@@ -1,0 +1,45 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Microsoft.Azure.Management.DataFactories.Runtime
+{
+    internal static class ActivityExecutor
+    {
+        public static IDictionary<string, string> Execute(object job, string configuration, Action<string> logAction)
+        {
+            ActivityConfiguration activityConfiguration = Utils.GetActivityConfiguration(configuration);
+
+            IDotNetActivity activityImplementation = job as IDotNetActivity;
+            if (job == null)
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
+                    "The type {0} in does not implement IDotNetActivity. Check the configuration and try again.", job == null ? "<null>" : job.GetType().FullName));
+            }
+
+            ActivityLogger logger = new ActivityLogger(logAction);
+
+            return activityImplementation.Execute(
+                activityConfiguration.InputDataSets,
+                activityConfiguration.OutputDataSets,
+                activityConfiguration.ExtendedProperties,
+                logger);
+        }
+    }
+
+}

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/ActivityLogger.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/ActivityLogger.cs
@@ -1,0 +1,50 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.Azure.Management.DataFactories.Runtime
+{
+    internal class ActivityLogger : IActivityLogger
+    {
+        private Action<string> logAction;
+
+        public ActivityLogger(Action<string> logAction)
+        {
+            this.logAction = logAction;
+        }
+
+        #region IActivityLogger implementation
+
+        public void Write(string format, params object[] args)
+        {
+            string value;
+
+            if (args != null && args.Length > 0)
+            {
+                value = string.Format(CultureInfo.InvariantCulture, format, args);
+            }
+            else
+            {
+                value = format;
+            }
+
+            this.logAction(value);
+        }
+
+        #endregion
+    }
+}

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DataSet.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DataSet.cs
@@ -1,0 +1,35 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using Microsoft.Azure.Management.DataFactories.Models;
+
+namespace Microsoft.Azure.Management.DataFactories.Runtime
+{
+    /// <summary>
+    /// Represents a set of resolved <see cref="Microsoft.Azure.Management.DataFactories.Models.Table"/> and <see cref="Microsoft.Azure.Management.DataFactories.Models.LinkedService"/> values.
+    /// </summary>
+    public class DataSet
+    {
+        /// <summary>
+        /// The <see cref="Microsoft.Azure.Management.DataFactories.Models.Table"/> value.
+        /// </summary>
+        public Table Table { get; internal set; }
+
+        /// <summary>
+        /// The <see cref="Microsoft.Azure.Management.DataFactories.Models.LinkedService"/> value.
+        /// </summary>
+        public LinkedService LinkedService { get; internal set; }
+    }
+}

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DataSet.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DataSet.cs
@@ -14,12 +14,14 @@
 //
 
 using Microsoft.Azure.Management.DataFactories.Models;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.Management.DataFactories.Runtime
 {
     /// <summary>
     /// Represents a set of resolved <see cref="Microsoft.Azure.Management.DataFactories.Models.Table"/> and <see cref="Microsoft.Azure.Management.DataFactories.Models.LinkedService"/> values.
     /// </summary>
+    [JsonConverter(typeof(DataSetConverter))]
     public class DataSet
     {
         /// <summary>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DataSet.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DataSet.cs
@@ -19,11 +19,19 @@ using Newtonsoft.Json;
 namespace Microsoft.Azure.Management.DataFactories.Runtime
 {
     /// <summary>
-    /// Represents a set of resolved <see cref="Microsoft.Azure.Management.DataFactories.Models.Table"/> and <see cref="Microsoft.Azure.Management.DataFactories.Models.LinkedService"/> values.
+    /// Represents a set of resolved <see cref="Microsoft.Azure.Management.DataFactories.Models.Table"/> and 
+    /// <see cref="Microsoft.Azure.Management.DataFactories.Models.LinkedService"/> values.
     /// </summary>
     [JsonConverter(typeof(DataSetConverter))]
     public class DataSet
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Microsoft.Azure.Management.DataFactories.Runtime.DataSet"/> class.
+        /// </summary>
+        public DataSet()
+        {
+        }
+
         /// <summary>
         /// The <see cref="Microsoft.Azure.Management.DataFactories.Models.Table"/> value.
         /// </summary>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DataSetConverter.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DataSetConverter.cs
@@ -1,0 +1,67 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using Microsoft.Azure.Management.DataFactories.Conversion;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace Microsoft.Azure.Management.DataFactories.Runtime
+{
+    internal sealed class DataSetConverter : JsonConverter
+    {
+        private TableConverter tableConverter;
+        private LinkedServiceConverter linkedServiceConverter;
+
+        public DataSetConverter()
+        {
+            tableConverter = new TableConverter();
+            linkedServiceConverter = new LinkedServiceConverter();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(DataSet);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            DataSet dataSet = new DataSet();
+
+            JObject jObject = JObject.Load(reader);
+            JToken tableJToken;
+            JToken linkedServiceJToken;
+
+            if (jObject.TryGetValue("table", StringComparison.OrdinalIgnoreCase, out tableJToken))
+            {
+                Core.Models.Table internalTable = Core.DataFactoryManagementClient.DeserializeInternalTableJson(tableJToken.ToString());
+                dataSet.Table = tableConverter.ToWrapperType(internalTable);
+            }
+
+            if (jObject.TryGetValue("linkedService", StringComparison.OrdinalIgnoreCase, out linkedServiceJToken))
+            {
+                Core.Models.LinkedService internalLinkedService = Core.DataFactoryManagementClient.DeserializeInternalLinkedServiceJson(linkedServiceJToken.ToString());
+                dataSet.LinkedService = linkedServiceConverter.ToWrapperType(internalLinkedService);
+            }
+
+            return dataSet;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DataSetConverter.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DataSetConverter.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Azure.Management.DataFactories.Runtime
 {
     internal sealed class DataSetConverter : JsonConverter
     {
+        private const string TableToken = "table";
+        private const string LinkedServiceToken = "linkedService";
+
         private TableConverter tableConverter;
         private LinkedServiceConverter linkedServiceConverter;
 
@@ -44,13 +47,13 @@ namespace Microsoft.Azure.Management.DataFactories.Runtime
             JToken tableJToken;
             JToken linkedServiceJToken;
 
-            if (jObject.TryGetValue("table", StringComparison.OrdinalIgnoreCase, out tableJToken))
+            if (jObject.TryGetValue(TableToken, StringComparison.OrdinalIgnoreCase, out tableJToken))
             {
                 Core.Models.Table internalTable = Core.DataFactoryManagementClient.DeserializeInternalTableJson(tableJToken.ToString());
                 dataSet.Table = tableConverter.ToWrapperType(internalTable);
             }
 
-            if (jObject.TryGetValue("linkedService", StringComparison.OrdinalIgnoreCase, out linkedServiceJToken))
+            if (jObject.TryGetValue(LinkedServiceToken, StringComparison.OrdinalIgnoreCase, out linkedServiceJToken))
             {
                 Core.Models.LinkedService internalLinkedService = Core.DataFactoryManagementClient.DeserializeInternalLinkedServiceJson(linkedServiceJToken.ToString());
                 dataSet.LinkedService = linkedServiceConverter.ToWrapperType(internalLinkedService);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DotNetActivityApiVersionAttribute.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/DotNetActivityApiVersionAttribute.cs
@@ -1,0 +1,28 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+
+namespace Microsoft.Azure.Management.DataFactories.Runtime
+{
+    [AttributeUsage(AttributeTargets.Interface, Inherited = true, AllowMultiple = false)]
+    internal sealed class DotNetActivityApiVersionAttribute : Attribute
+    {
+        public string ApiVersion
+        {
+            get { return "2015-07-01-preview"; }
+        }
+    }
+}

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/IActivityLogger.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/IActivityLogger.cs
@@ -1,0 +1,32 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+
+namespace Microsoft.Azure.Management.DataFactories.Runtime
+{
+    /// <summary>
+    /// Provides functionality for logging the execution of an activity.
+    /// </summary>
+    public interface IActivityLogger
+    {
+        /// <summary>
+        /// Log activity message.
+        /// </summary>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">The objects to format.</param>
+        void Write(string format, params object[] args);
+    }
+}

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/IDotNetActivity.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/IDotNetActivity.cs
@@ -1,0 +1,40 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Management.DataFactories.Runtime
+{
+    /// <summary>
+    /// Used to implement an activity.
+    /// </summary>
+    [DotNetActivityApiVersion]
+    public interface IDotNetActivity
+    {
+        /// <summary>
+        /// Called to execute an instance of the activity.
+        /// </summary>
+        /// <param name="inputDataSets">Input data sets defined in the activity definition.</param>
+        /// <param name="outputDataSets">Output data sets defined in the activity definition.</param>
+        /// <param name="extendedProperties">Extended properties defined in the activity definition.</param>
+        /// <param name="logger">Used to log messages during activity execution.</param>
+        /// <returns>Properties that may be passed to down-stream activites.</returns>
+        IDictionary<string, string> Execute(
+            IEnumerable<DataSet> inputDataSets,
+            IEnumerable<DataSet> outputDataSets,
+            IDictionary<string, string> extendedProperties,
+            IActivityLogger logger);
+    }
+}

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/Utils.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/Utils.cs
@@ -1,0 +1,96 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using Microsoft.Azure.Management.DataFactories.Conversion;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization.Formatters;
+
+namespace Microsoft.Azure.Management.DataFactories.Runtime
+{
+    internal static class Utils
+    {
+        private static readonly LinkedServiceConverter LinkedServiceConverter = GetLinkedServiceConverter();
+        private static readonly TableConverter TableConverter = GetTableConverter();
+        private static readonly PipelineConverter PipelineConverter = GetPipelineConverter();
+
+        internal static JsonConverter[] GetAllConverters()
+        {
+            return new JsonConverter[] { LinkedServiceConverter, PipelineConverter, TableConverter };
+        }
+
+        internal static JsonConverter[] GetConverters(
+            bool includelinkedServiceConverter = false,
+            bool includeTableConverter = false,
+            bool includePipelineConverter = false)
+        {
+            var converters = new List<JsonConverter>();
+
+            if (includelinkedServiceConverter)
+            {
+                converters.Add(LinkedServiceConverter);
+            }
+
+            if (includeTableConverter)
+            {
+                converters.Add(PipelineConverter);
+            }
+
+            if (includeTableConverter)
+            {
+                converters.Add(TableConverter);
+            }
+
+            return converters.ToArray();
+        }
+        
+        private static LinkedServiceConverter GetLinkedServiceConverter()
+        {
+            return new LinkedServiceConverter();
+        }
+
+        private static TableConverter GetTableConverter()
+        {
+            return new TableConverter();
+        }
+
+        private static PipelineConverter GetPipelineConverter()
+        {
+            return new PipelineConverter();
+        }
+
+        public static ActivityConfiguration GetActivityConfiguration(string configuration)
+        {
+            JsonSerializerSettings settings = new JsonSerializerSettings()
+            {
+                MissingMemberHandling = MissingMemberHandling.Ignore,
+                Formatting = Formatting.Indented,
+                TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple,
+                TypeNameHandling = TypeNameHandling.Objects,
+                DateParseHandling = DateParseHandling.None,
+            };
+
+
+            foreach (JsonConverter jsonConverter in Utils.GetConverters(true, true))
+            {
+                settings.Converters.Add(jsonConverter);
+            }
+
+            ActivityConfiguration activityConfiguration = JsonConvert.DeserializeObject<ActivityConfiguration>(configuration, settings);
+            return activityConfiguration;
+        }
+    }
+}

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/Utils.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Runtime/Utils.cs
@@ -17,7 +17,6 @@ using Microsoft.Azure.Management.DataFactories.Conversion;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization.Formatters;
 
 namespace Microsoft.Azure.Management.DataFactories.Runtime
 {
@@ -46,12 +45,12 @@ namespace Microsoft.Azure.Management.DataFactories.Runtime
 
             if (includeTableConverter)
             {
-                converters.Add(PipelineConverter);
+                converters.Add(TableConverter);
             }
 
-            if (includeTableConverter)
+            if (includePipelineConverter)
             {
-                converters.Add(TableConverter);
+                converters.Add(PipelineConverter);
             }
 
             return converters.ToArray();
@@ -74,15 +73,8 @@ namespace Microsoft.Azure.Management.DataFactories.Runtime
 
         public static ActivityConfiguration GetActivityConfiguration(string configuration)
         {
-            JsonSerializerSettings settings = new JsonSerializerSettings()
-            {
-                MissingMemberHandling = MissingMemberHandling.Ignore,
-                Formatting = Formatting.Indented,
-                TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple,
-                TypeNameHandling = TypeNameHandling.Objects,
-                DateParseHandling = DateParseHandling.None,
-            };
-
+            JsonSerializerSettings settings = ConversionCommon.DefaultSerializerSettings;
+            settings.MissingMemberHandling = MissingMemberHandling.Ignore;
 
             foreach (JsonConverter jsonConverter in Utils.GetConverters(true, true))
             {

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagement.csproj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagement.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Customizations\Runtime\ActivityExecutor.cs" />
     <Compile Include="Customizations\Runtime\ActivityConfiguration.cs" />
     <Compile Include="Customizations\Runtime\ActivityLogger.cs" />
+    <Compile Include="Customizations\Runtime\DataSetConverter.cs" />
     <Compile Include="Customizations\Runtime\DotNetActivityApiVersionAttribute.cs" />
     <Compile Include="Customizations\Runtime\IActivityLogger.cs" />
     <Compile Include="Customizations\Runtime\IDotNetActivity.cs" />

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagement.csproj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagement.csproj
@@ -43,6 +43,14 @@
     <Compile Include="Customizations\Operations\DataFactories\DataFactoryOperationsExtensions.cs" />
     <Compile Include="Customizations\Operations\DataFactories\IDataFactoryOperations.cs" />
     <Compile Include="Customizations\Operations\DataSlices\IDataSliceOperations.cs" />
+    <Compile Include="Customizations\Runtime\ActivityExecutor.cs" />
+    <Compile Include="Customizations\Runtime\ActivityConfiguration.cs" />
+    <Compile Include="Customizations\Runtime\ActivityLogger.cs" />
+    <Compile Include="Customizations\Runtime\DotNetActivityApiVersionAttribute.cs" />
+    <Compile Include="Customizations\Runtime\IActivityLogger.cs" />
+    <Compile Include="Customizations\Runtime\IDotNetActivity.cs" />
+    <Compile Include="Customizations\Runtime\DataSet.cs" />
+    <Compile Include="Customizations\Runtime\Utils.cs" />
     <Compile Include="Customizations\DataFactoryManagementClient.Registration.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Customizations\AdfResourceProperties.cs" />


### PR DESCRIPTION
ADF has a separate nugget called ADF Runtime. It exposes an interface utility to enable customers extend and run their own .Net activities in ADF pipelines. We are moving that feature into MAML's wrapper layer to make customer easier to use.

This feature is in our Wrapper layer only.
