### PR TITLE
HOTFIX - (ADF) suppress exceptions during deserialization 

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/LinkedServiceTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/LinkedServiceTests.cs
@@ -261,6 +261,26 @@ namespace DataFactory.Tests.UnitTests
                 Assert.Throws<InvalidOperationException>(() => this.TestLinkedServiceValidation(json));
             Assert.Contains("is required", ex.Message);
         }
+
+        [Theory]
+        [InlineData(@"{
+    name: ""MyLinkedService"",
+    properties: 
+    {
+        type: ""AzureSqlDatabase"", 
+        typeProperties: {
+            connectionString: null
+        }
+    }
+}")]
+        [Trait(TraitName.TestType, TestType.Unit)]
+        [Trait(TraitName.Function, TestType.Conversion)]
+
+        public void CanConvertLinkedServiceWithNullTypePropertyValuesTest(string json)
+        {
+            JsonSampleInfo sample = new JsonSampleInfo("LinkedServiceWithNullTypePropertyValues", json, null);
+            this.TestLinkedServiceJson(sample);
+        }
 #endif 
 
         #endregion Tests

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/PipelineTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/PipelineTests.cs
@@ -179,6 +179,38 @@ namespace DataFactory.Tests.UnitTests
             Assert.Null(((CopyActivity)pipeline.Properties.Activities[0].TypeProperties).Source);
         }
 
+        [Theory]
+        [InlineData(@"{
+    name: ""MyPipelineName"",
+    properties: 
+    {
+        activities:
+        [
+            {
+                type: ""Copy"",
+                name: ""TestActivity"",
+                description: ""Test activity description"", 
+                typeProperties:
+                {
+                    source: null,
+                    sink: null
+                },
+                inputs: [ { name: ""InputSqlDA"" } ],
+                outputs: [ { name: ""OutputBlobDA"" } ],
+                linkedServiceName: ""MyLinkedServiceName""
+            }
+        ]
+    }
+}")]
+        [Trait(TraitName.TestType, TestType.Unit)]
+        [Trait(TraitName.Function, TestType.Conversion)]
+
+        public void CanConvertPipelineWithNullTypePropertyValuesTest(string json)
+        {
+            JsonSampleInfo sample = new JsonSampleInfo("PipelineWithNullTypePropertyValues", json, null);
+            this.TestPipelineJson(sample);
+        }
+
         [Theory, InlineData(PipelineJsonSamples.HDInsightPipeline)]
         [Trait(TraitName.TestType, TestType.Unit)]
         [Trait(TraitName.Function, TestType.Conversion)]

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/TableTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/TableTests.cs
@@ -106,6 +106,31 @@ namespace DataFactory.Tests.UnitTests
             Assert.IsType<GenericDataset>(table.Properties.TypeProperties);
         }
 
+        [Theory]
+        [InlineData(@"{
+    name: ""MyTable"",
+    properties: 
+    {
+        type: ""AzureBlob"", 
+        linkedServiceName: ""MyBlobLinkedService"",
+        typeProperties: {
+            connectionString: null
+        }, 
+        availability: { 
+            frequency: ""Day"", 
+            interval: 1
+        }
+    }
+}")]
+        [Trait(TraitName.TestType, TestType.Unit)]
+        [Trait(TraitName.Function, TestType.Conversion)]
+
+        public void CanConvertTableWithNullTypePropertyValuesTest(string json)
+        {
+            JsonSampleInfo sample = new JsonSampleInfo("TableWithNullTypePropertyValues", json, null);
+            this.TestTableJson(sample);
+        }
+
         private void TestTableJson(JsonSampleInfo info)
         {
             string json = info.Json;

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/GenericRegisteredTypeConverter.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/GenericRegisteredTypeConverter.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Management.DataFactories.Conversion
             }
         }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        protected override object ReadJsonWrapper(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             JObject obj = JObject.Load(reader);
 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/PolymorphicTypeConverter.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/PolymorphicTypeConverter.cs
@@ -42,6 +42,23 @@ namespace Microsoft.Azure.Management.DataFactories.Conversion
             ReservedTypesList = new Lazy<Dictionary<string, Type>>(GetReservedTypes);
         }
 
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            try
+            {
+                return this.ReadJsonWrapper(reader, objectType, existingValue, serializer);
+            }
+            catch (Exception)
+            {
+                // Suppress any exception during deserialization; 
+                // we should assume that the service sends back valid JSON, 
+                // so return null if there is any problem deserializing.
+                return null;
+            }
+        }
+
+        protected abstract object ReadJsonWrapper(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer);
+
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             JObject obj = JObject.FromObject(

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/TypePropertiesConverter.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/TypePropertiesConverter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Management.DataFactories.Conversion
         private readonly CamelCasePropertyNamesContractResolver camelCaseResolver =
             new CamelCasePropertyNamesContractResolver();
 
-        public override object ReadJson(
+        protected override object ReadJsonWrapper(
             JsonReader reader,
             Type objectType,
             object existingValue,

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataFactories
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataFactories">
-      <PackageVersion>2.0.0</PackageVersion>
+      <PackageVersion>2.0.1</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Factory management operations.")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]


### PR DESCRIPTION
This change ensures that during JSON deserialization, any exceptions are suppressed so as not to break Get/List calls. We should assume that the service sends back valid JSON and not throw. 

This fix is needed in POSH as well. I will send a PR for that once this is merged and a new nuget is pushed. 

I will add logging later to ensure that we can capture stack traces, etc. for any such serialization issues. 
