### PR TITLE
[DO NOT MERGE]: Add support for WindowsAzure.Storage 7.0.0

### DIFF
--- a/src/ResourceManagement/HDInsightJob/HDInsightJob/HDInsightJob.csproj
+++ b/src/ResourceManagement/HDInsightJob/HDInsightJob/HDInsightJob.csproj
@@ -21,7 +21,7 @@
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\WindowsAzure.Storage.6.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>..\..\..\..\packages\WindowsAzure.Storage.7.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/ResourceManagement/HDInsightJob/HDInsightJob/Microsoft.Azure.Management.HDInsight.Job.nuget.proj
+++ b/src/ResourceManagement/HDInsightJob/HDInsightJob/Microsoft.Azure.Management.HDInsight.Job.nuget.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <SdkNuGetPackage Include="Microsoft.Azure.Management.HDInsight.Job">
-      <PackageVersion>2.0.2</PackageVersion>
+      <PackageVersion>2.0.3</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/HDInsightJob/HDInsightJob/Microsoft.Azure.Management.HDInsight.Job.nuspec
+++ b/src/ResourceManagement/HDInsightJob/HDInsightJob/Microsoft.Azure.Management.HDInsight.Job.nuspec
@@ -84,7 +84,7 @@ The methods “GetJobOutput”(+Async) and “GetJobErrorLogsAsync”(+Async) no
     </references>
     <dependencies>
       <dependency id="Microsoft.Azure.Common" version="[2.1.0,3.0)" />
-      <dependency id="WindowsAzure.Storage" version="[6.0.0,7.0)" />
+      <dependency id="WindowsAzure.Storage" version="[6.0.0,8.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/ResourceManagement/HDInsightJob/HDInsightJob/Microsoft.Azure.Management.HDInsight.Job.nuspec
+++ b/src/ResourceManagement/HDInsightJob/HDInsightJob/Microsoft.Azure.Management.HDInsight.Job.nuspec
@@ -4,6 +4,9 @@
     <id>Microsoft.Azure.Management.HDInsight.Job</id>
     <title>Microsoft Azure HDInsight Job Management Library</title>
     <releaseNotes><![CDATA[
+2.0.3
+  * Updated WindowsAzure.Storage to 7.0.0
+
 2.0.2
   * This package is now generally available.
   
@@ -84,7 +87,7 @@ The methods “GetJobOutput”(+Async) and “GetJobErrorLogsAsync”(+Async) no
     </references>
     <dependencies>
       <dependency id="Microsoft.Azure.Common" version="[2.1.0,3.0)" />
-      <dependency id="WindowsAzure.Storage" version="[6.0.0,8.0)" />
+      <dependency id="WindowsAzure.Storage" version="[7.0.0,7.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/ResourceManagement/HDInsightJob/HDInsightJob/packages.config
+++ b/src/ResourceManagement/HDInsightJob/HDInsightJob/packages.config
@@ -8,5 +8,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="6.0.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net45" />
 </packages>

--- a/src/TestDependencies/TestDependencies.csproj
+++ b/src/TestDependencies/TestDependencies.csproj
@@ -49,9 +49,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(LibraryNugetPackageFolder)\Microsoft.WindowsAzure.ConfigurationManager.3.2.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(LibraryNugetPackageFolder)\WindowsAzure.Storage.6.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>$(LibraryNugetPackageFolder)\WindowsAzure.Storage.7.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/TestDependencies/packages.config
+++ b/src/TestDependencies/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net451" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
-  <package id="WindowsAzure.Storage" version="6.0.0" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net451" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net451" />
   
   <package id="xunit" version="1.9.2" targetFramework="net451" />

--- a/tools/Test.Dependencies.target
+++ b/tools/Test.Dependencies.target
@@ -80,7 +80,7 @@
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(LibraryNugetPackageFolder)\WindowsAzure.Storage.6.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <HintPath>$(LibraryNugetPackageFolder)\WindowsAzure.Storage.7.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core">
       <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>


### PR DESCRIPTION
Attempting to gather dependency information for package 'WindowsAzure.Storage.7.0.0' with respect to project 'MyHdiProject', targeting '.NETFramework,Version=v4.5.2'
Attempting to resolve dependencies for package 'WindowsAzure.Storage.7.0.0' with DependencyBehavior 'Lowest'
Unable to resolve dependencies. 'WindowsAzure.Storage 7.0.0' is not compatible with 'Microsoft.Azure.Management.HDInsight.Job 2.0.2 constraint: WindowsAzure.Storage (>= 6.0.0 && < 7.0.0)'.
