### PR TITLE
Don't export the key as part of initializing RsaKey

### DIFF
--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/RsaKey.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/RsaKey.cs
@@ -105,8 +105,7 @@ namespace Microsoft.Azure.KeyVault
 
             Kid = kid;
 
-            _csp = new RSACryptoServiceProvider();
-            _csp.ImportParameters( csp.PublicOnly ? csp.ExportParameters( false ) : csp.ExportParameters( true ) );
+            _csp = csp;
         }
 
         // Intentionally excluded.


### PR DESCRIPTION
Don't export the key as part of initializing RsaKey from RSACryptoServiceProvider, so RsaKey's can wrap non-exportable keys loaded from the windows certificate store. Otherwise, an exception is thrown as part of ExportParameters.

Another way to do this would be a "don't export" constructor parameter, with the default being to export (ie - copy the RSACryptoServiceProvider), but the ability to wrap the provided RSACryptoServiceProvider as is.

Or, add a RSAKey.Attach(csp) that would set _csp is another idea.
