### PR TITLE
resolves #1287: preserve the case of dictionary keys during ADF object serialization 

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonComparer.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonComparer.cs
@@ -73,7 +73,9 @@ namespace DataFactory.Tests.Framework
                         string propertyName = pair.Key;
                         JToken value = pair.Value;
 
-                        string propertyPath = description + "." + propertyName;
+                        string propertyPath = string.IsNullOrEmpty(description)
+                                                  ? propertyName
+                                                  : description + "." + propertyName;
 
                         if (!string.Equals(propertyName, JsonUtilities.Type, JsonUtilities.PropertyNameComparison))
                         {

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSampleAttribute.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSampleAttribute.cs
@@ -59,6 +59,15 @@ namespace DataFactory.Tests.Framework
             {
                 this.Version = version;
             }
+        }
+
+        public JsonSampleAttribute(string version, params string[] propertyBagKeys)
+            : this(propertyBagKeys)
+        {
+            if (!string.IsNullOrEmpty(version))
+            {
+                this.Version = version;
+            }
         }        
 
         /// <summary>

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/PipelineJsonSamples.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/PipelineJsonSamples.cs
@@ -18,7 +18,13 @@ namespace DataFactory.Tests.Framework.JsonSamples
 {
     public class PipelineJsonSamples : JsonSampleCollection<PipelineJsonSamples>
     {
-        [JsonSample(JsonSampleType.Unregistered)]
+        [JsonSample(JsonSampleType.Unregistered,
+            propertyBagKeys:
+                new string[]
+                    {
+                        "properties.activities[0].typeProperties.AssemblyName",
+                        "properties.activities[0].typeProperties.SliceStart"
+                    })]
         public const string ActivityTypePipeline = @"
 {
     name: ""activityType pipeline name"",
@@ -53,7 +59,7 @@ namespace DataFactory.Tests.Framework.JsonSamples
         [JsonSample(propertyBagKeys: new string[] 
             { 
                 // Identify user-provided property names. These should always be cased exactly as the user specified, rather than converted to camel/Pascal-cased.
-                "properties.activities[0].typeProperties.extendedProperties.PropertyBagPropertyName1"
+                "properties.activities[0].typeProperties.defines.PropertyBagPropertyName1"
             }
         )]
         public const string HDInsightPipeline = @"
@@ -133,7 +139,11 @@ namespace DataFactory.Tests.Framework.JsonSamples
     }
 }
 ";
-        [JsonSample]
+
+        [JsonSample(propertyBagKeys: new string[]
+                        {
+                            "properties.activities[0].typeProperties.defines.PropertyBagPropertyName1"                     
+                        })]
         public const string HDInsightMapReducePipeline = @"
 {
     name: ""My HDInsight MapReduce pipeline"",
@@ -476,7 +486,8 @@ namespace DataFactory.Tests.Framework.JsonSamples
         [JsonSample(propertyBagKeys: new string[]
                     {
                         "properties.activities[0].typeProperties.webServiceParameters.oNe",
-                        "properties.activities[0].typeProperties.webServiceParameters.two NAME"
+                        "properties.activities[0].typeProperties.webServiceParameters.two NAME",
+                        "properties.activities[0].typeProperties.webServiceParameters.THREE"
                     })]
         public const string AzureMLPipelineWithWebParams = @"
 {
@@ -517,7 +528,8 @@ namespace DataFactory.Tests.Framework.JsonSamples
                     webServiceParameters:
                     {
                         ""oNe"": ""one value"",
-                        ""two NAME"": ""$$Text.Format('macro{0:yyyyMMddHH-mm}', Time.AddMinutes(SliceStart, 0))""
+                        ""two NAME"": ""$$Text.Format('macro{0:yyyyMMddHH-mm}', Time.AddMinutes(SliceStart, 0))"", 
+                        ""THREE"": ""HELLO""
                     }
                 }
             }
@@ -573,7 +585,7 @@ namespace DataFactory.Tests.Framework.JsonSamples
         [JsonSample(propertyBagKeys: new string[] 
             { 
                 // Identify user-provided property names. These should always be cased exactly as the user specified, rather than converted to camel/Pascal-cased.
-                "properties.activities[0].transformation.extendedProperties.PropertyBagPropertyName1",
+                "properties.activities[0].typeproperties.defines.PropertyBagPropertyName1"
             }
 )]
         public const string StreamingWithExtendedProperties = @"

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/RegisteredActivityTypeJsonSamples.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/RegisteredActivityTypeJsonSamples.cs
@@ -21,7 +21,11 @@ namespace DataFactory.Tests.Framework.JsonSamples
     /// </summary>
     public class RegisteredActivityTypeJsonSamples : JsonSampleCollection<RegisteredActivityTypeJsonSamples>
     {
-        [JsonSample]
+        [JsonSample(propertyBagKeys: new string[]
+             {
+                "properties.schema.properties.PackageFile",
+                "properties.schema.properties.Bar"
+             })]
         public const string DotNetActivity = @"
 { 
     ""name"": ""CloudMLActivity"", 
@@ -43,7 +47,11 @@ namespace DataFactory.Tests.Framework.JsonSamples
     }
 }";
 
-        [JsonSample]
+        [JsonSample(propertyBagKeys: new string[]
+             {
+                "properties.schema.properties.PackageFile",
+                "properties.schema.properties.Bar"
+             })]
         public const string DotNetActivityNestedProperties = @"
 { 
     ""name"": ""CloudMLActivity"", 

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/RegisteredComputeTypeJsonSamples.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/RegisteredComputeTypeJsonSamples.cs
@@ -21,7 +21,11 @@ namespace DataFactory.Tests.Framework.JsonSamples
     /// </summary>
     public class RegisteredComputeTypeJsonSamples : JsonSampleCollection<RegisteredComputeTypeJsonSamples>
     {
-        [JsonSample]
+        [JsonSample(propertyBagKeys: new string[]
+             {
+                "properties.schema.properties.KeyPairName",
+                "properties.schema.properties.KeyPairKey"
+             })]
         public const string AmazonEMRCompute_ServiceBusTransport = @"
 { 
     ""name"": ""AmazonEMR"", 
@@ -54,7 +58,11 @@ namespace DataFactory.Tests.Framework.JsonSamples
     }
 }";
 
-        [JsonSample]
+        [JsonSample(propertyBagKeys: new string[]
+             {
+                "properties.schema.properties.KeyPairName",
+                "properties.schema.properties.KeyPairKey"
+             })]
         public const string AmazonEMRCompute_ServiceBusTransport_NestedPropertiesAndDefinitions = @"
 { 
     ""name"": ""AmazonEMR"", 

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/TableJsonSamples.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/TableJsonSamples.cs
@@ -18,7 +18,11 @@ namespace DataFactory.Tests.Framework.JsonSamples
 {
     public class TableJsonSamples : JsonSampleCollection<TableJsonSamples>
     {
-        [JsonSample]
+        [JsonSample(propertyBagKeys: new string[]
+                        {                     
+                            "properties.typeProperties.PropertyBagPropertyName1",
+                            "properties.typeProperties.propertyBagPropertyName2"
+                        })]
         public const string CustomTable = @"
 {
     name: ""CustomTable"",

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/ActivityTypeTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/ActivityTypeTests.cs
@@ -18,6 +18,7 @@ using DataFactory.Tests.Framework;
 using DataFactory.Tests.Framework.JsonSamples;
 using Microsoft.Azure.Management.DataFactories;
 using Microsoft.Azure.Management.DataFactories.Registration.Models;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Extensions;
 using Core = Microsoft.Azure.Management.DataFactories.Core;
@@ -53,6 +54,9 @@ namespace DataFactory.Tests.UnitTests
 
             JsonComparer.ValidateAreSame(json, actualJson, ignoreDefaultValues: true);
             Assert.False(actualJson.Contains("ServiceExtraProperties"));
+
+            JObject actualJObject = JObject.Parse(actualJson);
+            JsonComparer.ValidatePropertyNameCasing(actualJObject, true, string.Empty, sampleInfo.PropertyBagKeys);
         }
 
         private ActivityType ConvertToWrapper(string json)

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/ComputeTypeTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/ComputeTypeTests.cs
@@ -18,6 +18,7 @@ using DataFactory.Tests.Framework;
 using DataFactory.Tests.Framework.JsonSamples;
 using Microsoft.Azure.Management.DataFactories;
 using Microsoft.Azure.Management.DataFactories.Registration.Models;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Extensions;
 using Core = Microsoft.Azure.Management.DataFactories.Core;
@@ -53,6 +54,9 @@ namespace DataFactory.Tests.UnitTests
 
             JsonComparer.ValidateAreSame(json, actualJson, ignoreDefaultValues: true);
             Assert.False(actualJson.Contains("ServiceExtraProperties"));
+
+            JObject actualJObject = JObject.Parse(actualJson);
+            JsonComparer.ValidatePropertyNameCasing(actualJObject, true, string.Empty, sampleInfo.PropertyBagKeys);
         }
 
         private ComputeType ConvertToWrapper(string json)

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/LinkedServiceTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/LinkedServiceTests.cs
@@ -15,11 +15,13 @@
 // 
 
 using System;
+using System.Collections.Generic;
 using DataFactory.Tests.Framework;
 using DataFactory.Tests.Framework.JsonSamples;
 using DataFactory.Tests.UnitTests.TestClasses;
 using Microsoft.Azure.Management.DataFactories;
 using Microsoft.Azure.Management.DataFactories.Models;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Extensions;
 using Core = Microsoft.Azure.Management.DataFactories.Core;
@@ -265,7 +267,7 @@ namespace DataFactory.Tests.UnitTests
 
         #region Test helpers
 
-        private LinkedService ConvertAndTestJson(string json, bool customTest = false)
+        private LinkedService ConvertAndTestJson(string json, bool customTest = false, HashSet<string> propertyBagKeys = null)
         {
             LinkedService linkedService = this.ConvertToWrapper(json);
             CoreModel.LinkedService actual = this.Operations.Converter.ToCoreType(linkedService);
@@ -283,6 +285,9 @@ namespace DataFactory.Tests.UnitTests
 
             JsonComparer.ValidateAreSame(json, actualJson, ignoreDefaultValues: true);
             Assert.DoesNotContain("ServiceExtraProperties", actualJson);
+
+            JObject actualJObject = JObject.Parse(actualJson);
+            JsonComparer.ValidatePropertyNameCasing(actualJObject, true, string.Empty, propertyBagKeys);
             
             return linkedService;
         }

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/PipelineTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/PipelineTests.cs
@@ -19,6 +19,7 @@ using DataFactory.Tests.Framework;
 using DataFactory.Tests.Framework.JsonSamples;
 using Microsoft.Azure.Management.DataFactories;
 using Microsoft.Azure.Management.DataFactories.Models;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Extensions;
 using Core = Microsoft.Azure.Management.DataFactories.Core;
@@ -166,13 +167,17 @@ namespace DataFactory.Tests.UnitTests
             JsonComparer.ValidateAreSame(json, actualJson, ignoreDefaultValues: true);
             Assert.DoesNotContain("ServiceExtraProperties", actualJson);
 
-            if (sampleInfo.Version == null)
+            if (sampleInfo.Version == null
+                || !sampleInfo.Version.Equals(JsonSampleType.Unregistered, StringComparison.OrdinalIgnoreCase))
             {
                 foreach (Activity activity in pipeline.Properties.Activities)
                 {
                     Assert.IsNotType<GenericActivity>(activity.TypeProperties);
                 }
             }
+
+            JObject actualJObject = JObject.Parse(actualJson);
+            JsonComparer.ValidatePropertyNameCasing(actualJObject, true, string.Empty, sampleInfo.PropertyBagKeys);
         }
 
         private void TestPipelineValidation(string json)

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/TableTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/TableTests.cs
@@ -19,6 +19,7 @@ using DataFactory.Tests.Framework;
 using DataFactory.Tests.Framework.JsonSamples;
 using Microsoft.Azure.Management.DataFactories;
 using Microsoft.Azure.Management.DataFactories.Models;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Extensions;
 using Core = Microsoft.Azure.Management.DataFactories.Core;
@@ -119,6 +120,9 @@ namespace DataFactory.Tests.UnitTests
             {
                 Assert.IsNotType<GenericDataset>(table.Properties.TypeProperties);
             }
+
+            JObject actualJObject = JObject.Parse(actualJson);
+            JsonComparer.ValidatePropertyNameCasing(actualJObject, true, string.Empty, info.PropertyBagKeys);
         }
 
         private void TestTableValidation(JsonSampleInfo sampleInfo)

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/DictionaryConverter.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/DictionaryConverter.cs
@@ -1,0 +1,60 @@
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+using System.Collections;
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.Management.DataFactories.Conversion
+{
+    /// <summary>
+    /// Preserves the case of dictionary keys during serialization.
+    /// </summary>
+    internal class DictionaryConverter : JsonConverter
+    {
+        public override bool CanRead
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            IDictionary dictionary = (IDictionary)value;
+            writer.WriteStartObject();
+            foreach (DictionaryEntry element in dictionary)
+            {
+                string key = Convert.ToString(element.Key, CultureInfo.InvariantCulture);
+                writer.WritePropertyName(key);
+                serializer.Serialize(writer, element.Value);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(IDictionary).IsAssignableFrom(objectType);
+        }
+    }
+}

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/TypeProperties.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/TypeProperties.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.Management.DataFactories.Models
 {
     public abstract class TypeProperties : IRegisteredType
     {
+        private static readonly DictionaryConverter DictionaryConverter = new DictionaryConverter();
+
         protected TypeProperties()
         {
         }
@@ -57,7 +59,7 @@ namespace Microsoft.Azure.Management.DataFactories.Models
                            DataFactoryManagementClient.CopyLocationConverter,
                            DataFactoryManagementClient.CopyTranslatorConverter,
                            DataFactoryManagementClient.PartitionValueConverter,
-                           DataFactoryManagementClient.StorageFormatConverter
+                           DataFactoryManagementClient.StorageFormatConverter, TypeProperties.DictionaryConverter
                        };
         }
     }

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagement.csproj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagement.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <Import Project="..\..\..\..\tools\Library.Settings.targets" />
   <ItemGroup>
+    <Compile Include="Customizations\Conversion\DictionaryConverter.cs" />
     <Compile Include="Customizations\Models\Activities\CopySinks\CopyBehavior\CopyBehaviorType.cs" />
     <Compile Include="Customizations\Models\Activities\CopySinks\FileSystemSink.cs" />
     <Compile Include="Customizations\Models\Activities\HDInsightActivityDebugInfoOption.cs" />


### PR DESCRIPTION
Fixes a bug during serialization for Data Factory objects with IDictionary<string, T> properties. This fixes the behavior to preserve the case of dictionary keys, rather than serializing them as camelCase like we would for a property name. 

Also fixes the tests which should have identified this bug. 
