### PR TITLE
Add ability to turn off trace logging

### DIFF
--- a/src/Common/Configuration/AzureApplicationSettings.cs
+++ b/src/Common/Configuration/AzureApplicationSettings.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Azure
     /// </summary>
     internal class AzureApplicationSettings
     {
+        public static bool WriteToTrace { get; set; }
+
         private const string RoleEnvironmentTypeName = "Microsoft.WindowsAzure.ServiceRuntime.RoleEnvironment";
         private const string RoleEnvironmentExceptionTypeName = "Microsoft.WindowsAzure.ServiceRuntime.RoleEnvironmentException";
         private const string IsAvailablePropertyName = "IsAvailable";
@@ -42,6 +44,14 @@ namespace Microsoft.Azure
 
         private Type _roleEnvironmentExceptionType;         // Exception thrown for missing settings.
         private MethodInfo _getServiceSettingMethod;        // Method for getting values from the service configuration.
+
+        /// <summary>
+        /// Initializes global application settings (such as writing to the Trace singleton)
+        /// </summary>
+        static AzureApplicationSettings()
+        {
+            WriteToTrace = true;
+        }
 
         /// <summary>
         /// Initializes the settings.
@@ -66,7 +76,7 @@ namespace Microsoft.Azure
 
                         if (isAvailable)
                         {
-                            Trace.WriteLine(message);
+                            WriteTraceLine(message);
                         }
                     }
                     catch (TargetInvocationException e)
@@ -155,11 +165,11 @@ namespace Microsoft.Azure
 
             try
             {
-                Trace.WriteLine(message);
+                WriteTraceLine(message);
             }
             catch (Exception)
             {
-                // Ommit writing the trace message, running outside of dev fabric.
+                // Omit writing the trace message, running outside of dev fabric.
             }
 
             return value;
@@ -198,8 +208,8 @@ namespace Microsoft.Azure
         /// runtime assembly.
         /// </summary>
         /// <returns>Loaded assembly, if any.</returns>
-        [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadFrom", 
-            Justification= "The ServiceRuntime.dll has to be loaded at runtime so calling Assembly.LoadFrom method is essential to do the loading")]
+        [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadFrom",
+            Justification = "The ServiceRuntime.dll has to be loaded at runtime so calling Assembly.LoadFrom method is essential to do the loading")]
         private Assembly GetServiceRuntimeAssembly()
         {
             Assembly assembly = null;
@@ -219,8 +229,8 @@ namespace Microsoft.Azure
                 {
                     // The following exceptions are ignored for enabling configuration manager to proceed
                     // and load the configuration from application settings instead of using ServiceRuntime.
-                    if (!(e is FileNotFoundException || 
-                          e is FileLoadException || 
+                    if (!(e is FileNotFoundException ||
+                          e is FileLoadException ||
                           e is BadImageFormatException))
                     {
                         throw;
@@ -229,6 +239,14 @@ namespace Microsoft.Azure
             }
 
             return assembly;
+        }
+
+        private static void WriteTraceLine(string message)
+        {
+            if (WriteToTrace)
+            {
+                Trace.WriteLine(message);
+            }
         }
     }
 }

--- a/src/Common/Configuration/AzureApplicationSettings.cs
+++ b/src/Common/Configuration/AzureApplicationSettings.cs
@@ -241,6 +241,10 @@ namespace Microsoft.Azure
             return assembly;
         }
 
+        /// <summary>
+        /// Writes to trace output if WriteToTrace is true
+        /// </summary>
+        /// <param name="message">The message to write to Trace</param>
         private static void WriteTraceLine(string message)
         {
             if (WriteToTrace)

--- a/src/Common/Configuration/CloudConfigurationManager.cs
+++ b/src/Common/Configuration/CloudConfigurationManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure
         /// </summary>
         /// <param name="name">Setting name.</param>
         /// <returns>Setting value or null if not found.</returns>
-        public static string GetSetting(string name)
+        public static string GetSetting(string name, bool outputResultsToTrace = true)
         {
             if (name == null)
             {
@@ -43,6 +43,8 @@ namespace Microsoft.Azure
                 string message = string.Format(CultureInfo.CurrentUICulture, Resources.ErrorArgumentEmptyString, "name");
                 throw new ArgumentException(message);
             }
+
+            AzureApplicationSettings.WriteToTrace = outputResultsToTrace;
 
             return AppSettings.GetSetting(name);
         }


### PR DESCRIPTION
CloudConfigurationManager always writes to Trace when loading settings. This can clutter trace logs, and it cannot be turned off... until now.
