### PR TITLE
Handle disposing cached key

### DIFF
--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/CachingKeyResolver.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/CachingKeyResolver.cs
@@ -16,6 +16,7 @@
 // governing permissions and limitations under the License.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault.Core;
@@ -29,7 +30,8 @@ namespace Microsoft.Azure.KeyVault
     {
         private LRUCache<string, IKey> _cache;
         private IKeyResolver           _inner;
-
+        private bool                   _isDisposed;
+ 
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -48,7 +50,7 @@ namespace Microsoft.Azure.KeyVault
 
         public async Task<IKey> ResolveKeyAsync( string kid, CancellationToken token )
         {
-            if ( _cache == null )
+            if ( _isDisposed )
                 throw new ObjectDisposedException( "CachingKeyResolver" );
 
             if ( string.IsNullOrWhiteSpace( kid ) )
@@ -59,10 +61,15 @@ namespace Microsoft.Azure.KeyVault
             if ( result == null )
             {
                 result = await _inner.ResolveKeyAsync( kid, token ).ConfigureAwait( false );
-
                 if ( result != null )
                 {
-                    _cache.Add( kid, result );
+                    // Cache the resolved key using the result's Kid.
+                    // This is especially for the case when the resolved key contains information about the key version
+                    var cacheKid = string.IsNullOrWhiteSpace( result.Kid ) ? kid : result.Kid;
+ 
+                    var cachedKey = new CacheKey(result);
+                    _cache.Add( cacheKid, cachedKey );
+                    return cachedKey;
                 }
             }
 
@@ -81,12 +88,110 @@ namespace Microsoft.Azure.KeyVault
         {
             if ( disposing )
             {
-                if ( _cache != null )
+                if ( !_isDisposed )
                 {
+                   _isDisposed = true;
+ 
+                    foreach (var cacheKey in _cache.OfType<CacheKey>())
+                    {
+                        cacheKey.Dispose(true);
+                    }
+ 
                     _cache.Dispose();
                     _cache = null;
                 }
             }
         }
+ 
+        # region CacheKey class
+ 
+        /// <summary>
+        /// This class wraps the key that is cached using <see cref="CachingKeyResolver"/>
+        /// The main purpose of <see cref="CacheKey"/> is to evict disposing cached key from the cache.
+        /// </summary>
+        class CacheKey : IKey
+        {
+            private readonly IKey _key;
+ 
+            public CacheKey(IKey key)
+            {
+                _key = key;
+            }
+ 
+            public string Kid
+            {
+                get { return _key.Kid; }
+            }
+ 
+            public string DefaultEncryptionAlgorithm
+            {
+                get { return _key.DefaultEncryptionAlgorithm; }
+            }
+ 
+            public string DefaultKeyWrapAlgorithm
+            {
+                get { return _key.DefaultKeyWrapAlgorithm; }
+            }
+ 
+            public string DefaultSignatureAlgorithm
+            {
+                get { return _key.DefaultSignatureAlgorithm; }
+            }
+ 
+            public Task<byte[]> DecryptAsync(byte[] ciphertext, byte[] iv, byte[] authenticationData = null, byte[] authenticationTag = null, string algorithm = null, CancellationToken token = default(CancellationToken))
+            {
+                return _key.DecryptAsync(ciphertext, iv, authenticationData, authenticationTag, algorithm, token);
+            }
+ 
+            public Task<Tuple<byte[], byte[], string>> EncryptAsync(byte[] plaintext, byte[] iv, byte[] authenticationData = null, string algorithm = null, CancellationToken token = default(CancellationToken))
+            {
+                return _key.EncryptAsync(plaintext, iv, authenticationData, algorithm, token);
+            }
+ 
+            public Task<Tuple<byte[], string>> WrapKeyAsync(byte[] key, string algorithm = null, CancellationToken token = default(CancellationToken))
+            {
+                return _key.WrapKeyAsync(key, algorithm, token);
+            }
+ 
+            public Task<byte[]> UnwrapKeyAsync(byte[] encryptedKey, string algorithm = null, CancellationToken token = default(CancellationToken))
+            {
+                return _key.UnwrapKeyAsync(encryptedKey, algorithm, token);
+            }
+ 
+            public Task<Tuple<byte[], string>> SignAsync(byte[] digest, string algorithm = null, CancellationToken token = default(CancellationToken))
+            {
+                return _key.SignAsync(digest, algorithm, token);
+            }
+ 
+            public Task<bool> VerifyAsync(byte[] digest, byte[] signature, string algorithm = null, CancellationToken token = default(CancellationToken))
+            {
+                return _key.VerifyAsync(digest, signature, algorithm, token);
+            }
+ 
+            public void Dispose()
+            {
+                // do not dispose because there may be multiple references to the cached object
+            }
+ 
+            /// <summary>
+            /// Disposes the cached key only when cache is disposing
+            /// </summary>
+            /// <param name="force"> whether to force dispose </param>
+            internal void Dispose(bool force)
+            {
+                Dispose(true, force);
+                GC.SuppressFinalize(this);
+            }
+ 
+            private void Dispose(bool disposing, bool force)
+            {
+                if (disposing & force)
+                {
+                    _key.Dispose();
+                }
+            }
+        }
+ 
+        # endregion CacheKey class
     }
 }

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/ByteExtensions.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Cryptography/ByteExtensions.cs
@@ -109,10 +109,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography
             if ( self == null )
                 throw new ArgumentNullException( "self" );
 
-            for ( var i = 0; i < self.Length; i++ )
-            {
-                self[i] = 0;
-            }
+            Array.Clear(self, 0, self.Length);
         }
     }
 }

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/LRUCache.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/LRUCache.cs
@@ -17,6 +17,7 @@
 
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -27,13 +28,14 @@ namespace Microsoft.Azure.KeyVault
     /// </summary>
     /// <typeparam name="K">The type of the key</typeparam>
     /// <typeparam name="V">The type of the value</typeparam>
-    internal class LRUCache<K, V> : IDisposable where K : class where V : class
+    internal class LRUCache<K, V> : IDisposable, IEnumerable<V> where K : class where V : class
     {
         private int                  _capacity;
         private Dictionary<K, V>     _cache = new Dictionary<K, V>();
         private LinkedList<K>        _list  = new LinkedList<K>();
         private ReaderWriterLockSlim _lock  = new ReaderWriterLockSlim();
-
+        private bool                 _isDisposed;
+ 
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -53,7 +55,7 @@ namespace Microsoft.Azure.KeyVault
         /// <param name="value">The value</param>
         public void Add( K key, V value )
         {
-            if ( _lock == null )
+            if ( _isDisposed )
                 throw new ObjectDisposedException( "LRUCache" );
 
             if ( key == null )
@@ -94,7 +96,7 @@ namespace Microsoft.Azure.KeyVault
         /// <returns>The value for the key or null</returns>
         public V Get( K key )
         {
-            if ( _lock == null )
+            if ( _isDisposed )
                 throw new ObjectDisposedException( "LRUCache" );
 
             if ( key == null )
@@ -136,7 +138,7 @@ namespace Microsoft.Azure.KeyVault
         /// <param name="key">The key to remove</param>
         public void Remove( K key )
         {
-            if ( _lock == null )
+            if ( _isDisposed )
                 throw new ObjectDisposedException( "LRUCache" );
 
             if ( key == null )
@@ -163,7 +165,7 @@ namespace Microsoft.Azure.KeyVault
         /// </summary>
         public void Reset()
         {
-            if ( _lock == null )
+            if ( _isDisposed )
                 throw new ObjectDisposedException( "LRUCache" );
 
             try
@@ -179,6 +181,20 @@ namespace Microsoft.Azure.KeyVault
             }
         }
 
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+ 
+        /// <summary>
+        /// Get enumerator on the cached values
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerator<V> GetEnumerator()
+        {
+            return _cache.Values.GetEnumerator();
+        }
+ 
         public void Dispose()
         {
             Dispose( true );
@@ -189,8 +205,9 @@ namespace Microsoft.Azure.KeyVault
         {
             if ( disposing )
             {
-                if ( _lock != null )
+                if ( !_isDisposed )
                 {
+                    _isDisposed = true;
                     _lock.Dispose();
                     _lock = null;
                 }

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/SymmetricKey.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/SymmetricKey.cs
@@ -16,7 +16,6 @@
 // governing permissions and limitations under the License.
 
 using System;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -40,6 +39,9 @@ namespace Microsoft.Azure.KeyVault
         private static readonly int                      DefaultKeySize = KeySize256;
         private static readonly RNGCryptoServiceProvider Rng            = new RNGCryptoServiceProvider();
 
+        private byte[] _key;
+        private bool   _isDisposed;
+ 
         /// <summary>
         /// Default constructor
         /// </summary>
@@ -71,9 +73,9 @@ namespace Microsoft.Azure.KeyVault
                 throw new ArgumentOutOfRangeException( "keySize", "The key size must be 128, 192, 256, 384 or 512 bits of data" );
 
             Kid = kid;
-            Key = new byte[keySize];
-
-            Rng.GetNonZeroBytes( Key );
+            _key = new byte[keySize];
+ 
+            Rng.GetNonZeroBytes( _key );
         }
 
         /// <summary>
@@ -93,11 +95,18 @@ namespace Microsoft.Azure.KeyVault
                 throw new ArgumentOutOfRangeException( "keyBytes", "The key material must be 128, 192, 256, 384 or 512 bits of data" );
 
             Kid = kid;
-            Key = keyBytes;
+            _key = keyBytes;
         }
-
-        public byte[] Key { get; private set; }
-
+ 
+        [Obsolete("The Key property will be removed in a future release, please remove references to it")]
+        public byte[] Key
+        {
+            get
+            {
+                return _key;
+            }
+        }
+ 
         #region IKey Implementation
 
         public string Kid { get; protected set; }
@@ -106,7 +115,7 @@ namespace Microsoft.Azure.KeyVault
         {
             get
             {
-                switch ( Key.Length )
+                switch ( _key.Length )
                 {
                     case KeySize128:
                         return Aes128Cbc.AlgorithmName;
@@ -132,7 +141,7 @@ namespace Microsoft.Azure.KeyVault
         {
             get
             {
-                switch ( Key.Length )
+                switch ( _key.Length )
                 {
                     case KeySize128:
                         return AesKw128.AlgorithmName;
@@ -166,6 +175,9 @@ namespace Microsoft.Azure.KeyVault
 
         public async Task<byte[]> DecryptAsync( byte[] ciphertext, byte[] iv, byte[] authenticationData = null, byte[] authenticationTag = null, string algorithm = null, CancellationToken token = default(CancellationToken) )
         {
+            if ( _isDisposed )
+                throw new ObjectDisposedException( string.Format( "SymmetricKey {0} is disposed", Kid ) );
+ 
             if ( string.IsNullOrWhiteSpace( algorithm ) )
                 algorithm = DefaultEncryptionAlgorithm;
 
@@ -179,8 +191,8 @@ namespace Microsoft.Azure.KeyVault
 
             if ( algo == null )
                 throw new NotSupportedException( algorithm );
-
-            using ( var encryptor = algo.CreateDecryptor( Key, iv, authenticationData ) )
+ 
+            using ( var encryptor = algo.CreateDecryptor( _key, iv, authenticationData ) )
             {
                 var result    = encryptor.TransformFinalBlock( ciphertext, 0, ciphertext.Length );
                 var transform = encryptor as IAuthenticatedCryptoTransform;
@@ -200,6 +212,9 @@ namespace Microsoft.Azure.KeyVault
 
         public async Task<Tuple<byte[], byte[], string>> EncryptAsync( byte[] plaintext, byte[] iv, byte[] authenticationData = null, string algorithm = null, CancellationToken token = default(CancellationToken) )
         {
+            if ( _isDisposed )
+                throw new ObjectDisposedException( string.Format( "SymmetricKey {0} is disposed", Kid ) );
+ 
             if ( string.IsNullOrWhiteSpace( algorithm ) )
                 algorithm = DefaultEncryptionAlgorithm;
 
@@ -213,8 +228,8 @@ namespace Microsoft.Azure.KeyVault
 
             if ( algo == null )
                 throw new NotSupportedException( algorithm );
-
-            using ( var encryptor = algo.CreateEncryptor( Key, iv, authenticationData ) )
+ 
+            using ( var encryptor = algo.CreateEncryptor( _key, iv, authenticationData ) )
             {
                 var    cipherText        = encryptor.TransformFinalBlock( plaintext, 0, plaintext.Length );
                 byte[] authenticationTag = null;
@@ -231,6 +246,9 @@ namespace Microsoft.Azure.KeyVault
 
         public async Task<Tuple<byte[], string>> WrapKeyAsync( byte[] key, string algorithm = null, CancellationToken token = default(CancellationToken) )
         {
+            if ( _isDisposed )
+                throw new ObjectDisposedException( string.Format( "SymmetricKey {0} is disposed", Kid ) );
+ 
             if ( string.IsNullOrWhiteSpace( algorithm ) )
                 algorithm = DefaultKeyWrapAlgorithm;
 
@@ -241,8 +259,8 @@ namespace Microsoft.Azure.KeyVault
 
             if ( algo == null )
                 throw new NotSupportedException( algorithm );
-
-            using ( var encryptor = algo.CreateEncryptor( Key, null ) )
+ 
+            using ( var encryptor = algo.CreateEncryptor( _key, null ) )
             {
                 return new Tuple<byte[], string>( encryptor.TransformFinalBlock( key, 0, key.Length ), algorithm );
             }
@@ -250,18 +268,21 @@ namespace Microsoft.Azure.KeyVault
 
         public async Task<byte[]> UnwrapKeyAsync( byte[] encryptedKey, string algorithm = null, CancellationToken token = default(CancellationToken) )
         {
+            if ( _isDisposed )
+                throw new ObjectDisposedException( string.Format( "SymmetricKey {0} is disposed", Kid ) );
+ 
             if ( string.IsNullOrWhiteSpace( algorithm ) )
                 algorithm = DefaultKeyWrapAlgorithm;
 
             if ( encryptedKey == null || encryptedKey.Length == 0 )
-                throw new ArgumentNullException( "wrappedKey" );
-
+                throw new ArgumentNullException( "encryptedKey" );
+ 
             var algo = AlgorithmResolver.Default[algorithm] as KeyWrapAlgorithm;
 
             if ( algo == null )
                 throw new NotSupportedException( algorithm );
-
-            using ( var encryptor = algo.CreateDecryptor( Key, null ) )
+ 
+            using ( var encryptor = algo.CreateDecryptor( _key, null ) )
             {
                 return encryptor.TransformFinalBlock( encryptedKey, 0, encryptedKey.Length );
             }
@@ -289,7 +310,14 @@ namespace Microsoft.Azure.KeyVault
 
         protected virtual void Dispose( bool disposing )
         {
-            // Intentionally empty: IDisposable is the base for IKey
+            if ( disposing )
+            {
+                if ( !_isDisposed )
+                {
+                    _isDisposed = true;
+                    _key.Zero();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The change is to properly handle the disposing cached key by defining a CacheKey class that overrides the dispose functionality and only disposes the object when cache is disposed.

In SymmetricKey class Key property is getting deprecated and dispose is implemented.

KeyVaultKeyResolverTests is refactored and has a step to dispose the IDisposable objects.
