### PR TITLE
Allow local registration for built-in ADF types.

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/DatasetTypeRegistrationTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/DatasetTypeRegistrationTests.cs
@@ -55,10 +55,10 @@ namespace DataFactory.Tests.UnitTests
         [PropertyData("ReservedTypes")]
         [Trait(TraitName.TestType, TestType.Unit)]
         [Trait(TraitName.Function, TestType.Registration)]
-        public void RegisteringDatasetTypeWithReservedNameThrowsException<T>(Type type, T registeredType)
+        public void CanRegisterTableTypeWithReservedName<T>(Type type, T registeredType)
             where T : TypeProperties
         {
-            this.TestRegisteringTypeWithReservedNameThrowsException<T>();
+            this.TestCanRegisterTypeWithReservedName<T>();
         }
 
         [Theory]

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/LinkedServiceTypeRegistrationTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/LinkedServiceTypeRegistrationTests.cs
@@ -65,10 +65,10 @@ namespace DataFactory.Tests.UnitTests
         [PropertyData("ReservedTypes")]
         [Trait(TraitName.TestType, TestType.Unit)]
         [Trait(TraitName.Function, TestType.Registration)]
-        public void RegisteringLinkedServiceTypeWithReservedNameThrowsException<T>(Type type, T registeredType)
+        public void CanRegisterLinkedServiceTypeWithReservedName<T>(Type type, T registeredType)
             where T : TypeProperties
         {
-            this.TestRegisteringTypeWithReservedNameThrowsException<T>();
+            this.TestCanRegisterTypeWithReservedName<T>();
         }
 
         [Fact]

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/PipelineTypeRegistrationTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/PipelineTypeRegistrationTests.cs
@@ -55,10 +55,10 @@ namespace DataFactory.Tests.UnitTests
         [PropertyData("ReservedTypes")]
         [Trait(TraitName.TestType, TestType.Unit)]
         [Trait(TraitName.Function, TestType.Registration)]
-        public void RegisteringActivityTypeForPipelineWithReservedNameThrowsException<T>(Type type, T registeredType)
+        public void CanRegisterActivityTypeForPipelineWithReservedName<T>(Type type, T registeredType)
             where T : ActivityTypeProperties
         {
-            this.TestRegisteringTypeWithReservedNameThrowsException<T>();
+            this.TestCanRegisterTypeWithReservedName<T>();
         }
 
         [Theory]

--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/TypeRegistrationTestBase.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/TypeRegistrationTestBase.cs
@@ -29,7 +29,7 @@ namespace DataFactory.Tests.UnitTests
         where TRegistered : TypeProperties
         where TGenericTypeProperties : TRegistered, IGenericTypeProperties, new()
     {
-        protected void TestRegisteringTypeWithReservedNameThrowsException<T>() where T : TypeProperties
+        protected void TestCanRegisterTypeWithReservedName<T>() where T : TypeProperties
         {
             // This is a bit of a hack to make the tests work if any reserved types are abstract
             if (typeof(T) == typeof(TGenericTypeProperties))
@@ -37,9 +37,11 @@ namespace DataFactory.Tests.UnitTests
                 return;
             }
 
-            InvalidOperationException ex =
-                Assert.Throws<InvalidOperationException>(() => this.Client.RegisterType<T>());
-            Assert.True(ex.Message.Contains("cannot be locally registered because it has the same name"));
+            // Ensure the reserved type was registered already
+            Assert.True(this.Client.TypeIsRegistered<T>());
+
+            this.Client.RegisterType<T>(force: true);
+            Assert.True(this.Client.TypeIsRegistered<T>());
         }
 
         protected void RegisteringTypeTwiceWithoutForceThrowsException<T>() where T : TypeProperties

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/GenericRegisteredTypeConverter.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/GenericRegisteredTypeConverter.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Microsoft.Azure.Management.DataFactories.Registration.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -30,8 +31,28 @@ namespace Microsoft.Azure.Management.DataFactories.Conversion
     {
         private static readonly object RegistrationLock = new object();
 
-        private static readonly IDictionary<string, Type> TypeMap =
-            new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+        // Delay evaluation until the first time (after the process is started) 
+        // that the user needs to do local type registration or conversion.
+        // This is done to prevent the need to iterate over the assembly more than once.  
+        private static readonly Lazy<IDictionary<string, Type>> reservedTypesFromAssembly =
+            new Lazy<IDictionary<string, Type>>(GetReservedTypes);
+
+        // Delay copying the backing dictionary until the first time (after object initialization) 
+        // that the user user needs to do local type registration or conversion. 
+        private readonly Lazy<IDictionary<string, Type>> typeMapLazy;
+
+        protected IDictionary<string, Type> TypeMap
+        {
+            get
+            {
+                return this.typeMapLazy.Value;
+            }
+        }
+        
+        public GenericRegisteredTypeConverter()
+        {
+            this.typeMapLazy = new Lazy<IDictionary<string, Type>>(GetReservedTypesForCopy);
+        }
 
         /// <summary>
         /// Registers a type for conversion inside the TypeProperties of an ADF resource.
@@ -48,22 +69,13 @@ namespace Microsoft.Azure.Management.DataFactories.Conversion
             string typeName = DataFactoryUtilities.GetResourceTypeName(type);
             string wrapperTypeName = wrapperType != null ? wrapperType.Name : typeof(TRegistered).Name;
 
-            if (ReservedTypes.ContainsKey(typeName))
-            {
-                throw new InvalidOperationException(string.Format(
-                    CultureInfo.InvariantCulture,
-                    "{0} type '{1}' cannot be locally registered because it has the same name as a built-in ADF {0} type.",
-                    wrapperTypeName,
-                    typeName));
-            }
-
             lock (RegistrationLock)
             {
-                if (TypeMap.ContainsKey(typeName))
+                if (this.TypeMap.ContainsKey(typeName))
                 {
                     if (force)
                     {
-                        TypeMap.Remove(typeName);
+                        this.TypeMap.Remove(typeName);
                     }
                     else
                     {
@@ -75,36 +87,26 @@ namespace Microsoft.Azure.Management.DataFactories.Conversion
                     }
                 }
 
-                TypeMap.Add(typeName, type);    
+                this.TypeMap.Add(typeName, type);    
             }
         }
 
         public bool TypeIsRegistered<T>()
         {
             this.EnsureIsAssignableRegisteredType<T>();
-
             string typeName = DataFactoryUtilities.GetResourceTypeName(typeof(T));
-            if (ReservedTypes.ContainsKey(typeName))
-            {
-                return true;
-            }
-            
+ 
             lock (RegistrationLock)
             {
-                return TypeMap.ContainsKey(typeName);
+                return this.TypeMap.ContainsKey(typeName);
             }
         }
 
         public bool TryGetRegisteredType(string typeName, out Type type)
-        {
-            if (ReservedTypes.TryGetValue(typeName, out type))
-            {
-                return true;
-            }
-            
+        {           
             lock (RegistrationLock)
             {
-                return TypeMap.TryGetValue(typeName, out type);
+                return this.TypeMap.TryGetValue(typeName, out type);
             }
         }
 
@@ -142,6 +144,19 @@ namespace Microsoft.Azure.Management.DataFactories.Conversion
                         type.FullName,
                         typeof(TRegistered).FullName));
             }
+        }
+
+        private static IDictionary<string, Type> GetReservedTypes()
+        {
+            Type rootType = typeof(TRegistered);
+            return rootType.Assembly.GetTypes()
+                .Where(rootType.IsAssignableFrom)
+                .ToDictionary(GetTypeName, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static IDictionary<string, Type> GetReservedTypesForCopy()
+        {
+            return reservedTypesFromAssembly.Value;
         }
     } 
 }

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/PolymorphicTypeConverter.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/PolymorphicTypeConverter.cs
@@ -14,8 +14,6 @@
 //
 
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using Microsoft.Azure.Management.DataFactories.Models;
 using Newtonsoft.Json;
@@ -26,22 +24,6 @@ namespace Microsoft.Azure.Management.DataFactories.Conversion
 {
     internal abstract class PolymorphicTypeConverter<T> : JsonConverter
     {
-        protected static IDictionary<string, Type> ReservedTypes
-        {
-            get
-            {
-                return ReservedTypesList.Value;
-            }
-        }
-
-        private static Lazy<Dictionary<string, Type>> ReservedTypesList { get; set; }
-
-        static PolymorphicTypeConverter()
-        {
-            // Delay evaluation until the user needs to do local type registration or conversion
-            ReservedTypesList = new Lazy<Dictionary<string, Type>>(GetReservedTypes);
-        }
-
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             try
@@ -81,20 +63,12 @@ namespace Microsoft.Azure.Management.DataFactories.Conversion
             return typeof(T).IsAssignableFrom(objectType);
         }
 
-        private static Dictionary<string, Type> GetReservedTypes()
-        {
-            Type rootType = typeof(T);
-            return rootType.Assembly.GetTypes()
-                .Where(rootType.IsAssignableFrom)
-                .ToDictionary(GetTypeName, StringComparer.OrdinalIgnoreCase);
-        }
-
         /// <summary>
         /// Get a name to use during serialization of a type. 
         /// </summary>
         /// <param name="type">The type to get a name for.</param>
         /// <returns>The name to use during serialization for <paramref name="type"/>.</returns>
-        private static string GetTypeName(Type type)
+        protected static string GetTypeName(Type type)
         {
             object typeNameAttribute = type.GetCustomAttributes(typeof(AdfTypeNameAttribute), true).FirstOrDefault();
             if (typeNameAttribute != null)


### PR DESCRIPTION
- Users can locally register types with the same JSON type name used for
  de/serialization as the type name for some built-in Linked Service,
  Dataset or Activity type.
- Converters now use one type mapping to keep track of the types it can
  de/serialize.
- Make the list of reserved types non-static, but keep the lazy
  initialization of the list to prevent the need to hit the assembly more
  than once per process.
- Each initialization of a client object will get its
- Enables the scenario for testing new properties on existing types.

We will be bumping the package version before the release at the end of the week. 
