### PR TITLE
Search SDK: Removing dependency on JsonConvert.DefaultSettings

### DIFF
--- a/src/Search/Search/Customizations/Documents/DocumentOperations.Get.Customization.cs
+++ b/src/Search/Search/Customizations/Documents/DocumentOperations.Get.Customization.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Search
                 key,
                 selectedFields,
                 cancellationToken,
-                s => JsonConvert.DeserializeObject<Document>(s, JsonUtility.DocumentDeserializerSettings));
+                s => JsonUtility.DeserializeObject<Document>(s, JsonUtility.DocumentDeserializerSettings));
         }
 
         public Task<DocumentGetResponse<T>> GetAsync<T>(
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Search
                 key,
                 selectedFields,
                 cancellationToken,
-                s => JsonConvert.DeserializeObject<T>(s, jsonSettings));
+                s => JsonUtility.DeserializeObject<T>(s, jsonSettings));
         }
 
         private async Task<TResponse> DoGetAsync<TResponse, TDoc>(

--- a/src/Search/Search/Customizations/Documents/DocumentOperations.Index.Customization.cs
+++ b/src/Search/Search/Customizations/Documents/DocumentOperations.Index.Customization.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Search
                 throw new ArgumentNullException("batch");
             }
 
-            string payload = JsonConvert.SerializeObject(batch, JsonUtility.DocumentSerializerSettings);
+            string payload = JsonUtility.SerializeObject(batch, JsonUtility.DocumentSerializerSettings);
             return await DoIndexAsync(payload, cancellationToken).ConfigureAwait(false);
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Search
             }
 
             bool useCamelCase = SerializePropertyNamesAsCamelCaseAttribute.IsDefinedOnType<T>();
-            string payload = JsonConvert.SerializeObject(batch, JsonUtility.CreateSerializerSettings<T>(useCamelCase));
+            string payload = JsonUtility.SerializeObject(batch, JsonUtility.CreateSerializerSettings<T>(useCamelCase));
 
             return await DoIndexAsync(payload, cancellationToken).ConfigureAwait(false);
         }
@@ -144,7 +144,10 @@ namespace Microsoft.Azure.Search
                     if (string.IsNullOrEmpty(responseContent) == false)
                     {
                         var deserializedResult = 
-                            JsonConvert.DeserializeObject<DocumentIndexResponsePayload>(responseContent);
+                            JsonUtility.DeserializeObject<DocumentIndexResponsePayload>(
+                                responseContent, 
+                                new JsonSerializerSettings());
+                        
                         result.Results = new LazyList<IndexResult>(deserializedResult.Value);
                     }
 

--- a/src/Search/Search/Customizations/Documents/DocumentOperations.Search.Customization.cs
+++ b/src/Search/Search/Customizations/Documents/DocumentOperations.Search.Customization.cs
@@ -58,14 +58,14 @@ namespace Microsoft.Azure.Search
         private static DocumentSearchResponsePayload<SearchResult<T>, T> DeserializeForSearch<T>(string payload) 
             where T : class
         {
-            return JsonConvert.DeserializeObject<DocumentSearchResponsePayload<SearchResult<T>, T>>(
+            return JsonUtility.DeserializeObject<DocumentSearchResponsePayload<SearchResult<T>, T>>(
                 payload, 
                 JsonUtility.CreateTypedDeserializerSettings<T>());
         }
 
         private static DocumentSearchResponsePayload<SearchResult, Document> DeserializeForSearch(string payload)
         {
-            return JsonConvert.DeserializeObject<DocumentSearchResponsePayload<SearchResult, Document>>(
+            return JsonUtility.DeserializeObject<DocumentSearchResponsePayload<SearchResult, Document>>(
                 payload, 
                 JsonUtility.DocumentDeserializerSettings);
         }
@@ -160,8 +160,8 @@ namespace Microsoft.Azure.Search
                 // Serialize Request for POST only
                 if (!useGet)
                 {
-                    string requestContent = 
-                        JsonConvert.SerializeObject(searchParameters, JsonUtility.DefaultSerializerSettings);
+                    string requestContent =
+                        JsonUtility.SerializeObject(searchParameters, JsonUtility.DefaultSerializerSettings);
                     httpRequest.Content = new StringContent(requestContent, Encoding.UTF8);
                     httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
                 }

--- a/src/Search/Search/Customizations/Documents/DocumentOperations.Suggest.Customization.cs
+++ b/src/Search/Search/Customizations/Documents/DocumentOperations.Suggest.Customization.cs
@@ -62,14 +62,14 @@ namespace Microsoft.Azure.Search
         private static DocumentSuggestResponsePayload<SuggestResult<T>, T> DeserializeForSuggest<T>(string payload) 
             where T : class
         {
-            return JsonConvert.DeserializeObject<DocumentSuggestResponsePayload<SuggestResult<T>, T>>(
+            return JsonUtility.DeserializeObject<DocumentSuggestResponsePayload<SuggestResult<T>, T>>(
                 payload,
                 JsonUtility.CreateTypedDeserializerSettings<T>());
         }
 
         private static DocumentSuggestResponsePayload<SuggestResult, Document> DeserializeForSuggest(string payload)
         {
-            return JsonConvert.DeserializeObject<DocumentSuggestResponsePayload<SuggestResult, Document>>(
+            return JsonUtility.DeserializeObject<DocumentSuggestResponsePayload<SuggestResult, Document>>(
                 payload, 
                 JsonUtility.DocumentDeserializerSettings);
         }
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.Search
                 {
                     SuggestParametersPayload payload = suggestParameters.ToPayload(searchText, suggesterName);
                     string requestContent =
-                        JsonConvert.SerializeObject(payload, JsonUtility.DefaultSerializerSettings);
+                        JsonUtility.SerializeObject(payload, JsonUtility.DefaultSerializerSettings);
                     httpRequest.Content = new StringContent(requestContent, Encoding.UTF8);
                     httpRequest.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
                 }


### PR DESCRIPTION
This fixes issue: https://github.com/Azure/azure-sdk-for-net/issues/1438
In one case, we were calling JsonConvert.DeserializeObject without passing in
JsonSerializerSettings. However, just adding the settings wasn't sufficient to
completely fix the issue because JsonConvert merges some of the settings with
the defaults. The solution was to roll our own DeserializeObject and
SerializeObject methods that ignore JsonConvert.DefaultSettings.

Note that more changes are on the way that are unrelated to this bug fix, so we're not ready to bump the NuGet version yet.
