### PR TITLE
[Engineering Improvement] Updating testFramework variables to avoid confusion

### DIFF
--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ConnectionStringFields.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ConnectionStringFields.cs
@@ -63,12 +63,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         /// The key inside the connection string for a Microsoft ID (OrgId or LiveId)
         /// </summary>
         public const string UserId = "UserId";
-
-        /// <summary>
-        /// Service principal key
-        /// </summary>
-        //public const string ServicePrincipal = "ServicePrincipal";
-
+        
         /// <summary>
         /// The key inside the connection string for a user password matching the Microsoft ID
         /// </summary>

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ConnectionStringFields.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ConnectionStringFields.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         /// <summary>
         /// Service principal key
         /// </summary>
-        public const string ServicePrincipal = "ServicePrincipal";
+        //public const string ServicePrincipal = "ServicePrincipal";
 
         /// <summary>
         /// The key inside the connection string for a user password matching the Microsoft ID
@@ -88,6 +88,11 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         /// The client ID to use when authenticating with AAD
         /// </summary>
         public const string AADClientId = "AADClientId";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public const string AADClientSecret = "AADClientSecret";
 
         /// <summary>
         /// Endpoint to use for AAD authentication

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironment.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironment.cs
@@ -35,12 +35,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         /// The resource management endpoint name
         /// </summary>
         public const string ResourceManagementUri = "ResourceManagementUri";
-
-        /// <summary>
-        /// Service principal key
-        /// </summary>
-        //public const string ServicePrincipalKey = ConnectionStringFields.ServicePrincipal;
-
+        
         /// <summary>
         /// The key inside the connection string for the userId identifier
         /// </summary>
@@ -291,8 +286,6 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         }
 
         public Dictionary<TokenAudience,TokenCredentials> TokenInfo { get; private set; }
-
-        //public string ServicePrincipal { get; set; }
 
         public string UserName { get; set; }
 

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironment.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironment.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         /// <summary>
         /// Service principal key
         /// </summary>
-        public const string ServicePrincipalKey = ConnectionStringFields.ServicePrincipal;
+        //public const string ServicePrincipalKey = ConnectionStringFields.ServicePrincipal;
 
         /// <summary>
         /// The key inside the connection string for the userId identifier
@@ -58,8 +58,13 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         /// <summary>
         /// The key inside the connection string for the AAD client ID"
         /// </summary>
-        public const string ClientIdKey = ConnectionStringFields.AADClientId;
-        public const string ClientIdDefault = "1950a258-227b-4e31-a9cf-717495945fc2";
+        public const string AADClientIdKey = ConnectionStringFields.AADClientId;
+        public const string AADClientIdDefault = "1950a258-227b-4e31-a9cf-717495945fc2";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public const string AADClientSecretKey = ConnectionStringFields.AADClientSecret;
 
         /// <summary>
         /// The key inside the connection string for the AAD Tenant
@@ -157,7 +162,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
             this.Endpoints = TestEnvironment.EnvEndpoints[EnvironmentDefault];
 
             this.BaseUri = this.Endpoints.ResourceManagementUri;
-            this.ClientId = TestEnvironment.ClientIdDefault;
+            this.AADClientId = TestEnvironment.AADClientIdDefault;
             this.Tenant = TestEnvironment.AADTenantDefault;
 
             if (connection != null)
@@ -171,10 +176,6 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
                         this.Tenant = splitUser[1];
                     }
                 }
-                if (connection.ContainsKey(TestEnvironment.ServicePrincipalKey))
-                {
-                    this.ServicePrincipal = connection[TestEnvironment.ServicePrincipalKey];
-                }
                 if (connection.ContainsKey(TestEnvironment.AADTenantKey))
                 {
                     this.Tenant = connection[TestEnvironment.AADTenantKey];
@@ -183,10 +184,16 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
                 {
                     this.SubscriptionId = connection[TestEnvironment.SubscriptionIdKey];
                 }
-                if (connection.ContainsKey(TestEnvironment.ClientIdKey))
+                if (connection.ContainsKey(TestEnvironment.AADClientIdKey))
                 {
-                    this.ClientId = connection[TestEnvironment.ClientIdKey];
+                    this.AADClientId = connection[TestEnvironment.AADClientIdKey];
                 }
+
+                if (connection.ContainsKey(TestEnvironment.AADClientSecretKey))
+                {
+                    this.AADClientSecret = connection[TestEnvironment.AADClientSecretKey];
+                }
+
                 if (connection.ContainsKey(TestEnvironment.EnvironmentKey))
                 {
                     if (ConnectionStringContainsEndpoint(connection))
@@ -285,13 +292,15 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
 
         public Dictionary<TokenAudience,TokenCredentials> TokenInfo { get; private set; }
 
-        public string ServicePrincipal { get; set; }
+        //public string ServicePrincipal { get; set; }
 
         public string UserName { get; set; }
 
         public string Tenant { get; set; }
 
-        public string ClientId { get; set; }
+        public string AADClientId { get; set; }
+
+        public string AADClientSecret { get; set; }
 
         public string SubscriptionId { get; set; }
         

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironmentFactory.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironmentFactory.cs
@@ -81,14 +81,13 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
                                 testEnv.Endpoints)
                                 .ConfigureAwait(false).GetAwaiter().GetResult();
                         }
-                        //else if (testEnv.ServicePrincipal != null && password != null)
+                        
                         else if (testEnv.AADClientId != null && password != null)
                         {
                             TestEnvironmentFactory.LoginServicePrincipalAsync(
                                 testEnv.TokenInfo,
                                 testEnv.Tenant,
                                 testEnv.AADClientId,
-                                //testEnv.ServicePrincipal, 
                                 password, 
                                 testEnv.Endpoints)
                                 .ConfigureAwait(false).GetAwaiter().GetResult();

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironmentFactory.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/TestEnvironmentFactory.cs
@@ -81,12 +81,14 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
                                 testEnv.Endpoints)
                                 .ConfigureAwait(false).GetAwaiter().GetResult();
                         }
-                        else if (testEnv.ServicePrincipal != null && password != null)
+                        //else if (testEnv.ServicePrincipal != null && password != null)
+                        else if (testEnv.AADClientId != null && password != null)
                         {
                             TestEnvironmentFactory.LoginServicePrincipalAsync(
                                 testEnv.TokenInfo,
                                 testEnv.Tenant,
-                                testEnv.ServicePrincipal, 
+                                testEnv.AADClientId,
+                                //testEnv.ServicePrincipal, 
                                 password, 
                                 testEnv.Endpoints)
                                 .ConfigureAwait(false).GetAwaiter().GetResult();
@@ -194,7 +196,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         {
             var request = new HttpRequestMessage
             {
-                RequestUri = new Uri(string.Format("{0}/subscriptions?api-version=2014-04-01-preview", baseuri))
+                RequestUri = new Uri(string.Format("{0}subscriptions?api-version=2014-04-01-preview", baseuri))
             };
 
             HttpClient client = new HttpClient();
@@ -230,13 +232,13 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
             };
 
             var mgmAuthResult = (TokenCredentials) await UserTokenProvider
-                                .LoginSilentAsync(TestEnvironment.ClientIdDefault, domain, username, password, mgmSettings)
+                                .LoginSilentAsync(TestEnvironment.AADClientIdDefault, domain, username, password, mgmSettings)
                                 .ConfigureAwait(false);
 
             try
             {
                 var graphAuthResult = (TokenCredentials)await UserTokenProvider
-                                .LoginSilentAsync(TestEnvironment.ClientIdDefault, domain, username, password, grpSettings)
+                                .LoginSilentAsync(TestEnvironment.AADClientIdDefault, domain, username, password, grpSettings)
                                 .ConfigureAwait(false);
                 tokens[TokenAudience.Graph] = graphAuthResult;
             }
@@ -250,31 +252,31 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
 
         private static async Task LoginServicePrincipalAsync(
             Dictionary<TokenAudience, TokenCredentials> tokens,
-            string domain, 
-            string servicePrincipalId, 
-            string key,
+            string aadTenantId, 
+            string aadClientId, 
+            string aadClientSecret,
             TestEndpoints endpoints)
         {
             var mgmSettings = new ActiveDirectoryServiceSettings()
             {
-                AuthenticationEndpoint = new Uri(endpoints.AADAuthUri.ToString() + domain),
+                AuthenticationEndpoint = new Uri(endpoints.AADAuthUri.ToString() + aadTenantId),
                 TokenAudience = endpoints.AADTokenAudienceUri
             };
 
             var mgmAuthResult = (TokenCredentials) await ApplicationTokenProvider
-                            .LoginSilentAsync(domain, servicePrincipalId, key, mgmSettings)
+                            .LoginSilentAsync(aadTenantId, aadClientId, aadClientSecret, mgmSettings)
                             .ConfigureAwait(false);
 
             var grpSettings = new ActiveDirectoryServiceSettings()
             {
-                AuthenticationEndpoint = new Uri(endpoints.AADAuthUri.ToString() + domain),
+                AuthenticationEndpoint = new Uri(endpoints.AADAuthUri.ToString() + aadTenantId),
                 TokenAudience = endpoints.GraphTokenAudienceUri
             };
 
             try
             {
                 var graphAuthResult = (TokenCredentials)await ApplicationTokenProvider
-                                .LoginSilentAsync(domain, servicePrincipalId, key, grpSettings)
+                                .LoginSilentAsync(aadTenantId, aadClientId, aadClientSecret, grpSettings)
                                 .ConfigureAwait(false);
                 tokens[TokenAudience.Graph] = graphAuthResult;
             }
@@ -289,35 +291,35 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
 #if NET45
         private static void LoginWithPromptAsync(
             Dictionary<TokenAudience, TokenCredentials> tokens,
-            string domain,
+            string aadTenantId,
             TestEndpoints endpoints)
         {
             var mgmSettings = new ActiveDirectoryServiceSettings()
             {
-                AuthenticationEndpoint = new Uri(endpoints.AADAuthUri.ToString() + domain),
+                AuthenticationEndpoint = new Uri(endpoints.AADAuthUri.ToString() + aadTenantId),
                 TokenAudience = endpoints.AADTokenAudienceUri
             };
             var grpSettings = new ActiveDirectoryServiceSettings()
             {
-                AuthenticationEndpoint = new Uri(endpoints.AADAuthUri.ToString() + domain),
+                AuthenticationEndpoint = new Uri(endpoints.AADAuthUri.ToString() + aadTenantId),
                 TokenAudience = endpoints.GraphTokenAudienceUri
             };
 
             var clientSettings = new ActiveDirectoryClientSettings()
             {
-                ClientId = TestEnvironment.ClientIdDefault,
+                ClientId = TestEnvironment.AADClientIdDefault,
                 ClientRedirectUri = new Uri("urn:ietf:wg:oauth:2.0:oob"),
                 PromptBehavior = PromptBehavior.Auto
             };
 
             var mgmAuthResult = (TokenCredentials) UserTokenProvider
-                          .LoginWithPromptAsync(domain, clientSettings, mgmSettings)
+                          .LoginWithPromptAsync(aadTenantId, clientSettings, mgmSettings)
                           .ConfigureAwait(false)
                           .GetAwaiter().GetResult();
             try
             {
                 var graphAuthResult = (TokenCredentials)UserTokenProvider
-                               .LoginWithPromptAsync(domain, clientSettings, grpSettings)
+                               .LoginWithPromptAsync(aadTenantId, clientSettings, grpSettings)
                               .GetAwaiter().GetResult();
                 tokens[TokenAudience.Graph] = graphAuthResult;
             }


### PR DESCRIPTION
All the variable names related to service principal can create confusion when setting environment connection string. Especially Service principal client secret is being passed by overloading existing Password key.
Removing ServicePrincipal references and replacing with appropriate clientId and clientSecret keys.
This change will be accompanied with a check-in in PowerShell repo by updating SetupLiveScenarioTestEnv.ps1 script.
