### PR TITLE
Search SDK: Adding maximum constraint validation for maxTokenLength

### DIFF
--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ClassicTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ClassicTokenizer.cs
@@ -56,6 +56,10 @@ namespace Microsoft.Azure.Search.Models
         public override void Validate()
         {
             base.Validate();
+            if (this.MaxTokenLength > 300)
+            {
+                throw new ValidationException(ValidationRules.InclusiveMaximum, "MaxTokenLength", 300);
+            }
         }
     }
 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MicrosoftLanguageStemmingTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MicrosoftLanguageStemmingTokenizer.cs
@@ -84,6 +84,10 @@ namespace Microsoft.Azure.Search.Models
         public override void Validate()
         {
             base.Validate();
+            if (this.MaxTokenLength > 300)
+            {
+                throw new ValidationException(ValidationRules.InclusiveMaximum, "MaxTokenLength", 300);
+            }
         }
     }
 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MicrosoftLanguageTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MicrosoftLanguageTokenizer.cs
@@ -81,6 +81,10 @@ namespace Microsoft.Azure.Search.Models
         public override void Validate()
         {
             base.Validate();
+            if (this.MaxTokenLength > 300)
+            {
+                throw new ValidationException(ValidationRules.InclusiveMaximum, "MaxTokenLength", 300);
+            }
         }
     }
 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StandardAnalyzer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StandardAnalyzer.cs
@@ -62,6 +62,10 @@ namespace Microsoft.Azure.Search.Models
         public override void Validate()
         {
             base.Validate();
+            if (this.MaxTokenLength > 300)
+            {
+                throw new ValidationException(ValidationRules.InclusiveMaximum, "MaxTokenLength", 300);
+            }
         }
     }
 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StandardTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StandardTokenizer.cs
@@ -55,6 +55,10 @@ namespace Microsoft.Azure.Search.Models
         public override void Validate()
         {
             base.Validate();
+            if (this.MaxTokenLength > 300)
+            {
+                throw new ValidationException(ValidationRules.InclusiveMaximum, "MaxTokenLength", 300);
+            }
         }
     }
 }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/UaxUrlEmailTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/UaxUrlEmailTokenizer.cs
@@ -55,6 +55,10 @@ namespace Microsoft.Azure.Search.Models
         public override void Validate()
         {
             base.Validate();
+            if (this.MaxTokenLength > 300)
+            {
+                throw new ValidationException(ValidationRules.InclusiveMaximum, "MaxTokenLength", 300);
+            }
         }
     }
 }

--- a/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
+++ b/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Makes it easy to develop a .NET application that uses Azure Search.")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.3.0")]
+[assembly: AssemblyFileVersion("2.0.4.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/Search/Microsoft.Azure.Search/project.json
+++ b/src/Search/Microsoft.Azure.Search/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.3-preview",
+  "version": "2.0.4-preview",
   "title": "Microsoft Azure Search Library",
   "description": "Makes it easy to develop a .NET application that uses Azure Search.",
   "authors": [ "Microsoft" ],

--- a/src/Search/Search.Tests/project.json
+++ b/src/Search/Search.Tests/project.json
@@ -29,7 +29,7 @@
       "version": "1.0.0" 
     }, 
     "Search.Management.Tests": "1.0.0",
-    "Microsoft.Azure.Search": "2.0.3-preview",
+    "Microsoft.Azure.Search": "2.0.4-preview",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0"
   }
 }


### PR DESCRIPTION
This isn't technically a breaking change since setting maxTokenLength larger than the maximum would have failed before anyway, but the failure mode has changed.

FYI @Yahnoosh
