### PR TITLE
Search SDK: Ensuring UserAgent includes full file version

### DIFF
--- a/src/Search/Microsoft.Azure.Search/Customizations/UserAgentHelper.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/UserAgentHelper.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+namespace Microsoft.Azure.Search
+{
+    using System;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+
+    internal static class UserAgentHelper
+    {
+        public static void SetUserAgent(HttpClient httpClient, Type serviceClientType)
+        {
+            httpClient.DefaultRequestHeaders.UserAgent.Clear();
+            httpClient.DefaultRequestHeaders.UserAgent.Add(
+                new ProductInfoHeaderValue(serviceClientType.FullName, Consts.AssemblyFileVersion));
+        }
+    }
+}

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchIndex/SearchIndexClient.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchIndex/SearchIndexClient.cs
@@ -278,7 +278,9 @@ namespace Microsoft.Azure.Search
                     }
             };
             DeserializationSettings.Converters.Add(new ResourceJsonConverter()); 
-            DeserializationSettings.Converters.Add(new CloudErrorJsonConverter()); 
-        }    
+            DeserializationSettings.Converters.Add(new CloudErrorJsonConverter());
+
+            UserAgentHelper.SetUserAgent(HttpClient, this.GetType());
+        }
     }
 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/SearchServiceClient.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/SearchServiceClient.cs
@@ -290,7 +290,9 @@ namespace Microsoft.Azure.Search
             SerializationSettings.Converters.Add(new PolymorphicSerializeJsonConverter<ScoringFunction>("type"));
             DeserializationSettings.Converters.Add(new PolymorphicDeserializeJsonConverter<ScoringFunction>("type"));
             DeserializationSettings.Converters.Add(new ResourceJsonConverter()); 
-            DeserializationSettings.Converters.Add(new CloudErrorJsonConverter()); 
-        }    
+            DeserializationSettings.Converters.Add(new CloudErrorJsonConverter());
+
+            UserAgentHelper.SetUserAgent(HttpClient, this.GetType());
+        }
     }
 }

--- a/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
+++ b/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
@@ -6,12 +6,13 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.Azure.Search;
 
 [assembly: AssemblyTitle("Microsoft Azure Search Library")]
 [assembly: AssemblyDescription("Makes it easy to develop a .NET application that uses Azure Search.")]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion(Consts.AssemblyFileVersion)]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
@@ -32,5 +33,8 @@ namespace Microsoft.Azure.Search
     {
         // Putting this in AssemblyInfo.cs so we remember to change it when the major SDK version changes.
         public const string TargetApiVersion = "2015-02-28";
+
+        // Making this a constant so we can use it to set the UserAgent header.
+        public const string AssemblyFileVersion = "1.0.0.0";
     }
 }

--- a/src/Search/Search.Management.Tests/Customizations/UserAgentHelper.cs
+++ b/src/Search/Search.Management.Tests/Customizations/UserAgentHelper.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+namespace Microsoft.Azure.Management.Search
+{
+    using System;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+
+    internal static class UserAgentHelper
+    {
+        public static void SetUserAgent(HttpClient httpClient, Type serviceClientType)
+        {
+            httpClient.DefaultRequestHeaders.UserAgent.Clear();
+            httpClient.DefaultRequestHeaders.UserAgent.Add(
+                new ProductInfoHeaderValue(serviceClientType.FullName, Consts.AssemblyFileVersion));
+        }
+    }
+}

--- a/src/Search/Search.Management.Tests/Generated/SearchManagementClient.cs
+++ b/src/Search/Search.Management.Tests/Generated/SearchManagementClient.cs
@@ -290,7 +290,9 @@ namespace Microsoft.Azure.Management.Search
                     }
             };
             DeserializationSettings.Converters.Add(new ResourceJsonConverter()); 
-            DeserializationSettings.Converters.Add(new CloudErrorJsonConverter()); 
+            DeserializationSettings.Converters.Add(new CloudErrorJsonConverter());
+
+            UserAgentHelper.SetUserAgent(HttpClient, this.GetType());
         }    
     }
 }

--- a/src/Search/Search.Management.Tests/Properties/AssemblyInfo.cs
+++ b/src/Search/Search.Management.Tests/Properties/AssemblyInfo.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Xunit;
+using Microsoft.Azure.Management.Search;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -37,4 +36,13 @@ using Xunit;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion(Consts.AssemblyFileVersion)]
+
+namespace Microsoft.Azure.Management.Search
+{
+    internal class Consts
+    {
+        // Making this a constant so we can use it to set the UserAgent header.
+        public const string AssemblyFileVersion = "1.0.0.0";
+    }
+}

--- a/src/Search/Search.Management.Tests/Search.Management.Tests.csproj
+++ b/src/Search/Search.Management.Tests/Search.Management.Tests.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
   <Import Project="..\..\..\tools\Library.Settings.targets" />
   <ItemGroup>
+    <Compile Include="Customizations\UserAgentHelper.cs" />
     <Compile Include="Generated\**\*.cs" />
     <Compile Include="Tests\AdminKeyTests.cs" />
     <Compile Include="Tests\QueryKeyTests.cs" />

--- a/src/Search/Search.Tests/Tests/Serialization/SearchContinuationTokenConverterTests.cs
+++ b/src/Search/Search.Tests/Tests/Serialization/SearchContinuationTokenConverterTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Search.Tests
 
         private const string TokenWithOnlyLinkJson =
  @"{
-  ""@odata.nextLink"": ""https://tempuri.org?=&a=&=a&a=b=c&api-version=2015-02-28"",
+  ""@odata.nextLink"": ""https://tempuri.org?=&a=&=a&a=b=c&a=b&api-version=2015-02-28"",
   ""@search.nextPageParameters"": null
 }";
 
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Search.Tests
                 });
 
         private SearchContinuationToken _tokenWithOnlyLink =
-            new SearchContinuationToken("https://tempuri.org?=&a=&=a&a=b=c&api-version=2015-02-28", null);
+            new SearchContinuationToken("https://tempuri.org?=&a=&=a&a=b=c&a=b&api-version=2015-02-28", null);
 
         private TokenComparer _tokenComparer = new TokenComparer();
 


### PR DESCRIPTION
This is a workaround for this issue: https://github.com/Azure/autorest/issues/583

It is helpful to have the file version instead of assembly version in the UserAgent header so that we (the Azure Search team) can track adoption of specific versions of the SDK via telemetry.
