### PR TITLE
TestFramework: Remove hard dependencies on rest client run-time packages

### DIFF
--- a/src/ResourceManagement/Authorization/Authorization.Tests/Graph/GraphManagementClient.cs
+++ b/src/ResourceManagement/Authorization/Authorization.Tests/Graph/GraphManagementClient.cs
@@ -258,7 +258,7 @@ namespace Authorization.Tests
             httpRequest.Headers.Add("Accept", "application/json;odata=minimalmetadata");
 
 
-            if (this.testEnvironment != null && this.testEnvironment.Credentials != null)
+            if (this.testEnvironment != null && this.testEnvironment.TokenInfo != null)
             {
                 // Not Supported in current code
                 // var tokenCredentials = (TokenCredentials)this.testEnvironment.Credentials;

--- a/src/ResourceManagement/Authorization/Authorization.Tests/Tests/TestFixtureData.cs
+++ b/src/ResourceManagement/Authorization/Authorization.Tests/Tests/TestFixtureData.cs
@@ -25,6 +25,7 @@ using System.Net;
 using Xunit;
 using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
 using Microsoft.Azure.Management.Resources;
+using Microsoft.Rest;
 
 namespace Authorization.Tests
 {
@@ -165,9 +166,11 @@ namespace Authorization.Tests
                 this.GraphClient.DeleteGroup(group);
             }
 
+            var env = TestEnvironmentFactory.GetTestEnvironment();
+            var cred = new TokenCredentials(env.TokenInfo.AccessToken, env.TokenInfo.AccessTokenType);
             var authorizationClient = new AuthorizationManagementClient(
                 TestEnvironmentFactory.GetTestEnvironment().BaseUri,
-                TestEnvironmentFactory.GetTestEnvironment().Credentials);
+                cred);
             foreach (var assignment in authorizationClient.RoleAssignments.List(null))
             {
                 authorizationClient.RoleAssignments.DeleteById(assignment.Id);

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/MockContext.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/MockContext.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
             var constructors = typeof(T).GetConstructors();
 
             Type tokeCredType = Type.GetType("Microsoft.Rest.TokenCredentials, Microsoft.Rest.ClientRuntime");
-            object tokenCred = Activator.CreateInstance(tokeCredType, new object[] { currentEnvironment.Token});
+            object tokenCred = Activator.CreateInstance(tokeCredType, new object[] { currentEnvironment.TokenInfo.AccessToken});
 
             ConstructorInfo constructor = null;
             if (currentEnvironment.UsesCustomUri())
@@ -122,7 +122,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
                 }
                 client = constructor.Invoke(new object[]
                 {
-                    currentEnvironment.Token,
+                    tokenCred,
                     handlers
                 }) as T;
             }
@@ -176,7 +176,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
                 handlers.Add(server);
             }
 
-            ResourceGroupCleaner cleaner = new ResourceGroupCleaner(currentEnvironment.Token);
+            ResourceGroupCleaner cleaner = new ResourceGroupCleaner(currentEnvironment.TokenInfo);
             handlers.Add(cleaner);
             undoHandlers.Add(cleaner);
 

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/MockContext.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/MockContext.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Reflection;
-using Microsoft.Rest.Azure;
 using Microsoft.Azure.Test.HttpRecorder;
 
 namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
@@ -28,7 +27,6 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
 
         static MockContext()
         {
-            ServiceClientTracing.AddTracingInterceptor(new TestingTracingInterceptor());
         }
 
         /// <summary>
@@ -72,32 +70,59 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         {
             T client;
             handlers = AddHandlers(currentEnvironment, handlers);
+            var constructors = typeof(T).GetConstructors();
 
+            Type tokeCredType = Type.GetType("Microsoft.Rest.TokenCredentials, Microsoft.Rest.ClientRuntime");
+            object tokenCred = Activator.CreateInstance(tokeCredType, new object[] { currentEnvironment.Token});
+
+            ConstructorInfo constructor = null;
             if (currentEnvironment.UsesCustomUri())
             {
-                ConstructorInfo constructor = typeof(T).GetConstructor(new Type[]
+                foreach (var c in constructors)
                 {
-                    typeof(Uri),
-                    typeof(ServiceClientCredentials),
-                    typeof(DelegatingHandler[])
-                });
+                    var parameters = c.GetParameters();
+                    if (parameters.Length == 3 && 
+                        parameters[0].ParameterType.Name == "Uri" && 
+                        parameters[1].ParameterType.Name == "ServiceClientCredentials" &&
+                        parameters[2].ParameterType.Name == "DelegatingHandler[]")
+                    {
+                        constructor = c;
+                        break;
+                    }
+                }
+                if (constructor == null)
+                {
+                    throw new InvalidOperationException(
+                        "can't find constructor (uri, ServiceClientCredentials, DelegatingHandler[]) to create client");
+                }
                 client = constructor.Invoke(new object[]
                 {
                     currentEnvironment.BaseUri,
-                    currentEnvironment.Credentials,
+                    tokenCred,
                     handlers
                 }) as T;
             }
             else
             {
-                ConstructorInfo constructor = typeof(T).GetConstructor(new Type[]
+                foreach (var c in constructors)
                 {
-                    typeof(ServiceClientCredentials),
-                    typeof(DelegatingHandler[])
-                });
+                    var parameters = c.GetParameters();
+                    if (parameters.Length == 2 && 
+                        parameters[0].ParameterType.Name == "ServiceClientCredentials" &&
+                        parameters[1].ParameterType.Name == "DelegatingHandler[]")
+                    {
+                        constructor = c;
+                        break;
+                    }
+                }
+                if (constructor == null)
+                {
+                    throw new InvalidOperationException(
+                        "can't find constructor (ServiceClientCredentials, DelegatingHandler[]) to create client");
+                }
                 client = constructor.Invoke(new object[]
                 {
-                    currentEnvironment.Credentials,
+                    currentEnvironment.Token,
                     handlers
                 }) as T;
             }
@@ -151,7 +176,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
                 handlers.Add(server);
             }
 
-            ResourceGroupCleaner cleaner = new ResourceGroupCleaner(currentEnvironment.Credentials);
+            ResourceGroupCleaner cleaner = new ResourceGroupCleaner(currentEnvironment.Token);
             handlers.Add(cleaner);
             undoHandlers.Add(cleaner);
 

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ResourceGroupCleaner.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ResourceGroupCleaner.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,11 +18,11 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
     {
         private Regex _resourceGroupPattern = new Regex(@"/subscriptions/[^/]+/resourcegroups/([^?]+)\?api-version");
         private HashSet<string> _resourceGroupsCreated = new HashSet<string>();
-        private string _token;
+        private TokenInfo _tokenInfo;
 
-        public ResourceGroupCleaner(string token)
+        public ResourceGroupCleaner(TokenInfo tokenInfo)
         {
-            _token = token;
+            _tokenInfo = tokenInfo;
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -43,7 +45,8 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
                 httpRequest.Method = new HttpMethod("DELETE");
                 httpRequest.RequestUri = new Uri(resourceGroupUri);
 
-                httpRequest.Headers.Add("Authorization", "Bearer " + _token); //TODO, try to use .Authorization field
+                httpRequest.Headers.Authorization = new AuthenticationHeaderValue(_tokenInfo.AccessTokenType,
+                    _tokenInfo.AccessToken);
 
                 HttpResponseMessage httpResponse = await httpClient.SendAsync(httpRequest).ConfigureAwait(false);
                 string groupName = _resourceGroupPattern.Match(resourceGroupUri).Groups[1].Value;

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ResourceGroupCleaner.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ResourceGroupCleaner.cs
@@ -16,11 +16,11 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
     {
         private Regex _resourceGroupPattern = new Regex(@"/subscriptions/[^/]+/resourcegroups/([^?]+)\?api-version");
         private HashSet<string> _resourceGroupsCreated = new HashSet<string>();
-        private ServiceClientCredentials _credentials;
+        private string _token;
 
-        public ResourceGroupCleaner(ServiceClientCredentials credentials)
+        public ResourceGroupCleaner(string token)
         {
-            _credentials = credentials;
+            _token = token;
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -43,7 +43,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
                 httpRequest.Method = new HttpMethod("DELETE");
                 httpRequest.RequestUri = new Uri(resourceGroupUri);
 
-                await _credentials.ProcessHttpRequestAsync(httpRequest, CancellationToken.None).ConfigureAwait(false);
+                httpRequest.Headers.Add("Authorization", "Bearer " + _token); //TODO, try to use .Authorization field
 
                 HttpResponseMessage httpResponse = await httpClient.SendAsync(httpRequest).ConfigureAwait(false);
                 string groupName = _resourceGroupPattern.Match(resourceGroupUri).Groups[1].Value;

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironment.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironment.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
             }
         }
 
-        public string Token { get; set; }
+        public TokenInfo TokenInfo { get; set; }
 
         public string ServicePrincipal { get; set; }
 

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironment.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironment.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Rest;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
 {
@@ -277,7 +278,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
             }
         }
 
-        public ServiceClientCredentials Credentials { get; set; }
+        public string Token { get; set; }
 
         public string ServicePrincipal { get; set; }
 

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironmentFactory.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironmentFactory.cs
@@ -8,8 +8,8 @@ using System.Net.Http;
 using Newtonsoft.Json.Linq;
 using System.Threading;
 using Microsoft.Azure.Test.HttpRecorder;
-using Microsoft.Rest.Azure.Authentication;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using System.Threading.Tasks;
 
 namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
 {
@@ -44,7 +44,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
             {
                 testEnv.UserName = TestEnvironment.UserIdDefault;
                 SetEnvironmentSubscriptionId(testEnv, connectionString);
-                testEnv.Credentials = new TokenCredentials(TestEnvironment.RawTokenDefault);
+                testEnv.Token = TestEnvironment.RawTokenDefault;
             }
             else //Record or None
             {
@@ -61,62 +61,42 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
                     if (parsedConnection.ContainsKey(TestEnvironment.RawToken))
                     {
                         var token = parsedConnection[TestEnvironment.RawToken];
-                        testEnv.Credentials = new TokenCredentials(token);
+                        testEnv.Token = token;
                     }
                     else
                     {
                         string password = null;
-                        if(testEnv.UserName != null && 
-                           !parsedConnection.TryGetValue(TestEnvironment.AADPasswordKey, out password))
-                        {
-                            throw new InvalidOperationException("Certificate is not yet supported on dnxcore platform");
-                        }
+                        parsedConnection.TryGetValue(TestEnvironment.AADPasswordKey, out password);
 
                         if (testEnv.UserName != null && password != null)
                         {
-                            ServiceClientTracing.Information("Using AAD auth with username and password combination");
-                            testEnv.Credentials = UserTokenProvider.LoginSilentAsync(testEnv.ClientId,
-                                testEnv.Tenant, testEnv.UserName, password, testEnv.AsAzureEnvironment(), null)
-                                .ConfigureAwait(false).GetAwaiter().GetResult();
+                            testEnv.Token = TestEnvironmentFactory.LoginUserAsync(testEnv.Tenant, 
+                                testEnv.UserName, 
+                                password, 
+                                testEnv.Endpoints.AADTokenAudienceUri.ToString(),
+                                testEnv.Endpoints.AADAuthUri.ToString())
+                                .ConfigureAwait(false).GetAwaiter().GetResult().AccessToken;
                         }
                         else if (testEnv.ServicePrincipal != null && password != null)
                         {
-                            ServiceClientTracing.Information("Using AAD auth with service principal and password combination");
-                            testEnv.Credentials = ApplicationTokenProvider.LoginSilentAsync(testEnv.Tenant,
-                                testEnv.ServicePrincipal, password, testEnv.AsAzureEnvironment())
-                                .ConfigureAwait(false).GetAwaiter().GetResult();
+                            testEnv.Token = TestEnvironmentFactory.LoginServicePrincipalAsync(testEnv.Tenant,
+                                testEnv.ServicePrincipal, 
+                                password, 
+                                testEnv.Endpoints.AADTokenAudienceUri.ToString(),
+                                testEnv.Endpoints.AADAuthUri.ToString())
+                                .ConfigureAwait(false).GetAwaiter().GetResult().AccessToken;
                         }
 #if NET45
                         else
                         {
-                            ServiceClientTracing.Information("Using AAD auth with pop-up dialog using default environment...");
-                            ActiveDirectoryClientSettings directoryClientSettings = new ActiveDirectoryClientSettings()
-                            {
-                                ClientId = testEnv.ClientId,
-                                PromptBehavior = PromptBehavior.Auto,
-                                ClientRedirectUri = new Uri("urn:ietf:wg:oauth:2.0:oob")
-                            };
-                            testEnv.Credentials = UserTokenProvider.LoginWithPromptAsync(testEnv.Tenant, directoryClientSettings, TestUtilities.AsAzureEnvironment(testEnv)).ConfigureAwait(false).GetAwaiter().GetResult();
+                            testEnv.Token = LoginWithPromptAsync(testEnv.Tenant,
+                                testEnv.Endpoints.AADTokenAudienceUri.ToString(),
+                                testEnv.Endpoints.AADAuthUri.ToString())
+                                .ConfigureAwait(false).GetAwaiter().GetResult().AccessToken;
                         }
 #endif
                     }
                 }//end-of-if connectionString present
-
-                if (testEnv.Credentials == null)
-                {
-                    throw new InvalidOperationException("Prompting for credential is not yet supported for cross-platform testing");
-                    //will authenticate the user if the connection string is nullOrEmpty and the mode is not playback
-                    //ServiceClientTracing.Information("Using AAD auth with pop-up dialog using default environment...");
-                    //var clientSettings = new ActiveDirectoryClientSettings
-                    //{
-                    //    ClientId = testEnv.ClientId,
-                    //    PromptBehavior = PromptBehavior.Auto,
-                    //    ClientRedirectUri = new Uri("urn:ietf:wg:oauth:2.0:oob")
-                    //};
-                    //testEnv.Credentials = UserTokenProvider.LoginWithPromptAsync(testEnv.Tenant,
-                    //        clientSettings, testEnv.AsAzureEnvironment())
-                    //        .ConfigureAwait(false).GetAwaiter().GetResult();
-                }
 
                 // Management Clients that are not subscription based should set "SubscriptionId=None" in
                 // the connection string.
@@ -125,7 +105,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
                     //Getting subscriptions from server
                     var subscriptions = ListSubscriptions(
                         testEnv.BaseUri.ToString(),
-                        testEnv.Credentials);
+                        testEnv.Token);
 
                     if (subscriptions.Count == 0)
                     {
@@ -205,7 +185,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
             }
         }
 
-        public static List<SubscriptionInfo> ListSubscriptions(string baseuri, ServiceClientCredentials credentials)
+        public static List<SubscriptionInfo> ListSubscriptions(string baseuri, string token)
         {
             var request = new HttpRequestMessage
             {
@@ -213,7 +193,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
             };
 
             HttpClient client = new HttpClient();
-            credentials.ProcessHttpRequestAsync(request, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            request.Headers.Add("Authorization", "Bearer " + token);
             HttpResponseMessage response = client.SendAsync(request).Result;
             response.EnsureSuccessStatusCode();
 
@@ -223,5 +203,58 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
             var results = ((JArray)jsonResult["value"]).Select(item => new SubscriptionInfo((JObject)item)).ToList();
             return results;
         }
+
+        private static async Task<AuthenticationResult> LoginUserAsync(string domain, 
+            string username, 
+            string password,
+            string resource,
+            string authenticationEndpoint)
+        {
+            var credentials = new UserCredential(username, password);
+            var authenticationContext = new AuthenticationContext(authenticationEndpoint + domain, 
+                false);
+            return await authenticationContext.AcquireTokenAsync(resource,
+                  TestEnvironment.ClientIdDefault, credentials).ConfigureAwait(false);
+               
+        }
+
+        private static async Task<AuthenticationResult> LoginServicePrincipalAsync(string domain, 
+            string servicePrincipalId, 
+            string key,
+            string resource,
+            string authenticationEndpoint)
+        {
+            var credentials = new ClientCredential(servicePrincipalId, key);
+            var authenticationContext = new AuthenticationContext(authenticationEndpoint + domain, 
+                false);
+            return await authenticationContext.AcquireTokenAsync(resource, credentials)
+                .ConfigureAwait(false);
+               
+        }
+#if NET45
+
+        private static async Task<AuthenticationResult> LoginWithPromptAsync(string domain,
+            string resource,
+            string authenticationEndpoint)
+        {
+            var authenticationContext = new AuthenticationContext(authenticationEndpoint + domain, 
+                false, 
+                TokenCache.DefaultShared);
+            TaskScheduler scheduler = TaskScheduler.FromCurrentSynchronizationContext();
+            var task = new Task<AuthenticationResult>(() =>
+            {
+                var result = authenticationContext.AcquireToken(
+                    resource,
+                    TestEnvironment.ClientIdDefault,
+                    new Uri("urn:ietf:wg:oauth:2.0:oob"),
+                    PromptBehavior.Auto,
+                    UserIdentifier.AnyUser);
+                return result;
+            });
+
+            task.Start(scheduler);
+            return await task.ConfigureAwait(false);
+        }
+#endif
     }
 }

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestUtilities.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestUtilities.cs
@@ -11,22 +11,11 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using Microsoft.Azure.Test.HttpRecorder;
-using Microsoft.Rest.Azure.Authentication;
 
 namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
 {
     public static partial class TestUtilities
     {
-        public static ActiveDirectoryServiceSettings AsAzureEnvironment(this TestEnvironment env)
-        {
-            return new ActiveDirectoryServiceSettings
-            {
-                AuthenticationEndpoint = env.Endpoints.AADAuthUri,
-                TokenAudience = env.Endpoints.AADTokenAudienceUri,
-                ValidateAuthority = false
-            };
-        }
-
         /// <summary>
         /// Simply function determining retry policy - retry on any internal server error
         /// </summary>

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestingTracingInterceptor.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestingTracingInterceptor.cs
@@ -4,12 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
-using Microsoft.Rest;
+using System.Text;
 
 namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
 {
-    public class TestingTracingInterceptor : IServiceClientTracingInterceptor
+    public class TestingTracingInterceptor
     {
         private void Write(string message, params object[] arguments)
         {
@@ -36,12 +37,32 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         
         public void SendRequest(string invocationId, HttpRequestMessage request)
         {
-            Write("{0} - {1}", invocationId, request.AsFormattedString());
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine(request.ToString());
+            if (request.Content != null)
+            {
+                stringBuilder.AppendLine();
+                stringBuilder.AppendLine("Body:");
+                stringBuilder.AppendLine("{");
+                stringBuilder.AppendLine(request.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult());
+                stringBuilder.AppendLine("}");
+            }
+            Write("{0} - {1}", invocationId, stringBuilder.ToString());
         }
 
         public void ReceiveResponse(string invocationId, HttpResponseMessage response)
         {
-            Write("{0} - {1}", invocationId, response.AsFormattedString());
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine(response.ToString());
+            if (response.Content != null)
+            {
+                stringBuilder.AppendLine();
+                stringBuilder.AppendLine("Body:");
+                stringBuilder.AppendLine("{");
+                stringBuilder.AppendLine(response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult());
+                stringBuilder.AppendLine("}");
+            }
+            Write("{0} - {1}", invocationId, stringBuilder.ToString());
         }
 
         public void EnterMethod(string invocationId, object instance, string method, IDictionary<string, object> parameters)

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TokenInfo.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TokenInfo.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
+{
+    public class TokenInfo
+    {
+        public TokenInfo(string accessToken)
+        {
+            AccessToken = accessToken;
+            AccessTokenType = "Bearer";
+        }
+
+        public TokenInfo(AuthenticationResult result)
+        {
+            AccessToken = result.AccessToken;
+            AccessTokenType = result.AccessTokenType;
+        }
+
+        public string AccessToken { get; private set; }
+        public string AccessTokenType { get; private set; }
+    }
+}

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/project.json
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/project.json
@@ -10,6 +10,9 @@
   },
   "frameworks": {
     "net45": {
+      "dependencies": {
+        "Microsoft.IdentityModel.Clients.ActiveDirectory": "2.18.206251556"
+      },
       "frameworkAssemblies": {
         "System.Net.Http": "",
         "System.Runtime": { "type": "build" },
@@ -27,12 +30,12 @@
         "System.Linq": "4.0.1-beta-23516",
         "System.Runtime": "4.0.21-beta-23516",
         "System.Threading": "4.0.11-beta-23516",
-        "System.Net.Http": "4.0.1-beta-23516"
+        "System.Net.Http": "4.0.1-beta-23516",
+        "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.6.212041202-alpha"
       }
     }
   },
   "dependencies": {
-    "Microsoft.Rest.ClientRuntime.Azure.Authentication": "1.2.1-preview",
     "Microsoft.Azure.Test.HttpRecorder": ""
   }
 }

--- a/src/TestFramework/TestFramework.Tests/Client/ISimpleClient.cs
+++ b/src/TestFramework/TestFramework.Tests/Client/ISimpleClient.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Rest.Azure;
-using Microsoft.Rest;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework.Test.Client
 {

--- a/src/TestFramework/TestFramework.Tests/Client/MockHandler.cs
+++ b/src/TestFramework/TestFramework.Tests/Client/MockHandler.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Rest.Azure;
-using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
-using System;
 using System.Net.Http;
-using System.Threading;
-using Microsoft.Rest;
 
 namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework.Test.Client
 {

--- a/src/TestFramework/TestFramework.Tests/Client/SimpleClient.cs
+++ b/src/TestFramework/TestFramework.Tests/Client/SimpleClient.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Rest.Azure;
-using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
 using System;
 using System.Net.Http;
 using System.Threading;
-using Microsoft.Rest;
 
 namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework.Test.Client
 {
@@ -50,12 +47,12 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework.Test.Client
             get { throw new NotImplementedException(); }
         }
 
-        public Uri BaseUri { get; set;  }
+        public Uri BaseUri { get; set; }
 
         public ServiceClientCredentials Credentials { get; set; }
-        
+
         public string SubscriptionId { get; set; }
-        
+
         public int? LongRunningOperationRetryTimeout { get; set; }
 
         public HttpResponseMessage CsmGetLocation()

--- a/src/TestFramework/TestFramework.Tests/project.json
+++ b/src/TestFramework/TestFramework.Tests/project.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "Microsoft.Azure.Test.HttpRecorder": "",
     "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "",
+    "Microsoft.Rest.ClientRuntime": "1.8.1",
     "xunit": "2.1.0"
   },
   "compileFiles": "../../../tools/DisableTestRunParallel.cs"


### PR DESCRIPTION
Ideally, we don't need to do this if the client run-time will never change, but the reality is in the whole year it has never stopped changing. This has landed us in a messy situation that the run-time packages TestFramework brings in will conflict with ones brought in by the individual maml libs. We then saw build/run-time errors reported from both sdk-for-net or power-shell repositories. Code reusing is a good thing, but the cost of aligning to the same runt-time version has become complicated enough that 20 or 30 lines of reusing doesn't justify. We are better off without it.

So with this PR
1. The test framework has no dependency on client run-time. It adds a very limited usage of reflection so to create a service client.
2. It takes direct dependency on adal so to acquire tokens using around 20 lines of new code.
3. Existing warnings for version conflicts, which were hard to fix, are fixed now.

Most important, updating and deploying test framework will become much easier w/o worrying about run-time packages conflict. Service teams can pull in any new versions, and are still able to debug&trace to diagnose their test issues by themselves.
