### PR TITLE
ADF - Add MultipleWebServiceInputs to AzureMLBatchExecutionActivity

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/PipelineJsonSamples.cs
+++ b/src/ResourceManagement/DataFactory/DataFactory.Tests/Framework/JsonSamples/PipelineJsonSamples.cs
@@ -598,6 +598,59 @@ namespace DataFactory.Tests.Framework.JsonSamples
 }
 ";
 
+        [JsonSample]
+        public const string AzureMLPipelineWithWebServiceInputs = @"
+{
+    name: ""My machine learning pipeline WebServiceInputs"",
+    properties: 
+    {
+        description : ""ML pipeline description"",
+        hubName : ""someHub"",
+        activities:
+        [
+            {
+                name: ""MLActivity"",
+                description: ""Test activity description"", 
+                type: ""AzureMLBatchExecution"",
+                typeProperties: {
+                    webServiceInputs: {
+                        ""webServiceInput1"": ""csvBlob1"",
+                        ""webServiceInput2"": ""csvBlob2""
+                    },
+                    webServiceOutputs: {
+                        ""webServiceOutput1"": ""sasCopyBlob""
+                    }
+                },
+                inputs: 
+                [ 
+                    {
+                        name: ""csvBlob1""
+                    },
+                    {   
+                        name: ""csvBLob2""
+                    }
+                ],
+                outputs: 
+                [ 
+                    {
+                        name: ""sasCopyBlob""
+                    }
+                ],
+                linkedServiceName: ""mlLinkedService"",
+                policy:
+                {
+                    concurrency: 3,
+                    executionPriorityOrder: ""NewestFirst"",
+                    retry: 3,
+                        timeout: ""00:00:05"",
+                        delay: ""00:00:01""
+                }
+            }
+        ]
+    }
+}
+";
+
         [JsonSample(propertyBagKeys: new string[]
                     {
                         "properties.activities[0].typeProperties.webServiceParameters.oNe",

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Activities/AzureMLBatchExecutionActivity .cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Customizations/Models/Activities/AzureMLBatchExecutionActivity .cs
@@ -26,25 +26,35 @@ namespace Microsoft.Azure.Management.DataFactories.Models
         /// <summary>
         /// Optional. Key,Value pairs to be passed to the Azure ML Batch Execution Service Endpoint. 
         /// Keys must match the names of web service parameters defined in the published Azure ML web service. 
-        /// Values may include ADF functions to be resolved at each slice execution time 
-        /// (See https://msdn.microsoft.com/en-us/library/azure/dn835056.aspx). 
+        /// Values may include Azure Data Factory functions to be resolved at each slice execution time 
+        /// (See http://go.microsoft.com/fwlink/?LinkId=823697). 
         /// Values will be passed in the GlobalParameters property of the Azure ML batch execution request.
         /// </summary>
         public IDictionary<string, string> GlobalParameters { get; set; }
 
         /// <summary>
-        /// Optional. Key,Value pairs mapping the Azure ML endpoint's Web Service Output names to names of ADF Blob
-        /// Datasets where the batch execution output should be written. This information will be passed in the 
-        /// WebServiceOutputs property of the Azure ML batch execution request.
-        /// Mapped Datasets must be included in the Activity's Outputs.
+        /// Optional. Key, Value pairs mapping the names of Azure ML web service outputs to names of Data Factory datasets.
+        /// The batch execution output is written to these datasets.
+        /// This information will be passed in the WebServiceOutputs property of the Azure ML batch execution request.
+        /// Mapped datasets must be included in the Activity's outputs.
         /// </summary>
         public IDictionary<string, string> WebServiceOutputs { get; set; }
 
         /// <summary>
-        /// Optional. Name of ADF Blob Dataset giving the input to the batch execution. This information will be passed
-        /// in the WebServiceInput property of the Azure ML batch execution request.
+        /// Optional. Name of Data Factory dataset giving the input to the batch execution. 
+        /// This information will be passed in the WebServiceInput property of the Azure ML batch execution request. 
+        /// WebServiceInput cannot be used simultaneously with WebServiceInputs.
         /// </summary>
         public string WebServiceInput { get; set; }
+
+        /// <summary>
+        /// Optional. Key, Value pairs mapping the names of Azure ML web service inputs to names of Data Factory datasets.
+        /// The batch execution input is stored in these datasets.
+        /// This information will be passed in the WebServiceInputs property of the Azure ML batch execution request.
+        /// Mapped datasets must be included in the Activity's inputs. 
+        /// WebServiceInputs cannot be used simultaneously with WebServiceInput.
+        /// </summary>
+        public IDictionary<string, string> WebServiceInputs { get; set; }
 
         public AzureMLBatchExecutionActivity()
         {

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
@@ -1,7 +1,7 @@
 For additional details on features, see the full [Azure Data Factory Release Notes](https://azure.microsoft.com/en-us/documentation/articles/data-factory-release-notes). 
 
-## Version 4.11.0
-_Release date: 2016.08.31_ 
+## Version 4.10.0
+_Release date: 2016.09.09_ 
 
 ### Feature Additions
 
@@ -9,12 +9,6 @@ _Release date: 2016.08.31_
     * SkipLineCount
     * FirstRowAsHeader 
     * TreatEmptyAsNull
-
-## Version 4.10.0
-_Release date: 2016.08.09_ 
-
-### Feature Additions
-
 * The following linked service types have been added: 
     * OnPremisesCassandraLinkedService, SalesforceLinkedService
 * The following dataset types have been added: 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
@@ -15,6 +15,8 @@ _Release date: 2016.09.09_
     * OnPremisesCassandraTableDataset
 * The following copy source types have been added: 	
     * CassandraSource
+* Add WebServiceInputs property to AzureMLBatchExecutionActivity
+    * Enable passing multiple web service inputs to an Azure Machine Learning experiment
 
 ## Version 4.9.1
 _Release date: 2016.07.05_ 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataFactories
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataFactories">
-      <PackageVersion>4.11.0</PackageVersion>
+      <PackageVersion>4.10.0</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
@@ -3,7 +3,7 @@
   <metadata minClientVersion="2.5">
     <id>Microsoft.Azure.Management.DataFactories</id>
     <title>Microsoft Azure Data Factory Management Library</title>
-    <releaseNotes>https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log/#version-4110</releaseNotes>
+    <releaseNotes>https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log/#version-4100</releaseNotes>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>azure-sdk, Microsoft</owners>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Factory management operations.")]
 
 [assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.11.0.0")]
+[assembly: AssemblyFileVersion("4.10.0.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
Add MultipleWebServiceInputs to AzureMLBatchExecutionActivity
- Enable passing multiple web service inputs to an Azure Machine Learning experiment
- Also reverts the nuget package version back to 4.10.0 since that version was never published. The package will be pushed after this change is merged. 
