### PR TITLE
Remove the net45 framework dependencies and bumped the package version.

### DIFF
--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions.Tests/project.json
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions.Tests/project.json
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.Azure.KeyVault": "2.0.0-preview",
+    "Microsoft.Azure.KeyVault": "2.0.1-preview",
     "Microsoft.Azure.KeyVault.Cryptography": "2.0.0-preview",
     "Microsoft.Azure.KeyVault.Extensions": "2.0.0-preview",
     "Microsoft.Azure.KeyVault.Core": "2.0.0-preview",

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/project.json
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/project.json
@@ -18,7 +18,7 @@
     "keyFile": "../../../tools/MSSharedLibKey.snk"
   },
   "dependencies": {
-    "Microsoft.Azure.KeyVault": "2.0.0-preview",
+    "Microsoft.Azure.KeyVault": "2.0.1-preview",
     "Microsoft.Azure.KeyVault.Core": "2.0.0-preview",
     "Microsoft.Azure.KeyVault.Cryptography": "2.0.0-preview",
     "Microsoft.Azure.KeyVault.WebKey": "2.0.0-preview"

--- a/src/KeyVault/Microsoft.Azure.KeyVault.TestFramework/project.json
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.TestFramework/project.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "Microsoft.Rest.ClientRuntime": "[2.3.2, 3.0)",
     "Microsoft.Rest.ClientRuntime.Azure": "[3.3.1, 4.0)",
-    "Microsoft.Azure.KeyVault": "2.0.0-preview",
+    "Microsoft.Azure.KeyVault": "2.0.1-preview",
     "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "[1.3.5-preview,2.0.0)",
     "Microsoft.Azure.Graph.RBAC": "2.2.2-preview",
     "Microsoft.Azure.Management.ResourceManager": "1.1.4-preview",

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Tests/project.json
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-preview",
+  "version": "2.0.1-preview",
   "description": "Microsoft.Azure.KeyVault.Tests Class Library",
   "authors": [ "Microsoft Corporation" ],
 
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.Azure.KeyVault": "2.0.0-preview",
+    "Microsoft.Azure.KeyVault": "2.0.1-preview",
     "Microsoft.Azure.KeyVault.TestFramework": "2.0.0-preview",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "xunit": "2.2.0-beta2-build3300"

--- a/src/KeyVault/Microsoft.Azure.KeyVault/project.json
+++ b/src/KeyVault/Microsoft.Azure.KeyVault/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-preview",
+  "version": "2.0.1-preview",
   "title": "Microsoft Azure key vault",
   "description": "Azure Key Vault enables users to store and use cryptographic keys within the Microsoft Azure environment. Azure Key Vault supports multiple key types and algorithms and enables the use of Hardware Security Modules (HSM) for high value customer keys. In addition, Azure Key Vault allows users to securely store secrets in a Key Vault; secrets are limited size octet objects and Azure Key Vault applies no specific semantics to these objects. A Key Vault may contain a mix of keys and secrets at the same time, and access control for the two types of object is independently controlled. Users, subject to appropriate authorization, may: 1) Manage cryptographic keys using Create, Import, Update, Delete and other operations 2) Manage secrets using Get, Set, Delete and other operations 3) Use cryptographic keys with Sign/Verify, WrapKey/UnwrapKey and Encrypt/Decrypt operations. Operations against Key Vaults are authenticated and authorized using Azure Active Directory.",
   "authors": [ "Microsoft" ],
@@ -28,13 +28,6 @@
 
   "frameworks": {
     "net45": {
-      "frameworkAssemblies": {
-        "System.Collections": "",
-        "System.Linq.Expressions": "",
-        "System.Runtime": "",
-        "System.Runtime.Serialization": "",
-        "System.Threading.Tasks": ""
-      }
     },
     "netstandard1.5": {
       "buildOptions": { "define": [ "PORTABLE" ] },


### PR DESCRIPTION
This is a fix to the keyvault package for the unnecessary framework references to net45.
