### PR TITLE
Fix the description for pipeline start/end time

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Pipelines/PipelineProperties.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Pipelines/PipelineProperties.cs
@@ -35,13 +35,19 @@ namespace Microsoft.Azure.Management.DataFactories.Models
         [AdfRequired]
         public IList<Activity> Activities { get; set; }
 
-        /// <summary>
-        /// The start time of the pipeline.
-        /// </summary>
+        /// <summary>                                                         
+        /// The start time of the pipeline. The start and end time  
+        /// can both be empty to create a pipeline; they must both have values
+        /// to set an active period for the pipeline and one cannot have a    
+        /// value if the other does not.                                      
+        /// </summary>                                                        
         public DateTime? Start { get; set; }
 
         /// <summary>
-        /// The end time of the pipeline.
+        /// The end time of the pipeline. The start and end time can
+        /// both be empty to create a pipeline; they must both have values to
+        /// set an active period for the pipeline and one cannot have a value
+        /// if the other does not.
         /// </summary>
         public DateTime? End { get; set; }
 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/Models/PipelineProperties.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/Models/PipelineProperties.cs
@@ -58,7 +58,10 @@ namespace Microsoft.Azure.Management.DataFactories.Core.Models
         private System.DateTime? _end;
         
         /// <summary>
-        /// Optional. The end time of the pipeline.
+        /// Optional. The end time of the pipeline. The start and end time can
+        /// both be empty to create a pipeline; they must both have values to
+        /// set an active period for the pipeline and one cannot have a value
+        /// if the other does not.
         /// </summary>
         public System.DateTime? End
         {
@@ -125,7 +128,10 @@ namespace Microsoft.Azure.Management.DataFactories.Core.Models
         private System.DateTime? _start;
         
         /// <summary>
-        /// Optional. The start time of the pipeline.
+        /// Optional. The start time of the pipeline. The start and end time
+        /// can both be empty to create a pipeline; they must both have values
+        /// to set an active period for the pipeline and one cannot have a
+        /// value if the other does not.
         /// </summary>
         public System.DateTime? Start
         {


### PR DESCRIPTION
- Explain that the start and end time must be either both empty or
  both have values.
- Pipelines can have empty start and end times to create the
  pipeline; both must have values for the pipeline to execute.
