### PR TITLE
Add SecondaryKey to UpdateAuthorizationRuleAsync

### DIFF
--- a/src/ServiceManagement/ServiceBus/ServiceBusManagement/Generated/NamespaceOperations.cs
+++ b/src/ServiceManagement/ServiceBus/ServiceBusManagement/Generated/NamespaceOperations.cs
@@ -2581,6 +2581,13 @@ namespace Microsoft.WindowsAzure.Management.ServiceBus
                         primaryKeyElement.Value = rule.PrimaryKey;
                         sharedAccessAuthorizationRuleElement.Add(primaryKeyElement);
                     }
+
+                    if (rule.SecondaryKey != null)
+                    {
+                        XElement secondaryKeyElement = new XElement(XName.Get("SecondaryKey", "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"));
+                        secondaryKeyElement.Value = rule.SecondaryKey;
+                        sharedAccessAuthorizationRuleElement.Add(secondaryKeyElement);
+                    }
                 }
                 
                 requestContent = requestDoc.ToString();


### PR DESCRIPTION
In NamespaceOperations.UpdateAuthorizationRuleAsync, there is no
handling for the secondary key of the
ServiceBusSharedAccessAuthorizationRule, which causes it to be set to
NULL.

This patch adds handling for the SecondaryKey, mimicing how the
PrimaryKey is being added.

This commit is related to issue #1553:
    https://github.com/Azure/azure-sdk-for-net/issues/1553
