### PR TITLE
Address web site test flakiness

### DIFF
--- a/src/ClientRuntime.Azure.TestFramework/TestFramework.Tests/Properties/AssemblyInfo.cs
+++ b/src/ClientRuntime.Azure.TestFramework/TestFramework.Tests/Properties/AssemblyInfo.cs
@@ -12,5 +12,4 @@ using Xunit;
 [assembly: Guid("1ef9815c-0ff0-4e5e-b80b-5d6db86c16fd")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]
 

--- a/src/ResourceManagement/Compute/Compute.Tests/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Compute/Compute.Tests/Properties/AssemblyInfo.cs
@@ -24,4 +24,3 @@ using Xunit;
 [assembly: Guid("1050e361-5461-40c6-a866-6b90e01aac9c")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/ResourceManagement/Logic/Logic.Tests/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Logic/Logic.Tests/Properties/AssemblyInfo.cs
@@ -20,5 +20,3 @@ using Xunit;
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: ComVisible(false)]
-
-[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/ResourceManagement/Network/Network.Tests/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Network/Network.Tests/Properties/AssemblyInfo.cs
@@ -35,4 +35,3 @@ using Xunit;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/ResourceManagement/Resource/Resources.Tests/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Resource/Resources.Tests/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -35,4 +38,3 @@ using Xunit;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/ResourceManagement/Storage/Storage.Tests/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Storage/Storage.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -35,4 +38,3 @@ using Xunit;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/ResourceManagement/WebSite/WebSites.Tests/ScenarioTests/SourceControls.ScenarioTests.cs
+++ b/src/ResourceManagement/WebSite/WebSites.Tests/ScenarioTests/SourceControls.ScenarioTests.cs
@@ -43,7 +43,7 @@ namespace WebSites.Tests.ScenarioTests
             SourceControlName = "Bitbucket"
         };
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void TestUpdateSourceControlUpdates()
         {
             var handler = new RecordedDelegatingHandler { StatusCodeToReturn = HttpStatusCode.OK };

--- a/src/ResourceManagement/WebSite/WebSites.Tests/ScenarioTests/WebHostingPlan.ScenarioTests.cs
+++ b/src/ResourceManagement/WebSite/WebSites.Tests/ScenarioTests/WebHostingPlan.ScenarioTests.cs
@@ -28,7 +28,7 @@ namespace WebSites.Tests.ScenarioTests
 {
     public class WebHostingPlanScenarioTests : TestBase
     {
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void CreateAndVerifyWebHostingPlan()
         {
             var handler = new RecordedDelegatingHandler {StatusCodeToReturn = HttpStatusCode.OK};
@@ -70,7 +70,7 @@ namespace WebSites.Tests.ScenarioTests
             }
         }
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void CreateAndVerifyListOfWebHostingPlan()
         {
             var handler = new RecordedDelegatingHandler { StatusCodeToReturn = HttpStatusCode.OK };
@@ -124,7 +124,7 @@ namespace WebSites.Tests.ScenarioTests
             }
         }
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void CreateAndDeleteWebHostingPlan()
         {
             var handler = new RecordedDelegatingHandler { StatusCodeToReturn = HttpStatusCode.OK };
@@ -167,7 +167,7 @@ namespace WebSites.Tests.ScenarioTests
             }
         }
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void GetAndSetAdminSiteWebHostingPlan()
         {
             var handler = new RecordedDelegatingHandler { StatusCodeToReturn = HttpStatusCode.OK };

--- a/src/ResourceManagement/WebSite/WebSites.Tests/ScenarioTests/WebSite.ScenarioTests.cs
+++ b/src/ResourceManagement/WebSite/WebSites.Tests/ScenarioTests/WebSite.ScenarioTests.cs
@@ -35,7 +35,7 @@ namespace WebSites.Tests.ScenarioTests
     {
         private delegate void WebsiteTestDelegate(string webSiteName, string resourceGroupName, string webHostingPlanName, string location, WebSiteManagementClient webSitesClient, ResourceManagementClient resourcesClient);
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void CreateAndVerifyGetOnAWebsite()
         {
             RunWebsiteTestScenario(
@@ -55,7 +55,7 @@ namespace WebSites.Tests.ScenarioTests
                 });
         }
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void CreateAndVerifyListOfWebsites()
         {
             RunWebsiteTestScenario(
@@ -71,7 +71,7 @@ namespace WebSites.Tests.ScenarioTests
                 });
         }
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact(Skip = "Test ERROR, please investigate")]
         public void CreateAndDeleteWebsite()
         {
             RunWebsiteTestScenario(
@@ -142,7 +142,7 @@ namespace WebSites.Tests.ScenarioTests
                 });
         }
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact(Skip = "Test ERROR, please investigate")]
         public void GetAndSetNonSensitiveSiteConfigs()
         {
             RunWebsiteTestScenario(
@@ -266,7 +266,7 @@ namespace WebSites.Tests.ScenarioTests
                 });
         }
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void GetAndSetSlotSettingsConfigs()
         {
             RunWebsiteTestScenario(
@@ -385,7 +385,7 @@ namespace WebSites.Tests.ScenarioTests
             }
         }
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void GetAndSetSiteLimits()
         {
             var handler = new RecordedDelegatingHandler() { StatusCodeToReturn = HttpStatusCode.OK };

--- a/src/ResourceManagement/WebSite/WebSites.Tests/ScenarioTests/WebSiteSlot.ScenarioTests.cs
+++ b/src/ResourceManagement/WebSite/WebSites.Tests/ScenarioTests/WebSiteSlot.ScenarioTests.cs
@@ -28,7 +28,7 @@ namespace WebSites.Tests.ScenarioTests
 {
     public class WebSiteSlotScenarioTests : TestBase
     {
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void CreateAndVerifyGetOnAWebsiteSlot()
         {
             var handler = new RecordedDelegatingHandler { StatusCodeToReturn = HttpStatusCode.OK };
@@ -85,7 +85,7 @@ namespace WebSites.Tests.ScenarioTests
             }
         }
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void CreateAndVerifyListOfSlots()
         {
             var handler = new RecordedDelegatingHandler() { StatusCodeToReturn = HttpStatusCode.OK };
@@ -144,7 +144,7 @@ namespace WebSites.Tests.ScenarioTests
             }
         }
 
-        [Fact(Skip = "TEMPORARILY DISABLING TESTS DUE TO ENVIRONMENT ISSUE")]
+        [Fact]
         public void CreateAndDeleteWebSiteSlot()
         {
             var handler = new RecordedDelegatingHandler() { StatusCodeToReturn = HttpStatusCode.OK };

--- a/src/Search/Search.Management.Tests/Properties/AssemblyInfo.cs
+++ b/src/Search/Search.Management.Tests/Properties/AssemblyInfo.cs
@@ -1,17 +1,5 @@
-﻿// 
-// Copyright (c) Microsoft.  All rights reserved. 
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); 
-// you may not use this file except in compliance with the License. 
-// You may obtain a copy of the License at 
-//   http://www.apache.org/licenses/LICENSE-2.0 
-// 
-// Unless required by applicable law or agreed to in writing, software 
-// distributed under the License is distributed on an "AS IS" BASIS, 
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-// See the License for the specific language governing permissions and 
-// limitations under the License. 
-// 
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -50,4 +38,3 @@ using Xunit;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/tools/DisableTestRunParallel.cs
+++ b/tools/DisableTestRunParallel.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/tools/Library.Settings.targets
+++ b/tools/Library.Settings.targets
@@ -96,6 +96,12 @@
     <ProjectTypeGuids />
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(SDKTestProject)' == 'true' and '$(AutoRestProjects)' == 'true' ">
+    <Compile Include="$(LibraryToolsFolder)\DisableTestRunParallel.cs">
+      <Link>DisableTestRunParallel.cs</Link>
+    </Compile>
+  </ItemGroup>   
+  
   <Target Name="InformationAboutThisBuild" BeforeTargets="BeforeBuild">
     <Error Text="The current build type has not been defined." Condition=" '$(LibraryFxTarget)' == '' " />
     <Message Text="Current build type:            $(LibraryFxTarget)" />


### PR DESCRIPTION
The fix is to disable parallel running like other projects. We have to do this, unless we could update test mock support to no longer use singleton, which we should in future.
