### PR TITLE
Fix the delegating handler issue

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/DataFactoryManagementClient.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/DataFactoryManagementClient.cs
@@ -242,6 +242,14 @@ namespace Microsoft.Azure.Management.DataFactories
             }
         }
 
+        protected override DataFactoryManagementClient WithHandler(ServiceClient<DataFactoryManagementClient> newClient,
+            DelegatingHandler handler)
+        {
+            DataFactoryManagementClient client = base.WithHandler(newClient, handler);
+            client.InternalClient.HttpClient = client.HttpClient;
+            return client;
+        }
+
         private void Initialize()
         {
             this.InternalClient = new Core.DataFactoryManagementClient();

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataFactories
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataFactories">
-      <PackageVersion>1.0.0</PackageVersion>
+      <PackageVersion>1.0.1</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,12 +21,12 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Factory management operations.")]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]
-[assembly: AssemblyCopyright("Copyright © Microsoft Corporation")]
+[assembly: AssemblyCopyright("Copyright � Microsoft Corporation")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]


### PR DESCRIPTION
My POSH mock tests always fail to record session because we have a wrapper layer and generated codes layer DataFactoryManagementClient, each has it's own HttpClient instance.

This fix will make sure when WithHandler is called on the Wrapper layer DataFactoryManagementClient, the handler is passed into the underlying client.

I choose just reset the HttpClient property here instead of adding handler into handler pipeline because:
1. we don't need two http clients
2. user should be able to just reset handler and overwriting any exsiting handling in the pipeline
3. also the session records nicely writes DataFactoryManagementClient as the user agent instead of Core.DataFactoryManagementClient
