### PR TITLE
Removing unnecessary references from keyvault global.json and renaming test library project to have .Tests in the name.

### DIFF
--- a/src/KeyVault/Microsoft.Azure.KeyVault.sln
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.sln
@@ -7,8 +7,6 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.KeyVault", 
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.KeyVault.Tests", "Microsoft.Azure.KeyVault.Tests\Microsoft.Azure.KeyVault.Tests.xproj", "{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}"
 EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "TestFramework", "..\TestFramework\Microsoft.Rest.ClientRuntime.Azure.TestFramework\TestFramework.xproj", "{C4C4E1C8-B99D-4D90-8C27-6D0C0A268BA5}"
-EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.KeyVault.Core", "Microsoft.Azure.KeyVault.Core\Microsoft.Azure.KeyVault.Core.xproj", "{BE53CF33-9A3D-4101-9DFD-62AC09CADADA}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.KeyVault.Cryptography", "Microsoft.Azure.KeyVault.Cryptography\Microsoft.Azure.KeyVault.Cryptography.xproj", "{9021F320-DE06-433B-ADBC-25A5BC0AA43B}"
@@ -20,8 +18,6 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.KeyVault.Extensions.Tests", "Microsoft.Azure.KeyVault.Extensions.Tests\Microsoft.Azure.KeyVault.Extensions.Tests.xproj", "{E01674C0-B8D7-4598-971C-48B0180E274A}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.KeyVault.TestFramework", "Microsoft.Azure.KeyVault.TestFramework\Microsoft.Azure.KeyVault.TestFramework.xproj", "{6F5823CD-D1D7-4DF4-BE61-F07FD8134433}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "HttpRecorder", "..\TestFramework\Microsoft.Azure.Test.HttpRecorder\HttpRecorder.xproj", "{5D12D45A-E55F-410E-B8AF-9DC90E81B237}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.KeyVault.WebKey", "Microsoft.Azure.KeyVault.WebKey\Microsoft.Azure.KeyVault.WebKey.xproj", "{643372AD-2DBC-4395-95B9-61183D3F2904}"
 EndProject
@@ -41,10 +37,6 @@ Global
 		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F5823CD-D1D7-4DF4-BE61-F07FD8134400}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C4C4E1C8-B99D-4D90-8C27-6D0C0A268BA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C4C4E1C8-B99D-4D90-8C27-6D0C0A268BA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C4C4E1C8-B99D-4D90-8C27-6D0C0A268BA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C4C4E1C8-B99D-4D90-8C27-6D0C0A268BA5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BE53CF33-9A3D-4101-9DFD-62AC09CADADA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BE53CF33-9A3D-4101-9DFD-62AC09CADADA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE53CF33-9A3D-4101-9DFD-62AC09CADADA}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -69,10 +61,6 @@ Global
 		{6F5823CD-D1D7-4DF4-BE61-F07FD8134433}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F5823CD-D1D7-4DF4-BE61-F07FD8134433}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F5823CD-D1D7-4DF4-BE61-F07FD8134433}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5D12D45A-E55F-410E-B8AF-9DC90E81B237}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5D12D45A-E55F-410E-B8AF-9DC90E81B237}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5D12D45A-E55F-410E-B8AF-9DC90E81B237}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5D12D45A-E55F-410E-B8AF-9DC90E81B237}.Release|Any CPU.Build.0 = Release|Any CPU
 		{643372AD-2DBC-4395-95B9-61183D3F2904}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{643372AD-2DBC-4395-95B9-61183D3F2904}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{643372AD-2DBC-4395-95B9-61183D3F2904}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/KeyVault/global.json
+++ b/src/KeyVault/global.json
@@ -1,13 +1,8 @@
 {
   "projects": [
-    "../TestFramework/",
-    "../ResourceManagement/KeyVaultManagement",
     "Microsoft.Azure.KeyVault",
-    "Microsoft.Azure.KeyVault.Tests",
     "Microsoft.Azure.KeyVault.Core",
     "Microsoft.Azure.KeyVault.Cryptography",
-    "Microsoft.Azure.KeyVault.Cryptography.Tests",
-    "Microsoft.Azure.KeyVault.Extensions",
-    "Microsoft.Azure.KeyVault.Extensions.Tests"
+    "Microsoft.Azure.KeyVault.Extensions"
   ]
 }


### PR DESCRIPTION
Fixing the keyvault build project by removing references to the external projects.
