### PR TITLE
match casing of types that the service returns

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/TableJsonSamples.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/TableJsonSamples.cs
@@ -28,7 +28,7 @@ namespace DataFactory.Tests.Framework.JsonSamples
     name: ""CustomTable"",
     properties:
     {
-        type: ""CustomDataSet"",
+        type: ""CustomDataset"",
         linkedServiceName: ""MyCustomServiceName"",
         typeProperties:
         {   

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Tables/CustomDataset.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Tables/CustomDataset.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Management.DataFactories.Models
     /// <summary>
     /// Custom location.
     /// </summary>
-    [AdfTypeName("CustomDataSet")]
+    [AdfTypeName("CustomDataset")]
     public sealed class CustomDataset : TableTypeProperties, IGenericTypeProperties
     {
         public IDictionary<string, JToken> ServiceExtraProperties { get; set; } 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Common/Models/PropertyDataType.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Common/Models/PropertyDataType.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Management.DataFactories.Common.Models
         /// <summary>
         /// DateTime type.
         /// </summary>
-        public const string DateTime = "DateTime";
+        public const string DateTime = "Datetime";
         
         /// <summary>
         /// DateTimeOffset type.


### PR DESCRIPTION
This is not a breaking change since the client is case-insensitive; the
change needs to be made since the SDK object model is used to verify the
content of Data Factory JSON schemas and schemas are case-sensitive.
- change CustomDataSet to CustomDataset
- change PropertyDataType.DateTime from DateTime to Datetime
- does not require a nuget version bump as this is not a client-impacting change
