### PR TITLE
Excessive memory usage when downloading logs or results from HDInsight

### DIFF
--- a/src/ServiceManagement/HDInsight/Microsoft.Hadoop.Client/Storage/WabStorageAbstraction.cs
+++ b/src/ServiceManagement/HDInsight/Microsoft.Hadoop.Client/Storage/WabStorageAbstraction.cs
@@ -128,10 +128,8 @@ namespace Microsoft.Hadoop.Client.Storage
             this.AssertPathRootedToThisAccount(httpPath);
             var blobReference = await this.GetBlobReference(httpPath, true);
 
-            var blobStream = new MemoryStream();
-            blobReference.DownloadToStream(blobStream);
-            blobStream.Seek(0, SeekOrigin.Begin);
-
+            var blobStream = await blobReference.OpenReadAsync();
+            
             return blobStream;
         }
 

--- a/src/ServiceManagement/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/JobSubmission/HDInsightHadoopClient.cs
+++ b/src/ServiceManagement/HDInsight/Microsoft.WindowsAzure.Management.HDInsight/JobSubmission/HDInsightHadoopClient.cs
@@ -366,8 +366,10 @@ namespace Microsoft.WindowsAzure.Management.HDInsight.JobSubmission
                 // create local file in the targetdirectory.
                 var localFilePath = Path.Combine(targetDirectory, taskLogFilePath.Segments.Last());
                 var fileContentStream = await storageClient.Read(taskLogFilePath);
-                var fileContents = new StreamReader(fileContentStream).ReadToEnd();
-                File.WriteAllText(localFilePath, fileContents);
+                using (var localFileStream = File.Create(localFilePath))
+                {
+                    await fileContentStream.CopyToAsync(localFileStream);
+                }
             }
         }
 


### PR DESCRIPTION
Recreated: https://github.com/Azure/azure-sdk-for-net/pull/1263

The previous pull request was closed because, I assume, I took too long rebasing it.

Details:

In our application the following causes an eventual out of memory exception _client.GetJobOutput(JobId);

(For completeness, a Pig script has a DUMP statement that dumps ~3GB of output).

GetJobOutput returns a stream, which we stream through to another blob. The internal implementation of GetJobOutput ends up where copies the contents of the blob to a memory stream, then returns the memory stream (in WabStorageAbstraction).

This appears to be unexpected behaviour, the stream implies it's safe to use with large contents

Therefore, I replaced the current approach with blobReference.OpenRead (thus returning a BlobReadStream).

I checked for usages of the WabStorageAbstraction Read method and found that HDInsightHadoopClient DownloadJobTaskLogsAsync also loads the contents of the blob into memory (via a string reader ReadAllText). Although this isn't a problem for us, I assume someone might run into it one day so I replaced that with File.Create and stream.CopyTo

Additional Info:

I think there is now an edge case that if the logs are changed whilst they are being downloaded a HTTP conflict will occur.  This is the downside of using the OpenRead approach.

The only way round this is to do DownloadToFile, return a file stream and add something to clean up the output.

I think this isn't a problem because I logs are downloaded once a job completes, so won't change.
