### PR TITLE
Bumping Up Nuget Proj Version of Recovery Services Backup module

### DIFF
--- a/src/ResourceManagement/RecoveryServices.Backup/RecoveryServicesBackupManagement/Microsoft.Azure.Management.RecoveryServices.Backup.nuget.proj
+++ b/src/ResourceManagement/RecoveryServices.Backup/RecoveryServicesBackupManagement/Microsoft.Azure.Management.RecoveryServices.Backup.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.RecoveryServices
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.RecoveryServices.Backup">
-      <PackageVersion>0.1.0-preview</PackageVersion>
+      <PackageVersion>0.1.1-preview</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/RecoveryServices.Backup/RecoveryServicesBackupManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/RecoveryServices.Backup/RecoveryServicesBackupManagement/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure Backup Services.")]
 
 [assembly: AssemblyVersion("0.9.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
This PR is to bump up the nuget project version of the Recovery Services Backup module from 0.1.0-preview to 0.1.1-preview. 

We've added an extra property ProtectedItemsCount to ProtectionPolicy base class in the RecoveryServices.Backup module. Also, we have modified the class hierarchy to accommodate this change. 

This change was merged as part of a previous PR: https://github.com/Azure/hydra-specs-pr/pull/1294
