### PR TITLE
ADF - use API version 2015-09-01

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Resources/DP_Wikisamplev2json.json
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Resources/DP_Wikisamplev2json.json
@@ -53,8 +53,7 @@
         },
         "typeProperties": {
           "source": {
-            "type": "BlobSource",
-            "blobColumnSeparators": ","
+            "type": "BlobSource"
           },
           "sink": {
             "type": "SqlSink",

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/ScenarioTests/TestHelper.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/ScenarioTests/TestHelper.cs
@@ -44,7 +44,7 @@ namespace DataFactory.Tests.ScenarioTests
         public static string GetDefaultLocation()
         {
             // ADF will always use the below region for http mock test in Dogfood
-            return "Brazil South";
+            return "East US 2";
         }
     }
 }

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.PipelineTests/WikipediaPipelineE2ETest.json
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.PipelineTests/WikipediaPipelineE2ETest.json
@@ -1,25 +1,25 @@
 {
   "Entries": [
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402?api-version=2014-04-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899?api-version=2014-04-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtcHJldmlldw==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"location\": \"Brazil South\"\r\n}",
+      "RequestBody": "{\r\n  \"location\": \"East US 2\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "34"
+          "31"
         ],
         "User-Agent": [
           "Microsoft.Azure.Management.Resources.ResourceManagementClient/2.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourceGroups/resourcegroup8402\",\r\n  \"name\": \"resourcegroup8402\",\r\n  \"location\": \"brazilsouth\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourceGroups/resourcegroup6899\",\r\n  \"name\": \"resourcegroup6899\",\r\n  \"location\": \"eastus2\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "192"
+          "188"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -31,16 +31,16 @@
           "no-cache"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1197"
+          "1199"
         ],
         "x-ms-request-id": [
-          "bdc43eea-1ffa-479e-b6eb-08d01b60466d"
+          "4f4ac645-4c46-4f54-a46f-f3c45e892d84"
         ],
         "x-ms-correlation-request-id": [
-          "bdc43eea-1ffa-479e-b6eb-08d01b60466d"
+          "4f4ac645-4c46-4f54-a46f-f3c45e892d84"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222901Z:bdc43eea-1ffa-479e-b6eb-08d01b60466d"
+          "CENTRALUS:20150828T230230Z:4f4ac645-4c46-4f54-a46f-f3c45e892d84"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -49,34 +49,34 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:01 GMT"
+          "Fri, 28 Aug 2015 23:02:30 GMT"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTY/YXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzE/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"name\": \"DataFactory8496\",\r\n  \"location\": \"Brazil South\"\r\n}",
+      "RequestBody": "{\r\n  \"name\": \"DataFactory3531\",\r\n  \"location\": \"East US 2\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json"
         ],
         "Content-Length": [
-          "64"
+          "61"
         ],
         "x-ms-client-request-id": [
-          "8180568b-4a66-476a-a185-7372213e3fde"
+          "4f488096-9d76-415c-bf6e-57a6c137f7de"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DataFactory8496\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496\",\r\n  \"type\": \"Microsoft.DataFactory/datafactories\",\r\n  \"location\": \"Brazil South\",\r\n  \"tags\": null,\r\n  \"properties\": {\r\n    \"dataFactoryId\": \"a37258c3-b1d2-499b-83e8-db0d123e4a65\",\r\n    \"provisioningState\": \"PendingCreation\",\r\n    \"error\": null,\r\n    \"errorMessage\": null\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DataFactory3531\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531\",\r\n  \"type\": \"Microsoft.DataFactory/datafactories\",\r\n  \"location\": \"East US 2\",\r\n  \"tags\": null,\r\n  \"properties\": {\r\n    \"dataFactoryId\": \"82877575-ab65-4cfe-9129-1fd4da00597e\",\r\n    \"provisioningState\": \"PendingCreation\",\r\n    \"error\": null,\r\n    \"errorMessage\": null\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "468"
+          "465"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -88,16 +88,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "c7a8cd50-09d6-4a8f-8300-3a15f7b82522"
+          "df41bef9-1535-4f4f-82da-724f64a72537"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1196"
+          "1198"
         ],
         "x-ms-correlation-request-id": [
-          "f31bd9c6-4102-4f5c-b7a0-384fb6b56285"
+          "52245f74-e96a-4035-b1f7-d780b7aad956"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222904Z:f31bd9c6-4102-4f5c-b7a0-384fb6b56285"
+          "CENTRALUS:20150828T230231Z:52245f74-e96a-4035-b1f7-d780b7aad956"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -106,10 +106,10 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:04 GMT"
+          "Fri, 28 Aug 2015 23:02:31 GMT"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496?api-version=2015-08-01"
+          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531?api-version=2015-09-01"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -121,25 +121,25 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTY/YXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzE/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "05c36bcc-b52e-41e0-884b-de5965800a13"
+          "ba79a7b2-2b84-49e9-bd67-e104b37efbb7"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DataFactory8496\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496\",\r\n  \"type\": \"Microsoft.DataFactory/datafactories\",\r\n  \"location\": \"Brazil South\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"dataFactoryId\": \"a37258c3-b1d2-499b-83e8-db0d123e4a65\",\r\n    \"provisioningState\": \"PendingCreation\",\r\n    \"error\": null,\r\n    \"errorMessage\": null\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DataFactory3531\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531\",\r\n  \"type\": \"Microsoft.DataFactory/datafactories\",\r\n  \"location\": \"East US 2\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"dataFactoryId\": \"82877575-ab65-4cfe-9129-1fd4da00597e\",\r\n    \"provisioningState\": \"PendingCreation\",\r\n    \"error\": null,\r\n    \"errorMessage\": null\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "466"
+          "463"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -151,16 +151,136 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "7d60465a-d476-46c9-b8a7-436c4963701c"
+          "e8b2424a-b642-4ed9-8b6e-c517212f05d4"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14999"
+        ],
+        "x-ms-correlation-request-id": [
+          "d3ac53af-8279-472f-a521-0344966129ee"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20150828T230231Z:d3ac53af-8279-472f-a521-0344966129ee"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 28 Aug 2015 23:02:31 GMT"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.5"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzE/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "88f48da7-978b-4118-bc07-21ecb272f2a3"
+        ],
+        "x-ms-version": [
+          "2015-09-01"
+        ],
+        "User-Agent": [
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"DataFactory3531\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531\",\r\n  \"type\": \"Microsoft.DataFactory/datafactories\",\r\n  \"location\": \"East US 2\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"dataFactoryId\": \"82877575-ab65-4cfe-9129-1fd4da00597e\",\r\n    \"provisioningState\": \"PendingCreation\",\r\n    \"error\": null,\r\n    \"errorMessage\": null\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "463"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "b1559af8-72f3-4d2e-a55f-b9b8d96cbcbf"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14998"
+        ],
+        "x-ms-correlation-request-id": [
+          "70235789-f3df-4b3f-b918-2b0bb69d2356"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20150828T230236Z:70235789-f3df-4b3f-b918-2b0bb69d2356"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 28 Aug 2015 23:02:36 GMT"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.5"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzE/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "e2206c9e-8a99-4ce4-b188-52369623d3d3"
+        ],
+        "x-ms-version": [
+          "2015-09-01"
+        ],
+        "User-Agent": [
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"DataFactory3531\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531\",\r\n  \"type\": \"Microsoft.DataFactory/datafactories\",\r\n  \"location\": \"East US 2\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"dataFactoryId\": \"82877575-ab65-4cfe-9129-1fd4da00597e\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"error\": null,\r\n    \"errorMessage\": null\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "457"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "814389c7-37aa-4394-9276-d5b6b78fdb8a"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14997"
         ],
         "x-ms-correlation-request-id": [
-          "c5cc8c73-6806-4333-ac2c-2063dfdcefc0"
+          "c9281143-fa73-42fd-a3da-172cee77ecaf"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222905Z:c5cc8c73-6806-4333-ac2c-2063dfdcefc0"
+          "CENTRALUS:20150828T230242Z:c9281143-fa73-42fd-a3da-172cee77ecaf"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -169,7 +289,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:04 GMT"
+          "Fri, 28 Aug 2015 23:02:41 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -181,25 +301,22 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTY/YXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzE/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "c87e8103-07e9-4766-b2f1-9647d6df6700"
-        ],
-        "x-ms-version": [
-          "2015-08-01"
+          "151f4c2f-2d22-438b-b959-d5078f0e91bf"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DataFactory8496\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496\",\r\n  \"type\": \"Microsoft.DataFactory/datafactories\",\r\n  \"location\": \"Brazil South\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"dataFactoryId\": \"a37258c3-b1d2-499b-83e8-db0d123e4a65\",\r\n    \"provisioningState\": \"PendingCreation\",\r\n    \"error\": null,\r\n    \"errorMessage\": null\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DataFactory3531\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531\",\r\n  \"type\": \"Microsoft.DataFactory/datafactories\",\r\n  \"location\": \"East US 2\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"dataFactoryId\": \"82877575-ab65-4cfe-9129-1fd4da00597e\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"error\": null,\r\n    \"errorMessage\": null\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "466"
+          "457"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -211,16 +328,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "f85e7395-c00c-41b5-9593-79a9981781ff"
+          "07857bce-ce55-4191-ac01-0ebd221cb29b"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14996"
         ],
         "x-ms-correlation-request-id": [
-          "51674434-b425-4137-9e68-0a69d8c36679"
+          "5fa327c1-fe1a-4777-9304-850ea7a6324a"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222910Z:51674434-b425-4137-9e68-0a69d8c36679"
+          "CENTRALUS:20150828T230242Z:5fa327c1-fe1a-4777-9304-850ea7a6324a"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -229,7 +346,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:10 GMT"
+          "Fri, 28 Aug 2015 23:02:41 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -241,125 +358,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTY/YXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "0a9f0d43-c41a-40c7-aa6f-ef0d5e7ba0aa"
-        ],
-        "x-ms-version": [
-          "2015-08-01"
-        ],
-        "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"DataFactory8496\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496\",\r\n  \"type\": \"Microsoft.DataFactory/datafactories\",\r\n  \"location\": \"Brazil South\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"dataFactoryId\": \"a37258c3-b1d2-499b-83e8-db0d123e4a65\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"error\": null,\r\n    \"errorMessage\": null\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "460"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "510c7e35-7d2e-428b-bffc-57d6f7471f57"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14995"
-        ],
-        "x-ms-correlation-request-id": [
-          "eec37e09-5ae7-4f60-9bce-6db403e9ab39"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222915Z:eec37e09-5ae7-4f60-9bce-6db403e9ab39"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Fri, 31 Jul 2015 22:29:15 GMT"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "X-Powered-By": [
-          "ASP.NET"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTY/YXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "b04a6dbb-1d5b-4374-bf17-82db4bf95cb6"
-        ],
-        "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"DataFactory8496\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496\",\r\n  \"type\": \"Microsoft.DataFactory/datafactories\",\r\n  \"location\": \"Brazil South\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"dataFactoryId\": \"a37258c3-b1d2-499b-83e8-db0d123e4a65\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"error\": null,\r\n    \"errorMessage\": null\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "460"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "411c5190-98a6-4949-8860-6ccf66e7ec9c"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14994"
-        ],
-        "x-ms-correlation-request-id": [
-          "a7a9a711-48a7-41f0-9357-ff9da6d57d5c"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222916Z:a7a9a711-48a7-41f0-9357-ff9da6d57d5c"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Fri, 31 Jul 2015 22:29:15 GMT"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "X-Powered-By": [
-          "ASP.NET"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikipediaClickEvents?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpcGVkaWFDbGlja0V2ZW50cz9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikipediaClickEvents?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpcGVkaWFDbGlja0V2ZW50cz9hcGktdmVyc2lvbj0yMDE1LTA5LTAx",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"name\": \"LinkedService-WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"ConnectionString\": \"DefaultEndpointsProtocol=https;AccountName=mywikistorage;AccountKey=mytestaccountkey\"\r\n    }\r\n  }\r\n}",
       "RequestHeaders": {
@@ -370,16 +370,16 @@
           "254"
         ],
         "x-ms-client-request-id": [
-          "362b9310-3985-4545-89e3-db36f912b9a2"
+          "bd736fda-912d-4a4f-928b-1b63ede52447"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikipediaClickEvents\",\r\n  \"name\": \"LinkedService-WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mywikistorage;AccountKey=**********\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikipediaClickEvents\",\r\n  \"name\": \"LinkedService-WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mywikistorage;AccountKey=**********\"\r\n    },\r\n    \"id\": \"13050880-1bc2-41e9-9790-a7bfb33fe6cd\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "469"
+          "513"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -391,16 +391,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "ee75ddda-8234-4e22-94cf-b4fdb3c9c32d"
+          "05b86ef1-1ee3-48fb-b85d-35d382269e86"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1195"
+          "1197"
         ],
         "x-ms-correlation-request-id": [
-          "6adcc095-b0fe-4f5b-939c-7d788c586ef5"
+          "bee7ae93-26ef-4de4-9d4d-56a96dfadb65"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222919Z:6adcc095-b0fe-4f5b-939c-7d788c586ef5"
+          "CENTRALUS:20150828T230242Z:bee7ae93-26ef-4de4-9d4d-56a96dfadb65"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -409,10 +409,10 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:18 GMT"
+          "Fri, 28 Aug 2015 23:02:41 GMT"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikipediaClickEvents?api-version=2015-08-01"
+          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikipediaClickEvents?api-version=2015-09-01"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -424,25 +424,25 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikipediaClickEvents?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpcGVkaWFDbGlja0V2ZW50cz9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikipediaClickEvents?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpcGVkaWFDbGlja0V2ZW50cz9hcGktdmVyc2lvbj0yMDE1LTA5LTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "bebaaaa2-5cb2-4557-81ad-9bf5f7543433"
+          "abd94eb2-7ae9-4200-b668-43d3dadd6d9b"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikipediaClickEvents\",\r\n  \"name\": \"LinkedService-WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mywikistorage;AccountKey=**********\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikipediaClickEvents\",\r\n  \"name\": \"LinkedService-WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mywikistorage;AccountKey=**********\"\r\n    },\r\n    \"id\": \"13050880-1bc2-41e9-9790-a7bfb33fe6cd\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "469"
+          "513"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -454,16 +454,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "ed0fd167-a549-4602-b1fa-1a9a90c6fe25"
+          "4edf1318-dda3-4fb9-92e3-292c4d4a71ff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14993"
+          "14995"
         ],
         "x-ms-correlation-request-id": [
-          "ed2efd20-7c28-4039-b5ae-983fd404bf05"
+          "f8fb3146-d9f5-459e-b6bd-2be7241e02c4"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222919Z:ed2efd20-7c28-4039-b5ae-983fd404bf05"
+          "CENTRALUS:20150828T230242Z:f8fb3146-d9f5-459e-b6bd-2be7241e02c4"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -472,7 +472,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:18 GMT"
+          "Fri, 28 Aug 2015 23:02:41 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -484,8 +484,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-CuratedWikiData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1DdXJhdGVkV2lraURhdGE/YXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-CuratedWikiData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1DdXJhdGVkV2lraURhdGE/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"name\": \"LinkedService-CuratedWikiData\",\r\n  \"properties\": {\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"ConnectionString\": \"DefaultEndpointsProtocol=https;AccountName=mytestaccountname;AccountKey=mytestaccountkey\"\r\n    }\r\n  }\r\n}",
       "RequestHeaders": {
@@ -496,16 +496,16 @@
           "253"
         ],
         "x-ms-client-request-id": [
-          "ca66ddf5-1213-4bd2-a574-3cdebc75f8e0"
+          "6f240da6-1764-4b86-9e27-c56065a27138"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-CuratedWikiData\",\r\n  \"name\": \"LinkedService-CuratedWikiData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mytestaccountname;AccountKey=**********\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-CuratedWikiData\",\r\n  \"name\": \"LinkedService-CuratedWikiData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mytestaccountname;AccountKey=**********\"\r\n    },\r\n    \"id\": \"32d9a8f2-7e32-4847-858e-74f0a3ab739e\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "463"
+          "507"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -517,16 +517,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "f79fcec1-5e5b-4b1d-9f33-1cee9c57d8ac"
+          "8a0bbef9-1406-4911-a794-43fb6fb05e11"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1194"
+          "1196"
         ],
         "x-ms-correlation-request-id": [
-          "f77ae85c-12ae-4e9d-bc18-39ee75ac6a58"
+          "11a4afa0-fd21-44c0-a6c6-790f4f9a9ccb"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222919Z:f77ae85c-12ae-4e9d-bc18-39ee75ac6a58"
+          "CENTRALUS:20150828T230242Z:11a4afa0-fd21-44c0-a6c6-790f4f9a9ccb"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -535,10 +535,10 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:19 GMT"
+          "Fri, 28 Aug 2015 23:02:41 GMT"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-CuratedWikiData?api-version=2015-08-01"
+          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-CuratedWikiData?api-version=2015-09-01"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -550,25 +550,25 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-CuratedWikiData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1DdXJhdGVkV2lraURhdGE/YXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-CuratedWikiData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1DdXJhdGVkV2lraURhdGE/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "69cc0998-91d0-4173-a5a7-8f347402a44d"
+          "66b2d8be-4bd8-4cf0-8080-e7161b51ebdc"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-CuratedWikiData\",\r\n  \"name\": \"LinkedService-CuratedWikiData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mytestaccountname;AccountKey=**********\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-CuratedWikiData\",\r\n  \"name\": \"LinkedService-CuratedWikiData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mytestaccountname;AccountKey=**********\"\r\n    },\r\n    \"id\": \"32d9a8f2-7e32-4847-858e-74f0a3ab739e\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "463"
+          "507"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -580,16 +580,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "9a8e1fbf-1250-40c0-a3b8-71f4ec155389"
+          "551aa07a-e8d8-4c0a-8d91-0eaf75282472"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14992"
+          "14994"
         ],
         "x-ms-correlation-request-id": [
-          "eec9c19a-1f53-473e-964c-9443104c550f"
+          "c74e3132-c64f-47e9-9f22-4b3d1a7e5d3d"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222920Z:eec9c19a-1f53-473e-964c-9443104c550f"
+          "CENTRALUS:20150828T230243Z:c74e3132-c64f-47e9-9f22-4b3d1a7e5d3d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -598,7 +598,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:19 GMT"
+          "Fri, 28 Aug 2015 23:02:43 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -610,8 +610,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikiAggregatedData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpQWdncmVnYXRlZERhdGE/YXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikiAggregatedData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpQWdncmVnYXRlZERhdGE/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"name\": \"LinkedService-WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"type\": \"AzureSqlDatabase\",\r\n    \"typeProperties\": {\r\n      \"ConnectionString\": \"Server=tcp:mytestsql.database.windows.net,1433;Database=mdpwikisamplev2;User ID=test@test.net;Password=fakepassword;Trusted_Connection=False;Encrypt=True;Connection Timeout=30\"\r\n    }\r\n  }\r\n}",
       "RequestHeaders": {
@@ -622,16 +622,16 @@
           "347"
         ],
         "x-ms-client-request-id": [
-          "82a323cc-64ac-4c92-bcbb-bb3df2d55793"
+          "9e081ce8-2a89-43c5-9ff9-ff099e889fff"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikiAggregatedData\",\r\n  \"name\": \"LinkedService-WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"AzureSqlDatabase\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"Data Source=tcp:mytestsql.database.windows.net,1433;Initial Catalog=mdpwikisamplev2;Integrated Security=False;User ID=test@test.net;Password=**********;Connect Timeout=30;Encrypt=True\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikiAggregatedData\",\r\n  \"name\": \"LinkedService-WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"AzureSqlDatabase\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"Data Source=tcp:mytestsql.database.windows.net,1433;Initial Catalog=mdpwikisamplev2;Integrated Security=False;User ID=test@test.net;Password=**********;Connect Timeout=30;Encrypt=True\"\r\n    },\r\n    \"id\": \"eb0b324f-03a5-4aad-8da6-a151a127ce71\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "574"
+          "618"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -643,16 +643,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "c6edf524-7153-4a3f-a0b5-738dbcb50c96"
+          "2cfc43a8-c491-4528-927c-8b6352d54480"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1193"
+          "1195"
         ],
         "x-ms-correlation-request-id": [
-          "fb2d2f57-a0d5-4137-96be-23373f79a068"
+          "da4d3cca-25a7-4b05-95c5-70babb86974f"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222920Z:fb2d2f57-a0d5-4137-96be-23373f79a068"
+          "CENTRALUS:20150828T230243Z:da4d3cca-25a7-4b05-95c5-70babb86974f"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -661,10 +661,10 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:20 GMT"
+          "Fri, 28 Aug 2015 23:02:43 GMT"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikiAggregatedData?api-version=2015-08-01"
+          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikiAggregatedData?api-version=2015-09-01"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -676,25 +676,25 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikiAggregatedData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpQWdncmVnYXRlZERhdGE/YXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikiAggregatedData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpQWdncmVnYXRlZERhdGE/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "f8bdd401-0541-41c0-9721-e3fae5fead89"
+          "7a6afc7b-553f-41ce-8306-b6c50ca1bfac"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikiAggregatedData\",\r\n  \"name\": \"LinkedService-WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"AzureSqlDatabase\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"Data Source=tcp:mytestsql.database.windows.net,1433;Initial Catalog=mdpwikisamplev2;Integrated Security=False;User ID=test@test.net;Password=**********;Connect Timeout=30;Encrypt=True\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikiAggregatedData\",\r\n  \"name\": \"LinkedService-WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"AzureSqlDatabase\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"Data Source=tcp:mytestsql.database.windows.net,1433;Initial Catalog=mdpwikisamplev2;Integrated Security=False;User ID=test@test.net;Password=**********;Connect Timeout=30;Encrypt=True\"\r\n    },\r\n    \"id\": \"eb0b324f-03a5-4aad-8da6-a151a127ce71\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "574"
+          "618"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -706,16 +706,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "e0c7a4d5-dd58-481d-b3f6-c9e9a4cd8da1"
+          "485bb653-3a40-4f2f-a06c-64a47ec5a4a5"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14991"
+          "14993"
         ],
         "x-ms-correlation-request-id": [
-          "67825c77-cc24-4b9f-8cb1-1859c401fcd6"
+          "b85634a0-f008-4ae3-87fd-90ad6bae3921"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222921Z:67825c77-cc24-4b9f-8cb1-1859c401fcd6"
+          "CENTRALUS:20150828T230243Z:b85634a0-f008-4ae3-87fd-90ad6bae3921"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -724,7 +724,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:20 GMT"
+          "Fri, 28 Aug 2015 23:02:43 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -736,8 +736,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/HDILinkedService?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvSERJTGlua2VkU2VydmljZT9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/HDILinkedService?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvSERJTGlua2VkU2VydmljZT9hcGktdmVyc2lvbj0yMDE1LTA5LTAx",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"name\": \"HDILinkedService\",\r\n  \"properties\": {\r\n    \"type\": \"HDInsight\",\r\n    \"typeProperties\": {\r\n      \"ClusterUri\": \"https://testhdi.azurehdinsight.net/\",\r\n      \"UserName\": \"testaccount\",\r\n      \"Password\": \"fakepassword\",\r\n      \"LinkedServiceName\": \"LinkedService-CuratedWikiData\"\r\n    }\r\n  }\r\n}",
       "RequestHeaders": {
@@ -748,16 +748,16 @@
           "308"
         ],
         "x-ms-client-request-id": [
-          "d959b09a-dd75-4c3d-b0ac-ecbf582c4fc5"
+          "dd03ebd6-baf0-4b1b-9a5e-ec28c31693f5"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/HDILinkedService\",\r\n  \"name\": \"HDILinkedService\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"HDInsight\",\r\n    \"typeProperties\": {\r\n      \"clusterUri\": \"https://testhdi.azurehdinsight.net/\",\r\n      \"userName\": \"testaccount\",\r\n      \"password\": \"**********\",\r\n      \"storageAccountName\": null,\r\n      \"storageAccountKey\": null,\r\n      \"location\": null,\r\n      \"linkedServiceName\": \"LinkedService-CuratedWikiData\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/HDILinkedService\",\r\n  \"name\": \"HDILinkedService\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"HDInsight\",\r\n    \"typeProperties\": {\r\n      \"clusterUri\": \"https://testhdi.azurehdinsight.net/\",\r\n      \"userName\": \"testaccount\",\r\n      \"password\": \"**********\",\r\n      \"linkedServiceName\": \"LinkedService-CuratedWikiData\"\r\n    },\r\n    \"id\": \"c62b33b1-07a3-487b-8219-a0aaa84b6005\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "549"
+          "526"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -769,16 +769,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "2c5dbc7d-a153-4384-bb70-2adaf9d494d1"
+          "328b8800-535a-4c21-bb90-b1172935bb56"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1192"
+          "1194"
         ],
         "x-ms-correlation-request-id": [
-          "0714c4e8-4a92-4e42-9dd6-da1f75151e8f"
+          "6f726efc-5305-4193-ad26-63c2f70ed6c5"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222922Z:0714c4e8-4a92-4e42-9dd6-da1f75151e8f"
+          "CENTRALUS:20150828T230243Z:6f726efc-5305-4193-ad26-63c2f70ed6c5"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -787,10 +787,10 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:22 GMT"
+          "Fri, 28 Aug 2015 23:02:43 GMT"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/HDILinkedService?api-version=2015-08-01"
+          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/HDILinkedService?api-version=2015-09-01"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -802,25 +802,25 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/HDILinkedService?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvSERJTGlua2VkU2VydmljZT9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/HDILinkedService?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvSERJTGlua2VkU2VydmljZT9hcGktdmVyc2lvbj0yMDE1LTA5LTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "ddb89ff1-945f-42e3-8d33-ec4027948bb9"
+          "0b04f0f4-2187-409b-adf9-eb7c2674b950"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/HDILinkedService\",\r\n  \"name\": \"HDILinkedService\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"HDInsight\",\r\n    \"typeProperties\": {\r\n      \"clusterUri\": \"https://testhdi.azurehdinsight.net/\",\r\n      \"userName\": \"testaccount\",\r\n      \"password\": \"**********\",\r\n      \"storageAccountName\": null,\r\n      \"storageAccountKey\": null,\r\n      \"location\": null,\r\n      \"linkedServiceName\": \"LinkedService-CuratedWikiData\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/HDILinkedService\",\r\n  \"name\": \"HDILinkedService\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"HDInsight\",\r\n    \"typeProperties\": {\r\n      \"clusterUri\": \"https://testhdi.azurehdinsight.net/\",\r\n      \"userName\": \"testaccount\",\r\n      \"password\": \"**********\",\r\n      \"linkedServiceName\": \"LinkedService-CuratedWikiData\"\r\n    },\r\n    \"id\": \"c62b33b1-07a3-487b-8219-a0aaa84b6005\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "549"
+          "526"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -832,16 +832,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "94246025-28a9-4b31-bd40-6fd59eb5d670"
+          "1dd94df1-cdbc-4c76-b0ec-9db057483a1d"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14990"
+          "14992"
         ],
         "x-ms-correlation-request-id": [
-          "9cf0c5ef-22d4-4561-913c-a5f9b3b61de5"
+          "3adcb558-a933-481e-92ea-da3362a11080"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222922Z:9cf0c5ef-22d4-4561-913c-a5f9b3b61de5"
+          "CENTRALUS:20150828T230243Z:3adcb558-a933-481e-92ea-da3362a11080"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -850,7 +850,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:22 GMT"
+          "Fri, 28 Aug 2015 23:02:43 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -862,8 +862,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lBZ2dyZWdhdGVkRGF0YT9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikiAggregatedData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfV2lraUFnZ3JlZ2F0ZWREYXRhP2FwaS12ZXJzaW9uPTIwMTUtMDktMDE=",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"name\": \"DA_WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"hits\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumRows\": 8\r\n      }\r\n    },\r\n    \"type\": \"AzureSqlTable\",\r\n    \"linkedServiceName\": \"LinkedService-WikiAggregatedData\",\r\n    \"typeProperties\": {\r\n      \"tableName\": \"wikiaggregateddata\"\r\n    }\r\n  }\r\n}",
       "RequestHeaders": {
@@ -874,16 +874,16 @@
           "649"
         ],
         "x-ms-client-request-id": [
-          "8a2ab906-062b-464e-8e8a-aeb6c0fb2740"
+          "7966595f-2f4c-40d6-ac9c-ed6611792ff0"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DA_WikiAggregatedData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"hits\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureSqlTable\",\r\n    \"linkedServiceName\": \"LinkedService-WikiAggregatedData\",\r\n    \"typeProperties\": {\r\n      \"tableName\": \"wikiaggregateddata\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumRows\": 8\r\n      }\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:24.2161289Z\",\r\n    \"provisioningState\": \"PendingCreation\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DA_WikiAggregatedData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/tables/DA_WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"hits\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureSqlTable\",\r\n    \"linkedServiceName\": \"LinkedService-WikiAggregatedData\",\r\n    \"typeProperties\": {\r\n      \"tableName\": \"wikiaggregateddata\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumRows\": 8\r\n      }\r\n    },\r\n    \"id\": \"29b99c1d-f29c-4a55-8de6-eccc7ef391a5\",\r\n    \"createTime\": \"2015-08-28T23:02:43.8947336Z\",\r\n    \"provisioningState\": \"PendingCreation\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "679"
+          "723"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -895,16 +895,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "ec2bcdb1-8d73-4da1-ae32-5a8e07dc162f"
+          "9bcab0b3-6f0f-4f39-8076-3ab88e36b158"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1191"
+          "1193"
         ],
         "x-ms-correlation-request-id": [
-          "fe2adf7c-2d65-42b5-bf56-2f9e27a316a7"
+          "771d1897-f301-4a9e-9e8b-2c1ef219996e"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222925Z:fe2adf7c-2d65-42b5-bf56-2f9e27a316a7"
+          "CENTRALUS:20150828T230244Z:771d1897-f301-4a9e-9e8b-2c1ef219996e"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -913,10 +913,10 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:25 GMT"
+          "Fri, 28 Aug 2015 23:02:44 GMT"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData?api-version=2015-08-01"
+          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikiAggregatedData?api-version=2015-09-01"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -928,25 +928,25 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lBZ2dyZWdhdGVkRGF0YT9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikiAggregatedData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfV2lraUFnZ3JlZ2F0ZWREYXRhP2FwaS12ZXJzaW9uPTIwMTUtMDktMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "9d2e35f2-c83d-46ac-9cf6-c0d62ff1f5d2"
+          "8ece8ca2-5b12-41a5-ac7a-c11fca2cb20d"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DA_WikiAggregatedData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"hits\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureSqlTable\",\r\n    \"linkedServiceName\": \"LinkedService-WikiAggregatedData\",\r\n    \"typeProperties\": {\r\n      \"tableName\": \"wikiaggregateddata\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumRows\": 8\r\n      }\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:24.2161289Z\",\r\n    \"provisioningState\": \"PendingCreation\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DA_WikiAggregatedData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/tables/DA_WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"hits\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureSqlTable\",\r\n    \"linkedServiceName\": \"LinkedService-WikiAggregatedData\",\r\n    \"typeProperties\": {\r\n      \"tableName\": \"wikiaggregateddata\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumRows\": 8\r\n      }\r\n    },\r\n    \"id\": \"29b99c1d-f29c-4a55-8de6-eccc7ef391a5\",\r\n    \"createTime\": \"2015-08-28T23:02:43.8947336Z\",\r\n    \"provisioningState\": \"PendingCreation\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "679"
+          "723"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -958,16 +958,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "4a87d1d3-521c-4c72-8b4b-582b71611069"
+          "d9572227-2018-46ce-b3d3-4781c16c9ff3"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14989"
+          "14991"
         ],
         "x-ms-correlation-request-id": [
-          "0a4f2859-09f7-4fab-a12f-87ed44f7c799"
+          "2a79f729-496c-41f4-98a2-14106364b065"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222925Z:0a4f2859-09f7-4fab-a12f-87ed44f7c799"
+          "CENTRALUS:20150828T230244Z:2a79f729-496c-41f4-98a2-14106364b065"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -976,7 +976,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:25 GMT"
+          "Fri, 28 Aug 2015 23:02:44 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -988,25 +988,25 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lBZ2dyZWdhdGVkRGF0YT9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikiAggregatedData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfV2lraUFnZ3JlZ2F0ZWREYXRhP2FwaS12ZXJzaW9uPTIwMTUtMDktMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "133ac15a-735f-4818-a6f9-2e6d3124df11"
+          "a9a220b2-6701-4d33-8725-4bea5454cd41"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DA_WikiAggregatedData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"hits\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureSqlTable\",\r\n    \"linkedServiceName\": \"LinkedService-WikiAggregatedData\",\r\n    \"typeProperties\": {\r\n      \"tableName\": \"wikiaggregateddata\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumRows\": 8\r\n      }\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:24.2161289Z\",\r\n    \"provisioningState\": \"PendingCreation\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DA_WikiAggregatedData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/tables/DA_WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"hits\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureSqlTable\",\r\n    \"linkedServiceName\": \"LinkedService-WikiAggregatedData\",\r\n    \"typeProperties\": {\r\n      \"tableName\": \"wikiaggregateddata\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumRows\": 8\r\n      }\r\n    },\r\n    \"id\": \"29b99c1d-f29c-4a55-8de6-eccc7ef391a5\",\r\n    \"createTime\": \"2015-08-28T23:02:43.7416551Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "679"
+          "717"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1018,16 +1018,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "285aae2a-8d47-4473-8e52-ea13630830a9"
+          "9553dfaa-7c01-4a31-8d7e-a60624cb99a1"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14988"
+          "14990"
         ],
         "x-ms-correlation-request-id": [
-          "389f7caf-99bd-43b0-aefb-b893ebe9b6e4"
+          "25f8ee8f-c81e-42ba-83b6-e30162834a54"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222931Z:389f7caf-99bd-43b0-aefb-b893ebe9b6e4"
+          "CENTRALUS:20150828T230249Z:25f8ee8f-c81e-42ba-83b6-e30162834a54"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1036,7 +1036,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:30 GMT"
+          "Fri, 28 Aug 2015 23:02:48 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1048,68 +1048,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lBZ2dyZWdhdGVkRGF0YT9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "38953535-d792-4f03-8ef3-c2ee6e884852"
-        ],
-        "x-ms-version": [
-          "2015-08-01"
-        ],
-        "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"DA_WikiAggregatedData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"hits\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureSqlTable\",\r\n    \"linkedServiceName\": \"LinkedService-WikiAggregatedData\",\r\n    \"typeProperties\": {\r\n      \"tableName\": \"wikiaggregateddata\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumRows\": 8\r\n      }\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:23.4849863Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "673"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "575a764d-4078-4c02-aaf5-d772e2945c0e"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14987"
-        ],
-        "x-ms-correlation-request-id": [
-          "48f14f12-1ed9-416e-8a06-451164276a30"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222936Z:48f14f12-1ed9-416e-8a06-451164276a30"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Fri, 31 Jul 2015 22:29:36 GMT"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "X-Powered-By": [
-          "ASP.NET"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_CuratedWikiData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX0N1cmF0ZWRXaWtpRGF0YT9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_CuratedWikiData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfQ3VyYXRlZFdpa2lEYXRhP2FwaS12ZXJzaW9uPTIwMTUtMDktMDE=",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"name\": \"DA_CuratedWikiData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"pageviews\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-CuratedWikiData\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledataout/runtime={Slice}\",\r\n      \"partitionedBy\": [\r\n        {\r\n          \"name\": \"Slice\",\r\n          \"value\": {\r\n            \"type\": \"DateTime\",\r\n            \"date\": \"SliceStart\",\r\n            \"format\": \"yyyyMMddHH\"\r\n          }\r\n        }\r\n      ]\r\n    }\r\n  }\r\n}",
       "RequestHeaders": {
@@ -1120,16 +1060,16 @@
           "818"
         ],
         "x-ms-client-request-id": [
-          "40c9045f-518a-46f2-9003-2ceb6e4760c5"
+          "3f20d597-7847-43ab-87b3-2ba51517c60d"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DA_CuratedWikiData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_CuratedWikiData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"pageviews\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-CuratedWikiData\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledataout/runtime={Slice}\",\r\n      \"partitionedBy\": [\r\n        {\r\n          \"name\": \"Slice\",\r\n          \"value\": {\r\n            \"type\": \"DateTime\",\r\n            \"date\": \"SliceStart\",\r\n            \"format\": \"yyyyMMddHH\"\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:37.5539556Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DA_CuratedWikiData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/tables/DA_CuratedWikiData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"pageviews\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-CuratedWikiData\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledataout/runtime={Slice}\",\r\n      \"partitionedBy\": [\r\n        {\r\n          \"name\": \"Slice\",\r\n          \"value\": {\r\n            \"type\": \"DateTime\",\r\n            \"date\": \"SliceStart\",\r\n            \"format\": \"yyyyMMddHH\"\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"id\": \"0cb6178f-1de0-461a-82c5-25957131f3b9\",\r\n    \"createTime\": \"2015-08-28T23:02:49.4783297Z\",\r\n    \"provisioningState\": \"PendingCreation\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "760"
+          "810"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1141,16 +1081,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "1d6fc99c-d5d0-4abb-bc56-bf731488d631"
+          "403affc1-54a7-4d18-a90f-d2308f546b7c"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1190"
+          "1192"
         ],
         "x-ms-correlation-request-id": [
-          "ad5e80b8-7dd1-4836-b458-70ba10601d86"
+          "3c4d1444-5404-4491-abdf-10bb58cf4ff7"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222937Z:ad5e80b8-7dd1-4836-b458-70ba10601d86"
+          "CENTRALUS:20150828T230249Z:3c4d1444-5404-4491-abdf-10bb58cf4ff7"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1159,10 +1099,10 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:36 GMT"
+          "Fri, 28 Aug 2015 23:02:49 GMT"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_CuratedWikiData?api-version=2015-08-01"
+          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_CuratedWikiData?api-version=2015-09-01"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1174,25 +1114,25 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_CuratedWikiData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX0N1cmF0ZWRXaWtpRGF0YT9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_CuratedWikiData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfQ3VyYXRlZFdpa2lEYXRhP2FwaS12ZXJzaW9uPTIwMTUtMDktMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "c2e8a2d1-8442-4898-b4bc-0b0cc80e67f7"
+          "10f6f74c-528e-4313-ac62-3090130b2177"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DA_CuratedWikiData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_CuratedWikiData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"pageviews\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-CuratedWikiData\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledataout/runtime={Slice}\",\r\n      \"partitionedBy\": [\r\n        {\r\n          \"name\": \"Slice\",\r\n          \"value\": {\r\n            \"type\": \"DateTime\",\r\n            \"date\": \"SliceStart\",\r\n            \"format\": \"yyyyMMddHH\"\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:37.5539556Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DA_CuratedWikiData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/tables/DA_CuratedWikiData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"pageviews\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-CuratedWikiData\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledataout/runtime={Slice}\",\r\n      \"partitionedBy\": [\r\n        {\r\n          \"name\": \"Slice\",\r\n          \"value\": {\r\n            \"type\": \"DateTime\",\r\n            \"date\": \"SliceStart\",\r\n            \"format\": \"yyyyMMddHH\"\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"id\": \"0cb6178f-1de0-461a-82c5-25957131f3b9\",\r\n    \"createTime\": \"2015-08-28T23:02:49.3239307Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "760"
+          "804"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1204,16 +1144,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "087c39f8-e922-4d9f-82a2-7f348fadb21f"
+          "38b953b6-2b76-4afb-ad21-2ab56a33b52e"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14986"
+          "14989"
         ],
         "x-ms-correlation-request-id": [
-          "352173e0-08d7-4a4b-b9aa-edbcceea2ec3"
+          "0ad1771e-0105-4187-8bee-5b26b3c4e49d"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222937Z:352173e0-08d7-4a4b-b9aa-edbcceea2ec3"
+          "CENTRALUS:20150828T230249Z:0ad1771e-0105-4187-8bee-5b26b3c4e49d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1222,7 +1162,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:37 GMT"
+          "Fri, 28 Aug 2015 23:02:49 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1234,8 +1174,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikipediaClickEvents?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lwZWRpYUNsaWNrRXZlbnRzP2FwaS12ZXJzaW9uPTIwMTUtMDgtMDE=",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikipediaClickEvents?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfV2lraXBlZGlhQ2xpY2tFdmVudHM/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"name\": \"DA_WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumSizeMB\": 1.0\r\n      },\r\n      \"externalData\": {\r\n        \"retryInterval\": \"00:01:00\",\r\n        \"retryTimeout\": \"00:10:00\",\r\n        \"maximumRetry\": 3\r\n      }\r\n    },\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-WikipediaClickEvents\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledatain/\"\r\n    }\r\n  }\r\n}",
       "RequestHeaders": {
@@ -1246,16 +1186,16 @@
           "663"
         ],
         "x-ms-client-request-id": [
-          "f0125e68-db8b-47b4-9446-91a6d381289d"
+          "ccb600e9-222e-4382-9b27-6f96fd72f43b"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DA_WikipediaClickEvents\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-WikipediaClickEvents\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledatain/\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumSizeMB\": 1.0\r\n      },\r\n      \"externalData\": {\r\n        \"retryInterval\": \"00:01:00\",\r\n        \"retryTimeout\": \"00:10:00\",\r\n        \"maximumRetry\": 3\r\n      }\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:38.6311338Z\",\r\n    \"provisioningState\": \"PendingCreation\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DA_WikipediaClickEvents\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/tables/DA_WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-WikipediaClickEvents\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledatain/\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumSizeMB\": 1.0\r\n      },\r\n      \"externalData\": {\r\n        \"retryInterval\": \"00:01:00\",\r\n        \"retryTimeout\": \"00:10:00\",\r\n        \"maximumRetry\": 3\r\n      }\r\n    },\r\n    \"id\": \"d8697c82-e3de-4105-be69-b0da63d382ab\",\r\n    \"createTime\": \"2015-08-28T23:02:49.9007134Z\",\r\n    \"provisioningState\": \"PendingCreation\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "660"
+          "704"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1267,16 +1207,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "9c57cc8f-835c-4071-8cb0-f784b36e21d8"
+          "7828e358-e1d9-4407-b7e0-7810140b6e79"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1189"
+          "1191"
         ],
         "x-ms-correlation-request-id": [
-          "3acd6fb1-dd58-4e6a-a89d-4af8837fadca"
+          "83a4d22a-8831-4732-8f04-4b69dcfb147a"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222938Z:3acd6fb1-dd58-4e6a-a89d-4af8837fadca"
+          "CENTRALUS:20150828T230250Z:83a4d22a-8831-4732-8f04-4b69dcfb147a"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1285,10 +1225,10 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:37 GMT"
+          "Fri, 28 Aug 2015 23:02:49 GMT"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikipediaClickEvents?api-version=2015-08-01"
+          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikipediaClickEvents?api-version=2015-09-01"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1300,25 +1240,25 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikipediaClickEvents?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lwZWRpYUNsaWNrRXZlbnRzP2FwaS12ZXJzaW9uPTIwMTUtMDgtMDE=",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikipediaClickEvents?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfV2lraXBlZGlhQ2xpY2tFdmVudHM/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "058a9cfe-4406-4828-ad5f-ea0a1552359c"
+          "307aafc9-f460-496c-87fa-b3801799a9d0"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DA_WikipediaClickEvents\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-WikipediaClickEvents\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledatain/\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumSizeMB\": 1.0\r\n      },\r\n      \"externalData\": {\r\n        \"retryInterval\": \"00:01:00\",\r\n        \"retryTimeout\": \"00:10:00\",\r\n        \"maximumRetry\": 3\r\n      }\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:38.6311338Z\",\r\n    \"provisioningState\": \"PendingCreation\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DA_WikipediaClickEvents\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/tables/DA_WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-WikipediaClickEvents\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledatain/\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumSizeMB\": 1.0\r\n      },\r\n      \"externalData\": {\r\n        \"retryInterval\": \"00:01:00\",\r\n        \"retryTimeout\": \"00:10:00\",\r\n        \"maximumRetry\": 3\r\n      }\r\n    },\r\n    \"id\": \"d8697c82-e3de-4105-be69-b0da63d382ab\",\r\n    \"createTime\": \"2015-08-28T23:02:49.9007134Z\",\r\n    \"provisioningState\": \"PendingCreation\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "660"
+          "704"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1330,16 +1270,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "ea82a8b8-7cfd-4893-bb5f-5d002c2eed3e"
+          "f782429c-4fcd-4c9b-9e03-20f2c7eaaebf"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14985"
+          "14988"
         ],
         "x-ms-correlation-request-id": [
-          "43e5dd2c-7954-4ed7-a53b-7ba926d278d5"
+          "24aa356b-cbab-4add-94b8-7feff5a89d74"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222938Z:43e5dd2c-7954-4ed7-a53b-7ba926d278d5"
+          "CENTRALUS:20150828T230250Z:24aa356b-cbab-4add-94b8-7feff5a89d74"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1348,7 +1288,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:38 GMT"
+          "Fri, 28 Aug 2015 23:02:49 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1360,25 +1300,25 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikipediaClickEvents?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lwZWRpYUNsaWNrRXZlbnRzP2FwaS12ZXJzaW9uPTIwMTUtMDgtMDE=",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikipediaClickEvents?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfV2lraXBlZGlhQ2xpY2tFdmVudHM/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "f0a07b89-25e3-47fd-a981-5d227e13c1b4"
+          "e73bdde5-9760-4752-8952-50273932e240"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DA_WikipediaClickEvents\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-WikipediaClickEvents\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledatain/\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumSizeMB\": 1.0\r\n      },\r\n      \"externalData\": {\r\n        \"retryInterval\": \"00:01:00\",\r\n        \"retryTimeout\": \"00:10:00\",\r\n        \"maximumRetry\": 3\r\n      }\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:38.6549254Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DA_WikipediaClickEvents\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/tables/DA_WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-WikipediaClickEvents\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledatain/\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumSizeMB\": 1.0\r\n      },\r\n      \"externalData\": {\r\n        \"retryInterval\": \"00:01:00\",\r\n        \"retryTimeout\": \"00:10:00\",\r\n        \"maximumRetry\": 3\r\n      }\r\n    },\r\n    \"id\": \"d8697c82-e3de-4105-be69-b0da63d382ab\",\r\n    \"createTime\": \"2015-08-28T23:02:49.7512221Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "654"
+          "698"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1390,16 +1330,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "b9eac82f-97f2-4bbe-b816-5f851fea71c2"
+          "36eb46a6-4aaa-4024-bab2-04c5b5fd81d6"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14984"
+          "14987"
         ],
         "x-ms-correlation-request-id": [
-          "87e7f185-c1c4-4e4c-8bfb-278f6bfc184c"
+          "cbe5eacc-4bd7-4b75-8fea-0e5f1f337e49"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222944Z:87e7f185-c1c4-4e4c-8bfb-278f6bfc184c"
+          "CENTRALUS:20150828T230255Z:cbe5eacc-4bd7-4b75-8fea-0e5f1f337e49"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1408,7 +1348,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:44 GMT"
+          "Fri, 28 Aug 2015 23:02:54 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1420,28 +1360,28 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/datapipelines/DP_Wikipedia7127?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvZGF0YXBpcGVsaW5lcy9EUF9XaWtpcGVkaWE3MTI3P2FwaS12ZXJzaW9uPTIwMTUtMDgtMDE=",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datapipelines/DP_Wikipedia3128?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXBpcGVsaW5lcy9EUF9XaWtpcGVkaWEzMTI4P2FwaS12ZXJzaW9uPTIwMTUtMDktMDE=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"name\": \"DP_WikipediaSamplePipeline\",\r\n  \"properties\": {\r\n    \"description\": \"DP Wikipedia Sample Pipelines\",\r\n    \"activities\": [\r\n      {\r\n        \"name\": \"WikiHiveActivity\",\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_WikipediaClickEvents\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"linkedServiceName\": \"HDILinkedService\",\r\n        \"type\": \"HDInsightHive\",\r\n        \"policy\": {\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2,\r\n          \"timeout\": \"01:00:00\"\r\n        },\r\n        \"typeProperties\": {\r\n          \"script\": \"$$Text.Format('CREATE EXTERNAL TABLE IF NOT EXISTS values2 (projectname string, title string, pageviews string, bytestransfer string) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\' \\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledatain\\\\'; CREATE EXTERNAL TABLE IF NOT EXISTS stats2 (slicetimestamp string, projectname string, pageviews string) PARTITIONED BY (runtime STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\',\\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout\\\\'; ALTER TABLE stats2 ADD IF NOT EXISTS PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout/runtime={0:yyyyMMddHH}\\\\'; INSERT OVERWRITE TABLE stats2 PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') SELECT slicetimestamp, projectname, sum(pageviews) FROM (SELECT \\\\'{0:yyyy/MM/dd HH:00:00}\\\\' AS slicetimestamp, CASE WHEN size(split(projectname, \\\\'[.]\\\\'))=1 THEN \\\\'wikipedia\\\\' ELSE CASE split(projectname, \\\\'[.]\\\\')[1] WHEN \\\\'b\\\\' THEN \\\\'wikibooks\\\\' WHEN \\\\'d\\\\' THEN \\\\'wiktionary\\\\' WHEN \\\\'m\\\\' THEN \\\\'wikimedia\\\\' WHEN \\\\'mv\\\\' THEN \\\\'wikipedia mobile\\\\' WHEN \\\\'n\\\\' THEN \\\\'wikinews\\\\' WHEN \\\\'q\\\\' THEN \\\\'wikiquote\\\\' WHEN \\\\'s\\\\' THEN \\\\'wikisource\\\\' WHEN \\\\'v\\\\' THEN \\\\'wikiversity\\\\' WHEN \\\\'w\\\\' THEN \\\\'mediawiki\\\\' ELSE \\\\'n/a\\\\' END END AS projectname, pageviews FROM values2) A GROUP BY slicetimestamp, projectname;', SliceStart)\"\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"BlobToSqlCopyActivity\",\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_WikiAggregatedData\"\r\n          }\r\n        ],\r\n        \"linkedServiceName\": \"HDILinkedService\",\r\n        \"type\": \"Copy\",\r\n        \"policy\": {\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2,\r\n          \"timeout\": \"01:00:00\"\r\n        },\r\n        \"typeProperties\": {\r\n          \"source\": {\r\n            \"type\": \"BlobSource\",\r\n            \"blobColumnSeparators\": \",\"\r\n          },\r\n          \"sink\": {\r\n            \"type\": \"SqlSink\",\r\n            \"writeBatchSize\": 1000000,\r\n            \"writeBatchTimeout\": \"01:00:00\"\r\n          }\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"name\": \"DP_WikipediaSamplePipeline\",\r\n  \"properties\": {\r\n    \"description\": \"DP Wikipedia Sample Pipelines\",\r\n    \"activities\": [\r\n      {\r\n        \"name\": \"WikiHiveActivity\",\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_WikipediaClickEvents\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"linkedServiceName\": \"HDILinkedService\",\r\n        \"type\": \"HDInsightHive\",\r\n        \"policy\": {\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2,\r\n          \"timeout\": \"01:00:00\"\r\n        },\r\n        \"typeProperties\": {\r\n          \"script\": \"$$Text.Format('CREATE EXTERNAL TABLE IF NOT EXISTS values2 (projectname string, title string, pageviews string, bytestransfer string) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\' \\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledatain\\\\'; CREATE EXTERNAL TABLE IF NOT EXISTS stats2 (slicetimestamp string, projectname string, pageviews string) PARTITIONED BY (runtime STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\',\\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout\\\\'; ALTER TABLE stats2 ADD IF NOT EXISTS PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout/runtime={0:yyyyMMddHH}\\\\'; INSERT OVERWRITE TABLE stats2 PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') SELECT slicetimestamp, projectname, sum(pageviews) FROM (SELECT \\\\'{0:yyyy/MM/dd HH:00:00}\\\\' AS slicetimestamp, CASE WHEN size(split(projectname, \\\\'[.]\\\\'))=1 THEN \\\\'wikipedia\\\\' ELSE CASE split(projectname, \\\\'[.]\\\\')[1] WHEN \\\\'b\\\\' THEN \\\\'wikibooks\\\\' WHEN \\\\'d\\\\' THEN \\\\'wiktionary\\\\' WHEN \\\\'m\\\\' THEN \\\\'wikimedia\\\\' WHEN \\\\'mv\\\\' THEN \\\\'wikipedia mobile\\\\' WHEN \\\\'n\\\\' THEN \\\\'wikinews\\\\' WHEN \\\\'q\\\\' THEN \\\\'wikiquote\\\\' WHEN \\\\'s\\\\' THEN \\\\'wikisource\\\\' WHEN \\\\'v\\\\' THEN \\\\'wikiversity\\\\' WHEN \\\\'w\\\\' THEN \\\\'mediawiki\\\\' ELSE \\\\'n/a\\\\' END END AS projectname, pageviews FROM values2) A GROUP BY slicetimestamp, projectname;', SliceStart)\"\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"BlobToSqlCopyActivity\",\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_WikiAggregatedData\"\r\n          }\r\n        ],\r\n        \"linkedServiceName\": \"HDILinkedService\",\r\n        \"type\": \"Copy\",\r\n        \"policy\": {\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2,\r\n          \"timeout\": \"01:00:00\"\r\n        },\r\n        \"typeProperties\": {\r\n          \"source\": {\r\n            \"type\": \"BlobSource\"\r\n          },\r\n          \"sink\": {\r\n            \"type\": \"SqlSink\",\r\n            \"writeBatchSize\": 1000000,\r\n            \"writeBatchTimeout\": \"01:00:00\"\r\n          }\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json"
         ],
         "Content-Length": [
-          "3239"
+          "3197"
         ],
         "x-ms-client-request-id": [
-          "1a840cd5-1c59-4f63-9133-bfaf589221a9"
+          "c0a77310-7487-4724-8356-efdccb46b61d"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DP_Wikipedia7127\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/datapipelines/DP_Wikipedia7127\",\r\n  \"properties\": {\r\n    \"description\": \"DP Wikipedia Sample Pipelines\",\r\n    \"activities\": [\r\n      {\r\n        \"type\": \"HDInsightHive\",\r\n        \"typeProperties\": {\r\n          \"script\": \"$$Text.Format('CREATE EXTERNAL TABLE IF NOT EXISTS values2 (projectname string, title string, pageviews string, bytestransfer string) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\' \\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledatain\\\\'; CREATE EXTERNAL TABLE IF NOT EXISTS stats2 (slicetimestamp string, projectname string, pageviews string) PARTITIONED BY (runtime STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\',\\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout\\\\'; ALTER TABLE stats2 ADD IF NOT EXISTS PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout/runtime={0:yyyyMMddHH}\\\\'; INSERT OVERWRITE TABLE stats2 PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') SELECT slicetimestamp, projectname, sum(pageviews) FROM (SELECT \\\\'{0:yyyy/MM/dd HH:00:00}\\\\' AS slicetimestamp, CASE WHEN size(split(projectname, \\\\'[.]\\\\'))=1 THEN \\\\'wikipedia\\\\' ELSE CASE split(projectname, \\\\'[.]\\\\')[1] WHEN \\\\'b\\\\' THEN \\\\'wikibooks\\\\' WHEN \\\\'d\\\\' THEN \\\\'wiktionary\\\\' WHEN \\\\'m\\\\' THEN \\\\'wikimedia\\\\' WHEN \\\\'mv\\\\' THEN \\\\'wikipedia mobile\\\\' WHEN \\\\'n\\\\' THEN \\\\'wikinews\\\\' WHEN \\\\'q\\\\' THEN \\\\'wikiquote\\\\' WHEN \\\\'s\\\\' THEN \\\\'wikisource\\\\' WHEN \\\\'v\\\\' THEN \\\\'wikiversity\\\\' WHEN \\\\'w\\\\' THEN \\\\'mediawiki\\\\' ELSE \\\\'n/a\\\\' END END AS projectname, pageviews FROM values2) A GROUP BY slicetimestamp, projectname;', SliceStart)\"\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_WikipediaClickEvents\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"WikiHiveActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      },\r\n      {\r\n        \"type\": \"Copy\",\r\n        \"typeProperties\": {\r\n          \"source\": {\r\n            \"type\": \"BlobSource\",\r\n            \"blobColumnSeparators\": \",\"\r\n          },\r\n          \"sink\": {\r\n            \"type\": \"SqlSink\",\r\n            \"writeBatchSize\": 1000000,\r\n            \"writeBatchTimeout\": \"01:00:00\"\r\n          }\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_WikiAggregatedData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"BlobToSqlCopyActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      }\r\n    ],\r\n    \"isPaused\": false,\r\n    \"runtimeInfo\": {\r\n      \"deploymentTime\": \"2015-07-31T22:29:45.5791608Z\",\r\n      \"activePeriodSetTime\": \"2015-07-31T22:29:45.5791608Z\",\r\n      \"activityPeriods\": {\r\n        \"wikiHiveActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        },\r\n        \"blobToSqlCopyActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        }\r\n      }\r\n    },\r\n    \"provisioningState\": \"PendingCreation\",\r\n    \"hubName\": \"datafactory8496_hub\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DP_Wikipedia3128\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datapipelines/DP_Wikipedia3128\",\r\n  \"properties\": {\r\n    \"description\": \"DP Wikipedia Sample Pipelines\",\r\n    \"activities\": [\r\n      {\r\n        \"type\": \"HDInsightHive\",\r\n        \"typeProperties\": {\r\n          \"script\": \"$$Text.Format('CREATE EXTERNAL TABLE IF NOT EXISTS values2 (projectname string, title string, pageviews string, bytestransfer string) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\' \\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledatain\\\\'; CREATE EXTERNAL TABLE IF NOT EXISTS stats2 (slicetimestamp string, projectname string, pageviews string) PARTITIONED BY (runtime STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\',\\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout\\\\'; ALTER TABLE stats2 ADD IF NOT EXISTS PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout/runtime={0:yyyyMMddHH}\\\\'; INSERT OVERWRITE TABLE stats2 PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') SELECT slicetimestamp, projectname, sum(pageviews) FROM (SELECT \\\\'{0:yyyy/MM/dd HH:00:00}\\\\' AS slicetimestamp, CASE WHEN size(split(projectname, \\\\'[.]\\\\'))=1 THEN \\\\'wikipedia\\\\' ELSE CASE split(projectname, \\\\'[.]\\\\')[1] WHEN \\\\'b\\\\' THEN \\\\'wikibooks\\\\' WHEN \\\\'d\\\\' THEN \\\\'wiktionary\\\\' WHEN \\\\'m\\\\' THEN \\\\'wikimedia\\\\' WHEN \\\\'mv\\\\' THEN \\\\'wikipedia mobile\\\\' WHEN \\\\'n\\\\' THEN \\\\'wikinews\\\\' WHEN \\\\'q\\\\' THEN \\\\'wikiquote\\\\' WHEN \\\\'s\\\\' THEN \\\\'wikisource\\\\' WHEN \\\\'v\\\\' THEN \\\\'wikiversity\\\\' WHEN \\\\'w\\\\' THEN \\\\'mediawiki\\\\' ELSE \\\\'n/a\\\\' END END AS projectname, pageviews FROM values2) A GROUP BY slicetimestamp, projectname;', SliceStart)\"\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_WikipediaClickEvents\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"WikiHiveActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      },\r\n      {\r\n        \"type\": \"Copy\",\r\n        \"typeProperties\": {\r\n          \"source\": {\r\n            \"type\": \"BlobSource\"\r\n          },\r\n          \"sink\": {\r\n            \"type\": \"SqlSink\",\r\n            \"writeBatchSize\": 1000000,\r\n            \"writeBatchTimeout\": \"01:00:00\"\r\n          }\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_WikiAggregatedData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"BlobToSqlCopyActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      }\r\n    ],\r\n    \"isPaused\": false,\r\n    \"runtimeInfo\": {\r\n      \"deploymentTime\": \"2015-08-28T23:02:55.3347675Z\",\r\n      \"activePeriodSetTime\": \"2015-08-28T23:02:55.3347675Z\",\r\n      \"activityPeriods\": {\r\n        \"wikiHiveActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        },\r\n        \"blobToSqlCopyActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        }\r\n      }\r\n    },\r\n    \"id\": \"b48772bf-085d-4215-b976-0387731202aa\",\r\n    \"provisioningState\": \"PendingCreation\",\r\n    \"hubName\": \"datafactory3531_hub\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "3096"
+          "3113"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1453,16 +1393,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "71f355b7-3854-4fa3-80c8-473e8a27c37e"
+          "88b6cd1d-e555-46b9-8985-af5bb3825a7d"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1188"
+          "1190"
         ],
         "x-ms-correlation-request-id": [
-          "18b4eaac-b104-424b-9888-e2331e7ad57d"
+          "4a134233-fce2-4fb4-933b-142c126847b0"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222948Z:18b4eaac-b104-424b-9888-e2331e7ad57d"
+          "CENTRALUS:20150828T230257Z:4a134233-fce2-4fb4-933b-142c126847b0"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1471,10 +1411,10 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:47 GMT"
+          "Fri, 28 Aug 2015 23:02:57 GMT"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/datapipelines/DP_Wikipedia7127?api-version=2015-08-01"
+          "https://api-dogfood.resources.windows-int.net/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datapipelines/DP_Wikipedia3128?api-version=2015-09-01"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1486,25 +1426,25 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/datapipelines/DP_Wikipedia7127?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvZGF0YXBpcGVsaW5lcy9EUF9XaWtpcGVkaWE3MTI3P2FwaS12ZXJzaW9uPTIwMTUtMDgtMDE=",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datapipelines/DP_Wikipedia3128?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXBpcGVsaW5lcy9EUF9XaWtpcGVkaWEzMTI4P2FwaS12ZXJzaW9uPTIwMTUtMDktMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "1d264379-25d8-4389-8061-ee4f4e37f6a7"
+          "863a1b13-0a61-4fc3-a7f8-355a8fb932a2"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DP_Wikipedia7127\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/datapipelines/DP_Wikipedia7127\",\r\n  \"properties\": {\r\n    \"description\": \"DP Wikipedia Sample Pipelines\",\r\n    \"activities\": [\r\n      {\r\n        \"type\": \"HDInsightHive\",\r\n        \"typeProperties\": {\r\n          \"script\": \"$$Text.Format('CREATE EXTERNAL TABLE IF NOT EXISTS values2 (projectname string, title string, pageviews string, bytestransfer string) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\' \\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledatain\\\\'; CREATE EXTERNAL TABLE IF NOT EXISTS stats2 (slicetimestamp string, projectname string, pageviews string) PARTITIONED BY (runtime STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\',\\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout\\\\'; ALTER TABLE stats2 ADD IF NOT EXISTS PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout/runtime={0:yyyyMMddHH}\\\\'; INSERT OVERWRITE TABLE stats2 PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') SELECT slicetimestamp, projectname, sum(pageviews) FROM (SELECT \\\\'{0:yyyy/MM/dd HH:00:00}\\\\' AS slicetimestamp, CASE WHEN size(split(projectname, \\\\'[.]\\\\'))=1 THEN \\\\'wikipedia\\\\' ELSE CASE split(projectname, \\\\'[.]\\\\')[1] WHEN \\\\'b\\\\' THEN \\\\'wikibooks\\\\' WHEN \\\\'d\\\\' THEN \\\\'wiktionary\\\\' WHEN \\\\'m\\\\' THEN \\\\'wikimedia\\\\' WHEN \\\\'mv\\\\' THEN \\\\'wikipedia mobile\\\\' WHEN \\\\'n\\\\' THEN \\\\'wikinews\\\\' WHEN \\\\'q\\\\' THEN \\\\'wikiquote\\\\' WHEN \\\\'s\\\\' THEN \\\\'wikisource\\\\' WHEN \\\\'v\\\\' THEN \\\\'wikiversity\\\\' WHEN \\\\'w\\\\' THEN \\\\'mediawiki\\\\' ELSE \\\\'n/a\\\\' END END AS projectname, pageviews FROM values2) A GROUP BY slicetimestamp, projectname;', SliceStart)\"\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_WikipediaClickEvents\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"WikiHiveActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      },\r\n      {\r\n        \"type\": \"Copy\",\r\n        \"typeProperties\": {\r\n          \"source\": {\r\n            \"type\": \"BlobSource\",\r\n            \"blobColumnSeparators\": \",\"\r\n          },\r\n          \"sink\": {\r\n            \"type\": \"SqlSink\",\r\n            \"writeBatchSize\": 1000000,\r\n            \"writeBatchTimeout\": \"01:00:00\"\r\n          }\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_WikiAggregatedData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"BlobToSqlCopyActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      }\r\n    ],\r\n    \"isPaused\": false,\r\n    \"runtimeInfo\": {\r\n      \"deploymentTime\": \"2015-07-31T22:29:45.5791608Z\",\r\n      \"activePeriodSetTime\": \"2015-07-31T22:29:45.5791608Z\",\r\n      \"activityPeriods\": {\r\n        \"wikiHiveActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        },\r\n        \"blobToSqlCopyActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        }\r\n      }\r\n    },\r\n    \"provisioningState\": \"PendingCreation\",\r\n    \"hubName\": \"datafactory8496_hub\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DP_Wikipedia3128\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datapipelines/DP_Wikipedia3128\",\r\n  \"properties\": {\r\n    \"description\": \"DP Wikipedia Sample Pipelines\",\r\n    \"activities\": [\r\n      {\r\n        \"type\": \"HDInsightHive\",\r\n        \"typeProperties\": {\r\n          \"script\": \"$$Text.Format('CREATE EXTERNAL TABLE IF NOT EXISTS values2 (projectname string, title string, pageviews string, bytestransfer string) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\' \\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledatain\\\\'; CREATE EXTERNAL TABLE IF NOT EXISTS stats2 (slicetimestamp string, projectname string, pageviews string) PARTITIONED BY (runtime STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\',\\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout\\\\'; ALTER TABLE stats2 ADD IF NOT EXISTS PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout/runtime={0:yyyyMMddHH}\\\\'; INSERT OVERWRITE TABLE stats2 PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') SELECT slicetimestamp, projectname, sum(pageviews) FROM (SELECT \\\\'{0:yyyy/MM/dd HH:00:00}\\\\' AS slicetimestamp, CASE WHEN size(split(projectname, \\\\'[.]\\\\'))=1 THEN \\\\'wikipedia\\\\' ELSE CASE split(projectname, \\\\'[.]\\\\')[1] WHEN \\\\'b\\\\' THEN \\\\'wikibooks\\\\' WHEN \\\\'d\\\\' THEN \\\\'wiktionary\\\\' WHEN \\\\'m\\\\' THEN \\\\'wikimedia\\\\' WHEN \\\\'mv\\\\' THEN \\\\'wikipedia mobile\\\\' WHEN \\\\'n\\\\' THEN \\\\'wikinews\\\\' WHEN \\\\'q\\\\' THEN \\\\'wikiquote\\\\' WHEN \\\\'s\\\\' THEN \\\\'wikisource\\\\' WHEN \\\\'v\\\\' THEN \\\\'wikiversity\\\\' WHEN \\\\'w\\\\' THEN \\\\'mediawiki\\\\' ELSE \\\\'n/a\\\\' END END AS projectname, pageviews FROM values2) A GROUP BY slicetimestamp, projectname;', SliceStart)\"\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_WikipediaClickEvents\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"WikiHiveActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      },\r\n      {\r\n        \"type\": \"Copy\",\r\n        \"typeProperties\": {\r\n          \"source\": {\r\n            \"type\": \"BlobSource\"\r\n          },\r\n          \"sink\": {\r\n            \"type\": \"SqlSink\",\r\n            \"writeBatchSize\": 1000000,\r\n            \"writeBatchTimeout\": \"01:00:00\"\r\n          }\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_WikiAggregatedData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"BlobToSqlCopyActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      }\r\n    ],\r\n    \"isPaused\": false,\r\n    \"runtimeInfo\": {\r\n      \"deploymentTime\": \"2015-08-28T23:02:55.3347675Z\",\r\n      \"activePeriodSetTime\": \"2015-08-28T23:02:55.3347675Z\",\r\n      \"activityPeriods\": {\r\n        \"wikiHiveActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        },\r\n        \"blobToSqlCopyActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        }\r\n      }\r\n    },\r\n    \"id\": \"b48772bf-085d-4215-b976-0387731202aa\",\r\n    \"provisioningState\": \"PendingCreation\",\r\n    \"hubName\": \"datafactory3531_hub\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "3096"
+          "3113"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1516,16 +1456,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "db390e63-9ec1-4021-b697-e0b1104804c7"
+          "9d3fa24c-44ab-49c0-94bb-a4d92fe29f48"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14983"
+          "14986"
         ],
         "x-ms-correlation-request-id": [
-          "7f8b7a7b-745f-4f9a-937b-0280b6c78aa4"
+          "2fa448a0-f919-4769-81f3-1ced65712eea"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222948Z:7f8b7a7b-745f-4f9a-937b-0280b6c78aa4"
+          "CENTRALUS:20150828T230257Z:2fa448a0-f919-4769-81f3-1ced65712eea"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1534,7 +1474,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:47 GMT"
+          "Fri, 28 Aug 2015 23:02:57 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1546,25 +1486,25 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/datapipelines/DP_Wikipedia7127?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvZGF0YXBpcGVsaW5lcy9EUF9XaWtpcGVkaWE3MTI3P2FwaS12ZXJzaW9uPTIwMTUtMDgtMDE=",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datapipelines/DP_Wikipedia3128?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXBpcGVsaW5lcy9EUF9XaWtpcGVkaWEzMTI4P2FwaS12ZXJzaW9uPTIwMTUtMDktMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "587e6931-a4bb-4cf7-a09b-91d6f4cd041f"
+          "fa2c9813-f361-41a0-ab21-8aee9be30b4b"
         ],
         "x-ms-version": [
-          "2015-08-01"
+          "2015-09-01"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DP_Wikipedia7127\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/datapipelines/DP_Wikipedia7127\",\r\n  \"properties\": {\r\n    \"description\": \"DP Wikipedia Sample Pipelines\",\r\n    \"activities\": [\r\n      {\r\n        \"type\": \"HDInsightHive\",\r\n        \"typeProperties\": {\r\n          \"script\": \"$$Text.Format('CREATE EXTERNAL TABLE IF NOT EXISTS values2 (projectname string, title string, pageviews string, bytestransfer string) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\' \\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledatain\\\\'; CREATE EXTERNAL TABLE IF NOT EXISTS stats2 (slicetimestamp string, projectname string, pageviews string) PARTITIONED BY (runtime STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\',\\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout\\\\'; ALTER TABLE stats2 ADD IF NOT EXISTS PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout/runtime={0:yyyyMMddHH}\\\\'; INSERT OVERWRITE TABLE stats2 PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') SELECT slicetimestamp, projectname, sum(pageviews) FROM (SELECT \\\\'{0:yyyy/MM/dd HH:00:00}\\\\' AS slicetimestamp, CASE WHEN size(split(projectname, \\\\'[.]\\\\'))=1 THEN \\\\'wikipedia\\\\' ELSE CASE split(projectname, \\\\'[.]\\\\')[1] WHEN \\\\'b\\\\' THEN \\\\'wikibooks\\\\' WHEN \\\\'d\\\\' THEN \\\\'wiktionary\\\\' WHEN \\\\'m\\\\' THEN \\\\'wikimedia\\\\' WHEN \\\\'mv\\\\' THEN \\\\'wikipedia mobile\\\\' WHEN \\\\'n\\\\' THEN \\\\'wikinews\\\\' WHEN \\\\'q\\\\' THEN \\\\'wikiquote\\\\' WHEN \\\\'s\\\\' THEN \\\\'wikisource\\\\' WHEN \\\\'v\\\\' THEN \\\\'wikiversity\\\\' WHEN \\\\'w\\\\' THEN \\\\'mediawiki\\\\' ELSE \\\\'n/a\\\\' END END AS projectname, pageviews FROM values2) A GROUP BY slicetimestamp, projectname;', SliceStart)\"\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_WikipediaClickEvents\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"WikiHiveActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      },\r\n      {\r\n        \"type\": \"Copy\",\r\n        \"typeProperties\": {\r\n          \"source\": {\r\n            \"type\": \"BlobSource\",\r\n            \"blobColumnSeparators\": \",\"\r\n          },\r\n          \"sink\": {\r\n            \"type\": \"SqlSink\",\r\n            \"writeBatchSize\": 1000000,\r\n            \"writeBatchTimeout\": \"01:00:00\"\r\n          }\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_WikiAggregatedData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"BlobToSqlCopyActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      }\r\n    ],\r\n    \"isPaused\": false,\r\n    \"runtimeInfo\": {\r\n      \"deploymentTime\": \"2015-07-31T22:29:45.5791608Z\",\r\n      \"activePeriodSetTime\": \"2015-07-31T22:29:45.5791608Z\",\r\n      \"activityPeriods\": {\r\n        \"wikiHiveActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        },\r\n        \"blobToSqlCopyActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        }\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"hubName\": \"datafactory8496_hub\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DP_Wikipedia3128\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datapipelines/DP_Wikipedia3128\",\r\n  \"properties\": {\r\n    \"description\": \"DP Wikipedia Sample Pipelines\",\r\n    \"activities\": [\r\n      {\r\n        \"type\": \"HDInsightHive\",\r\n        \"typeProperties\": {\r\n          \"script\": \"$$Text.Format('CREATE EXTERNAL TABLE IF NOT EXISTS values2 (projectname string, title string, pageviews string, bytestransfer string) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\' \\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledatain\\\\'; CREATE EXTERNAL TABLE IF NOT EXISTS stats2 (slicetimestamp string, projectname string, pageviews string) PARTITIONED BY (runtime STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY \\\\',\\\\' LINES TERMINATED BY \\\\'10\\\\' STORED AS TEXTFILE LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout\\\\'; ALTER TABLE stats2 ADD IF NOT EXISTS PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') LOCATION \\\\'wasb://wikidatagateway@mdpbvthadoopstore.blob.core.windows.net/wikisampledataout/runtime={0:yyyyMMddHH}\\\\'; INSERT OVERWRITE TABLE stats2 PARTITION (runtime = \\\\'{0:yyyyMMddHH}\\\\') SELECT slicetimestamp, projectname, sum(pageviews) FROM (SELECT \\\\'{0:yyyy/MM/dd HH:00:00}\\\\' AS slicetimestamp, CASE WHEN size(split(projectname, \\\\'[.]\\\\'))=1 THEN \\\\'wikipedia\\\\' ELSE CASE split(projectname, \\\\'[.]\\\\')[1] WHEN \\\\'b\\\\' THEN \\\\'wikibooks\\\\' WHEN \\\\'d\\\\' THEN \\\\'wiktionary\\\\' WHEN \\\\'m\\\\' THEN \\\\'wikimedia\\\\' WHEN \\\\'mv\\\\' THEN \\\\'wikipedia mobile\\\\' WHEN \\\\'n\\\\' THEN \\\\'wikinews\\\\' WHEN \\\\'q\\\\' THEN \\\\'wikiquote\\\\' WHEN \\\\'s\\\\' THEN \\\\'wikisource\\\\' WHEN \\\\'v\\\\' THEN \\\\'wikiversity\\\\' WHEN \\\\'w\\\\' THEN \\\\'mediawiki\\\\' ELSE \\\\'n/a\\\\' END END AS projectname, pageviews FROM values2) A GROUP BY slicetimestamp, projectname;', SliceStart)\"\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_WikipediaClickEvents\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"WikiHiveActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      },\r\n      {\r\n        \"type\": \"Copy\",\r\n        \"typeProperties\": {\r\n          \"source\": {\r\n            \"type\": \"BlobSource\"\r\n          },\r\n          \"sink\": {\r\n            \"type\": \"SqlSink\",\r\n            \"writeBatchSize\": 1000000,\r\n            \"writeBatchTimeout\": \"01:00:00\"\r\n          }\r\n        },\r\n        \"inputs\": [\r\n          {\r\n            \"name\": \"DA_CuratedWikiData\"\r\n          }\r\n        ],\r\n        \"outputs\": [\r\n          {\r\n            \"name\": \"DA_WikiAggregatedData\"\r\n          }\r\n        ],\r\n        \"policy\": {\r\n          \"timeout\": \"01:00:00\",\r\n          \"concurrency\": 1,\r\n          \"executionPriorityOrder\": \"NewestFirst\",\r\n          \"retry\": 2\r\n        },\r\n        \"scheduler\": {\r\n          \"frequency\": \"Hour\",\r\n          \"interval\": 1\r\n        },\r\n        \"name\": \"BlobToSqlCopyActivity\",\r\n        \"linkedServiceName\": \"HDILinkedService\"\r\n      }\r\n    ],\r\n    \"isPaused\": false,\r\n    \"runtimeInfo\": {\r\n      \"deploymentTime\": \"2015-08-28T23:02:55.3347675Z\",\r\n      \"activePeriodSetTime\": \"2015-08-28T23:02:55.3347675Z\",\r\n      \"activityPeriods\": {\r\n        \"wikiHiveActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        },\r\n        \"blobToSqlCopyActivity\": {\r\n          \"start\": \"1601-01-01T00:00:00Z\",\r\n          \"end\": \"1601-01-01T00:00:00Z\"\r\n        }\r\n      }\r\n    },\r\n    \"id\": \"b48772bf-085d-4215-b976-0387731202aa\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"hubName\": \"datafactory3531_hub\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "3090"
+          "3107"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1576,16 +1516,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "9e1d0406-0c21-4c1e-a6af-5dcb56d16184"
+          "d50230a3-adc5-4047-9324-fa26645116c6"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14982"
+          "14985"
         ],
         "x-ms-correlation-request-id": [
-          "a2de7948-39c6-481c-bfa4-11ed7f6666eb"
+          "d7e51481-90e8-4474-9565-65a595c72c54"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222953Z:a2de7948-39c6-481c-bfa4-11ed7f6666eb"
+          "CENTRALUS:20150828T230302Z:d7e51481-90e8-4474-9565-65a595c72c54"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1594,7 +1534,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:53 GMT"
+          "Fri, 28 Aug 2015 23:03:02 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1606,16 +1546,16 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/datapipelines/DP_Wikipedia7127/update?start=2014-10-08T08:00:00&end=2014-10-08T10:00:00&autoResolve=false&forceRecalc=false&api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvZGF0YXBpcGVsaW5lcy9EUF9XaWtpcGVkaWE3MTI3L3VwZGF0ZT9zdGFydD0yMDE0LTEwLTA4VDA4JTNBMDAlM0EwMCZlbmQ9MjAxNC0xMC0wOFQxMCUzQTAwJTNBMDAmYXV0b1Jlc29sdmU9ZmFsc2UmZm9yY2VSZWNhbGM9ZmFsc2UmYXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datapipelines/DP_Wikipedia3128/update?start=2014-10-08T08:00:00&end=2014-10-08T10:00:00&autoResolve=false&forceRecalc=false&api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXBpcGVsaW5lcy9EUF9XaWtpcGVkaWEzMTI4L3VwZGF0ZT9zdGFydD0yMDE0LTEwLTA4VDA4JTNBMDAlM0EwMCZlbmQ9MjAxNC0xMC0wOFQxMCUzQTAwJTNBMDAmYXV0b1Jlc29sdmU9ZmFsc2UmZm9yY2VSZWNhbGM9ZmFsc2UmYXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "POST",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "430a1d42-5c3c-4891-8dfb-6c5102554dbd"
+          "8cdba5d2-a403-427b-a4d6-66c6b37a9c3f"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
       "ResponseBody": "",
@@ -1630,16 +1570,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "e2cfc9ad-1041-4721-b09a-da7cf199f3bc"
+          "64be54c5-550d-4458-aa7c-64ab58017782"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1187"
+          "1189"
         ],
         "x-ms-correlation-request-id": [
-          "0dd42ff6-b282-4f29-81ec-b78128ef2248"
+          "159fe4d6-9c50-40d1-8717-30540ae37663"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222957Z:0dd42ff6-b282-4f29-81ec-b78128ef2248"
+          "CENTRALUS:20150828T230304Z:159fe4d6-9c50-40d1-8717-30540ae37663"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1648,7 +1588,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:56 GMT"
+          "Fri, 28 Aug 2015 23:03:03 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1660,22 +1600,22 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikipediaClickEvents?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpcGVkaWFDbGlja0V2ZW50cz9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikipediaClickEvents?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpcGVkaWFDbGlja0V2ZW50cz9hcGktdmVyc2lvbj0yMDE1LTA5LTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "8cf993c8-51cb-481a-b59a-e78307003c8b"
+          "63b79a38-6b81-42f2-9c71-e74698442637"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikipediaClickEvents\",\r\n  \"name\": \"LinkedService-WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mywikistorage;AccountKey=**********\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikipediaClickEvents\",\r\n  \"name\": \"LinkedService-WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mywikistorage;AccountKey=**********\"\r\n    },\r\n    \"id\": \"13050880-1bc2-41e9-9790-a7bfb33fe6cd\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "469"
+          "513"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1687,16 +1627,187 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "cb1ee260-0a36-4acb-b5d8-6ab632770131"
+          "41dceb92-b43f-4393-8d86-6c5e0fac22d8"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14984"
+        ],
+        "x-ms-correlation-request-id": [
+          "60e22922-40cc-4595-bb05-39f112a1e91a"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20150828T230304Z:60e22922-40cc-4595-bb05-39f112a1e91a"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 28 Aug 2015 23:03:03 GMT"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.5"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-CuratedWikiData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1DdXJhdGVkV2lraURhdGE/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "e7e0a260-6011-451e-92cf-674c5bbb0637"
+        ],
+        "User-Agent": [
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-CuratedWikiData\",\r\n  \"name\": \"LinkedService-CuratedWikiData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mytestaccountname;AccountKey=**********\"\r\n    },\r\n    \"id\": \"32d9a8f2-7e32-4847-858e-74f0a3ab739e\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "507"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "8ed81a07-013d-45f8-b2cc-8ed09833f685"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14983"
+        ],
+        "x-ms-correlation-request-id": [
+          "74d87d8e-d5fe-4508-9ce5-40c6d30c2dbb"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20150828T230305Z:74d87d8e-d5fe-4508-9ce5-40c6d30c2dbb"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 28 Aug 2015 23:03:05 GMT"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.5"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikiAggregatedData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpQWdncmVnYXRlZERhdGE/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "ef349610-911c-45b3-b6f5-2d4301ab4216"
+        ],
+        "User-Agent": [
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/LinkedService-WikiAggregatedData\",\r\n  \"name\": \"LinkedService-WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"AzureSqlDatabase\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"Data Source=tcp:mytestsql.database.windows.net,1433;Initial Catalog=mdpwikisamplev2;Integrated Security=False;User ID=test@test.net;Password=**********;Connect Timeout=30;Encrypt=True\"\r\n    },\r\n    \"id\": \"eb0b324f-03a5-4aad-8da6-a151a127ce71\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "618"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "0a099a00-3774-486e-b3c4-4e634c1a8b50"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14982"
+        ],
+        "x-ms-correlation-request-id": [
+          "79f65733-6f53-4c2e-8bd3-7c5e94126d2b"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20150828T230305Z:79f65733-6f53-4c2e-8bd3-7c5e94126d2b"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 28 Aug 2015 23:03:05 GMT"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.5"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/HDILinkedService?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvbGlua2Vkc2VydmljZXMvSERJTGlua2VkU2VydmljZT9hcGktdmVyc2lvbj0yMDE1LTA5LTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "5ebb2984-aa9b-43ff-a510-16d66cddc48f"
+        ],
+        "User-Agent": [
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/linkedservices/HDILinkedService\",\r\n  \"name\": \"HDILinkedService\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory3531_hub\",\r\n    \"type\": \"HDInsight\",\r\n    \"typeProperties\": {\r\n      \"clusterUri\": \"https://testhdi.azurehdinsight.net/\",\r\n      \"userName\": \"testaccount\",\r\n      \"password\": \"**********\",\r\n      \"linkedServiceName\": \"LinkedService-CuratedWikiData\"\r\n    },\r\n    \"id\": \"c62b33b1-07a3-487b-8219-a0aaa84b6005\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "526"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "bdbcc06e-a4bd-45bd-baea-e4e0d7e9b50c"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14981"
         ],
         "x-ms-correlation-request-id": [
-          "fef629be-5305-47ff-8d9d-320a320b4e9b"
+          "68d24c24-2c8c-44af-b466-1348817cb365"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222957Z:fef629be-5305-47ff-8d9d-320a320b4e9b"
+          "CENTRALUS:20150828T230305Z:68d24c24-2c8c-44af-b466-1348817cb365"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1705,7 +1816,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:57 GMT"
+          "Fri, 28 Aug 2015 23:03:05 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1717,22 +1828,22 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-CuratedWikiData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1DdXJhdGVkV2lraURhdGE/YXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikipediaClickEvents?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfV2lraXBlZGlhQ2xpY2tFdmVudHM/YXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "0631ba34-63e5-4e40-bf60-935a74f5ab09"
+          "a8d1473b-c199-4f71-93db-65cb27eed0e6"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-CuratedWikiData\",\r\n  \"name\": \"LinkedService-CuratedWikiData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"AzureStorage\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"DefaultEndpointsProtocol=https;AccountName=mytestaccountname;AccountKey=**********\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DA_WikipediaClickEvents\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/tables/DA_WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-WikipediaClickEvents\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledatain/\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumSizeMB\": 1.0\r\n      },\r\n      \"externalData\": {\r\n        \"retryInterval\": \"00:01:00\",\r\n        \"retryTimeout\": \"00:10:00\",\r\n        \"maximumRetry\": 3\r\n      }\r\n    },\r\n    \"id\": \"d8697c82-e3de-4105-be69-b0da63d382ab\",\r\n    \"createTime\": \"2015-08-28T23:02:49.7512221Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "463"
+          "698"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1744,16 +1855,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "592041ec-4cea-4fdc-b39d-3d64633f92b8"
+          "b889f631-44de-403e-bacc-a3611fd66198"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14980"
         ],
         "x-ms-correlation-request-id": [
-          "cb538b63-6ce6-454c-8501-672eb9ced41f"
+          "470a9139-0754-4eb3-bcbc-8c4dc257e4b2"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222958Z:cb538b63-6ce6-454c-8501-672eb9ced41f"
+          "CENTRALUS:20150828T230305Z:470a9139-0754-4eb3-bcbc-8c4dc257e4b2"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1762,7 +1873,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:57 GMT"
+          "Fri, 28 Aug 2015 23:03:05 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1774,22 +1885,22 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikiAggregatedData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvTGlua2VkU2VydmljZS1XaWtpQWdncmVnYXRlZERhdGE/YXBpLXZlcnNpb249MjAxNS0wOC0wMQ==",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_CuratedWikiData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfQ3VyYXRlZFdpa2lEYXRhP2FwaS12ZXJzaW9uPTIwMTUtMDktMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "99256f5a-2e0f-4010-9f84-b64005fd267b"
+          "11a51789-52be-4a25-9ec3-54de22636de0"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/LinkedService-WikiAggregatedData\",\r\n  \"name\": \"LinkedService-WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"AzureSqlDatabase\",\r\n    \"typeProperties\": {\r\n      \"connectionString\": \"Data Source=tcp:mytestsql.database.windows.net,1433;Initial Catalog=mdpwikisamplev2;Integrated Security=False;User ID=test@test.net;Password=**********;Connect Timeout=30;Encrypt=True\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DA_CuratedWikiData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/tables/DA_CuratedWikiData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"pageviews\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-CuratedWikiData\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledataout/runtime={Slice}\",\r\n      \"partitionedBy\": [\r\n        {\r\n          \"name\": \"Slice\",\r\n          \"value\": {\r\n            \"type\": \"DateTime\",\r\n            \"date\": \"SliceStart\",\r\n            \"format\": \"yyyyMMddHH\"\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"id\": \"0cb6178f-1de0-461a-82c5-25957131f3b9\",\r\n    \"createTime\": \"2015-08-28T23:02:49.3239307Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "574"
+          "804"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1801,16 +1912,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "04e01edd-700c-4a3d-9b41-16bd5d1b4d47"
+          "e4ec7ac6-55be-414a-b154-1646f5cc3cc1"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14979"
         ],
         "x-ms-correlation-request-id": [
-          "bbeb45fd-108c-474e-999c-dd454a7c995f"
+          "7aec0c49-3df8-4b4d-8c36-21aa9642765f"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222958Z:bbeb45fd-108c-474e-999c-dd454a7c995f"
+          "CENTRALUS:20150828T230305Z:7aec0c49-3df8-4b4d-8c36-21aa9642765f"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1819,7 +1930,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:58 GMT"
+          "Fri, 28 Aug 2015 23:03:05 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1831,22 +1942,22 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/HDILinkedService?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvbGlua2Vkc2VydmljZXMvSERJTGlua2VkU2VydmljZT9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikiAggregatedData?api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfV2lraUFnZ3JlZ2F0ZWREYXRhP2FwaS12ZXJzaW9uPTIwMTUtMDktMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "f68a27e5-cb82-44ee-a93e-54111eadcbe6"
+          "16a34820-60de-412e-9590-cc9e4f62a000"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/linkedservices/HDILinkedService\",\r\n  \"name\": \"HDILinkedService\",\r\n  \"properties\": {\r\n    \"hubName\": \"datafactory8496_hub\",\r\n    \"type\": \"HDInsight\",\r\n    \"typeProperties\": {\r\n      \"clusterUri\": \"https://testhdi.azurehdinsight.net/\",\r\n      \"userName\": \"testaccount\",\r\n      \"password\": \"**********\",\r\n      \"storageAccountName\": null,\r\n      \"storageAccountKey\": null,\r\n      \"location\": null,\r\n      \"linkedServiceName\": \"LinkedService-CuratedWikiData\"\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"DA_WikiAggregatedData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/tables/DA_WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"hits\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureSqlTable\",\r\n    \"linkedServiceName\": \"LinkedService-WikiAggregatedData\",\r\n    \"typeProperties\": {\r\n      \"tableName\": \"wikiaggregateddata\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumRows\": 8\r\n      }\r\n    },\r\n    \"id\": \"29b99c1d-f29c-4a55-8de6-eccc7ef391a5\",\r\n    \"createTime\": \"2015-08-28T23:02:43.7416551Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "549"
+          "717"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1858,16 +1969,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "73b9de6b-f50e-4880-9c18-04d43349c7da"
+          "788006b8-6023-47f9-9975-b97ecc6ced46"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14978"
         ],
         "x-ms-correlation-request-id": [
-          "49169e99-59a4-4ea3-aabf-a73017243c1e"
+          "cf74a329-3bb9-4f9f-b2d9-1dadc4c1c562"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222959Z:49169e99-59a4-4ea3-aabf-a73017243c1e"
+          "CENTRALUS:20150828T230305Z:cf74a329-3bb9-4f9f-b2d9-1dadc4c1c562"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1876,7 +1987,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:58 GMT"
+          "Fri, 28 Aug 2015 23:03:05 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -1888,190 +1999,19 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikipediaClickEvents?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lwZWRpYUNsaWNrRXZlbnRzP2FwaS12ZXJzaW9uPTIwMTUtMDgtMDE=",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikiAggregatedData/slices?start=2014-10-08T08:00:00&end=2014-10-08T10:00:00&api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfV2lraUFnZ3JlZ2F0ZWREYXRhL3NsaWNlcz9zdGFydD0yMDE0LTEwLTA4VDA4JTNBMDAlM0EwMCZlbmQ9MjAxNC0xMC0wOFQxMCUzQTAwJTNBMDAmYXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "15a6d418-a665-4e15-98dd-2b61b38747d3"
+          "c63902e7-a592-4e19-96c3-56df5626c302"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"DA_WikipediaClickEvents\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikipediaClickEvents\",\r\n  \"properties\": {\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-WikipediaClickEvents\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledatain/\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumSizeMB\": 1.0\r\n      },\r\n      \"externalData\": {\r\n        \"retryInterval\": \"00:01:00\",\r\n        \"retryTimeout\": \"00:10:00\",\r\n        \"maximumRetry\": 3\r\n      }\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:38.6549254Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "654"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "8e42b1c2-668e-422c-9bbd-39e530068e43"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14977"
-        ],
-        "x-ms-correlation-request-id": [
-          "7634ccae-7190-4a27-acba-8df754955e3a"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222959Z:7634ccae-7190-4a27-acba-8df754955e3a"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Fri, 31 Jul 2015 22:29:58 GMT"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "X-Powered-By": [
-          "ASP.NET"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_CuratedWikiData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX0N1cmF0ZWRXaWtpRGF0YT9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "78c24f94-00e0-4253-a5e9-87066928cc66"
-        ],
-        "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"DA_CuratedWikiData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_CuratedWikiData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"pageviews\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureBlob\",\r\n    \"linkedServiceName\": \"LinkedService-CuratedWikiData\",\r\n    \"typeProperties\": {\r\n      \"folderPath\": \"wikidatagateway/wikisampledataout/runtime={Slice}\",\r\n      \"partitionedBy\": [\r\n        {\r\n          \"name\": \"Slice\",\r\n          \"value\": {\r\n            \"type\": \"DateTime\",\r\n            \"date\": \"SliceStart\",\r\n            \"format\": \"yyyyMMddHH\"\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:37.5539556Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "760"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "150884f5-cb9f-43ad-a773-45e581862874"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14976"
-        ],
-        "x-ms-correlation-request-id": [
-          "7069cbe5-01b8-4153-ae26-89ad899c3fe3"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T222959Z:7069cbe5-01b8-4153-ae26-89ad899c3fe3"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Fri, 31 Jul 2015 22:29:59 GMT"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "X-Powered-By": [
-          "ASP.NET"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData?api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lBZ2dyZWdhdGVkRGF0YT9hcGktdmVyc2lvbj0yMDE1LTA4LTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "334e15a6-32ef-423f-a490-28c1642ff6cb"
-        ],
-        "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"DA_WikiAggregatedData\",\r\n  \"id\": \"/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData\",\r\n  \"properties\": {\r\n    \"structure\": [\r\n      {\r\n        \"name\": \"slicetimestamp\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"projectname\",\r\n        \"type\": \"String\"\r\n      },\r\n      {\r\n        \"name\": \"hits\",\r\n        \"type\": \"Decimal\"\r\n      }\r\n    ],\r\n    \"published\": false,\r\n    \"type\": \"AzureSqlTable\",\r\n    \"linkedServiceName\": \"LinkedService-WikiAggregatedData\",\r\n    \"typeProperties\": {\r\n      \"tableName\": \"wikiaggregateddata\"\r\n    },\r\n    \"availability\": {\r\n      \"frequency\": \"Hour\",\r\n      \"interval\": 1\r\n    },\r\n    \"policy\": {\r\n      \"validation\": {\r\n        \"minimumRows\": 8\r\n      }\r\n    },\r\n    \"createTime\": \"2015-07-31T22:29:23.4849863Z\",\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "673"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "3e6ad209-98da-4772-847b-8826d9ad7597"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14975"
-        ],
-        "x-ms-correlation-request-id": [
-          "4ab71e73-0cae-4fa5-ac9f-85f080cebb83"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T223000Z:4ab71e73-0cae-4fa5-ac9f-85f080cebb83"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Fri, 31 Jul 2015 22:29:59 GMT"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "X-Powered-By": [
-          "ASP.NET"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData/slices?start=2014-10-08T08:00:00&end=2014-10-08T10:00:00&api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lBZ2dyZWdhdGVkRGF0YS9zbGljZXM/c3RhcnQ9MjAxNC0xMC0wOFQwOCUzQTAwJTNBMDAmZW5kPTIwMTQtMTAtMDhUMTAlM0EwMCUzQTAwJmFwaS12ZXJzaW9uPTIwMTUtMDgtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "35938980-93af-4046-b83e-c14caa1aa1a8"
-        ],
-        "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"status\": \"PendingExecution\",\r\n      \"state\": \"Waiting\",\r\n      \"substate\": \"DatasetDependencies\",\r\n      \"retryCount\": 0,\r\n      \"longRetryCount\": 0,\r\n      \"statusUpdateTimestamp\": \"2015-07-31T22:29:59.0895482Z\",\r\n      \"start\": \"2014-10-08T08:00:00Z\",\r\n      \"end\": \"2014-10-08T09:00:00Z\"\r\n    },\r\n    {\r\n      \"status\": \"PendingExecution\",\r\n      \"state\": \"Waiting\",\r\n      \"substate\": \"DatasetDependencies\",\r\n      \"retryCount\": 0,\r\n      \"longRetryCount\": 0,\r\n      \"statusUpdateTimestamp\": \"2015-07-31T22:29:59.0895482Z\",\r\n      \"start\": \"2014-10-08T09:00:00Z\",\r\n      \"end\": \"2014-10-08T10:00:00Z\"\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"status\": \"PendingExecution\",\r\n      \"state\": \"Waiting\",\r\n      \"substate\": \"DatasetDependencies\",\r\n      \"retryCount\": 0,\r\n      \"longRetryCount\": 0,\r\n      \"statusUpdateTimestamp\": \"2015-08-28T23:03:05.3216954Z\",\r\n      \"start\": \"2014-10-08T08:00:00Z\",\r\n      \"end\": \"2014-10-08T09:00:00Z\"\r\n    },\r\n    {\r\n      \"status\": \"PendingExecution\",\r\n      \"state\": \"Waiting\",\r\n      \"substate\": \"DatasetDependencies\",\r\n      \"retryCount\": 0,\r\n      \"longRetryCount\": 0,\r\n      \"statusUpdateTimestamp\": \"2015-08-28T23:03:05.3216954Z\",\r\n      \"start\": \"2014-10-08T09:00:00Z\",\r\n      \"end\": \"2014-10-08T10:00:00Z\"\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "471"
@@ -2086,16 +2026,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "fd82e82e-9954-4245-9b98-6a78b9ed3763"
+          "8e02dae1-14c0-47a7-8e1e-80c1597124b4"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14974"
+          "14977"
         ],
         "x-ms-correlation-request-id": [
-          "1c45e763-22f1-4a3e-aa29-c8f80a0c5781"
+          "7b45f325-6121-478e-9a07-5afd8e45fc50"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T223000Z:1c45e763-22f1-4a3e-aa29-c8f80a0c5781"
+          "CENTRALUS:20150828T230306Z:7b45f325-6121-478e-9a07-5afd8e45fc50"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -2104,7 +2044,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:29:59 GMT"
+          "Fri, 28 Aug 2015 23:03:06 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -2116,16 +2056,16 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData/sliceruns?startTime=2014-10-08T08:00:00.0000000Z&api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lBZ2dyZWdhdGVkRGF0YS9zbGljZXJ1bnM/c3RhcnRUaW1lPTIwMTQtMTAtMDhUMDglM0EwMCUzQTAwLjAwMDAwMDBaJmFwaS12ZXJzaW9uPTIwMTUtMDgtMDE=",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikiAggregatedData/sliceruns?startTime=2014-10-08T08:00:00.0000000Z&api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfV2lraUFnZ3JlZ2F0ZWREYXRhL3NsaWNlcnVucz9zdGFydFRpbWU9MjAxNC0xMC0wOFQwOCUzQTAwJTNBMDAuMDAwMDAwMFomYXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "22b9f596-c3e1-4bf5-a77a-733338c782c2"
+          "c6f4a110-f632-4195-88ba-43d5a19bff89"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
       "ResponseBody": "{\r\n  \"value\": []\r\n}",
@@ -2143,16 +2083,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "deaad0b2-7f37-42d4-a7b8-0d52f9c43a5e"
+          "61a839b1-cf98-4f0d-89c2-b9052a1bc061"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14973"
+          "14976"
         ],
         "x-ms-correlation-request-id": [
-          "bb20fdc1-8731-4fe9-aeee-e86fd9b020cc"
+          "f5438835-5ceb-4b43-997b-0e2295548ab9"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T223001Z:bb20fdc1-8731-4fe9-aeee-e86fd9b020cc"
+          "CENTRALUS:20150828T230306Z:f5438835-5ceb-4b43-997b-0e2295548ab9"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -2161,7 +2101,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:30:00 GMT"
+          "Fri, 28 Aug 2015 23:03:06 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -2173,16 +2113,16 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup8402/providers/Microsoft.DataFactory/datafactories/DataFactory8496/tables/DA_WikiAggregatedData/sliceruns?startTime=2014-10-08T09:00:00.0000000Z&api-version=2015-08-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA4NDAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTg0OTYvdGFibGVzL0RBX1dpa2lBZ2dyZWdhdGVkRGF0YS9zbGljZXJ1bnM/c3RhcnRUaW1lPTIwMTQtMTAtMDhUMDklM0EwMCUzQTAwLjAwMDAwMDBaJmFwaS12ZXJzaW9uPTIwMTUtMDgtMDE=",
+      "RequestUri": "/subscriptions/4431ebb2-5a07-4d85-85cf-7af34ae85ff5/resourcegroups/resourcegroup6899/providers/Microsoft.DataFactory/datafactories/DataFactory3531/datasets/DA_WikiAggregatedData/sliceruns?startTime=2014-10-08T09:00:00.0000000Z&api-version=2015-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNDQzMWViYjItNWEwNy00ZDg1LTg1Y2YtN2FmMzRhZTg1ZmY1L3Jlc291cmNlZ3JvdXBzL3Jlc291cmNlZ3JvdXA2ODk5L3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUZhY3RvcnkvZGF0YWZhY3Rvcmllcy9EYXRhRmFjdG9yeTM1MzEvZGF0YXNldHMvREFfV2lraUFnZ3JlZ2F0ZWREYXRhL3NsaWNlcnVucz9zdGFydFRpbWU9MjAxNC0xMC0wOFQwOSUzQTAwJTNBMDAuMDAwMDAwMFomYXBpLXZlcnNpb249MjAxNS0wOS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "cf2660f7-904f-42c4-889e-98a6d503e6fa"
+          "d6b7363f-abaf-4f54-99a5-12d6911a7ee3"
         ],
         "User-Agent": [
-          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/2.0.0.0"
+          "Microsoft.Azure.Management.DataFactories.Core.DataFactoryManagementClient/3.0.0.0"
         ]
       },
       "ResponseBody": "{\r\n  \"value\": []\r\n}",
@@ -2200,16 +2140,16 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "ae64ebfb-24b5-41f1-a8c4-3f4ee482ed44"
+          "c7a93fe2-c7ac-46b8-95fb-c7fd65d5f530"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14972"
+          "14975"
         ],
         "x-ms-correlation-request-id": [
-          "b2fd0dc0-6acf-440f-9bac-59a854330447"
+          "0e880a2e-60ea-4f82-a101-59b545193417"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20150731T223001Z:b2fd0dc0-6acf-440f-9bac-59a854330447"
+          "CENTRALUS:20150828T230306Z:0e880a2e-60ea-4f82-a101-59b545193417"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -2218,7 +2158,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 31 Jul 2015 22:30:00 GMT"
+          "Fri, 28 Aug 2015 23:03:06 GMT"
         ],
         "Server": [
           "Microsoft-IIS/8.5"
@@ -2232,9 +2172,9 @@
   ],
   "Names": {
     "WikipediaPipelineE2ETest": [
-      "resourcegroup8402",
-      "DataFactory8496",
-      "DP_Wikipedia7127"
+      "resourcegroup6899",
+      "DataFactory3531",
+      "DP_Wikipedia3128"
     ]
   },
   "Variables": {

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/ActivityTypeOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/ActivityTypeOperations.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/activityTypes/";
             url = url + Uri.EscapeDataString(activityTypeName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -369,7 +369,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/activityTypes/";
             url = url + Uri.EscapeDataString(parameters.ActivityType.Name);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -636,7 +636,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/activityTypes/";
             url = url + Uri.EscapeDataString(activityTypeName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -954,7 +954,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/activityTypes/";
             url = url + Uri.EscapeDataString(parameters.ActivityTypeName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             queryParameters.Add("scope=" + Uri.EscapeDataString(parameters.RegistrationScope));
             queryParameters.Add("resolved=" + Uri.EscapeDataString(parameters.Resolved.ToString().ToLower()));
             if (queryParameters.Count > 0)
@@ -1178,7 +1178,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(dataFactoryName);
             url = url + "/activityTypes";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (parameters.ActivityTypeName != null)
             {
                 queryParameters.Add("name=" + Uri.EscapeDataString(parameters.ActivityTypeName));

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/ComputeTypeOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/ComputeTypeOperations.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/computeTypes/";
             url = url + Uri.EscapeDataString(computeTypeName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -232,11 +232,11 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                     {
                         result.Status = OperationStatus.Failed;
                     }
-                    if (statusCode == HttpStatusCode.NoContent)
+                    if (statusCode == HttpStatusCode.OK)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }
-                    if (statusCode == HttpStatusCode.OK)
+                    if (statusCode == HttpStatusCode.NoContent)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/computeTypes/";
             url = url + Uri.EscapeDataString(parameters.ComputeType.Name);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -731,7 +731,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/computeTypes/";
             url = url + Uri.EscapeDataString(computeTypeName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -1103,7 +1103,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/computeTypes/";
             url = url + Uri.EscapeDataString(parameters.ComputeTypeName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             queryParameters.Add("scope=" + Uri.EscapeDataString(parameters.RegistrationScope));
             if (queryParameters.Count > 0)
             {
@@ -1384,7 +1384,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(dataFactoryName);
             url = url + "/computeTypes";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (parameters.ComputeTypeName != null)
             {
                 queryParameters.Add("name=" + Uri.EscapeDataString(parameters.ComputeTypeName));

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/DataFactoryManagementClient.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/DataFactoryManagementClient.cs
@@ -424,7 +424,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 httpRequest.RequestUri = new Uri(url);
                 
                 // Set Headers
-                httpRequest.Headers.Add("x-ms-version", "2015-08-01");
+                httpRequest.Headers.Add("x-ms-version", "2015-09-01");
                 
                 // Set Credentials
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/DataFactoryOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/DataFactoryOperations.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 url = url + Uri.EscapeDataString(parameters.DataFactory.Name);
             }
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -508,7 +508,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(dataFactoryName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -667,7 +667,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(dataFactoryName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -885,7 +885,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 
                 // Set Headers
                 httpRequest.Headers.Add("x-ms-client-request-id", Guid.NewGuid().ToString());
-                httpRequest.Headers.Add("x-ms-version", "2015-08-01");
+                httpRequest.Headers.Add("x-ms-version", "2015-09-01");
                 
                 // Set Credentials
                 cancellationToken.ThrowIfCancellationRequested();
@@ -1087,7 +1087,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(resourceGroupName);
             url = url + "/providers/Microsoft.DataFactory/datafactories";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/DataSliceOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/DataSliceOperations.cs
@@ -164,13 +164,13 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(resourceGroupName);
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(dataFactoryName);
-            url = url + "/tables/";
+            url = url + "/datasets/";
             url = url + Uri.EscapeDataString(tableName);
             url = url + "/slices";
             List<string> queryParameters = new List<string>();
             queryParameters.Add("start=" + Uri.EscapeDataString(parameters.DataSliceRangeStartTime));
             queryParameters.Add("end=" + Uri.EscapeDataString(parameters.DataSliceRangeEndTime));
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -624,7 +624,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(resourceGroupName);
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(dataFactoryName);
-            url = url + "/tables/";
+            url = url + "/datasets/";
             url = url + Uri.EscapeDataString(tableName);
             url = url + "/slices/setstatus";
             List<string> queryParameters = new List<string>();
@@ -636,7 +636,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             {
                 queryParameters.Add("end=" + Uri.EscapeDataString(parameters.DataSliceRangeEndTime));
             }
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/DataSliceRunOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/DataSliceRunOperations.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/runs/";
             url = url + Uri.EscapeDataString(runId);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -592,7 +592,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(dataSliceRunId);
             url = url + "/logInfo";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -797,12 +797,12 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(resourceGroupName);
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(dataFactoryName);
-            url = url + "/tables/";
+            url = url + "/datasets/";
             url = url + Uri.EscapeDataString(tableName);
             url = url + "/sliceruns";
             List<string> queryParameters = new List<string>();
             queryParameters.Add("startTime=" + Uri.EscapeDataString(parameters.DataSliceStartTime));
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/GatewayOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/GatewayOperations.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 url = url + Uri.EscapeDataString(parameters.Gateway.Name);
             }
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -499,7 +499,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/gateways/";
             url = url + Uri.EscapeDataString(gatewayName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -824,7 +824,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/gateways/";
             url = url + Uri.EscapeDataString(gatewayName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -1066,7 +1066,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 
                 // Set Headers
                 httpRequest.Headers.Add("x-ms-client-request-id", Guid.NewGuid().ToString());
-                httpRequest.Headers.Add("x-ms-version", "2015-08-01");
+                httpRequest.Headers.Add("x-ms-version", "2015-09-01");
                 
                 // Set Credentials
                 cancellationToken.ThrowIfCancellationRequested();
@@ -1309,7 +1309,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(dataFactoryName);
             url = url + "/gateways";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -1587,7 +1587,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(gatewayName);
             url = url + "/regeneratekey";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -1778,7 +1778,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(gatewayName);
             url = url + "/connectioninfo";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -2007,7 +2007,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 url = url + Uri.EscapeDataString(parameters.Gateway.Name);
             }
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/HubOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/HubOperations.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 url = url + Uri.EscapeDataString(parameters.Hub.Name);
             }
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -455,7 +455,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/hubs/";
             url = url + Uri.EscapeDataString(hubName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -727,7 +727,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/hubs/";
             url = url + Uri.EscapeDataString(hubName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -1053,7 +1053,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/hubs/";
             url = url + Uri.EscapeDataString(hubName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -1256,7 +1256,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 
                 // Set Headers
                 httpRequest.Headers.Add("x-ms-client-request-id", Guid.NewGuid().ToString());
-                httpRequest.Headers.Add("x-ms-version", "2015-08-01");
+                httpRequest.Headers.Add("x-ms-version", "2015-09-01");
                 
                 // Set Credentials
                 cancellationToken.ThrowIfCancellationRequested();
@@ -1467,7 +1467,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(dataFactoryName);
             url = url + "/hubs";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/LinkedServiceOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/LinkedServiceOperations.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 url = url + Uri.EscapeDataString(parameters.LinkedService.Name);
             }
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -483,7 +483,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/linkedservices/";
             url = url + Uri.EscapeDataString(linkedServiceName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -739,7 +739,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/linkedservices/";
             url = url + Uri.EscapeDataString(linkedServiceName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -819,11 +819,11 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                     {
                         result.Status = OperationStatus.Failed;
                     }
-                    if (statusCode == HttpStatusCode.NoContent)
+                    if (statusCode == HttpStatusCode.OK)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }
-                    if (statusCode == HttpStatusCode.OK)
+                    if (statusCode == HttpStatusCode.NoContent)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }
@@ -1152,7 +1152,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/linkedservices/";
             url = url + Uri.EscapeDataString(linkedServiceName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -1360,7 +1360,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 
                 // Set Headers
                 httpRequest.Headers.Add("x-ms-client-request-id", Guid.NewGuid().ToString());
-                httpRequest.Headers.Add("x-ms-version", "2015-08-01");
+                httpRequest.Headers.Add("x-ms-version", "2015-09-01");
                 
                 // Set Credentials
                 cancellationToken.ThrowIfCancellationRequested();
@@ -1576,7 +1576,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(dataFactoryName);
             url = url + "/linkedServices";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/PipelineOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/PipelineOperations.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 url = url + Uri.EscapeDataString(parameters.Pipeline.Name);
             }
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -902,7 +902,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/datapipelines/";
             url = url + Uri.EscapeDataString(dataPipelineName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -1377,7 +1377,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/datapipelines/";
             url = url + Uri.EscapeDataString(dataPipelineName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -1457,11 +1457,11 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                     {
                         result.Status = OperationStatus.Failed;
                     }
-                    if (statusCode == HttpStatusCode.NoContent)
+                    if (statusCode == HttpStatusCode.OK)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }
-                    if (statusCode == HttpStatusCode.OK)
+                    if (statusCode == HttpStatusCode.NoContent)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }
@@ -1787,7 +1787,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + "/datapipelines/";
             url = url + Uri.EscapeDataString(dataPipelineName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -2214,7 +2214,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 
                 // Set Headers
                 httpRequest.Headers.Add("x-ms-client-request-id", Guid.NewGuid().ToString());
-                httpRequest.Headers.Add("x-ms-version", "2015-08-01");
+                httpRequest.Headers.Add("x-ms-version", "2015-09-01");
                 
                 // Set Credentials
                 cancellationToken.ThrowIfCancellationRequested();
@@ -2649,7 +2649,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(dataFactoryName);
             url = url + "/datapipelines";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -3551,7 +3551,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(dataPipelineName);
             url = url + "/resume";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -3751,7 +3751,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             queryParameters.Add("end=" + Uri.EscapeDataString(parameters.ActivePeriodEndTime));
             queryParameters.Add("autoResolve=" + Uri.EscapeDataString(parameters.AutoResolve.ToString().ToLower()));
             queryParameters.Add("forceRecalc=" + Uri.EscapeDataString(parameters.ForceRecalc.ToString().ToLower()));
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -3930,7 +3930,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(dataPipelineName);
             url = url + "/pause";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/TableOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/TableOperations.cs
@@ -180,13 +180,13 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(resourceGroupName);
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(dataFactoryName);
-            url = url + "/tables/";
+            url = url + "/datasets/";
             if (parameters.Table != null && parameters.Table.Name != null)
             {
                 url = url + Uri.EscapeDataString(parameters.Table.Name);
             }
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -807,10 +807,10 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(resourceGroupName);
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(dataFactoryName);
-            url = url + "/tables/";
+            url = url + "/datasets/";
             url = url + Uri.EscapeDataString(tableName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -1248,10 +1248,10 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(resourceGroupName);
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(dataFactoryName);
-            url = url + "/tables/";
+            url = url + "/datasets/";
             url = url + Uri.EscapeDataString(tableName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -1659,10 +1659,10 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(resourceGroupName);
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(dataFactoryName);
-            url = url + "/tables/";
+            url = url + "/datasets/";
             url = url + Uri.EscapeDataString(tableName);
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);
@@ -2055,7 +2055,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                 
                 // Set Headers
                 httpRequest.Headers.Add("x-ms-client-request-id", Guid.NewGuid().ToString());
-                httpRequest.Headers.Add("x-ms-version", "2015-08-01");
+                httpRequest.Headers.Add("x-ms-version", "2015-09-01");
                 
                 // Set Credentials
                 cancellationToken.ThrowIfCancellationRequested();
@@ -2454,9 +2454,9 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(resourceGroupName);
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(dataFactoryName);
-            url = url + "/tables";
+            url = url + "/datasets";
             List<string> queryParameters = new List<string>();
-            queryParameters.Add("api-version=2015-08-01");
+            queryParameters.Add("api-version=2015-09-01");
             if (queryParameters.Count > 0)
             {
                 url = url + "?" + string.Join("&", queryParameters);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataFactories
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataFactories">
-      <PackageVersion>2.1.0</PackageVersion>
+      <PackageVersion>3.0.0</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
@@ -22,6 +22,9 @@
       <group targetFramework="net40">
         <reference file="Microsoft.Azure.Management.DataFactories.dll" />
       </group>
+      <group targetFramework="net45">
+        <reference file="Microsoft.Azure.Management.DataFactories.dll" />
+      </group>
     </references>
     <dependencies>
       <dependency id="Microsoft.Azure.Common" version="[2.0.4,3.0)" />

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft Azure Data Factory Management Library")]
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Factory management operations.")]
 
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]


### PR DESCRIPTION
- Stops accepting and returning several copy-related properties in
  objects.
- Imposes message size limits for all authoring resources.
- Removes unsupported properties from TeradataLinkedService.
