### PR TITLE
HOTFIX! (ADF) - add required BatchUri property to AzureBatchLinkedService

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/LinkedServiceJsonSamples.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/LinkedServiceJsonSamples.cs
@@ -211,7 +211,8 @@ namespace DataFactory.Tests.Framework.JsonSamples
         type: ""AzureBatch"",
         hubName: ""hubName"",
         typeProperties: {
-            accountName: ""MyAzureBatchAccount"",
+            accountName: ""myaccount"",
+            batchUri: ""myaccount.region.batch.windows.com"",
             accessKey: ""accessKey"",
             poolName: ""MyAzureBatchPool"",
             linkedServiceName: ""MyStorageAssetName""

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/LinkedServices/AzureBatchLinkedService.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/LinkedServices/AzureBatchLinkedService.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Azure.Management.DataFactories.Models
         public string AccountName { get; set; }
 
         /// <summary>
+        /// Required. The Azure Batch URI.
+        /// </summary>
+        [AdfRequired]
+        public string BatchUri { get; set; }
+
+        /// <summary>
         /// Required. The azure storage linked service name.
         /// </summary>
         [AdfRequired]
@@ -48,17 +54,20 @@ namespace Microsoft.Azure.Management.DataFactories.Models
 
         public AzureBatchLinkedService(
             string accountName, 
+            string batchUri, 
             string accessKey, 
             string poolName, 
             string linkedServiceName)
             : this()
         {
             Ensure.IsNotNullOrEmpty(accountName, "accountName");
+            Ensure.IsNotNullOrEmpty(batchUri, "batchUri");
             Ensure.IsNotNullOrEmpty(accessKey, "accessKey");
             Ensure.IsNotNullOrEmpty(poolName, "poolName");
             Ensure.IsNotNullOrEmpty(linkedServiceName, "linkedServiceName");
 
             this.AccountName = accountName;
+            this.BatchUri = batchUri;
             this.AccessKey = accessKey;
             this.PoolName = poolName;
             this.LinkedServiceName = linkedServiceName;


### PR DESCRIPTION
This is a hotfix to account for the breaking change to the Azure Batch service. 

Will get published as a breaking change along with version 2.0.0 of the ADF SDK. 
