### PR TITLE
One missed change.

### DIFF
--- a/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/DataLakeStoreUploader.Tests.csproj
+++ b/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/DataLakeStoreUploader.Tests.csproj
@@ -36,8 +36,8 @@
     <Compile Include="UnitTests\UploadSegmentMetadataTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.Management.DataLake.Store, Version=0.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.10.0-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Management.DataLake.Store, Version=0.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.11.0-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/packages.config
+++ b/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.10.0-preview" targetFramework="net45" />
+  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.11.0-preview" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.0.1" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.0.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/DataLakeStoreUploader/DataLakeStoreFrontEndAdapter.cs
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/DataLakeStoreUploader/DataLakeStoreFrontEndAdapter.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Management.DataLake.StoreUploader
         {
             using (var toAppend = data != null ? new MemoryStream(data, 0, byteCount) : new MemoryStream())
             {
-                var task = _client.FileSystem.CreateAsync(streamPath, _accountName, toAppend, overwrite: overwrite, cancellationToken: _token);
+                var task = _client.FileSystem.CreateAsync(_accountName, streamPath, toAppend, overwrite: overwrite, cancellationToken: _token);
 
                 if (!task.Wait(PerRequestTimeoutMs))
                 {
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Management.DataLake.StoreUploader
         /// <param name="recurse">if set to <c>true</c> [recurse]. This is used for folder streams only.</param>
         public void DeleteStream(string streamPath, bool recurse = false)
         {
-            var task = _client.FileSystem.DeleteAsync(streamPath, _accountName, recurse, cancellationToken: _token);
+            var task = _client.FileSystem.DeleteAsync(_accountName, streamPath, recurse, cancellationToken: _token);
             if (!task.Wait(PerRequestTimeoutMs))
             {
                 throw new TaskCanceledException(string.Format("Delete stream operation did not complete after {0} milliseconds.", PerRequestTimeoutMs));
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Management.DataLake.StoreUploader
         {
             using (var stream = new MemoryStream(data, 0, byteCount))
             {
-                var task = _client.FileSystem.AppendAsync(streamPath, stream, _accountName, cancellationToken: _token);
+                var task = _client.FileSystem.AppendAsync(_accountName, streamPath, stream, cancellationToken: _token);
                 
                 if (!task.Wait(PerRequestTimeoutMs))
                 {
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.Management.DataLake.StoreUploader
         {
             try
             {
-                var task = _client.FileSystem.GetFileStatusAsync(streamPath, _accountName, cancellationToken: _token);
+                var task = _client.FileSystem.GetFileStatusAsync(_accountName, streamPath, cancellationToken: _token);
                 if (!task.Wait(PerRequestTimeoutMs))
                 {
                     throw new TaskCanceledException(
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Management.DataLake.StoreUploader
         /// </returns>
         public long GetStreamLength(string streamPath)
         {
-            var task = _client.FileSystem.GetFileStatusAsync(streamPath, _accountName, cancellationToken: _token);
+            var task = _client.FileSystem.GetFileStatusAsync(_accountName, streamPath, cancellationToken: _token);
 
             if (!task.Wait(PerRequestTimeoutMs))
             {
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.Management.DataLake.StoreUploader
             // For the current implementation, we require UTF8 encoding.
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(paths)))
             {
-                var task = _client.FileSystem.MsConcatAsync(targetStreamPath, stream, _accountName, true, cancellationToken: _token);
+                var task = _client.FileSystem.MsConcatAsync(_accountName, targetStreamPath, stream, true, cancellationToken: _token);
 
                 if (!task.Wait(PerRequestTimeoutMs))
                 {

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/DataLakeStoreUploader/UploadParameters.cs
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/DataLakeStoreUploader/UploadParameters.cs
@@ -35,9 +35,7 @@ namespace Microsoft.Azure.Management.DataLake.StoreUploader
         /// <param name="isBinary">(Optional) Indicates whether to treat the input file as a binary file (true), or whether to align upload blocks to record boundaries (false).</param>
         /// <param name="maxSegmentLength">Maximum length of each segment. The default is 256mb, which gives optimal performance. Modify at your own risk.</param>
         /// <param name="localMetadataLocation">(Optional) Indicates the directory path where to store the local upload metadata file while the upload is in progress. This location must be writeable from this application. Default location: SpecialFolder.LocalApplicationData.</param>
-        /// <param name="fileEncoding">(Optional) Indicates the type of encoding the file was saved in and should be interpreted as having. The default is UTF-8.</param>
-        /// <param name="delimiter">(Optional) Indicates the character delimter for record boundaries within the file, if any.This must be a single character. The default is new lines (\r, \n or \r\n).</param>
-        public UploadParameters(string inputFilePath, string targetStreamPath, string accountName, int threadCount = 1, bool isOverwrite = false, bool isResume = false, bool isBinary = true, long maxSegmentLength = 256*1024*1024, string localMetadataLocation = null, System.Text.Encoding fileEncoding = null, string delimiter = null)
+        public UploadParameters(string inputFilePath, string targetStreamPath, string accountName, int threadCount = 1, bool isOverwrite = false, bool isResume = false, bool isBinary = true, long maxSegmentLength = 256*1024*1024, string localMetadataLocation = null)
         {
             this.InputFilePath = inputFilePath;
             this.TargetStreamPath = targetStreamPath;
@@ -55,7 +53,10 @@ namespace Microsoft.Azure.Management.DataLake.StoreUploader
             this.LocalMetadataLocation = localMetadataLocation;
 
             this.UseSegmentBlockBackOffRetryStrategy = true;
-            this.FileEncoding = fileEncoding ?? System.Text.Encoding.UTF8;
+
+            // TODO: in the future we will expose these as optional parameters, allowing customers to specify encoding and delimiters.
+            this.FileEncoding = System.Text.Encoding.UTF8;
+            this.Delimiter = null;
         }
 
         /// <summary>
@@ -70,10 +71,8 @@ namespace Microsoft.Azure.Management.DataLake.StoreUploader
         /// <param name="isResume">(Optional) Indicates whether to resume a previously interrupted upload.</param>
         /// <param name="isBinary">(Optional) Indicates whether to treat the input file as a binary file (true), or whether to align upload blocks to record boundaries (false).</param>
         /// <param name="localMetadataLocation">(Optional) Indicates the directory path where to store the local upload metadata file while the upload is in progress. This location must be writeable from this application. Default location: SpecialFolder.LocalApplicationData.</param>
-        /// <param name="fileEncoding">(Optional) Indicates the type of encoding the file was saved in and should be interpreted as having. The default is UTF-8.</param>
-        /// <param name="delimiter">(Optional) Indicates the character delimter for record boundaries within the file, if any.This must be a single character. The default is new lines (\r, \n or \r\n).</param>
-        internal UploadParameters(string inputFilePath, string targetStreamPath, string accountName, bool useSegmentBlockBackOffRetryStrategy, int threadCount = 1, bool isOverwrite = false, bool isResume = false, bool isBinary = true, long maxSegmentLength = 256*1024*1024, string localMetadataLocation = null, System.Text.Encoding fileEncoding = null, string delimiter = null) :
-            this(inputFilePath, targetStreamPath, accountName, threadCount, isOverwrite, isResume, isBinary, maxSegmentLength, localMetadataLocation, fileEncoding, delimiter)
+        internal UploadParameters(string inputFilePath, string targetStreamPath, string accountName, bool useSegmentBlockBackOffRetryStrategy, int threadCount = 1, bool isOverwrite = false, bool isResume = false, bool isBinary = true, long maxSegmentLength = 256*1024*1024, string localMetadataLocation = null) :
+            this(inputFilePath, targetStreamPath, accountName, threadCount, isOverwrite, isResume, isBinary, maxSegmentLength, localMetadataLocation)
         {
             this.UseSegmentBlockBackOffRetryStrategy = useSegmentBlockBackOffRetryStrategy;
         }

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.csproj
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.Management.DataLake.Store">
-      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.10.0-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
+      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.11.0-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.nuspec
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.nuspec
@@ -22,7 +22,7 @@
       </group>
     </references>
     <dependencies>
-      <dependency id="Microsoft.Azure.Management.DataLake.Store" version="[0.10.0-preview,3.0)" />
+      <dependency id="Microsoft.Azure.Management.DataLake.Store" version="[0.11.0-preview,3.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/packages.config
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.10.0-preview" targetFramework="net45" />
+  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.11.0-preview" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.0.1" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.0.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />


### PR DESCRIPTION
The two new parameters for UploadParameters have been removed from public use for now to remove confusion for customers (since using them will not doing anything yet), but the infrastructure needs to be there.

Also, now that the DataLake.Store package is published I can rev the version of the package that this library uses and refactor the code as needed.
