### PR TITLE
Search SDK: Regenerating v2-preview code with new AutoRest version

### DIFF
--- a/src/Search/Microsoft.Azure.Management.Search/Generated/AdminKeysOperations.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Generated/AdminKeysOperations.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='client'>
         /// Reference to the service client.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         internal AdminKeysOperations(SearchManagementClient client)
         {
             if (client == null) 
@@ -52,6 +55,7 @@ namespace Microsoft.Azure.Management.Search
         /// <summary>
         /// Returns the primary and secondary API keys for the given Azure Search
         /// service.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn832685.aspx" />
         /// </summary>
         /// <param name='resourceGroupName'>
         /// The name of the resource group within the current subscription.
@@ -65,6 +69,15 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>

--- a/src/Search/Microsoft.Azure.Management.Search/Generated/AdminKeysOperationsExtensions.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Generated/AdminKeysOperationsExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Management.Search
             /// <summary>
             /// Returns the primary and secondary API keys for the given Azure Search
             /// service.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn832685.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -43,6 +44,7 @@ namespace Microsoft.Azure.Management.Search
             /// <summary>
             /// Returns the primary and secondary API keys for the given Azure Search
             /// service.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn832685.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/Search/Microsoft.Azure.Management.Search/Generated/IAdminKeysOperations.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Generated/IAdminKeysOperations.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Management.Search
         /// <summary>
         /// Returns the primary and secondary API keys for the given Azure
         /// Search service.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn832685.aspx" />
         /// </summary>
         /// <param name='resourceGroupName'>
         /// The name of the resource group within the current subscription.
@@ -38,6 +39,15 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<AdminKeyResult>> ListWithHttpMessagesAsync(string resourceGroupName, string serviceName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Search/Microsoft.Azure.Management.Search/Generated/IQueryKeysOperations.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Generated/IQueryKeysOperations.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Management.Search
         /// <summary>
         /// Returns the list of query API keys for the given Azure Search
         /// service.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn832701.aspx" />
         /// </summary>
         /// <param name='resourceGroupName'>
         /// The name of the resource group within the current subscription.
@@ -38,6 +39,15 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<ListQueryKeysResult>> ListWithHttpMessagesAsync(string resourceGroupName, string serviceName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Search/Microsoft.Azure.Management.Search/Generated/ISearchManagementClient.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Generated/ISearchManagementClient.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Management.Search
         JsonSerializerSettings DeserializationSettings { get; }
 
         /// <summary>
-        /// Gets Azure subscription credentials.
+        /// Credentials needed for the client to connect to Azure.
         /// </summary>
         ServiceClientCredentials Credentials { get; }
 

--- a/src/Search/Microsoft.Azure.Management.Search/Generated/IServicesOperations.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Generated/IServicesOperations.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.Management.Search
         /// Creates or updates a Search service in the given resource group.
         /// If the Search service already exists, all properties will be
         /// updated with the given values.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn832687.aspx" />
         /// </summary>
         /// <param name='resourceGroupName'>
         /// The name of the resource group within the current subscription.
@@ -42,10 +43,20 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<SearchServiceResource>> CreateOrUpdateWithHttpMessagesAsync(string resourceGroupName, string serviceName, SearchServiceCreateOrUpdateParameters parameters, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes a Search service in the given resource group, along with
         /// its associated resources.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn832692.aspx" />
         /// </summary>
         /// <param name='resourceGroupName'>
         /// The name of the resource group within the current subscription.
@@ -59,9 +70,16 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse> DeleteWithHttpMessagesAsync(string resourceGroupName, string serviceName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Returns a list of all Search services in the given resource group.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn832688.aspx" />
         /// </summary>
         /// <param name='resourceGroupName'>
         /// The name of the resource group within the current subscription.
@@ -72,6 +90,15 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<SearchServiceListResult>> ListWithHttpMessagesAsync(string resourceGroupName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Search/Microsoft.Azure.Management.Search/Generated/QueryKeysOperations.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Generated/QueryKeysOperations.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='client'>
         /// Reference to the service client.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         internal QueryKeysOperations(SearchManagementClient client)
         {
             if (client == null) 
@@ -51,6 +54,7 @@ namespace Microsoft.Azure.Management.Search
 
         /// <summary>
         /// Returns the list of query API keys for the given Azure Search service.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn832701.aspx" />
         /// </summary>
         /// <param name='resourceGroupName'>
         /// The name of the resource group within the current subscription.
@@ -64,6 +68,15 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>

--- a/src/Search/Microsoft.Azure.Management.Search/Generated/QueryKeysOperationsExtensions.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Generated/QueryKeysOperationsExtensions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.Management.Search
     {
             /// <summary>
             /// Returns the list of query API keys for the given Azure Search service.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn832701.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -41,6 +42,7 @@ namespace Microsoft.Azure.Management.Search
 
             /// <summary>
             /// Returns the list of query API keys for the given Azure Search service.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn832701.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/Search/Microsoft.Azure.Management.Search/Generated/SearchManagementClient.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Generated/SearchManagementClient.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Management.Search
         public JsonSerializerSettings DeserializationSettings { get; private set; }        
 
         /// <summary>
-        /// Gets Azure subscription credentials.
+        /// Credentials needed for the client to connect to Azure.
         /// </summary>
         public ServiceClientCredentials Credentials { get; private set; }
 
@@ -128,6 +128,9 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         protected SearchManagementClient(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
@@ -149,6 +152,9 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         protected SearchManagementClient(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
@@ -162,11 +168,14 @@ namespace Microsoft.Azure.Management.Search
         /// Initializes a new instance of the SearchManagementClient class.
         /// </summary>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchManagementClient(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (credentials == null)
@@ -184,7 +193,7 @@ namespace Microsoft.Azure.Management.Search
         /// Initializes a new instance of the SearchManagementClient class.
         /// </summary>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='rootHandler'>
         /// Optional. The http client handler used to handle http transport.
@@ -192,6 +201,9 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchManagementClient(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (credentials == null)
@@ -212,11 +224,14 @@ namespace Microsoft.Azure.Management.Search
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchManagementClient(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
@@ -242,7 +257,7 @@ namespace Microsoft.Azure.Management.Search
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='rootHandler'>
         /// Optional. The http client handler used to handle http transport.
@@ -250,6 +265,9 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchManagementClient(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
@@ -268,6 +286,10 @@ namespace Microsoft.Azure.Management.Search
             }
         }
 
+        /// <summary>
+        /// An optional partial-method to perform custom initialization.
+        /// </summary>
+        partial void CustomInitialize();
         /// <summary>
         /// Initializes client properties.
         /// </summary>
@@ -306,6 +328,7 @@ namespace Microsoft.Azure.Management.Search
                         new Iso8601TimeSpanConverter()
                     }
             };
+            CustomInitialize();
             DeserializationSettings.Converters.Add(new CloudErrorJsonConverter()); 
         }    
     }

--- a/src/Search/Microsoft.Azure.Management.Search/Generated/ServicesOperations.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Generated/ServicesOperations.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='client'>
         /// Reference to the service client.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         internal ServicesOperations(SearchManagementClient client)
         {
             if (client == null) 
@@ -53,6 +56,7 @@ namespace Microsoft.Azure.Management.Search
         /// Creates or updates a Search service in the given resource group. If the
         /// Search service already exists, all properties will be updated with the
         /// given values.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn832687.aspx" />
         /// </summary>
         /// <param name='resourceGroupName'>
         /// The name of the resource group within the current subscription.
@@ -69,6 +73,15 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -268,6 +281,7 @@ namespace Microsoft.Azure.Management.Search
         /// <summary>
         /// Deletes a Search service in the given resource group, along with its
         /// associated resources.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn832692.aspx" />
         /// </summary>
         /// <param name='resourceGroupName'>
         /// The name of the resource group within the current subscription.
@@ -281,6 +295,12 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -384,7 +404,12 @@ namespace Microsoft.Azure.Management.Search
             if ((int)_statusCode != 200 && (int)_statusCode != 404 && (int)_statusCode != 204)
             {
                 var ex = new CloudException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_httpResponse.Headers.Contains("x-ms-request-id"))
@@ -419,6 +444,7 @@ namespace Microsoft.Azure.Management.Search
 
         /// <summary>
         /// Returns a list of all Search services in the given resource group.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn832688.aspx" />
         /// </summary>
         /// <param name='resourceGroupName'>
         /// The name of the resource group within the current subscription.
@@ -429,6 +455,15 @@ namespace Microsoft.Azure.Management.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>

--- a/src/Search/Microsoft.Azure.Management.Search/Generated/ServicesOperationsExtensions.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Generated/ServicesOperationsExtensions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.Management.Search
             /// Creates or updates a Search service in the given resource group. If the
             /// Search service already exists, all properties will be updated with the
             /// given values.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn832687.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -48,6 +49,7 @@ namespace Microsoft.Azure.Management.Search
             /// Creates or updates a Search service in the given resource group. If the
             /// Search service already exists, all properties will be updated with the
             /// given values.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn832687.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -75,6 +77,7 @@ namespace Microsoft.Azure.Management.Search
             /// <summary>
             /// Deletes a Search service in the given resource group, along with its
             /// associated resources.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn832692.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -93,6 +96,7 @@ namespace Microsoft.Azure.Management.Search
             /// <summary>
             /// Deletes a Search service in the given resource group, along with its
             /// associated resources.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn832692.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -113,6 +117,7 @@ namespace Microsoft.Azure.Management.Search
 
             /// <summary>
             /// Returns a list of all Search services in the given resource group.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn832688.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -127,6 +132,7 @@ namespace Microsoft.Azure.Management.Search
 
             /// <summary>
             /// Returns a list of all Search services in the given resource group.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn832688.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/Search/Microsoft.Azure.Management.Search/generate.cmd
+++ b/src/Search/Microsoft.Azure.Management.Search/generate.cmd
@@ -4,7 +4,7 @@
 ::
 
 @echo off
-set autoRestVersion=0.17.0-Nightly20160522
+set autoRestVersion=0.17.0-Nightly20160626
 if  "%1" == "" (
     set specFile="https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-search/2015-02-28/swagger/search.json"
 ) else (

--- a/src/Search/Microsoft.Azure.Search/Fix-GeneratedCode.ps1
+++ b/src/Search/Microsoft.Azure.Search/Fix-GeneratedCode.ps1
@@ -12,7 +12,3 @@ Replace-InFile $generatedFolder\IDocumentsProxyOperations.cs "public partial int
 # Change the public property on ISearchIndexClient and SearchIndexClient to refer to our public interface instead of the internal one.
 Replace-InFile $generatedFolder\ISearchIndexClient.cs "DocumentsProxy" "Documents"
 Replace-InFile $generatedFolder\SearchIndexClient.cs "DocumentsProxy" "Documents"
-
-# Inject initialization method into SearchIndexClient. This is a workaround for this issue in AutoRest: https://github.com/Azure/autorest/issues/1087
-Replace-InFile $generatedFolder\SearchIndexClient.cs "private void Initialize()" "partial void CustomInitialize();`r`n`r`n        private void Initialize()"
-Replace-InFile $generatedFolder\SearchIndexClient.cs "DeserializationSettings.Converters.Add(new CloudErrorJsonConverter());" "DeserializationSettings.Converters.Add(new CloudErrorJsonConverter());`r`n            CustomInitialize();"

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchIndex/DocumentsProxyOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchIndex/DocumentsProxyOperations.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Azure.Search
         /// <param name='client'>
         /// Reference to the service client.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         internal DocumentsProxyOperations(SearchIndexClient client)
         {
             if (client == null) 
@@ -51,6 +54,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Queries the number of documents in the Azure Search index.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798924.aspx" />
         /// </summary>
         /// <param name='searchRequestOptions'>
         /// Additional parameters for the operation
@@ -61,6 +65,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -106,7 +119,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchIndex/IDocumentsProxyOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchIndex/IDocumentsProxyOperations.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.Search
     {
         /// <summary>
         /// Queries the number of documents in the Azure Search index.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798924.aspx" />
         /// </summary>
         /// <param name='searchRequestOptions'>
         /// Additional parameters for the operation
@@ -34,6 +35,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<long?>> CountWithHttpMessagesAsync(SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchIndex/ISearchIndexClient.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchIndex/ISearchIndexClient.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Search
         JsonSerializerSettings DeserializationSettings { get; }
 
         /// <summary>
-        /// Gets Azure subscription credentials.
+        /// Credentials needed for the client to connect to Azure.
         /// </summary>
         ServiceClientCredentials Credentials { get; }
 

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchIndex/SearchIndexClient.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchIndex/SearchIndexClient.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Search
         public JsonSerializerSettings DeserializationSettings { get; private set; }        
 
         /// <summary>
-        /// Gets Azure subscription credentials.
+        /// Credentials needed for the client to connect to Azure.
         /// </summary>
         public ServiceClientCredentials Credentials { get; private set; }
 
@@ -112,6 +112,9 @@ namespace Microsoft.Azure.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         protected SearchIndexClient(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
@@ -133,6 +136,9 @@ namespace Microsoft.Azure.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         protected SearchIndexClient(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
@@ -146,11 +152,14 @@ namespace Microsoft.Azure.Search
         /// Initializes a new instance of the SearchIndexClient class.
         /// </summary>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchIndexClient(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (credentials == null)
@@ -168,7 +177,7 @@ namespace Microsoft.Azure.Search
         /// Initializes a new instance of the SearchIndexClient class.
         /// </summary>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='rootHandler'>
         /// Optional. The http client handler used to handle http transport.
@@ -176,6 +185,9 @@ namespace Microsoft.Azure.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchIndexClient(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (credentials == null)
@@ -196,11 +208,14 @@ namespace Microsoft.Azure.Search
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchIndexClient(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
@@ -226,7 +241,7 @@ namespace Microsoft.Azure.Search
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='rootHandler'>
         /// Optional. The http client handler used to handle http transport.
@@ -234,6 +249,9 @@ namespace Microsoft.Azure.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchIndexClient(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
@@ -253,10 +271,12 @@ namespace Microsoft.Azure.Search
         }
 
         /// <summary>
-        /// Initializes client properties.
+        /// An optional partial-method to perform custom initialization.
         /// </summary>
         partial void CustomInitialize();
-
+        /// <summary>
+        /// Initializes client properties.
+        /// </summary>
         private void Initialize()
         {
             this.Documents = new DocumentsOperations(this);
@@ -290,8 +310,8 @@ namespace Microsoft.Azure.Search
                         new Iso8601TimeSpanConverter()
                     }
             };
-            DeserializationSettings.Converters.Add(new CloudErrorJsonConverter());
-            CustomInitialize(); 
+            CustomInitialize();
+            DeserializationSettings.Converters.Add(new CloudErrorJsonConverter()); 
         }    
     }
 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/DataSourcesOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/DataSourcesOperations.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Azure.Search
         /// <param name='client'>
         /// Reference to the service client.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         internal DataSourcesOperations(SearchServiceClient client)
         {
             if (client == null) 
@@ -52,6 +55,7 @@ namespace Microsoft.Azure.Search
         /// <summary>
         /// Creates a new Azure Search datasource or updates a datasource if it
         /// already exists.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946900.aspx" />
         /// </summary>
         /// <param name='dataSourceName'>
         /// The name of the datasource to create or update.
@@ -68,6 +72,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -128,7 +141,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -273,6 +286,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Deletes an Azure Search datasource.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946881.aspx" />
         /// </summary>
         /// <param name='dataSourceName'>
         /// The name of the datasource to delete.
@@ -286,6 +300,12 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -337,7 +357,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -392,7 +412,12 @@ namespace Microsoft.Azure.Search
             if ((int)_statusCode != 204 && (int)_statusCode != 404)
             {
                 var ex = new CloudException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_httpResponse.Headers.Contains("request-id"))
@@ -427,6 +452,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves a datasource definition from Azure Search.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946893.aspx" />
         /// </summary>
         /// <param name='dataSourceName'>
         /// The name of the datasource to retrieve.
@@ -440,6 +466,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -491,7 +526,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -612,6 +647,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Lists all datasources available for an Azure Search service.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946878.aspx" />
         /// </summary>
         /// <param name='searchRequestOptions'>
         /// Additional parameters for the operation
@@ -622,6 +658,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -667,7 +712,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -788,6 +833,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Creates a new Azure Search datasource.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946876.aspx" />
         /// </summary>
         /// <param name='dataSource'>
         /// The definition of the datasource to create.
@@ -801,6 +847,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -855,7 +910,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/DataSourcesOperationsExtensions.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/DataSourcesOperationsExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Search
             /// <summary>
             /// Creates a new Azure Search datasource or updates a datasource if it
             /// already exists.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946900.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -46,6 +47,7 @@ namespace Microsoft.Azure.Search
             /// <summary>
             /// Creates a new Azure Search datasource or updates a datasource if it
             /// already exists.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946900.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -72,6 +74,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Deletes an Azure Search datasource.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946881.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -89,6 +92,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Deletes an Azure Search datasource.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946881.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -109,6 +113,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Retrieves a datasource definition from Azure Search.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946893.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -126,6 +131,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Retrieves a datasource definition from Azure Search.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946893.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -149,6 +155,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Lists all datasources available for an Azure Search service.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946878.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -163,6 +170,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Lists all datasources available for an Azure Search service.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946878.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -183,6 +191,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Creates a new Azure Search datasource.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946876.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -200,6 +209,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Creates a new Azure Search datasource.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946876.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IDataSourcesOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IDataSourcesOperations.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Search
         /// <summary>
         /// Creates a new Azure Search datasource or updates a datasource if
         /// it already exists.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946900.aspx" />
         /// </summary>
         /// <param name='dataSourceName'>
         /// The name of the datasource to create or update.
@@ -41,9 +42,19 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(string dataSourceName, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes an Azure Search datasource.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946881.aspx" />
         /// </summary>
         /// <param name='dataSourceName'>
         /// The name of the datasource to delete.
@@ -57,9 +68,16 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse> DeleteWithHttpMessagesAsync(string dataSourceName, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Retrieves a datasource definition from Azure Search.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946893.aspx" />
         /// </summary>
         /// <param name='dataSourceName'>
         /// The name of the datasource to retrieve.
@@ -73,9 +91,19 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<DataSource>> GetWithHttpMessagesAsync(string dataSourceName, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all datasources available for an Azure Search service.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946878.aspx" />
         /// </summary>
         /// <param name='searchRequestOptions'>
         /// Additional parameters for the operation
@@ -86,9 +114,19 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<DataSourceListResult>> ListWithHttpMessagesAsync(SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Creates a new Azure Search datasource.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946876.aspx" />
         /// </summary>
         /// <param name='dataSource'>
         /// The definition of the datasource to create.
@@ -102,6 +140,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<DataSource>> CreateWithHttpMessagesAsync(DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IIndexersOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IIndexersOperations.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Search
         /// <summary>
         /// Resets the change tracking state associated with an Azure Search
         /// indexer.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946897.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer to reset.
@@ -38,9 +39,16 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse> ResetWithHttpMessagesAsync(string indexerName, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Runs an Azure Search indexer on-demand.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946885.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer to run.
@@ -54,10 +62,17 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse> RunWithHttpMessagesAsync(string indexerName, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Creates a new Azure Search indexer or updates an indexer if it
         /// already exists.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946899.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer to create or update.
@@ -74,9 +89,19 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(string indexerName, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes an Azure Search indexer.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946898.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer to delete.
@@ -90,9 +115,16 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse> DeleteWithHttpMessagesAsync(string indexerName, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Retrieves an indexer definition from Azure Search.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946874.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer to retrieve.
@@ -106,9 +138,19 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<Indexer>> GetWithHttpMessagesAsync(string indexerName, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all indexers available for an Azure Search service.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946883.aspx" />
         /// </summary>
         /// <param name='searchRequestOptions'>
         /// Additional parameters for the operation
@@ -119,9 +161,19 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<IndexerListResult>> ListWithHttpMessagesAsync(SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Creates a new Azure Search indexer.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946899.aspx" />
         /// </summary>
         /// <param name='indexer'>
         /// The definition of the indexer to create.
@@ -135,9 +187,19 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<Indexer>> CreateWithHttpMessagesAsync(Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Returns the current status and execution history of an indexer.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946884.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer for which to retrieve status.
@@ -151,6 +213,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<IndexerExecutionInfo>> GetStatusWithHttpMessagesAsync(string indexerName, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IIndexesOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IIndexesOperations.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.Search
     {
         /// <summary>
         /// Creates a new Azure Search index.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798941.aspx" />
         /// </summary>
         /// <param name='index'>
         /// The definition of the index to create.
@@ -37,9 +38,19 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<Index>> CreateWithHttpMessagesAsync(Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all indexes available for an Azure Search service.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798923.aspx" />
         /// </summary>
         /// <param name='select'>
         /// Selects which properties of the index definitions to retrieve.
@@ -55,10 +66,20 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<IndexListResult>> ListWithHttpMessagesAsync(string select = default(string), SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Creates a new Azure Search index or updates an index if it already
         /// exists.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn800964.aspx" />
         /// </summary>
         /// <param name='indexName'>
         /// The definition of the index to create or update.
@@ -75,9 +96,19 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(string indexName, Index index, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes an Azure Search index and all the documents it contains.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798926.aspx" />
         /// </summary>
         /// <param name='indexName'>
         /// The name of the index to delete.
@@ -91,9 +122,16 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse> DeleteWithHttpMessagesAsync(string indexName, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Retrieves an index definition from Azure Search.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798939.aspx" />
         /// </summary>
         /// <param name='indexName'>
         /// The name of the index to retrieve.
@@ -107,10 +145,20 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<Index>> GetWithHttpMessagesAsync(string indexName, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Returns statistics for the given index, including a document count
         /// and storage usage.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798942.aspx" />
         /// </summary>
         /// <param name='indexName'>
         /// The name of the index for which to retrieve statistics.
@@ -124,6 +172,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         Task<AzureOperationResponse<IndexGetStatisticsResult>> GetStatisticsWithHttpMessagesAsync(string indexName, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/ISearchServiceClient.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/ISearchServiceClient.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Search
         JsonSerializerSettings DeserializationSettings { get; }
 
         /// <summary>
-        /// Gets Azure subscription credentials.
+        /// Credentials needed for the client to connect to Azure.
         /// </summary>
         ServiceClientCredentials Credentials { get; }
 

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexersOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexersOperations.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Azure.Search
         /// <param name='client'>
         /// Reference to the service client.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         internal IndexersOperations(SearchServiceClient client)
         {
             if (client == null) 
@@ -51,6 +54,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Resets the change tracking state associated with an Azure Search indexer.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946897.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer to reset.
@@ -64,6 +68,12 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -115,7 +125,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -170,7 +180,12 @@ namespace Microsoft.Azure.Search
             if ((int)_statusCode != 204)
             {
                 var ex = new CloudException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_httpResponse.Headers.Contains("request-id"))
@@ -205,6 +220,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Runs an Azure Search indexer on-demand.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946885.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer to run.
@@ -218,6 +234,12 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -269,7 +291,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -324,7 +346,12 @@ namespace Microsoft.Azure.Search
             if ((int)_statusCode != 202)
             {
                 var ex = new CloudException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_httpResponse.Headers.Contains("request-id"))
@@ -360,6 +387,7 @@ namespace Microsoft.Azure.Search
         /// <summary>
         /// Creates a new Azure Search indexer or updates an indexer if it already
         /// exists.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946899.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer to create or update.
@@ -376,6 +404,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -436,7 +473,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -581,6 +618,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Deletes an Azure Search indexer.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946898.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer to delete.
@@ -594,6 +632,12 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -645,7 +689,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -700,7 +744,12 @@ namespace Microsoft.Azure.Search
             if ((int)_statusCode != 404 && (int)_statusCode != 204)
             {
                 var ex = new CloudException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_httpResponse.Headers.Contains("request-id"))
@@ -735,6 +784,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves an indexer definition from Azure Search.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946874.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer to retrieve.
@@ -748,6 +798,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -799,7 +858,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -920,6 +979,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Lists all indexers available for an Azure Search service.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946883.aspx" />
         /// </summary>
         /// <param name='searchRequestOptions'>
         /// Additional parameters for the operation
@@ -930,6 +990,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -975,7 +1044,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -1096,6 +1165,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Creates a new Azure Search indexer.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946899.aspx" />
         /// </summary>
         /// <param name='indexer'>
         /// The definition of the indexer to create.
@@ -1109,6 +1179,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -1163,7 +1242,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -1290,6 +1369,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Returns the current status and execution history of an indexer.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn946884.aspx" />
         /// </summary>
         /// <param name='indexerName'>
         /// The name of the indexer for which to retrieve status.
@@ -1303,6 +1383,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -1354,7 +1443,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexersOperationsExtensions.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexersOperationsExtensions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.Search
     {
             /// <summary>
             /// Resets the change tracking state associated with an Azure Search indexer.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946897.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -41,6 +42,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Resets the change tracking state associated with an Azure Search indexer.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946897.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -61,6 +63,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Runs an Azure Search indexer on-demand.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946885.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -78,6 +81,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Runs an Azure Search indexer on-demand.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946885.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -99,6 +103,7 @@ namespace Microsoft.Azure.Search
             /// <summary>
             /// Creates a new Azure Search indexer or updates an indexer if it already
             /// exists.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946899.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -120,6 +125,7 @@ namespace Microsoft.Azure.Search
             /// <summary>
             /// Creates a new Azure Search indexer or updates an indexer if it already
             /// exists.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946899.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -146,6 +152,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Deletes an Azure Search indexer.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946898.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -163,6 +170,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Deletes an Azure Search indexer.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946898.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -183,6 +191,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Retrieves an indexer definition from Azure Search.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946874.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -200,6 +209,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Retrieves an indexer definition from Azure Search.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946874.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -223,6 +233,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Lists all indexers available for an Azure Search service.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946883.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -237,6 +248,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Lists all indexers available for an Azure Search service.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946883.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -257,6 +269,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Creates a new Azure Search indexer.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946899.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -274,6 +287,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Creates a new Azure Search indexer.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946899.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -297,6 +311,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Returns the current status and execution history of an indexer.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946884.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -314,6 +329,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Returns the current status and execution history of an indexer.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn946884.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexesOperations.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexesOperations.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Azure.Search
         /// <param name='client'>
         /// Reference to the service client.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         internal IndexesOperations(SearchServiceClient client)
         {
             if (client == null) 
@@ -51,6 +54,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Creates a new Azure Search index.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798941.aspx" />
         /// </summary>
         /// <param name='index'>
         /// The definition of the index to create.
@@ -64,6 +68,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -118,7 +131,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -245,6 +258,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Lists all indexes available for an Azure Search service.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798923.aspx" />
         /// </summary>
         /// <param name='select'>
         /// Selects which properties of the index definitions to retrieve. Specified
@@ -260,6 +274,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -310,7 +333,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -431,6 +454,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Creates a new Azure Search index or updates an index if it already exists.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn800964.aspx" />
         /// </summary>
         /// <param name='indexName'>
         /// The definition of the index to create or update.
@@ -447,6 +471,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -507,7 +540,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -652,6 +685,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Deletes an Azure Search index and all the documents it contains.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798926.aspx" />
         /// </summary>
         /// <param name='indexName'>
         /// The name of the index to delete.
@@ -665,6 +699,12 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -716,7 +756,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -771,7 +811,12 @@ namespace Microsoft.Azure.Search
             if ((int)_statusCode != 204 && (int)_statusCode != 404)
             {
                 var ex = new CloudException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_httpResponse.Headers.Contains("request-id"))
@@ -806,6 +851,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Retrieves an index definition from Azure Search.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798939.aspx" />
         /// </summary>
         /// <param name='indexName'>
         /// The name of the index to retrieve.
@@ -819,6 +865,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -870,7 +925,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {
@@ -992,6 +1047,7 @@ namespace Microsoft.Azure.Search
         /// <summary>
         /// Returns statistics for the given index, including a document count and
         /// storage usage.
+        /// <see href="https://msdn.microsoft.com/library/azure/dn798942.aspx" />
         /// </summary>
         /// <param name='indexName'>
         /// The name of the index for which to retrieve statistics.
@@ -1005,6 +1061,15 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
@@ -1056,7 +1121,7 @@ namespace Microsoft.Azure.Search
             // Set Headers
             if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
             {
-                _httpRequest.Headers.TryAddWithoutValidation("x-ms-client-request-id", Guid.NewGuid().ToString());
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Guid.NewGuid().ToString());
             }
             if (this.Client.AcceptLanguage != null)
             {

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexesOperationsExtensions.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/IndexesOperationsExtensions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.Search
     {
             /// <summary>
             /// Creates a new Azure Search index.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn798941.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -41,6 +42,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Creates a new Azure Search index.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn798941.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -64,6 +66,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Lists all indexes available for an Azure Search service.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn798923.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -83,6 +86,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Lists all indexes available for an Azure Search service.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn798923.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -108,6 +112,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Creates a new Azure Search index or updates an index if it already exists.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn800964.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -128,6 +133,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Creates a new Azure Search index or updates an index if it already exists.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn800964.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -154,6 +160,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Deletes an Azure Search index and all the documents it contains.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn798926.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -171,6 +178,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Deletes an Azure Search index and all the documents it contains.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn798926.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -191,6 +199,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Retrieves an index definition from Azure Search.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn798939.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -208,6 +217,7 @@ namespace Microsoft.Azure.Search
 
             /// <summary>
             /// Retrieves an index definition from Azure Search.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn798939.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -232,6 +242,7 @@ namespace Microsoft.Azure.Search
             /// <summary>
             /// Returns statistics for the given index, including a document count and
             /// storage usage.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn798942.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -250,6 +261,7 @@ namespace Microsoft.Azure.Search
             /// <summary>
             /// Returns statistics for the given index, including a document count and
             /// storage usage.
+            /// <see href="https://msdn.microsoft.com/library/azure/dn798942.aspx" />
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/CorsOptions.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/CorsOptions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Search.Models
     /// <summary>
     /// Defines options to control Cross-Origin Resource Sharing (CORS) for an
     /// index.
+    /// <see href="https://msdn.microsoft.com/library/azure/dn798941.aspx" />
     /// </summary>
     public partial class CorsOptions
     {
@@ -53,8 +54,11 @@ namespace Microsoft.Azure.Search.Models
         public long? MaxAgeInSeconds { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (AllowedOrigins == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DataContainer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DataContainer.cs
@@ -52,8 +52,11 @@ namespace Microsoft.Azure.Search.Models
         public string Query { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (Name == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DataSource.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DataSource.cs
@@ -84,8 +84,11 @@ namespace Microsoft.Azure.Search.Models
         public DataDeletionDetectionPolicy DataDeletionDetectionPolicy { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (Name == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DataSourceCredentials.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DataSourceCredentials.cs
@@ -41,8 +41,11 @@ namespace Microsoft.Azure.Search.Models
         public string ConnectionString { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (ConnectionString == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DistanceScoringFunction.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DistanceScoringFunction.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Search.Models
     /// <summary>
     /// Defines a function that boosts scores based on distance from a
     /// geographic location.
+    /// <see href="https://msdn.microsoft.com/library/azure/dn798928.aspx" />
     /// </summary>
     [JsonObject("distance")]
     public partial class DistanceScoringFunction : ScoringFunction
@@ -44,8 +45,11 @@ namespace Microsoft.Azure.Search.Models
         public DistanceScoringParameters Parameters { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public override void Validate()
         {
             base.Validate();

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DistanceScoringParameters.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DistanceScoringParameters.cs
@@ -50,8 +50,11 @@ namespace Microsoft.Azure.Search.Models
         public double BoostingDistance { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (ReferencePointParameter == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/FreshnessScoringFunction.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/FreshnessScoringFunction.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Search.Models
     /// <summary>
     /// Defines a function that boosts scores based on the value of a
     /// date-time field.
+    /// <see href="https://msdn.microsoft.com/library/azure/dn798928.aspx" />
     /// </summary>
     [JsonObject("freshness")]
     public partial class FreshnessScoringFunction : ScoringFunction
@@ -44,8 +45,11 @@ namespace Microsoft.Azure.Search.Models
         public FreshnessScoringParameters Parameters { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public override void Validate()
         {
             base.Validate();

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/FreshnessScoringParameters.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/FreshnessScoringParameters.cs
@@ -42,8 +42,11 @@ namespace Microsoft.Azure.Search.Models
         public TimeSpan BoostingDuration { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             //Nothing to validate

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/HighWaterMarkChangeDetectionPolicy.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/HighWaterMarkChangeDetectionPolicy.cs
@@ -45,8 +45,11 @@ namespace Microsoft.Azure.Search.Models
         public string HighWaterMarkColumnName { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (HighWaterMarkColumnName == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/Index.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/Index.cs
@@ -81,8 +81,11 @@ namespace Microsoft.Azure.Search.Models
         public IList<Suggester> Suggesters { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (Name == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/Indexer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/Indexer.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Search.Models
 
     /// <summary>
     /// Represents an Azure Search indexer.
+    /// <see href="https://msdn.microsoft.com/library/azure/dn946891.aspx" />
     /// </summary>
     public partial class Indexer
     {
@@ -78,8 +79,11 @@ namespace Microsoft.Azure.Search.Models
         public IndexingParameters Parameters { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (Name == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/IndexingSchedule.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/IndexingSchedule.cs
@@ -48,8 +48,11 @@ namespace Microsoft.Azure.Search.Models
         public DateTimeOffset? StartTime { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             //Nothing to validate

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MagnitudeScoringFunction.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MagnitudeScoringFunction.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Search.Models
     /// <summary>
     /// Defines a function that boosts scores based on the magnitude of a
     /// numeric field.
+    /// <see href="https://msdn.microsoft.com/library/azure/dn798928.aspx" />
     /// </summary>
     [JsonObject("magnitude")]
     public partial class MagnitudeScoringFunction : ScoringFunction
@@ -44,8 +45,11 @@ namespace Microsoft.Azure.Search.Models
         public MagnitudeScoringParameters Parameters { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public override void Validate()
         {
             base.Validate();

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MagnitudeScoringParameters.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MagnitudeScoringParameters.cs
@@ -56,8 +56,11 @@ namespace Microsoft.Azure.Search.Models
         public bool? ShouldBoostBeyondRangeByConstant { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             //Nothing to validate

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ScoringFunction.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ScoringFunction.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Search.Models
     /// <summary>
     /// Abstract base class for functions that can modify document scores
     /// during ranking.
+    /// <see href="https://msdn.microsoft.com/library/azure/dn798928.aspx" />
     /// </summary>
     public partial class ScoringFunction
     {
@@ -60,8 +61,11 @@ namespace Microsoft.Azure.Search.Models
         public ScoringFunctionInterpolation? Interpolation { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (FieldName == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ScoringProfile.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ScoringProfile.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Search.Models
     /// <summary>
     /// Defines parameters for an Azure Search index that influence scoring in
     /// search queries.
+    /// <see href="https://msdn.microsoft.com/library/azure/dn798928.aspx" />
     /// </summary>
     public partial class ScoringProfile
     {
@@ -68,8 +69,11 @@ namespace Microsoft.Azure.Search.Models
         public ScoringFunctionAggregation? FunctionAggregation { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (Name == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/Suggester.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/Suggester.cs
@@ -58,8 +58,11 @@ namespace Microsoft.Azure.Search.Models
         public IList<string> SourceFields { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (Name == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/TagScoringFunction.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/TagScoringFunction.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Search.Models
     /// <summary>
     /// Defines a function that boosts scores of documents with string values
     /// matching a given list of tags.
+    /// <see href="https://msdn.microsoft.com/library/azure/dn798928.aspx" />
     /// </summary>
     [JsonObject("tag")]
     public partial class TagScoringFunction : ScoringFunction
@@ -44,8 +45,11 @@ namespace Microsoft.Azure.Search.Models
         public TagScoringParameters Parameters { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public override void Validate()
         {
             base.Validate();

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/TagScoringParameters.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/TagScoringParameters.cs
@@ -42,8 +42,11 @@ namespace Microsoft.Azure.Search.Models
         public string TagsParameter { get; set; }
 
         /// <summary>
-        /// Validate the object. Throws ValidationException if validation fails.
+        /// Validate the object.
         /// </summary>
+        /// <exception cref="ValidationException">
+        /// Thrown if validation fails
+        /// </exception>
         public virtual void Validate()
         {
             if (TagsParameter == null)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/SearchServiceClient.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/SearchServiceClient.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Search
         public JsonSerializerSettings DeserializationSettings { get; private set; }        
 
         /// <summary>
-        /// Gets Azure subscription credentials.
+        /// Credentials needed for the client to connect to Azure.
         /// </summary>
         public ServiceClientCredentials Credentials { get; private set; }
 
@@ -122,6 +122,9 @@ namespace Microsoft.Azure.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         protected SearchServiceClient(Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
@@ -143,6 +146,9 @@ namespace Microsoft.Azure.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         protected SearchServiceClient(Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
@@ -156,11 +162,14 @@ namespace Microsoft.Azure.Search
         /// Initializes a new instance of the SearchServiceClient class.
         /// </summary>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchServiceClient(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (credentials == null)
@@ -178,7 +187,7 @@ namespace Microsoft.Azure.Search
         /// Initializes a new instance of the SearchServiceClient class.
         /// </summary>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='rootHandler'>
         /// Optional. The http client handler used to handle http transport.
@@ -186,6 +195,9 @@ namespace Microsoft.Azure.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchServiceClient(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (credentials == null)
@@ -206,11 +218,14 @@ namespace Microsoft.Azure.Search
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchServiceClient(Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
@@ -236,7 +251,7 @@ namespace Microsoft.Azure.Search
         /// Optional. The base URI of the service.
         /// </param>
         /// <param name='credentials'>
-        /// Required. Gets Azure subscription credentials.
+        /// Required. Credentials needed for the client to connect to Azure.
         /// </param>
         /// <param name='rootHandler'>
         /// Optional. The http client handler used to handle http transport.
@@ -244,6 +259,9 @@ namespace Microsoft.Azure.Search
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         public SearchServiceClient(Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
@@ -262,6 +280,10 @@ namespace Microsoft.Azure.Search
             }
         }
 
+        /// <summary>
+        /// An optional partial-method to perform custom initialization.
+        /// </summary>
+        partial void CustomInitialize();
         /// <summary>
         /// Initializes client properties.
         /// </summary>
@@ -306,6 +328,7 @@ namespace Microsoft.Azure.Search
             DeserializationSettings.Converters.Add(new PolymorphicDeserializeJsonConverter<DataDeletionDetectionPolicy>("@odata.type"));
             SerializationSettings.Converters.Add(new PolymorphicSerializeJsonConverter<ScoringFunction>("type"));
             DeserializationSettings.Converters.Add(new PolymorphicDeserializeJsonConverter<ScoringFunction>("type"));
+            CustomInitialize();
             DeserializationSettings.Converters.Add(new CloudErrorJsonConverter()); 
         }    
     }

--- a/src/Search/Microsoft.Azure.Search/generate-searchindexclient.cmd
+++ b/src/Search/Microsoft.Azure.Search/generate-searchindexclient.cmd
@@ -4,7 +4,7 @@
 ::
 
 @echo off
-set autoRestVersion=0.17.0-Nightly20160522
+set autoRestVersion=0.17.0-Nightly20160626
 if  "%1" == "" (
     set specFile="https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/search/2015-02-28-Preview/swagger/searchindex.json"
 ) else (

--- a/src/Search/Microsoft.Azure.Search/generate-searchserviceclient.cmd
+++ b/src/Search/Microsoft.Azure.Search/generate-searchserviceclient.cmd
@@ -4,7 +4,7 @@
 ::
 
 @echo off
-set autoRestVersion=0.17.0-Nightly20160522
+set autoRestVersion=0.17.0-Nightly20160626
 if  "%1" == "" (
     set specFile="https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/search/2015-02-28-Preview/swagger/searchservice.json"
 ) else (

--- a/src/Search/Search.Management.Tests/project.json
+++ b/src/Search/Search.Management.Tests/project.json
@@ -20,7 +20,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "buildOptions": { "define": [ "PORTABLE" ] },
-      "imports": ["dnxcore50", "portable-net45+win8"]
+      "imports": [ "dnxcore50", "portable-net45+win8" ]
     }
   },
   "dependencies": {

--- a/src/Search/Search.Tests/project.json
+++ b/src/Search/Search.Tests/project.json
@@ -20,7 +20,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "buildOptions": { "define": [ "PORTABLE" ] },
-      "imports": ["dnxcore50", "portable-net45+win8"]
+      "imports": [ "dnxcore50", "portable-net45+win8" ]
     }
   },
   "dependencies": {


### PR DESCRIPTION
There are some recent fixes in AutoRest that we'd like to apply to our work on v2.0-preview, especially the introduction of `<see>` tags in C# `///` comments.

Note that I've already made this change in the  `search-custom-analyzers` branch, but I should have made it closer to master since it's needed for other 2.0-preview features too, hence re-applying it to `search-v2-preview-dev`.

FYI @seansaleh @chaosrealm @yahnoosh @mhko 
