### PR TITLE
Update to use the latest store package.

### DIFF
--- a/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/DataLakeStoreUploader.Tests.csproj
+++ b/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/DataLakeStoreUploader.Tests.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.Management.DataLake.Store, Version=0.12.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.12.0-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
+      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.12.2-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/packages.config
+++ b/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.12.0-preview" targetFramework="net45" />
+  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.12.2-preview" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.csproj
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.csproj
@@ -67,7 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.Management.DataLake.Store">
-      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.12.0-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
+      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.12.2-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.nuspec
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.nuspec
@@ -22,7 +22,7 @@
       </group>
     </references>
     <dependencies>
-      <dependency id="Microsoft.Azure.Management.DataLake.Store" version="[0.12.0-preview,3.0)" />
+      <dependency id="Microsoft.Azure.Management.DataLake.Store" version="[0.12.2-preview,3.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/packages.config
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.12.0-preview" targetFramework="net45" />
+  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.12.2-preview" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />


### PR DESCRIPTION
This brings the ADLS Uploader package dependencies up to the latest published, which we need for some minor performance and documentation improvements.
