### PR TITLE
Change the static variable indicating whether a trace should be written

### DIFF
--- a/src/Common/Configuration/CloudConfigurationManager.cs
+++ b/src/Common/Configuration/CloudConfigurationManager.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure
         /// Gets a setting with the given name.
         /// </summary>
         /// <param name="name">Setting name.</param>
+        /// <param name="outputResultsToTrace">If true, this will write that a setting was retrieved to Trace. If false, this will not write anything to Trace.</param>
         /// <returns>Setting value or null if not found.</returns>
         public static string GetSetting(string name, bool outputResultsToTrace)
         {
@@ -44,15 +45,13 @@ namespace Microsoft.Azure
                 throw new ArgumentException(message);
             }
 
-            AzureApplicationSettings.WriteToTrace = outputResultsToTrace;
-
-            return AppSettings.GetSetting(name);
+            return AppSettings.GetSetting(name, outputResultsToTrace);
         }
 
         /// <summary>
         /// Gets a setting with the given name. Trace results.
         /// </summary>
-        /// <remarks>This overloaded function is kept for backward compabability.</remarks>
+        /// <remarks>This overloaded function is kept for backward compatibility.</remarks>
         /// <param name="name">Setting name.</param>
         /// <returns>Setting value or null if not found.</returns>
         public static string GetSetting(string name)


### PR DESCRIPTION
My previous pull request, https://github.com/Azure/azure-sdk-for-net/pull/1693, introduced a static variable that @DixonDs mentioned could be random if accessed across threads.

This PR pulls that static out while preserving functionality.
