### PR TITLE
return null when deserializing unknown nested polymorphic types (ADF)

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/PipelineTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/PipelineTests.cs
@@ -139,6 +139,45 @@ namespace DataFactory.Tests.UnitTests
             Assert.IsType<GenericActivity>(pipeline.Properties.Activities[0].TypeProperties);
         }
 
+        [Theory]
+        [InlineData(@"
+{
+    name: ""MyPipelineName"",
+    properties: 
+    {
+        activities:
+        [
+            {
+                type: ""Copy"",
+                name: ""TestActivity"",
+                typeProperties:
+                {
+                    source:
+                    {
+                        type: ""UnknownSource"",
+                        sourceRetryCount: ""2"",
+                    }
+                },
+                inputs: [ ],
+                outputs: [ ],
+                linkedServiceName: ""MyLinkedServiceName""
+            }
+        ]
+    }
+}
+")]
+        [Trait(TraitName.TestType, TestType.Unit)]
+        [Trait(TraitName.Function, TestType.Conversion)]
+        public void UnknownCopySourceDoesNotThrowExceptionTest(string json)
+        {
+            Pipeline pipeline = null;
+
+            // When we try to deserialize an unknown nested polymorphic type, 
+            // the behavior should be to drop the object (return null) rather than throw an exception
+            Assert.DoesNotThrow(() => pipeline = this.ConvertToWrapper(json));
+            Assert.Null(((CopyActivity)pipeline.Properties.Activities[0].TypeProperties).Source);
+        }
+
         [Theory, InlineData(PipelineJsonSamples.HDInsightPipeline)]
         [Trait(TraitName.TestType, TestType.Unit)]
         [Trait(TraitName.Function, TestType.Conversion)]

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/GenericRegisteredTypeConverter.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/GenericRegisteredTypeConverter.cs
@@ -115,20 +115,13 @@ namespace Microsoft.Azure.Management.DataFactories.Conversion
             JToken token;
             if (!obj.TryGetTypeProperty(out token))
             {
-                throw new InvalidOperationException(string.Format(
-                        CultureInfo.InvariantCulture,
-                        "Could not find a string property '{0}' for the following JSON: {1}",
-                        DataFactoryConstants.KeyPolymorphicType,
-                        obj));
+                return null;
             }
 
             Type type;
             if (!this.TryGetRegisteredType(token.ToString(), out type))
             {
-                throw new InvalidOperationException(string.Format(
-                        CultureInfo.InvariantCulture,
-                        "There is no type available with the name '{0}'.",
-                        token));
+                return null;
             }
 
             TRegistered target = (TRegistered)Activator.CreateInstance(type);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataFactories
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataFactories">
-      <PackageVersion>1.0.1</PackageVersion>
+      <PackageVersion>1.0.2</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Factory management operations.")]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]


### PR DESCRIPTION
Deserialization should not throw an exception, as we should assume that the service sends back a valid JSON definition. If we see an unknown nested polymorphic type (in the case of CopyLocations for CopyActivity), instead return a null object. 
