### PR TITLE
Search SDK: Allowing redundant CreateOrUpdate methods to be generated

### DIFF
--- a/src/Search/Microsoft.Azure.Search/Customizations/DataSources/DataSourceOperations.Customization.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/DataSources/DataSourceOperations.Customization.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Azure.Search
     internal partial class DataSourcesOperations
     {
         /// <inheritdoc />
+        public Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return CreateOrUpdateWithHttpMessagesAsync(dataSource != null ? dataSource.Name : null, dataSource, searchRequestOptions, customHeaders, cancellationToken);
+        }
+        
+        /// <inheritdoc />
         public Task<AzureOperationResponse<bool>> ExistsWithHttpMessagesAsync(
             string dataSourceName, 
             SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), 

--- a/src/Search/Microsoft.Azure.Search/Customizations/DataSources/DataSourcesOperationsExtensions.Customization.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/DataSources/DataSourcesOperationsExtensions.Customization.cs
@@ -16,6 +16,48 @@ namespace Microsoft.Azure.Search
     public static partial class DataSourcesOperationsExtensions
     {
         /// <summary>
+        /// Creates a new Azure Search datasource or updates a datasource if it
+        /// already exists.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='dataSource'>
+        /// The definition of the datasource to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        public static DataSource CreateOrUpdate(this IDataSourcesOperations operations, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions))
+        {
+            return Task.Factory.StartNew(s => ((IDataSourcesOperations)s).CreateOrUpdateAsync(dataSource, searchRequestOptions), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Creates a new Azure Search datasource or updates a datasource if it
+        /// already exists.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='dataSource'>
+        /// The definition of the datasource to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        public static async Task<DataSource> CreateOrUpdateAsync(this IDataSourcesOperations operations, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(dataSource, searchRequestOptions, null, cancellationToken).ConfigureAwait(false))
+            {
+                return _result.Body;
+            }
+        }
+            
+        /// <summary>
         /// Determines whether or not the given data source exists in the Azure Search service.
         /// </summary>
         /// <param name='operations'>

--- a/src/Search/Microsoft.Azure.Search/Customizations/DataSources/IDataSourcesOperations.Customization.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/DataSources/IDataSourcesOperations.Customization.cs
@@ -13,6 +13,24 @@ namespace Microsoft.Azure.Search
     public partial interface IDataSourcesOperations
     {
         /// <summary>
+        /// Creates a new Azure Search datasource or updates a datasource if
+        /// it already exists.
+        /// </summary>
+        /// <param name='dataSource'>
+        /// The definition of the datasource to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Determines whether or not the given data source exists in the Azure Search service.
         /// </summary>
         /// <param name="dataSourceName">

--- a/src/Search/Microsoft.Azure.Search/Customizations/Indexers/IIndexersOperations.Customization.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Indexers/IIndexersOperations.Customization.cs
@@ -13,6 +13,24 @@ namespace Microsoft.Azure.Search
     public partial interface IIndexersOperations
     {
         /// <summary>
+        /// Creates a new Azure Search indexer or updates an indexer if it
+        /// already exists.
+        /// </summary>
+        /// <param name='indexer'>
+        /// The definition of the indexer to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Determines whether or not the given indexer exists in the Azure Search service.
         /// </summary>
         /// <param name="indexerName">

--- a/src/Search/Microsoft.Azure.Search/Customizations/Indexers/IndexersOperations.Customization.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Indexers/IndexersOperations.Customization.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Azure.Search
     internal partial class IndexersOperations
     {
         /// <inheritdoc />
+        public Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return CreateOrUpdateWithHttpMessagesAsync(indexer != null ? indexer.Name : null, indexer, searchRequestOptions, customHeaders, cancellationToken);
+        }
+        
+        /// <inheritdoc />
         public Task<AzureOperationResponse<bool>> ExistsWithHttpMessagesAsync(
             string indexerName,
             SearchRequestOptions searchRequestOptions = default(SearchRequestOptions),

--- a/src/Search/Microsoft.Azure.Search/Customizations/Indexers/IndexersOperationsExtensions.Customization.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Indexers/IndexersOperationsExtensions.Customization.cs
@@ -16,6 +16,48 @@ namespace Microsoft.Azure.Search
     public static partial class IndexersOperationsExtensions
     {
         /// <summary>
+        /// Creates a new Azure Search indexer or updates an indexer if it already
+        /// exists.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='indexer'>
+        /// The definition of the indexer to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        public static Indexer CreateOrUpdate(this IIndexersOperations operations, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions))
+        {
+            return Task.Factory.StartNew(s => ((IIndexersOperations)s).CreateOrUpdateAsync(indexer, searchRequestOptions), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Creates a new Azure Search indexer or updates an indexer if it already
+        /// exists.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='indexer'>
+        /// The definition of the indexer to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        public static async Task<Indexer> CreateOrUpdateAsync(this IIndexersOperations operations, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(indexer, searchRequestOptions, null, cancellationToken).ConfigureAwait(false))
+            {
+                return _result.Body;
+            }
+        }
+
+        /// <summary>
         /// Determines whether or not the given indexer exists in the Azure Search service.
         /// </summary>
         /// <param name='operations'>

--- a/src/Search/Microsoft.Azure.Search/Customizations/Indexes/IIndexesOperations.Customization.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Indexes/IIndexesOperations.Customization.cs
@@ -13,16 +13,22 @@ namespace Microsoft.Azure.Search
     public partial interface IIndexesOperations
     {
         /// <summary>
-        /// Creates a new index client for querying and managing documents in a given index.
+        /// Creates a new Azure Search index or updates an index if it already
+        /// exists.
         /// </summary>
-        /// <param name="indexName">The name of the index.</param>
-        /// <returns>A new <c cref="Microsoft.Azure.Search.SearchIndexClient">SearchIndexClient</c> instance.</returns>
-        /// <remarks>
-        /// The new client is configured with full read-write access to the index. If you are only planning to use the
-        /// client for query operations, we recommend directly creating a 
-        /// <c cref="Microsoft.Azure.Search.SearchIndexClient">SearchIndexClient</c> instance instead.
-        /// </remarks>
-        SearchIndexClient GetClient(string indexName);
+        /// <param name='index'>
+        /// The definition of the index to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Determines whether or not the given index exists in the Azure Search service.
@@ -43,5 +49,17 @@ namespace Microsoft.Azure.Search
         /// A response with the value <c>true</c> if the index exists; <c>false</c> otherwise.
         /// </returns>
         Task<AzureOperationResponse<bool>> ExistsWithHttpMessagesAsync(string indexName, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Creates a new index client for querying and managing documents in a given index.
+        /// </summary>
+        /// <param name="indexName">The name of the index.</param>
+        /// <returns>A new <c cref="Microsoft.Azure.Search.SearchIndexClient">SearchIndexClient</c> instance.</returns>
+        /// <remarks>
+        /// The new client is configured with full read-write access to the index. If you are only planning to use the
+        /// client for query operations, we recommend directly creating a 
+        /// <c cref="Microsoft.Azure.Search.SearchIndexClient">SearchIndexClient</c> instance instead.
+        /// </remarks>
+        SearchIndexClient GetClient(string indexName);
     }
 }

--- a/src/Search/Microsoft.Azure.Search/Customizations/Indexes/IndexesOperations.Customization.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Indexes/IndexesOperations.Customization.cs
@@ -13,14 +13,12 @@ namespace Microsoft.Azure.Search
 
     internal partial class IndexesOperations
     {
-        public SearchIndexClient GetClient(string indexName)
+        /// <inheritdoc />
+        public Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            // Argument checking is done by the SearchIndexClient constructor. Note that HttpClient can't be shared in
-            // case it has already been used (SearchIndexClient will attempt to set the Timeout property on it).
-            Uri indexBaseUri = new Uri(Client.BaseUri, String.Format("indexes('{0}')", indexName));
-            return new SearchIndexClient(indexBaseUri, Client.Credentials);
+            return CreateOrUpdateWithHttpMessagesAsync(index != null ? index.Name : null, index, searchRequestOptions, customHeaders, cancellationToken);
         }
-
+        
         /// <inheritdoc />
         public Task<AzureOperationResponse<bool>> ExistsWithHttpMessagesAsync(
             string indexName,
@@ -30,6 +28,15 @@ namespace Microsoft.Azure.Search
         {
             return ExistsHelper.ExistsFromGetResponse(() =>
                 this.GetWithHttpMessagesAsync(indexName, searchRequestOptions, customHeaders, cancellationToken));
+        }
+
+        /// <inheritdoc />
+        public SearchIndexClient GetClient(string indexName)
+        {
+            // Argument checking is done by the SearchIndexClient constructor. Note that HttpClient can't be shared in
+            // case it has already been used (SearchIndexClient will attempt to set the Timeout property on it).
+            Uri indexBaseUri = new Uri(Client.BaseUri, String.Format("indexes('{0}')", indexName));
+            return new SearchIndexClient(indexBaseUri, Client.Credentials);
         }
     }
 }

--- a/src/Search/Microsoft.Azure.Search/Customizations/Indexes/IndexesOperationsExtensions.Customization.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Indexes/IndexesOperationsExtensions.Customization.cs
@@ -18,6 +18,46 @@ namespace Microsoft.Azure.Search
     public static partial class IndexesOperationsExtensions
     {
         /// <summary>
+        /// Creates a new Azure Search index or updates an index if it already exists.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='index'>
+        /// The definition of the index to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        public static Index CreateOrUpdate(this IIndexesOperations operations, Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions))
+        {
+            return Task.Factory.StartNew(s => ((IIndexesOperations)s).CreateOrUpdateAsync(index, searchRequestOptions), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Creates a new Azure Search index or updates an index if it already exists.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='index'>
+        /// The definition of the index to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        public static async Task<Index> CreateOrUpdateAsync(this IIndexesOperations operations, Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(index, searchRequestOptions, null, cancellationToken).ConfigureAwait(false))
+            {
+                return _result.Body;
+            }
+        }
+
+        /// <summary>
         /// Determines whether or not the given index exists in the Azure Search service.
         /// </summary>
         /// <param name='operations'>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/DataSourcesOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/DataSourcesOperations.cs
@@ -53,6 +53,9 @@ namespace Microsoft.Azure.Search
         /// Creates a new Azure Search datasource or updates a datasource if it
         /// already exists.
         /// </summary>
+        /// <param name='dataSourceName'>
+        /// The name of the datasource to create or update.
+        /// </param>
         /// <param name='dataSource'>
         /// The definition of the datasource to create or update.
         /// </param>
@@ -68,8 +71,12 @@ namespace Microsoft.Azure.Search
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(string dataSourceName, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (dataSourceName == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "dataSourceName");
+            }
             if (dataSource == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "dataSource");
@@ -94,6 +101,7 @@ namespace Microsoft.Azure.Search
             {
                 _invocationId = ServiceClientTracing.NextInvocationId.ToString();
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("dataSourceName", dataSourceName);
                 tracingParameters.Add("dataSource", dataSource);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("cancellationToken", cancellationToken);
@@ -102,7 +110,7 @@ namespace Microsoft.Azure.Search
             // Construct URL
             var _baseUrl = this.Client.BaseUri.AbsoluteUri;
             var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "datasources('{dataSourceName}')").ToString();
-            _url = _url.Replace("{dataSourceName}", Uri.EscapeDataString(dataSource.Name));
+            _url = _url.Replace("{dataSourceName}", Uri.EscapeDataString(dataSourceName));
             List<string> _queryParameters = new List<string>();
             if (this.Client.ApiVersion != null)
             {

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/DataSourcesOperationsExtensions.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/DataSourcesOperationsExtensions.cs
@@ -29,15 +29,18 @@ namespace Microsoft.Azure.Search
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
+            /// <param name='dataSourceName'>
+            /// The name of the datasource to create or update.
+            /// </param>
             /// <param name='dataSource'>
             /// The definition of the datasource to create or update.
             /// </param>
             /// <param name='searchRequestOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static DataSource CreateOrUpdate(this IDataSourcesOperations operations, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions))
+            public static DataSource CreateOrUpdate(this IDataSourcesOperations operations, string dataSourceName, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions))
             {
-                return Task.Factory.StartNew(s => ((IDataSourcesOperations)s).CreateOrUpdateAsync(dataSource, searchRequestOptions), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return Task.Factory.StartNew(s => ((IDataSourcesOperations)s).CreateOrUpdateAsync(dataSourceName, dataSource, searchRequestOptions), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -46,6 +49,9 @@ namespace Microsoft.Azure.Search
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
+            /// </param>
+            /// <param name='dataSourceName'>
+            /// The name of the datasource to create or update.
             /// </param>
             /// <param name='dataSource'>
             /// The definition of the datasource to create or update.
@@ -56,9 +62,9 @@ namespace Microsoft.Azure.Search
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<DataSource> CreateOrUpdateAsync(this IDataSourcesOperations operations, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<DataSource> CreateOrUpdateAsync(this IDataSourcesOperations operations, string dataSourceName, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
-                using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(dataSource, searchRequestOptions, null, cancellationToken).ConfigureAwait(false))
+                using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(dataSourceName, dataSource, searchRequestOptions, null, cancellationToken).ConfigureAwait(false))
                 {
                     return _result.Body;
                 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IDataSourcesOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IDataSourcesOperations.cs
@@ -26,6 +26,9 @@ namespace Microsoft.Azure.Search
         /// Creates a new Azure Search datasource or updates a datasource if
         /// it already exists.
         /// </summary>
+        /// <param name='dataSourceName'>
+        /// The name of the datasource to create or update.
+        /// </param>
         /// <param name='dataSource'>
         /// The definition of the datasource to create or update.
         /// </param>
@@ -38,7 +41,7 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(string dataSourceName, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes an Azure Search datasource.
         /// </summary>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IIndexersOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IIndexersOperations.cs
@@ -59,6 +59,9 @@ namespace Microsoft.Azure.Search
         /// Creates a new Azure Search indexer or updates an indexer if it
         /// already exists.
         /// </summary>
+        /// <param name='indexerName'>
+        /// The name of the indexer to create or update.
+        /// </param>
         /// <param name='indexer'>
         /// The definition of the indexer to create or update.
         /// </param>
@@ -71,7 +74,7 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(string indexerName, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes an Azure Search indexer.
         /// </summary>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IIndexesOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IIndexesOperations.cs
@@ -60,6 +60,9 @@ namespace Microsoft.Azure.Search
         /// Creates a new Azure Search index or updates an index if it already
         /// exists.
         /// </summary>
+        /// <param name='indexName'>
+        /// The definition of the index to create or update.
+        /// </param>
         /// <param name='index'>
         /// The definition of the index to create or update.
         /// </param>
@@ -72,7 +75,7 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(string indexName, Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes an Azure Search index and all the documents it contains.
         /// </summary>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexersOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexersOperations.cs
@@ -361,6 +361,9 @@ namespace Microsoft.Azure.Search
         /// Creates a new Azure Search indexer or updates an indexer if it already
         /// exists.
         /// </summary>
+        /// <param name='indexerName'>
+        /// The name of the indexer to create or update.
+        /// </param>
         /// <param name='indexer'>
         /// The definition of the indexer to create or update.
         /// </param>
@@ -376,8 +379,12 @@ namespace Microsoft.Azure.Search
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(string indexerName, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (indexerName == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "indexerName");
+            }
             if (indexer == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "indexer");
@@ -402,6 +409,7 @@ namespace Microsoft.Azure.Search
             {
                 _invocationId = ServiceClientTracing.NextInvocationId.ToString();
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("indexerName", indexerName);
                 tracingParameters.Add("indexer", indexer);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("cancellationToken", cancellationToken);
@@ -410,7 +418,7 @@ namespace Microsoft.Azure.Search
             // Construct URL
             var _baseUrl = this.Client.BaseUri.AbsoluteUri;
             var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "indexers('{indexerName}')").ToString();
-            _url = _url.Replace("{indexerName}", Uri.EscapeDataString(indexer.Name));
+            _url = _url.Replace("{indexerName}", Uri.EscapeDataString(indexerName));
             List<string> _queryParameters = new List<string>();
             if (this.Client.ApiVersion != null)
             {

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexersOperationsExtensions.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexersOperationsExtensions.cs
@@ -103,15 +103,18 @@ namespace Microsoft.Azure.Search
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
+            /// <param name='indexerName'>
+            /// The name of the indexer to create or update.
+            /// </param>
             /// <param name='indexer'>
             /// The definition of the indexer to create or update.
             /// </param>
             /// <param name='searchRequestOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Indexer CreateOrUpdate(this IIndexersOperations operations, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions))
+            public static Indexer CreateOrUpdate(this IIndexersOperations operations, string indexerName, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions))
             {
-                return Task.Factory.StartNew(s => ((IIndexersOperations)s).CreateOrUpdateAsync(indexer, searchRequestOptions), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return Task.Factory.StartNew(s => ((IIndexersOperations)s).CreateOrUpdateAsync(indexerName, indexer, searchRequestOptions), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -120,6 +123,9 @@ namespace Microsoft.Azure.Search
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
+            /// </param>
+            /// <param name='indexerName'>
+            /// The name of the indexer to create or update.
             /// </param>
             /// <param name='indexer'>
             /// The definition of the indexer to create or update.
@@ -130,9 +136,9 @@ namespace Microsoft.Azure.Search
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<Indexer> CreateOrUpdateAsync(this IIndexersOperations operations, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<Indexer> CreateOrUpdateAsync(this IIndexersOperations operations, string indexerName, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
-                using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(indexer, searchRequestOptions, null, cancellationToken).ConfigureAwait(false))
+                using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(indexerName, indexer, searchRequestOptions, null, cancellationToken).ConfigureAwait(false))
                 {
                     return _result.Body;
                 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexesOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexesOperations.cs
@@ -432,6 +432,9 @@ namespace Microsoft.Azure.Search
         /// <summary>
         /// Creates a new Azure Search index or updates an index if it already exists.
         /// </summary>
+        /// <param name='indexName'>
+        /// The definition of the index to create or update.
+        /// </param>
         /// <param name='index'>
         /// The definition of the index to create or update.
         /// </param>
@@ -447,8 +450,12 @@ namespace Microsoft.Azure.Search
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(string indexName, Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (indexName == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "indexName");
+            }
             if (index == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "index");
@@ -473,6 +480,7 @@ namespace Microsoft.Azure.Search
             {
                 _invocationId = ServiceClientTracing.NextInvocationId.ToString();
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("indexName", indexName);
                 tracingParameters.Add("index", index);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("cancellationToken", cancellationToken);
@@ -481,7 +489,7 @@ namespace Microsoft.Azure.Search
             // Construct URL
             var _baseUrl = this.Client.BaseUri.AbsoluteUri;
             var _url = new Uri(new Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "indexes('{indexName}')").ToString();
-            _url = _url.Replace("{indexName}", Uri.EscapeDataString(index.Name));
+            _url = _url.Replace("{indexName}", Uri.EscapeDataString(indexName));
             List<string> _queryParameters = new List<string>();
             if (this.Client.ApiVersion != null)
             {

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexesOperationsExtensions.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexesOperationsExtensions.cs
@@ -112,15 +112,18 @@ namespace Microsoft.Azure.Search
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
+            /// <param name='indexName'>
+            /// The definition of the index to create or update.
+            /// </param>
             /// <param name='index'>
             /// The definition of the index to create or update.
             /// </param>
             /// <param name='searchRequestOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Index CreateOrUpdate(this IIndexesOperations operations, Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions))
+            public static Index CreateOrUpdate(this IIndexesOperations operations, string indexName, Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions))
             {
-                return Task.Factory.StartNew(s => ((IIndexesOperations)s).CreateOrUpdateAsync(index, searchRequestOptions), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return Task.Factory.StartNew(s => ((IIndexesOperations)s).CreateOrUpdateAsync(indexName, index, searchRequestOptions), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -128,6 +131,9 @@ namespace Microsoft.Azure.Search
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
+            /// </param>
+            /// <param name='indexName'>
+            /// The definition of the index to create or update.
             /// </param>
             /// <param name='index'>
             /// The definition of the index to create or update.
@@ -138,9 +144,9 @@ namespace Microsoft.Azure.Search
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<Index> CreateOrUpdateAsync(this IIndexesOperations operations, Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<Index> CreateOrUpdateAsync(this IIndexesOperations operations, string indexName, Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
-                using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(index, searchRequestOptions, null, cancellationToken).ConfigureAwait(false))
+                using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(indexName, index, searchRequestOptions, null, cancellationToken).ConfigureAwait(false))
                 {
                     return _result.Body;
                 }


### PR DESCRIPTION
This is related to the following issue: https://github.com/Azure/autorest/issues/382

Azure Search doesn't support renaming resources, so strictly speaking the overloads that take an extra name parameter are not required, but it doesn't hurt anything to have them there in case we support rename in the future. At least by moving our preferred overloads of `CreateOrUpdate` to custom code, we
can stop fighting the code generator.
