### PR TITLE
Fix for #1619: fixed property name and updated portable and net40 configurations

### DIFF
--- a/src/KeyVault/KeyVault.Tests/KeyVaultTestFixture.cs
+++ b/src/KeyVault/KeyVault.Tests/KeyVaultTestFixture.cs
@@ -56,7 +56,7 @@ namespace KeyVault.Tests
                     var secret = Guid.NewGuid().ToString();
                     var mgmtClient = TestBase.GetServiceClient<KeyVaultManagementClient>(testFactory);
                     var resourcesClient = TestBase.GetServiceClient<ResourceManagementClient>(testFactory);
-                    var tenantId = testEnv.AuthorizationContext.TenatId;
+                    var tenantId = testEnv.AuthorizationContext.TenantId;
                     var graphClient = TestBase.GetGraphServiceClient<GraphRbacManagementClient>(testFactory, tenantId);
                     var appDisplayName = TestUtilities.GenerateName("sdktestapp");
 
@@ -196,7 +196,7 @@ namespace KeyVault.Tests
                 var testEnv = testFactory.GetTestEnvironment();
                 var mgmtClient = TestBase.GetServiceClient<KeyVaultManagementClient>(testFactory);
                 var resourcesClient = TestBase.GetServiceClient<ResourceManagementClient>(testFactory);
-                var tenantId = testEnv.AuthorizationContext.TenatId;
+                var tenantId = testEnv.AuthorizationContext.TenantId;
                 var graphClient = TestBase.GetGraphServiceClient<GraphRbacManagementClient>(testFactory, tenantId);
 
                 mgmtClient.Vaults.Delete(rgName, vaultName);

--- a/src/KeyVault/KeyVault.sln
+++ b/src/KeyVault/KeyVault.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24709.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestDependencies", "..\TestDependencies\TestDependencies.csproj", "{40F35645-00EE-4DF2-B66E-7624546B66DF}"
 EndProject
@@ -45,16 +45,16 @@ Global
 		{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
 		{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56}.Net45-Release|Any CPU.Build.0 = Net45-Release|Any CPU
-		{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56}.Portable-Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
-		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Net40-Debug|Any CPU.ActiveCfg = Net40-Debug|Any CPU
-		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Net40-Release|Any CPU.ActiveCfg = Net40-Release|Any CPU
+		{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56}.Portable-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
+		{BEC7DBF7-A3B1-4088-BDFF-C1C2A0FD6F56}.Portable-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
+		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Net40-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
+		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Net40-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
 		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
 		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
 		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Net45-Release|Any CPU.Build.0 = Net45-Release|Any CPU
-		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Portable-Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
+		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Portable-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
+		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Portable-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
 		{B419782D-CA57-40F9-9322-340A4E852E82}.Net40-Debug|Any CPU.ActiveCfg = Net40-Debug|Any CPU
 		{B419782D-CA57-40F9-9322-340A4E852E82}.Net40-Debug|Any CPU.Build.0 = Net40-Debug|Any CPU
 		{B419782D-CA57-40F9-9322-340A4E852E82}.Net40-Release|Any CPU.ActiveCfg = Net40-Release|Any CPU
@@ -75,8 +75,8 @@ Global
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
 		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Net45-Release|Any CPU.Build.0 = Net45-Release|Any CPU
-		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
-		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
+		{937E445A-5604-4998-A9F5-9BE1E39001A4}.Portable-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Changed configuration for KeyVault.Test in Net40 and Portable configs to Net45 since they use some APIs that are available only in NET45.

cc @markcowl 
