### PR TITLE
Search SDK: Add support for serializing SearchContinuationToken

### DIFF
--- a/src/Search/Microsoft.Azure.Search/Customizations/Documents/DocumentsOperations.Customization.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Documents/DocumentsOperations.Customization.cs
@@ -1065,7 +1065,7 @@ namespace Microsoft.Azure.Search
             return shouldTrace;
         }
 
-        private class DocumentSearchResponsePayload<TResult, TDoc>
+        private class DocumentSearchResponsePayload<TResult, TDoc> : SearchContinuationTokenPayload
             where TResult : SearchResultBase<TDoc>
             where TDoc : class
         {
@@ -1080,12 +1080,6 @@ namespace Microsoft.Azure.Search
 
             [JsonProperty("value")]
             public List<TResult> Documents { get; set; }
-
-            [JsonProperty("@odata.nextLink")]
-            public string NextLink { get; set; }
-
-            [JsonProperty("@search.nextPageParameters")]
-            public SearchParametersPayload NextPageParameters { get; set; }
         }
 
         private class DocumentSuggestResponsePayload<TResult, TDoc>

--- a/src/Search/Microsoft.Azure.Search/Customizations/Documents/Models/SearchContinuationToken.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Documents/Models/SearchContinuationToken.cs
@@ -5,11 +5,14 @@
 namespace Microsoft.Azure.Search.Models
 {
     using System;
+    using Newtonsoft.Json;
+    using Serialization;
 
     /// <summary>
     /// Encapsulates state required to continue fetching search results. This is necessary when Azure Search cannot
     /// fulfill a search request with a single response.
     /// </summary>
+    [JsonConverter(typeof(SearchContinuationTokenConverter))]
     public class SearchContinuationToken
     {
         internal SearchContinuationToken(string nextLink, SearchParametersPayload nextPageParameters)

--- a/src/Search/Microsoft.Azure.Search/Customizations/Documents/Models/SearchContinuationTokenPayload.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Documents/Models/SearchContinuationTokenPayload.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+namespace Microsoft.Azure.Search.Models
+{
+    using Newtonsoft.Json;
+
+    internal class SearchContinuationTokenPayload
+    {
+        [JsonProperty("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        [JsonProperty("@search.nextPageParameters")]
+        public SearchParametersPayload NextPageParameters { get; set; }
+    }
+}

--- a/src/Search/Microsoft.Azure.Search/Customizations/Serialization/SearchContinuationTokenConverter.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Serialization/SearchContinuationTokenConverter.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+namespace Microsoft.Azure.Search.Serialization
+{
+    using System;
+    using Models;
+    using Newtonsoft.Json;
+
+    internal class SearchContinuationTokenConverter : ConverterBase
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(SearchContinuationToken);
+        }
+
+        public override object ReadJson(
+            JsonReader reader, 
+            Type objectType, 
+            object existingValue, 
+            JsonSerializer serializer)
+        {
+            SearchContinuationTokenPayload payload = serializer.Deserialize<SearchContinuationTokenPayload>(reader);
+
+            Uri nextLinkUri;
+            try
+            {
+                nextLinkUri = new Uri(payload.NextLink);
+            }
+            catch (UriFormatException e)
+            {
+                throw new JsonSerializationException(
+                    "Cannot deserialize continuation token. Failed to parse nextLink because it is not a valid URL.", 
+                    e);
+            }
+
+            string apiVersion = ParseApiVersion(nextLinkUri.Query);
+
+            if (string.IsNullOrWhiteSpace(apiVersion))
+            {
+                throw new JsonSerializationException(
+                    "Cannot deserialize continuation token because the api-version is missing.");
+            }
+
+            if (apiVersion != Consts.TargetApiVersion)
+            {
+                const string MessageFormat =
+                    "Cannot deserialize a continuation token for a different api-version. Token contains version " +
+                    "'{0}'; Expected version '{1}'.";
+
+                string message = string.Format(MessageFormat, apiVersion, Consts.TargetApiVersion);
+                throw new JsonSerializationException(message);
+            }
+
+            return new SearchContinuationToken(payload.NextLink, payload.NextPageParameters);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            SearchContinuationToken token = (SearchContinuationToken)value;
+
+            var payload = 
+                new SearchContinuationTokenPayload()
+                {
+                    NextLink = token.NextLink,
+                    NextPageParameters = token.NextPageParameters
+                };
+
+            serializer.Serialize(writer, payload);
+        }
+
+        private static string ParseApiVersion(string query)
+        {
+            if (String.IsNullOrWhiteSpace(query))
+            {
+                return null;
+            }
+
+            if (query[0] == '?')
+            {
+                query = query.Substring(1);
+            }
+
+            string[] pairs = query.Split('&');
+
+            foreach (string pair in pairs)
+            {
+                string[] nameAndValue = pair.Split('=');
+
+                if (nameAndValue.Length == 2 && nameAndValue[0] == "api-version")
+                {
+                    return nameAndValue[1];
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Search/Microsoft.Azure.Search/Customizations/Serialization/SearchContinuationTokenConverter.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Serialization/SearchContinuationTokenConverter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Search.Serialization
             {
                 nextLinkUri = new Uri(payload.NextLink);
             }
-            catch (UriFormatException e)
+            catch (FormatException e)
             {
                 throw new JsonSerializationException(
                     "Cannot deserialize continuation token. Failed to parse nextLink because it is not a valid URL.", 

--- a/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
+++ b/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
@@ -25,3 +25,12 @@ using System.Runtime.InteropServices;
 #else
 [assembly: InternalsVisibleTo("Search.Tests")]
 #endif
+
+namespace Microsoft.Azure.Search
+{
+    internal class Consts
+    {
+        // Putting this in AssemblyInfo.cs so we remember to change it when the major SDK version changes.
+        public const string TargetApiVersion = "2015-02-28";
+    }
+}

--- a/src/Search/Search.Tests/Search.Tests.csproj
+++ b/src/Search/Search.Tests/Search.Tests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Tests\SearchTests.cs" />
     <Compile Include="Tests\Serialization\DateTimeConverterTests.cs" />
     <Compile Include="Tests\Serialization\GeographyPointConverterTests.cs" />
+    <Compile Include="Tests\Serialization\SearchContinuationTokenConverterTests.cs" />
     <Compile Include="Tests\Serialization\SearchParametersTests.cs" />
     <Compile Include="Tests\Serialization\SuggestParametersTests.cs" />
     <Compile Include="Tests\SoftDeleteColumnDeletionDetectionPolicyTests.cs" />

--- a/src/Search/Search.Tests/Tests/Serialization/SearchContinuationTokenConverterTests.cs
+++ b/src/Search/Search.Tests/Tests/Serialization/SearchContinuationTokenConverterTests.cs
@@ -1,0 +1,222 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+namespace Microsoft.Azure.Search.Tests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Models;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public sealed class SearchContinuationTokenConverterTests
+    {
+        private const string TokenJson =
+ @"{
+  ""@odata.nextLink"": ""https://tempuri.org?api-version=2015-02-28"",
+  ""@search.nextPageParameters"": {
+    ""count"": true,
+    ""facets"": [
+      ""testfacets""
+    ],
+    ""filter"": ""testfilter"",
+    ""highlight"": ""testhighlight"",
+    ""highlightPostTag"": ""</b>"",
+    ""highlightPreTag"": ""<b>"",
+    ""minimumCoverage"": 50.0,
+    ""orderby"": ""testorderby"",
+    ""scoringParameters"": [
+      ""testscoringparameter""
+    ],
+    ""scoringProfile"": ""testscoringprofile"",
+    ""search"": ""some words"",
+    ""searchFields"": ""somefields"",
+    ""searchMode"": ""any"",
+    ""select"": ""*"",
+    ""skip"": 100,
+    ""top"": 10
+  }
+}";
+
+        private const string TokenWithOnlyLinkJson =
+ @"{
+  ""@odata.nextLink"": ""https://tempuri.org?=&a=&=a&a=b=c&api-version=2015-02-28"",
+  ""@search.nextPageParameters"": null
+}";
+
+        private SearchContinuationToken _token =
+            new SearchContinuationToken(
+                "https://tempuri.org?api-version=2015-02-28",
+                new SearchParametersPayload()
+                {
+                    Count = true,
+                    Facets = new[] { "testfacets" },
+                    Filter = "testfilter",
+                    Highlight = "testhighlight",
+                    HighlightPostTag = "</b>",
+                    HighlightPreTag = "<b>",
+                    MinimumCoverage = 50,
+                    OrderBy = "testorderby",
+                    ScoringParameters = new[] { "testscoringparameter" },
+                    ScoringProfile = "testscoringprofile",
+                    Search = "some words",
+                    SearchFields = "somefields",
+                    SearchMode = SearchMode.Any,
+                    Select = "*",
+                    Skip = 100,
+                    Top = 10
+                });
+
+        private SearchContinuationToken _tokenWithOnlyLink =
+            new SearchContinuationToken("https://tempuri.org?=&a=&=a&a=b=c&api-version=2015-02-28", null);
+
+        private TokenComparer _tokenComparer = new TokenComparer();
+
+        [Fact]
+        public void CanSerializeToken()
+        {
+            string json = JsonConvert.SerializeObject(_token, Formatting.Indented);
+            Assert.Equal(TokenJson, json);
+        }
+
+        [Fact]
+        public void CanDeserializeToken()
+        {
+            SearchContinuationToken token = JsonConvert.DeserializeObject<SearchContinuationToken>(TokenJson);
+            Assert.Equal(_token, token, _tokenComparer);
+        }
+
+        [Fact]
+        public void CanSerializeTokenWithOnlyLink()
+        {
+            string json = JsonConvert.SerializeObject(_tokenWithOnlyLink, Formatting.Indented);
+            Assert.Equal(TokenWithOnlyLinkJson, json);
+        }
+
+        [Fact]
+        public void CanDeserializeTokenWithOnlyLink()
+        {
+            SearchContinuationToken token = 
+                JsonConvert.DeserializeObject<SearchContinuationToken>(TokenWithOnlyLinkJson);
+            Assert.Equal(_tokenWithOnlyLink, token, _tokenComparer);
+        }
+
+        [Fact]
+        public void DeserializeTokenWithWrongVersionThrowsException()
+        {
+            string tokenJson = TokenJson.Replace("2015-02-28", "1999-12-31");
+
+            JsonSerializationException e =
+                Assert.Throws<JsonSerializationException>(
+                    () => JsonConvert.DeserializeObject<SearchContinuationToken>(tokenJson));
+
+            const string ExpectedMessage =
+                "Cannot deserialize a continuation token for a different api-version. Token contains version " +
+                "'1999-12-31'; Expected version '2015-02-28'.";
+
+            Assert.Equal(ExpectedMessage, e.Message);
+        }
+
+        [Fact]
+        public void DeserializeTokenWithMissingVersionThrowsException()
+        {
+            string tokenJson = TokenJson.Replace("api-version=", "not-api-version=");
+
+            JsonSerializationException e =
+                Assert.Throws<JsonSerializationException>(
+                    () => JsonConvert.DeserializeObject<SearchContinuationToken>(tokenJson));
+
+            const string ExpectedMessage = "Cannot deserialize continuation token because the api-version is missing.";
+            Assert.Equal(ExpectedMessage, e.Message);
+        }
+
+        [Fact]
+        public void DeserializeTokenWithMissingVersionValueThrowsException()
+        {
+            string tokenJson = TokenJson.Replace("2015-02-28", string.Empty);
+
+            JsonSerializationException e =
+                Assert.Throws<JsonSerializationException>(
+                    () => JsonConvert.DeserializeObject<SearchContinuationToken>(tokenJson));
+
+            const string ExpectedMessage = "Cannot deserialize continuation token because the api-version is missing.";
+            Assert.Equal(ExpectedMessage, e.Message);
+        }
+
+        [Fact]
+        public void DeserializeTokenWithInvalidUrlThrowsException()
+        {
+            string tokenJson = @"{ ""@odata.nextLink"": ""This is not a valid URL."" }";
+
+            JsonSerializationException e =
+                Assert.Throws<JsonSerializationException>(
+                    () => JsonConvert.DeserializeObject<SearchContinuationToken>(tokenJson));
+
+            const string ExpectedMessage = 
+                "Cannot deserialize continuation token. Failed to parse nextLink because it is not a valid URL.";
+
+            Assert.Equal(ExpectedMessage, e.Message);
+        }
+
+        [Fact]
+        public void DeserializeTokenWithNoQueryStringThrowsException()
+        {
+            string tokenJson = @"{ ""@odata.nextLink"": ""https://tempuri.org"" }";
+
+            JsonSerializationException e =
+                Assert.Throws<JsonSerializationException>(
+                    () => JsonConvert.DeserializeObject<SearchContinuationToken>(tokenJson));
+
+            const string ExpectedMessage = "Cannot deserialize continuation token because the api-version is missing.";
+            Assert.Equal(ExpectedMessage, e.Message);
+        }
+
+        private class TokenComparer : IEqualityComparer<SearchContinuationToken>
+        {
+            public bool Equals(SearchContinuationToken x, SearchContinuationToken y)
+            {
+                return 
+                    x.NextLink == y.NextLink &&
+                    NextPageParametersEquals(x.NextPageParameters, y.NextPageParameters);
+            }
+
+            public int GetHashCode(SearchContinuationToken obj)
+            {
+                return obj.GetHashCode();
+            }
+
+            private static bool NextPageParametersEquals(SearchParametersPayload x, SearchParametersPayload y)
+            {
+                if (x == null && y == null)
+                {
+                    return true;
+                }
+
+                if ((x == null) != (y == null))
+                {
+                    return false;
+                }
+
+                return
+                    x.Count == y.Count &&
+                    ((x.Facets == null && y.Facets == null) || x.Facets.SequenceEqual(y.Facets)) &&
+                    x.Filter == y.Filter &&
+                    x.Highlight == y.Highlight &&
+                    x.HighlightPostTag == y.HighlightPostTag &&
+                    x.HighlightPreTag == y.HighlightPreTag &&
+                    x.MinimumCoverage == y.MinimumCoverage &&
+                    x.OrderBy == y.OrderBy &&
+                    ((x.ScoringParameters == null && y.ScoringParameters == null) ||
+                      x.ScoringParameters.SequenceEqual(y.ScoringParameters)) &&
+                    x.ScoringProfile == y.ScoringProfile &&
+                    x.Search == y.Search &&
+                    x.SearchFields == y.SearchFields &&
+                    x.SearchMode == y.SearchMode &&
+                    x.Select == y.Select &&
+                    x.Skip == y.Skip &&
+                    x.Top == y.Top;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Many customers use Azure Search from a middle tier, but need to pass search results to a browser-based client. A frequent request is to be able to serialize `DocumentSearchResult` directly, including its `ContinuationToken` property. This allows the middle tier to remain stateless between search requests, since the continuation token is externalized and passed between the browser and the middle tier.
