### PR TITLE
Update package to latest version of ADLS client

### DIFF
--- a/src/ResourceManagement/DataLake.Store/Microsoft.Azure.Management.DataLake.Store/Microsoft.Azure.Management.DataLake.Store.xproj
+++ b/src/ResourceManagement/DataLake.Store/Microsoft.Azure.Management.DataLake.Store/Microsoft.Azure.Management.DataLake.Store.xproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>be53cf33-9a3d-4101-9dfd-62ac09cadada</ProjectGuid>
+    <ProjectGuid>192f53cc-693e-4990-8741-4e55b930821c</ProjectGuid>
     <RootNamespace>Microsoft.Azure.Management.DataLake.Store</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>

--- a/src/ResourceManagement/DataLake.Store/Microsoft.Azure.Management.DataLake.Store/Microsoft.Azure.Management.DataLake.Store.xproj
+++ b/src/ResourceManagement/DataLake.Store/Microsoft.Azure.Management.DataLake.Store/Microsoft.Azure.Management.DataLake.Store.xproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>192f53cc-693e-4990-8741-4e55b930821c</ProjectGuid>
+    <ProjectGuid>be53cf33-9a3d-4101-9dfd-62ac09cadada</ProjectGuid>
     <RootNamespace>Microsoft.Azure.Management.DataLake.Store</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>

--- a/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/DataLakeStoreUploader.Tests.csproj
+++ b/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/DataLakeStoreUploader.Tests.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.Management.DataLake.Store, Version=0.12.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.12.2-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
+      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.12.4-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/UnitTests/DataLakeUploaderTests.cs
+++ b/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/UnitTests/DataLakeUploaderTests.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Azure.Management.DataLake.StoreUploader.Tests
             uploader.DeleteMetadataFile();
 
             Assert.Throws<AggregateException>(() => uploader.Execute());
-            Assert.False(frontEnd.StreamExists(up.TargetStreamPath), "Target stream should not have been created");
+            Assert.Equal(1, frontEnd.ListDirectory(up.TargetStreamPath, false).Keys.Count);
             Assert.Equal(1, backingFrontEnd.StreamCount);
 
             //resume the upload but point it to the real back-end, which doesn't throw exceptions

--- a/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/packages.config
+++ b/src/ResourceManagement/DataLake.StoreUploader/DataLakeStoreUploader.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.12.2-preview" targetFramework="net45" />
+  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.12.4-preview" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.csproj
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.csproj
@@ -67,7 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.Management.DataLake.Store">
-      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.12.2-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
+      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.0.12.4-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.nuget.proj
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataLake.StoreUploader
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataLake.StoreUploader">
-      <PackageVersion>0.10.4-preview</PackageVersion>
+      <PackageVersion>0.10.5-preview</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.nuspec
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader.nuspec
@@ -22,7 +22,7 @@
       </group>
     </references>
     <dependencies>
-      <dependency id="Microsoft.Azure.Management.DataLake.Store" version="[0.12.2-preview,3.0)" />
+      <dependency id="Microsoft.Azure.Management.DataLake.Store" version="[0.12.4-preview,3.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/Properties/AssemblyInfo.cs
@@ -22,7 +22,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure DataLakeUploader functions for managing the Microsoft Azure DataLakeUploader service.")]
 
 [assembly: AssemblyVersion("0.10.0.0")]
-[assembly: AssemblyFileVersion("0.10.4.0")]
+[assembly: AssemblyFileVersion("0.10.5.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/packages.config
+++ b/src/ResourceManagement/DataLake.StoreUploader/Microsoft.Azure.Management.DataLake.StoreUploader/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.12.2-preview" targetFramework="net45" />
+  <package id="Microsoft.Azure.Management.DataLake.Store" version="0.12.4-preview" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />


### PR DESCRIPTION
The store uploader has to be updated once the ADLS client is published. This is just getting the uploader to depend on the latest version of the ADLS client. I also finally squashed all my commits so I don't get a red card :)
