### PR TITLE
ADF - Fix class names for Dataset types

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/AzureSqlDataWarehouseTableDataset.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/AzureSqlDataWarehouseTableDataset.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.DataFactories.Models
     /// The Azure SQL data warehouse dataset.
     /// </summary>
     [AdfTypeName("AzureSqlDWTable")]
-    public class AzureSqlDataWarehouseDataset : DatasetTypeProperties
+    public class AzureSqlDataWarehouseTableDataset : DatasetTypeProperties
     {
         /// <summary>
         /// Required. The table name of the Azure SQL data warehouse dataset.
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Management.DataFactories.Models
         /// <summary>
         /// Initializes a new instance of the AzureSqlDataWarehouseTableDataset class.
         /// </summary>
-        public AzureSqlDataWarehouseDataset()
+        public AzureSqlDataWarehouseTableDataset()
         {
         }
 
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Management.DataFactories.Models
         /// Initializes a new instance of the AzureSqlDataWarehouseTableDataset class with
         /// required arguments.
         /// </summary>
-        public AzureSqlDataWarehouseDataset(string tableName)
+        public AzureSqlDataWarehouseTableDataset(string tableName)
             : this()
         {
             Ensure.IsNotNullOrEmpty(tableName, "tableName");

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/AzureSqlTableDataset.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/AzureSqlTableDataset.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.DataFactories.Models
     /// The Azure SQL Server database.
     /// </summary>
     [AdfTypeName("AzureSqlTable")]
-    public class AzureSqlDataset : DatasetTypeProperties
+    public class AzureSqlTableDataset : DatasetTypeProperties
     {
         /// <summary>
         /// The table name of the Azure SQL database.
@@ -27,11 +27,11 @@ namespace Microsoft.Azure.Management.DataFactories.Models
         [AdfRequired]
         public string TableName { get; set; }
 
-        public AzureSqlDataset()
+        public AzureSqlTableDataset()
         {
         }
 
-        public AzureSqlDataset(string tableName)
+        public AzureSqlTableDataset(string tableName)
             : this()
         {
             Ensure.IsNotNullOrEmpty(tableName, "tableName");

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/AzureTableDataset.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/AzureTableDataset.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.DataFactories.Models
     /// The Azure table storage.
     /// </summary>
     [AdfTypeName("AzureTable")]
-    public class AzureDataset : DatasetTypeProperties
+    public class AzureTableDataset : DatasetTypeProperties
     {
         /// <summary>
         /// The table name of the Azure table storage.
@@ -27,11 +27,11 @@ namespace Microsoft.Azure.Management.DataFactories.Models
         [AdfRequired]
         public string TableName { get; set; }
 
-        public AzureDataset()
+        public AzureTableDataset()
         {
         }
 
-        public AzureDataset(string tableName)
+        public AzureTableDataset(string tableName)
             : this()
         {
             Ensure.IsNotNullOrEmpty(tableName, "tableName");

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/OracleTableDataset.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/OracleTableDataset.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.DataFactories.Models
     /// The on-premises Oracle database.
     /// </summary>
     [AdfTypeName("OracleTable")]
-    public class OracleDatasetDataset : DatasetTypeProperties
+    public class OracleTableDataset : DatasetTypeProperties
     {
         /// <summary>
         /// The table name of the on-premises Oracle database.
@@ -27,11 +27,11 @@ namespace Microsoft.Azure.Management.DataFactories.Models
         [AdfRequired]
         public string TableName { get; set; }
 
-        public OracleDatasetDataset()
+        public OracleTableDataset()
         {
         }
 
-        public OracleDatasetDataset(string tableName)
+        public OracleTableDataset(string tableName)
             : this()
         {
             Ensure.IsNotNullOrEmpty(tableName, "tableName");

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/RelationalTableLocation.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/RelationalTableLocation.cs
@@ -19,18 +19,18 @@ namespace Microsoft.Azure.Management.DataFactories.Models
     /// Relational Table location.
     /// </summary>
     [AdfTypeName("RelationalTable")]
-    public class RelationalDataset : DatasetTypeProperties
+    public class RelationalTableDataset : DatasetTypeProperties
     {
         /// <summary>
         /// The table name.
         /// </summary>
         public string TableName { get; set; }
 
-        public RelationalDataset()
+        public RelationalTableDataset()
         {
         }
 
-        public RelationalDataset(string tableName)
+        public RelationalTableDataset(string tableName)
             : this()
         {
             Ensure.IsNotNullOrEmpty(tableName, "tableName");

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/SqlServerTableDataset.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Datasets/SqlServerTableDataset.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.DataFactories.Models
     /// The on-premises SQL Server database.
     /// </summary>
     [AdfTypeName("SqlServerTable")]
-    public class SqlServerDataset : DatasetTypeProperties
+    public class SqlServerTableDataset : DatasetTypeProperties
     {
         /// <summary>
         /// The table name of the on-premises SQL database.
@@ -27,11 +27,11 @@ namespace Microsoft.Azure.Management.DataFactories.Models
         [AdfRequired]
         public string TableName { get; set; }
 
-        public SqlServerDataset()
+        public SqlServerTableDataset()
         {
         }
 
-        public SqlServerDataset(string tableName)
+        public SqlServerTableDataset(string tableName)
             : this()
         {
             Ensure.IsNotNullOrEmpty(tableName, "tableName");

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
@@ -1,5 +1,12 @@
 ﻿For additional details on features, see the full [Azure Data Factory Release Notes](https://azure.microsoft.com/en-us/documentation/articles/data-factory-release-notes). 
 
+## Version 4.0.1
+_Release date: 2015.10.13_
+
+## Bug Fixes
+* Fix Dataset class names which had "Table" removed from them. 
+    * For types such as AzureSqlTable, "AzureSqlTableDataset" is the correct naming, not "AzureSqlDataset". These were the names prior to 4.0.0 and this restores those names. 
+
 ## Version 4.0.0
 _Release date: 2015.10.02_
 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataFactories
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataFactories">
-      <PackageVersion>4.0.0</PackageVersion>
+      <PackageVersion>4.0.1</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Factory management operations.")]
 
 [assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.1.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]


### PR DESCRIPTION
- Several Dataset class names inadvertently had "Table" removed during
  the rename from "Table" to "Dataset". For types which are actually
  tables (e.g. AzureSqlTable) this is the correct naming.

Since the change restores (the correct) names from 3._._ versions, we consider this a bug fix release and not a breaking change. As such we will publish this as version 4.0.1 and not 5.0.0. 
