### PR TITLE
Introduce an overload of ActivityWindowOperationExtensions.List

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Operations/ActivityWindows/ActivityWindowOperationsExtensions.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Operations/ActivityWindows/ActivityWindowOperationsExtensions.cs
@@ -162,6 +162,30 @@ namespace Microsoft.Azure.Management.DataFactories
         /// <returns>
         /// The List activity windows operation response.
         /// </returns>
+        public static ActivityWindowListResponse List(this IActivityWindowOperations operations, ActivityWindowsByActivityListParameters parameters)
+        {
+            return Task.Factory.StartNew((object s) =>
+            {
+                return ((IActivityWindowOperations)s).ListAsync(parameters);
+            }
+            , operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Use List(ActivityWindowsByActivityListParameters parameters) instead. This will be deprecated soon.
+        /// Gets the first page of activity window instances for a pipeline
+        /// activity with the link to the next page.
+        /// </summary>
+        /// <param name='operations'>
+        /// Reference to the
+        /// Microsoft.Azure.Management.DataFactories.Core.IActivityWindowOperations.
+        /// </param>
+        /// <param name='parameters'>
+        /// Required. Activity windows list by pipeline activity parameters.
+        /// </param>
+        /// <returns>
+        /// The List activity windows operation response.
+        /// </returns>
         public static ActivityWindowListResponse ListByPipelineActivity(this IActivityWindowOperations operations, ActivityWindowsByActivityListParameters parameters)
         {
             return Task.Factory.StartNew((object s) =>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
@@ -1,5 +1,10 @@
 For additional details on features, see the full [Azure Data Factory Release Notes](https://azure.microsoft.com/en-us/documentation/articles/data-factory-release-notes). 
 
+## Version 4.10.0
+_Release date: 2016.06.03_
+
+### Bug fix
+* Introduce an overload of ActivityWindowOperationExtensions.List() which takes an ActivityWindowsByActivityListParameters instance. 
 
 ## Version 4.9.0
 _Release date: 2016.06.03_ 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataFactories
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataFactories">
-      <PackageVersion>4.9.0</PackageVersion>
+      <PackageVersion>4.10.0</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Factory management operations.")]
 
 [assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.9.0.0")]
+[assembly: AssemblyFileVersion("4.10.0.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
Introduce an overload of ActivityWindowOperationExtensions.List() which takes an ActivityWindowsByActivityListParameters instance.
