### PR TITLE
Fix for Azure Pack websites site slot operation

### DIFF
--- a/src/ServiceManagement/WebSite/WebSiteManagement/Generated/WebSiteOperations.cs
+++ b/src/ServiceManagement/WebSite/WebSiteManagement/Generated/WebSiteOperations.cs
@@ -729,7 +729,7 @@ namespace Microsoft.WindowsAzure.Management.WebSites
                         TracingAdapter.ReceiveResponse(invocationId, httpResponse);
                     }
                     HttpStatusCode statusCode = httpResponse.StatusCode;
-                    if (statusCode != HttpStatusCode.OK)
+                    if (statusCode != HttpStatusCode.OK && statusCode != HttpStatusCode.Accepted)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         CloudException ex = CloudException.Create(httpRequest, null, httpResponse, await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false));
@@ -743,7 +743,7 @@ namespace Microsoft.WindowsAzure.Management.WebSites
                     // Create Result
                     WebSiteOperationStatusResponse result = null;
                     // Deserialize Response
-                    if (statusCode == HttpStatusCode.OK)
+                    if (statusCode == HttpStatusCode.OK || statusCode != HttpStatusCode.Accepted)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         string responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);


### PR DESCRIPTION
Azure Pack returns 202 which is semantically correct for starting slot swapping operation. This change fixes the cmdlet.
