### PR TITLE
Deprecate WebApi authentication for WebLinkedService

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/LinkedServiceJsonSamples.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/LinkedServiceJsonSamples.cs
@@ -436,8 +436,7 @@ namespace DataFactory.Tests.Framework.JsonSamples
             url: ""http://myhost.com/"",
             authenticationType: ""Basic"",
             username: ""microsoft"",
-            password: ""fakepassword"",
-            apiKey: ""mykey""            
+            password: ""fakepassword""   
         }
     }
 }";

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/LinkedServices/WebLinkedService.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/LinkedServices/WebLinkedService.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 //
 
+using System;
+
 namespace Microsoft.Azure.Management.DataFactories.Models
 {
     /// <summary>
@@ -22,7 +24,7 @@ namespace Microsoft.Azure.Management.DataFactories.Models
     public class WebLinkedService : LinkedServiceTypeProperties
     {
         /// <summary>
-        /// Required. Type of authentication used to connect to the web table source. Possible values are: Anonymous, Basic, and WebApi.
+        /// Required. Type of authentication used to connect to the web table source. Possible values are: Anonymous and Basic.
         /// </summary>
         [AdfRequired]
         public string AuthenticationType { get; set; }
@@ -44,8 +46,9 @@ namespace Microsoft.Azure.Management.DataFactories.Models
         public string Password { get; set; }
 
         /// <summary>
-        /// Optional. API key for Web API authentication.
+        /// Obsolete. WebApi-based authentication has been deprecated.
         /// </summary>
+        [Obsolete]
         public string ApiKey { get; set; }
 
         public WebLinkedService()

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
@@ -1,5 +1,12 @@
 For additional details on features, see the full [Azure Data Factory Release Notes](https://azure.microsoft.com/en-us/documentation/articles/data-factory-release-notes). 
 
+## Version 4.9.1
+_Release date: 2016.07.05_ 
+
+### Bug fix
+
+* Deprecate WebApi-based authentication for WebLinkedService.
+
 ## Version 4.9.0
 _Release date: 2016.06.10_ 
 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataFactories
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataFactories">
-      <PackageVersion>4.9.0</PackageVersion>
+      <PackageVersion>4.9.1</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
@@ -3,7 +3,7 @@
   <metadata minClientVersion="2.5">
     <id>Microsoft.Azure.Management.DataFactories</id>
     <title>Microsoft Azure Data Factory Management Library</title>
-    <releaseNotes>https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log/#version-490</releaseNotes>
+    <releaseNotes>https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log/#version-491</releaseNotes>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>azure-sdk, Microsoft</owners>
@@ -14,7 +14,7 @@
     <summary>Provides data factory management capabilities for Microsoft Azure.</summary>
     <description>Data Factory is a fully managed service to compose data storage, processing, and movement services into streamlined, scalable and reliable data production pipelines. Use cloud and on-premises data sources with unstructured, semi-structured, and structured data over the Hadoop (HDInsight) ecosystem. Create, deploy, monitor, troubleshoot, and manage Data Factories using familiar APIs. For more information visit http://go.microsoft.com/fwlink/?LinkId=516909 </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
-    <tags>Microsoft Azure Data Factory management "data factory management" REST HTTP client windowsazureofficial</tags>
+    <tags>ADF Microsoft Azure Data Factory management "data factory management" REST HTTP client windowsazureofficial</tags>
     <references>
       <group targetFramework="portable-net45+wp8+wpa81+win">
         <reference file="Microsoft.Azure.Management.DataFactories.dll" />

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Factory management operations.")]
 
 [assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.9.0.0")]
+[assembly: AssemblyFileVersion("4.9.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
We found this authentication type does not work for our connector and decided to retire this property in a non-breaking way by mark it as Obsolete. 
We will remove the property once we introduce new breaking api-version. Right now, customer can still use it but won't get any useful result anyway.
