### PR TITLE
Error using Connection Pooling with DeviceClient, AMQP and X509 certificates

### DIFF
--- a/src/Authentication/Common.Authentication/Microsoft.Azure.Common.Authentication.nuspec
+++ b/src/Authentication/Common.Authentication/Microsoft.Azure.Common.Authentication.nuspec
@@ -17,7 +17,7 @@
     <dependencies>
       <dependency id="Microsoft.Azure.Common" version="[2.1.0,3.0)" />
       <dependency id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.18.206251556" />
-      <dependency id="Microsoft.Rest.ClientRuntime.Azure" version="[1.0.18-preview,2.0)" />
+      <dependency id="Microsoft.Rest.ClientRuntime.Azure.Authentication" version="[0.9.3,1)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Authentication/Common.Authentication/Microsoft.Azure.Common.Authentication.nuspec
+++ b/src/Authentication/Common.Authentication/Microsoft.Azure.Common.Authentication.nuspec
@@ -16,7 +16,7 @@
     <tags>Microsoft "Microsoft Azure" Azure cloud REST HTTP client core common azureofficial windowsazureofficial</tags>
     <dependencies>
       <dependency id="Microsoft.Azure.Common" version="[2.1.0,3.0)" />
-      <dependency id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.18.206251556" />
+      <dependency id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="[2.18.206251556]" />
       <dependency id="Microsoft.Rest.ClientRuntime.Azure.Authentication" version="[0.9.3,1)" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
We want to use AMQP to connect several IoT Devices through a field gateway to a Microsoft Azure IoT Hub. Each IoT Device has its own X509 certificate to authenticate itself at the IoT Hub.

Our field gateway will open a lot of connections to the IoT Hub - one for each IoT Device and one for himself. This may cause a firewall to block our communication because it looks like a DoS attack.

To prevent this, we want to use the AMQP Connection Pooling "feature". 
```
// some steps earlier I get the connection info from the 
// Azure Device Provisioning service
// and have the essential information stored
// in the _ConnectionInfo object

AmqpConnectionPoolSettings poolSettings = new AmqpConnectionPoolSettings();
poolSettings.MaxPoolSize = 1;
poolSettings.Pooling = true;
poolSettings.ConnectionIdleTimeout = new TimeSpan(0, 1, 0);

AmqpTransportSettings settings = new AmqpTransportSettings( TransportType.Amqp_WebSocket_Only , 50, poolSettings);
settings.ClientCertificate = _ConnectionInfo.ClientCertificate;
settings.OpenTimeout = new TimeSpan(0, 1, 0);
settings.OperationTimeout = new TimeSpan(0, 1, 0);

_Client = DeviceClient.Create(_ConnectionInfo.AssignedHub, _ConnectionInfo.AuthenticationMethod, new ITransportSettings[] { settings });
```
   
After doing some search at google it seems that the AMQP

Protocol does not support Connection Pooling wiht X509 certificate authentification.

Can someone confirm this or give me some hint what the reason for the connection issue may be.

Best Regards

Chris