### PR TITLE
Search SDK: Fixing more .NET Core port-related build errors

### DIFF
--- a/src/Search/Search.Management.Tests/project.json
+++ b/src/Search/Search.Management.Tests/project.json
@@ -28,7 +28,6 @@
       "type": "platform", 
       "version": "1.0.0-rc2-*" 
     }, 
-    "Microsoft.Azure.Test.HttpRecorder": "[1.6.1-preview,2.0.0)",
     "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "[1.2.2-preview,2.0.0)",
     "Microsoft.Rest.ClientRuntime.Azure": "[4.0.2,5.0.0)",
     "Microsoft.Azure.Management.ResourceManager": "1.1.2-preview",

--- a/src/Search/Search.sln
+++ b/src/Search/Search.sln
@@ -9,12 +9,6 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Search", "M
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Search.Tests", "Search.Tests\Search.Tests.xproj", "{3B082B9B-96DD-4112-88E3-BE89BAE124C1}"
 EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "HttpRecorder", "..\TestFramework\Microsoft.Azure.Test.HttpRecorder\HttpRecorder.xproj", "{5D12D45A-E55F-410E-B8AF-9DC90E81B237}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "TestFramework", "..\TestFramework\Microsoft.Rest.ClientRuntime.Azure.TestFramework\TestFramework.xproj", "{C4C4E1C8-B99D-4D90-8C27-6D0C0A268BA5}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.ResourceManager", "..\ResourceManagement\Resource\Microsoft.Azure.Management.ResourceManager\Microsoft.Azure.Management.ResourceManager.xproj", "{A5986BDB-0D0D-48AA-9E49-ECE96BAC8ADE}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,18 +27,6 @@ Global
 		{3B082B9B-96DD-4112-88E3-BE89BAE124C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B082B9B-96DD-4112-88E3-BE89BAE124C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B082B9B-96DD-4112-88E3-BE89BAE124C1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5D12D45A-E55F-410E-B8AF-9DC90E81B237}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5D12D45A-E55F-410E-B8AF-9DC90E81B237}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5D12D45A-E55F-410E-B8AF-9DC90E81B237}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5D12D45A-E55F-410E-B8AF-9DC90E81B237}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C4C4E1C8-B99D-4D90-8C27-6D0C0A268BA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C4C4E1C8-B99D-4D90-8C27-6D0C0A268BA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C4C4E1C8-B99D-4D90-8C27-6D0C0A268BA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C4C4E1C8-B99D-4D90-8C27-6D0C0A268BA5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8ADE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8ADE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8ADE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8ADE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Search/global.json
+++ b/src/Search/global.json
@@ -1,3 +1,3 @@
 {
-  "projects": [ "../TestFramework", "Microsoft.Azure.Search", "Search.Management.Tests", "Search.Tests" ]
+  "projects": [ "Microsoft.Azure.Search", "Search.Management.Tests", "Search.Tests" ]
 }


### PR DESCRIPTION
There was a very persistent error about a duplicate key 'HttpTestRecorder' until I removed all test projects from the .sln and global.json files.

FYI @chaosrealm @seansaleh @Yahnoosh @mhko 

@hovsepm Any idea why these problems aren't being caught by the CI build? I don't think it's specific to my local machine.
