### PR TITLE
[ADF]Mark WriteBatchSize and WriteBatchTimeout as optional properties

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Activities/CopySinks/CopySink.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Activities/CopySinks/CopySink.cs
@@ -25,13 +25,11 @@ namespace Microsoft.Azure.Management.DataFactories.Models
         /// <summary>
         /// Write batch size.
         /// </summary>
-        [AdfRequired]
         public int WriteBatchSize { get; set; }
 
         /// <summary>
         /// Write batch timeout.
         /// </summary>
-        [AdfRequired]
         public TimeSpan WriteBatchTimeout { get; set; }
 
         /// <summary>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
@@ -1,17 +1,17 @@
 For additional details on features, see the full [Azure Data Factory Release Notes](https://azure.microsoft.com/en-us/documentation/articles/data-factory-release-notes). 
 
-## Version 4.10.0
-_Release date: 2016.06.03_
-
-### Bug fix
-* Introduce an overload of ActivityWindowOperationExtensions.List() which takes an ActivityWindowsByActivityListParameters instance. 
-
 ## Version 4.9.0
-_Release date: 2016.06.03_ 
+_Release date: 2016.06.10_ 
 
 ### Feature Additions
+
 * Add EnableStaging and StagingSettings properties to CopyActivity
     * Enable copy via interim staging.
+
+### Bug fix
+
+* Introduce an overload of ActivityWindowOperationExtensions.List() which takes an ActivityWindowsByActivityListParameters instance. 
+* Mark WriteBatchSize and WriteBatchTimeout as optional in CopySink.
 
 ## Version 4.8.0
 _Release date: 2016.05.25_

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataFactories
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataFactories">
-      <PackageVersion>4.10.0</PackageVersion>
+      <PackageVersion>4.9.0</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
@@ -3,7 +3,7 @@
   <metadata minClientVersion="2.5">
     <id>Microsoft.Azure.Management.DataFactories</id>
     <title>Microsoft Azure Data Factory Management Library</title>
-    <releaseNotes>https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log/#version-480</releaseNotes>
+    <releaseNotes>https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log/#version-490</releaseNotes>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>azure-sdk, Microsoft</owners>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Factory management operations.")]
 
 [assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.10.0.0")]
+[assembly: AssemblyFileVersion("4.9.0.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
1. Mark the two properties as Optional in CopySink
2. Rename version to 4.9.0 as neither 4.9.0 or 4.10.0 has been published to Nuget.org yet. I had to revert them to 4.9.0 and then publish 4.9.0 first. 
