### PR TITLE
Search SDK: Updating to latest version of AutoRest and other fixes

### DIFF
--- a/src/Search/Search.Management.Tests/Generated/SearchManagementClient.cs
+++ b/src/Search/Search.Management.Tests/Generated/SearchManagementClient.cs
@@ -213,10 +213,10 @@ namespace Microsoft.Azure.Management.Search
             }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
-                if (this.Credentials != null)
-                {
-                    this.Credentials.InitializeServiceClient(this);
-                }
+            if (this.Credentials != null)
+            {
+                this.Credentials.InitializeServiceClient(this);
+            }
         }
 
         /// <summary>
@@ -246,10 +246,10 @@ namespace Microsoft.Azure.Management.Search
             }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
-                if (this.Credentials != null)
-                {
-                    this.Credentials.InitializeServiceClient(this);
-                }
+            if (this.Credentials != null)
+            {
+                this.Credentials.InitializeServiceClient(this);
+            }
         }
 
         /// <summary>

--- a/src/Search/Search.Management.Tests/generate.cmd
+++ b/src/Search/Search.Management.Tests/generate.cmd
@@ -4,7 +4,7 @@
 ::
 
 @echo off
-set autoRestVersion=0.13.0-Nightly20151111
+set autoRestVersion=0.13.0-Nightly20151115
 if  "%1" == "" (
     set specFile="https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-search/2015-02-28/swagger/search.json"
 ) else (

--- a/src/Search/Search/GeneratedSearchIndex/SearchIndexClient.cs
+++ b/src/Search/Search/GeneratedSearchIndex/SearchIndexClient.cs
@@ -203,10 +203,10 @@ namespace Microsoft.Azure.Search
             }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
-                if (this.Credentials != null)
-                {
-                    this.Credentials.InitializeServiceClient(this);
-                }
+            if (this.Credentials != null)
+            {
+                this.Credentials.InitializeServiceClient(this);
+            }
         }
 
         /// <summary>
@@ -236,10 +236,10 @@ namespace Microsoft.Azure.Search
             }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
-                if (this.Credentials != null)
-                {
-                    this.Credentials.InitializeServiceClient(this);
-                }
+            if (this.Credentials != null)
+            {
+                this.Credentials.InitializeServiceClient(this);
+            }
         }
 
         /// <summary>

--- a/src/Search/Search/GeneratedSearchService/Models/DistanceScoringFunction.cs
+++ b/src/Search/Search/GeneratedSearchService/Models/DistanceScoringFunction.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the DistanceScoringFunction class.
         /// </summary>
-        public DistanceScoringFunction(DistanceScoringParameters distance = default(DistanceScoringParameters))
+        public DistanceScoringFunction(DistanceScoringParameters distance)
         {
             Distance = distance;
         }
@@ -48,6 +48,10 @@ namespace Microsoft.Azure.Search.Models
         public override void Validate()
         {
             base.Validate();
+            if (Distance == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "Distance");
+            }
             if (this.Distance != null)
             {
                 this.Distance.Validate();

--- a/src/Search/Search/GeneratedSearchService/Models/FreshnessScoringFunction.cs
+++ b/src/Search/Search/GeneratedSearchService/Models/FreshnessScoringFunction.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the FreshnessScoringFunction class.
         /// </summary>
-        public FreshnessScoringFunction(FreshnessScoringParameters freshness = default(FreshnessScoringParameters))
+        public FreshnessScoringFunction(FreshnessScoringParameters freshness)
         {
             Freshness = freshness;
         }
@@ -48,6 +48,10 @@ namespace Microsoft.Azure.Search.Models
         public override void Validate()
         {
             base.Validate();
+            if (Freshness == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "Freshness");
+            }
             if (this.Freshness != null)
             {
                 this.Freshness.Validate();

--- a/src/Search/Search/GeneratedSearchService/Models/HighWaterMarkChangeDetectionPolicy.cs
+++ b/src/Search/Search/GeneratedSearchService/Models/HighWaterMarkChangeDetectionPolicy.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Search.Models
         /// Initializes a new instance of the
         /// HighWaterMarkChangeDetectionPolicy class.
         /// </summary>
-        public HighWaterMarkChangeDetectionPolicy(string highWaterMarkColumnName = default(string))
+        public HighWaterMarkChangeDetectionPolicy(string highWaterMarkColumnName)
         {
             HighWaterMarkColumnName = highWaterMarkColumnName;
         }
@@ -44,5 +44,15 @@ namespace Microsoft.Azure.Search.Models
         [JsonProperty(PropertyName = "highWaterMarkColumnName")]
         public string HighWaterMarkColumnName { get; set; }
 
+        /// <summary>
+        /// Validate the object. Throws ArgumentException or ArgumentNullException if validation fails.
+        /// </summary>
+        public virtual void Validate()
+        {
+            if (HighWaterMarkColumnName == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "HighWaterMarkColumnName");
+            }
+        }
     }
 }

--- a/src/Search/Search/GeneratedSearchService/Models/MagnitudeScoringFunction.cs
+++ b/src/Search/Search/GeneratedSearchService/Models/MagnitudeScoringFunction.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the MagnitudeScoringFunction class.
         /// </summary>
-        public MagnitudeScoringFunction(MagnitudeScoringParameters magnitude = default(MagnitudeScoringParameters))
+        public MagnitudeScoringFunction(MagnitudeScoringParameters magnitude)
         {
             Magnitude = magnitude;
         }
@@ -48,6 +48,10 @@ namespace Microsoft.Azure.Search.Models
         public override void Validate()
         {
             base.Validate();
+            if (Magnitude == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "Magnitude");
+            }
             if (this.Magnitude != null)
             {
                 this.Magnitude.Validate();

--- a/src/Search/Search/GeneratedSearchService/Models/TagScoringFunction.cs
+++ b/src/Search/Search/GeneratedSearchService/Models/TagScoringFunction.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the TagScoringFunction class.
         /// </summary>
-        public TagScoringFunction(TagScoringParameters tag = default(TagScoringParameters))
+        public TagScoringFunction(TagScoringParameters tag)
         {
             Tag = tag;
         }
@@ -48,6 +48,10 @@ namespace Microsoft.Azure.Search.Models
         public override void Validate()
         {
             base.Validate();
+            if (Tag == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "Tag");
+            }
             if (this.Tag != null)
             {
                 this.Tag.Validate();

--- a/src/Search/Search/GeneratedSearchService/SearchServiceClient.cs
+++ b/src/Search/Search/GeneratedSearchService/SearchServiceClient.cs
@@ -207,10 +207,10 @@ namespace Microsoft.Azure.Search
             }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
-                if (this.Credentials != null)
-                {
-                    this.Credentials.InitializeServiceClient(this);
-                }
+            if (this.Credentials != null)
+            {
+                this.Credentials.InitializeServiceClient(this);
+            }
         }
 
         /// <summary>
@@ -240,10 +240,10 @@ namespace Microsoft.Azure.Search
             }
             this.BaseUri = baseUri;
             this.Credentials = credentials;
-                if (this.Credentials != null)
-                {
-                    this.Credentials.InitializeServiceClient(this);
-                }
+            if (this.Credentials != null)
+            {
+                this.Credentials.InitializeServiceClient(this);
+            }
         }
 
         /// <summary>

--- a/src/Search/Search/generate-searchindex.cmd
+++ b/src/Search/Search/generate-searchindex.cmd
@@ -4,7 +4,7 @@
 ::
 
 @echo off
-set autoRestVersion=0.13.0-Nightly20151111
+set autoRestVersion=0.13.0-Nightly20151115
 if  "%1" == "" (
     set specFile="https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/search/2015-02-28/swagger/searchindex.json"
 ) else (

--- a/src/Search/Search/generate-searchservice.cmd
+++ b/src/Search/Search/generate-searchservice.cmd
@@ -4,7 +4,7 @@
 ::
 
 @echo off
-set autoRestVersion=0.13.0-Nightly20151111
+set autoRestVersion=0.13.0-Nightly20151115
 if  "%1" == "" (
     set specFile="https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/search/2015-02-28/swagger/searchservice.json"
 ) else (
@@ -15,3 +15,6 @@ set generateFolder=%~dp0GeneratedSearchService
 
 if exist %generateFolder% rd /S /Q  %generateFolder%
 call "%repoRoot%\tools\autorest.gen.cmd" %specFile% Microsoft.Azure.Search %autoRestVersion% %generateFolder% 
+
+:: Delete any extra files generated for types that are shared between SearchServiceClient and SearchIndexClient.
+del "%generateFolder%\Models\SearchRequestOptions.cs"


### PR DESCRIPTION
Also scripting a workaround to delete a redundant parameter group class that
is generated because it's shared between both Swagger specs
(SearchServiceClient and SearchIndexClient).
