### PR TITLE
Fix local type registration

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/LinkedServiceTypeRegistrationTests.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/UnitTests/LinkedServiceTypeRegistrationTests.cs
@@ -98,6 +98,23 @@ namespace DataFactory.Tests.UnitTests
         [Fact]
         [Trait(TraitName.TestType, TestType.Unit)]
         [Trait(TraitName.Function, TestType.Registration)]
+        public void ClientsDoNotShareTypeMap()
+        {
+            var client = new DataFactoryManagementClient();
+            Assert.False(client.TypeIsRegistered<MyLinkedServiceType>());
+
+            client.RegisterType<MyLinkedServiceType>();
+            Assert.True(client.TypeIsRegistered<MyLinkedServiceType>());
+
+            // Ensure that the backing type map is not static/shared; 
+            // MyLinkedServiceType should not be registered on a second client
+            var client2 = new DataFactoryManagementClient();
+            Assert.False(client2.TypeIsRegistered<MyLinkedServiceType>());
+        }
+
+        [Fact]
+        [Trait(TraitName.TestType, TestType.Unit)]
+        [Trait(TraitName.Function, TestType.Registration)]
         public void CanGetUserRegisteredLinkedServiceCaseInsensitive()
         {
             this.Client.RegisterType<MyLinkedServiceType>(true);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/GenericRegisteredTypeConverter.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Conversion/GenericRegisteredTypeConverter.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Management.DataFactories.Conversion
 
         private static IDictionary<string, Type> GetReservedTypesForCopy()
         {
-            return reservedTypesFromAssembly.Value;
+            return new Dictionary<string, Type>(reservedTypesFromAssembly.Value, StringComparer.OrdinalIgnoreCase);
         }
     } 
 }


### PR DESCRIPTION
- The backing type map for the client converters should not be
  static/shared. Fixes an issue where the same instance of the type map
  was being shared between any instance of DataFactoryManagementClient.
