### PR TITLE
remove the dependency on client runtime azure

### DIFF
--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/MockContext.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/MockContext.cs
@@ -57,8 +57,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         /// </summary>
         /// <typeparam name="T">The type of the service client to return</typeparam>
         /// <returns>A Service client using credentials and base uri from the current environment</returns>
-        public T GetServiceClient<T>(params DelegatingHandler[] handlers)
-            where T : ServiceClient<T>, IAzureClient
+        public T GetServiceClient<T>(params DelegatingHandler[] handlers) where T : class
         {
             return GetServiceClient<T>(TestEnvironmentFactory.GetTestEnvironment(), handlers);
         }
@@ -69,8 +68,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         /// <typeparam name="T"></typeparam>
         /// <param name="handlers">Delegating existingHandlers</param>
         /// <returns></returns>
-        public T GetServiceClient<T>(TestEnvironment currentEnvironment, params DelegatingHandler[] handlers)
-            where T : ServiceClient<T>, IAzureClient
+        public T GetServiceClient<T>(TestEnvironment currentEnvironment, params DelegatingHandler[] handlers) where T : class
         {
             T client;
             handlers = AddHandlers(currentEnvironment, handlers);

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/project.json
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.1.0-preview",
+  "version": "1.1.1-preview",
   "description": "Microsoft.Rest.ClientRuntime.Azure.TestFramework",
   "authors": [ "Microsoft Corporation" ],
   "projectUrl": "https://github.com/Azure/azure-sdk-for-net",
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "Microsoft.Rest.ClientRuntime.Azure.Authentication": "1.2.1-preview",
-    "Microsoft.Azure.Test.HttpRecorder": "",
-    "Microsoft.Rest.ClientRuntime.Azure": "[2.5.2, 3.0)"
+    "Microsoft.Azure.Test.HttpRecorder": ""
   }
 }

--- a/src/TestFramework/TestFramework.Tests/Client/SimpleClient.cs
+++ b/src/TestFramework/TestFramework.Tests/Client/SimpleClient.cs
@@ -10,7 +10,7 @@ using Microsoft.Rest;
 
 namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework.Test.Client
 {
-    public partial class SimpleClient : ServiceClient<SimpleClient>, ISimpleClient, IAzureClient
+    public partial class SimpleClient : ServiceClient<SimpleClient>, ISimpleClient
     {
         public SimpleClient(params DelegatingHandler[] handlers) : base(handlers)
         {

--- a/src/TestFramework/TestFramework.Tests/project.json
+++ b/src/TestFramework/TestFramework.Tests/project.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "Microsoft.Azure.Test.HttpRecorder": "",
     "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "",
-    "Microsoft.Rest.ClientRuntime.Azure": "[2.5.2, 3.0)",
     "xunit": "2.1.0"
   },
   "compileFiles": "../../../tools/DisableTestRunParallel.cs"


### PR DESCRIPTION
This unnecessary dependency is causing assembly version conflicts on powershell scenario tests 
