### PR TITLE
Bump up to 4.6.0 for JsonFormat

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
@@ -1,14 +1,7 @@
 ﻿For additional details on features, see the full [Azure Data Factory Release Notes](https://azure.microsoft.com/en-us/documentation/articles/data-factory-release-notes). 
 
-## Version 4.7.0
-_Release date: 2016-03-16_ 
-
-### Feature Additions
-
-* Added new StorageFormat type JsonFormat type to define datasets whose data is in JSON format. 
-
 ## Version 4.6.0
-Release date: 2016-03-03
+_Release date: 2016.03.22_ 
 
 ### Feature Additions
 
@@ -16,9 +9,9 @@ Release date: 2016-03-03
     * PipelineMode
     * ExpirationTime
     * Datasets
-
 * The following properties have been added to PipelineRuntimeInfo: 
     * PipelineState
+* Added new StorageFormat type JsonFormat type to define datasets whose data is in JSON format. 
 
 ## Version 4.5.0
 _Release date: 2016.02.24_

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
@@ -3,7 +3,7 @@
   <metadata minClientVersion="2.5">
     <id>Microsoft.Azure.Management.DataFactories</id>
     <title>Microsoft Azure Data Factory Management Library</title>
-    <releaseNotes>https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log/#version-450</releaseNotes>
+    <releaseNotes>https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log/#version-460</releaseNotes>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>azure-sdk, Microsoft</owners>


### PR DESCRIPTION
Release new feature JsonFormat. Bump up the version to 4.6.0 to release SDK.
