### PR TITLE
Fix Key Vault Test project

### DIFF
--- a/src/KeyVault/KeyVault.Tests/KeyVault.Tests.csproj
+++ b/src/KeyVault/KeyVault.Tests/KeyVault.Tests.csproj
@@ -110,43 +110,8 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Hyak.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Hyak.Common.1.0.2\lib\net45\Hyak.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Common, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.Azure.Common.2.1.0\lib\net45\Microsoft.Azure.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Azure.Common.NetFramework, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.Azure.Common.2.1.0\lib\net45\Microsoft.Azure.Common.NetFramework.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Azure.Management.KeyVault">
-      <HintPath>..\..\..\packages\Microsoft.Azure.Management.KeyVault.1.0.0\lib\net40\Microsoft.Azure.Management.KeyVault.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Extensions, Version=2.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=4.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Microsoft.Net.Http.2.2.22\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.KeyVault.1.0.0\lib\net40\Microsoft.Azure.Management.KeyVault.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Microsoft.Azure.Graph.RBAC">

--- a/src/KeyVault/KeyVault.Tests/KeyVaultTestFixture.cs
+++ b/src/KeyVault/KeyVault.Tests/KeyVaultTestFixture.cs
@@ -56,7 +56,7 @@ namespace KeyVault.Tests
                     var secret = Guid.NewGuid().ToString();
                     var mgmtClient = TestBase.GetServiceClient<KeyVaultManagementClient>(testFactory);
                     var resourcesClient = TestBase.GetServiceClient<ResourceManagementClient>(testFactory);
-                    var tenantId = testEnv.AuthorizationContext.TenatId;
+                    var tenantId = testEnv.AuthorizationContext.TenantId;
                     var graphClient = TestBase.GetGraphServiceClient<GraphRbacManagementClient>(testFactory, tenantId);
                     var appDisplayName = TestUtilities.GenerateName("sdktestapp");
 
@@ -196,7 +196,7 @@ namespace KeyVault.Tests
                 var testEnv = testFactory.GetTestEnvironment();
                 var mgmtClient = TestBase.GetServiceClient<KeyVaultManagementClient>(testFactory);
                 var resourcesClient = TestBase.GetServiceClient<ResourceManagementClient>(testFactory);
-                var tenantId = testEnv.AuthorizationContext.TenatId;
+                var tenantId = testEnv.AuthorizationContext.TenantId;
                 var graphClient = TestBase.GetGraphServiceClient<GraphRbacManagementClient>(testFactory, tenantId);
 
                 mgmtClient.Vaults.Delete(rgName, vaultName);

--- a/src/KeyVault/KeyVault.Tests/packages.config
+++ b/src/KeyVault/KeyVault.Tests/packages.config
@@ -1,13 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hyak.Common" version="1.0.2" targetFramework="net45" />
-  <package id="Microsoft.Azure.Common" version="2.1.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Graph.RBAC" version="1.7.0-preview" targetFramework="net45" />
   <package id="Microsoft.Azure.Management.KeyVault" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
1. Key Vault test dependency fixed a typo in a property name. Updating to consuming the correct property now.
2. Clean up duplicate Key Vault test project dependencies
