### PR TITLE
Newgatewaykey

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
@@ -1,4 +1,5 @@
 ﻿For additional details on features, see the full [Azure Data Factory Release Notes](https://azure.microsoft.com/en-us/documentation/articles/data-factory-release-notes). 
+
 ## Version 
 _Release date: 
 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
@@ -1,5 +1,10 @@
 ﻿For additional details on features, see the full [Azure Data Factory Release Notes](https://azure.microsoft.com/en-us/documentation/articles/data-factory-release-notes). 
+## Version 
+_Release date: 
 
+## Bug Fixes
+* Successful gateway creation response has status Succeeded and includes the gateway key.
+ 
 ## Version 4.0.1
 _Release date: 2015.10.13_
 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/GatewayOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/GatewayOperations.cs
@@ -397,6 +397,11 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                     {
                         result.RequestId = httpResponse.Headers.GetValues("x-ms-request-id").FirstOrDefault();
                     }
+                    if (statusCode == HttpStatusCode.OK)
+                    {
+                        result.Status = OperationStatus.Succeeded;
+                    }
+
                     result.Location = url;
                     
                     if (shouldTrace)


### PR DESCRIPTION
Setting proper status avoids spurious get that caused missing Key in gateway creation response, picked up from corresponding hydra spec change (hydra-specs-pr #1160), plus updated change log.
