### PR TITLE
Limit the KeyVault package dependency to V1 in master branch

### DIFF
--- a/src/KeyVault/KeyVault.Extensions.Tests/packages.config
+++ b/src/KeyVault/KeyVault.Extensions.Tests/packages.config
@@ -4,9 +4,9 @@
   <package id="Microsoft.Azure.Common" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Graph.RBAC" version="1.7.0-preview" targetFramework="net45" />
-  <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Management.KeyVault" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net45" allowedVersions="[1,2)" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" allowedVersions="[1,2)" />
+  <package id="Microsoft.Azure.Management.KeyVault" version="1.0.0" targetFramework="net45" allowedVersions="[1,2)" />
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />

--- a/src/KeyVault/KeyVault.Tests/packages.config
+++ b/src/KeyVault/KeyVault.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.Graph.RBAC" version="1.7.0-preview" targetFramework="net45" />
-  <package id="Microsoft.Azure.Management.KeyVault" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Management.KeyVault" version="1.0.0" targetFramework="net45" allowedVersions="[1,2)" />
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.nuget.proj
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.KeyVault.Extensions
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.KeyVault.Extensions">
-      <PackageVersion>1.0.4</PackageVersion>
+      <PackageVersion>1.0.5</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.nuspec
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.nuspec
@@ -28,12 +28,12 @@
         <dependency id="Microsoft.Bcl" version="1.1.9" />
         <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
         <dependency id="Microsoft.Bcl.Build" version="1.0.14" />
-        <dependency id="Microsoft.Azure.KeyVault" version="1.0.0" />
-        <dependency id="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
+        <dependency id="Microsoft.Azure.KeyVault" version="[1.0.0, 2.0.0)" />
+        <dependency id="Microsoft.Azure.KeyVault.Core" version="[1.0.0, 2.0.0)" />
       </group>
       <group targetFramework="net45">
-        <dependency id="Microsoft.Azure.KeyVault" version="1.0.0" />
-        <dependency id="Microsoft.Azure.KeyVault.Core" version="1.0.0" />
+        <dependency id="Microsoft.Azure.KeyVault" version="[1.0.0, 2.0.0)" />
+        <dependency id="Microsoft.Azure.KeyVault.Core" version="[1.0.0, 2.0.0)" />
       </group>
     </dependencies>
   </metadata>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Properties/AssemblyInfo.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using System.Resources;
 [assembly: AssemblyDescription( "Provides extended capabilities for Azure Key Vault." )]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.4.0")]
+[assembly: AssemblyFileVersion("1.0.5.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/packages.config
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/packages.config
@@ -3,8 +3,8 @@
   <package id="Hyak.Common" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.Azure.Common" version="2.0.4" targetFramework="net45" />
   <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net45" allowedVersions="[1,2)"/>
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" allowedVersions="[1,2)"/>
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/packages.config
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.Common" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net45" allowedVersions="[1,2)" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/packages.config
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/packages.config
@@ -10,8 +10,8 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.Common" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net45" allowedVersions="[1,2)" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" allowedVersions="[1,2)" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultConfigurationManager/packages.config
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultConfigurationManager/packages.config
@@ -3,7 +3,7 @@
   <package id="Hyak.Common" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Common" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net452" allowedVersions="[1,2)" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />


### PR DESCRIPTION
Key Vault V2 is in AutoRest branch and has breaking changes. This change is to limit Key Vault dependencies to version V1.
