### PR TITLE
Changing autorest gen script to use the correct package name

### DIFF
--- a/tools/autorest.composite.gen.cmd
+++ b/tools/autorest.composite.gen.cmd
@@ -3,13 +3,16 @@ set specFile=%1
 set namespace=%2
 set autoRestVersion=%3
 set generateFolder=%4
+set packageName=autorest
+
+if "%autoRestVersion%" gtr "0.17.0-Nightly20160707" set packageName=AutoRest
 
 set source=-Source https://www.myget.org/F/autorest/api/v2
 
 set repoRoot=%~dp0..
 set autoRestExe=%repoRoot%\packages\autorest.%autoRestVersion%\tools\AutoRest.exe
 
-%repoRoot%\tools\nuget.exe install autorest %source% -Version %autoRestVersion% -o %repoRoot%\packages -verbosity quiet
+%repoRoot%\tools\nuget.exe install %packageName% %source% -Version %autoRestVersion% -o %repoRoot%\packages -verbosity quiet
 
 @echo on
 %autoRestExe% -Modeler CompositeSwagger -CodeGenerator Azure.CSharp -Namespace %namespace% -Input %specFile% -outputDirectory %generateFolder% -Header MICROSOFT_MIT %~5

--- a/tools/autorest.gen.cmd
+++ b/tools/autorest.gen.cmd
@@ -4,15 +4,17 @@ set namespace=%2
 set autoRestVersion=%3
 set generateFolder=%4
 set header=%5
+set packageName=autorest
 
 if [%header%]==[] set header=MICROSOFT_MIT
+if "%autoRestVersion%" gtr "0.17.0-Nightly20160707" set packageName=AutoRest
 
 set source=-Source https://www.myget.org/F/autorest/api/v2
 
 set repoRoot=%~dp0..
 set autoRestExe=%repoRoot%\packages\autorest.%autoRestVersion%\tools\AutoRest.exe
 
-%repoRoot%\tools\nuget.exe install autorest %source% -Version %autoRestVersion% -o %repoRoot%\packages -verbosity quiet
+%repoRoot%\tools\nuget.exe install %packageName% %source% -Version %autoRestVersion% -o %repoRoot%\packages -verbosity quiet
 
 @echo on
 %autoRestExe% -Modeler Swagger -CodeGenerator Azure.CSharp -Namespace %namespace% -Input %specFile% -outputDirectory %generateFolder% -Header %header% %~6


### PR DESCRIPTION
On 2016-07-08, AutoRest nightly nuget builds started using the package id of "AutoRest" instead of "autorest". `nuget.exe` is not properly downloading these builds in `autorest.gen.cmd` and the composite version. This change uses the PascalCase version when the version requested is later than 20160707 in autorest.gen.cmd and autorest.composite.gen.cmd.

I've tested regeneration with both composite and non composite swagger files, as well as with versions older than 20160707 and newer.
