### PR TITLE
Remove redundant reference to KeyVault.Core created when…

### DIFF
--- a/src/KeyVault/KeyVault.Extensions.Tests/KeyVault.Extensions.Tests.csproj
+++ b/src/KeyVault/KeyVault.Extensions.Tests/KeyVault.Extensions.Tests.csproj
@@ -44,10 +44,6 @@
       <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.KeyVault.1.0.0\lib\net45\Microsoft.Azure.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Azure.Management.KeyVault, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.KeyVault.1.0.0\lib\net40\Microsoft.Azure.Management.KeyVault.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
…TestDependencies.target was modified to include KeyVault.Core
