### PR TITLE
ADF - Add link in nuspec to release notes on azure.com

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
@@ -3,7 +3,7 @@
   <metadata minClientVersion="2.5">
     <id>Microsoft.Azure.Management.DataFactories</id>
     <title>Microsoft Azure Data Factory Management Library</title>
-    <releaseNotes>__BASELINE_RELEASE_NOTES__</releaseNotes>
+    <releaseNotes>https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log/#version-401</releaseNotes>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>azure-sdk, Microsoft</owners>


### PR DESCRIPTION
- Release notes are published to
  https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log
- The release notes for each ADF SDK release are published as part of
  the documentation on azure.com and are based on the Markdown changelog
  that exists in this repo.
