### PR TITLE
Search SDK: Fixing datetime deserialization issue

### DIFF
--- a/src/Search/Microsoft.Azure.Search/Customizations/Serialization/Private/DocumentConverter.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Serialization/Private/DocumentConverter.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Azure.Search.Serialization
     using System;
     using System.Linq;
     using System.Reflection;
-    using Microsoft.Azure.Search.Models;
-    using Microsoft.Spatial;
+    using Models;
+    using Spatial;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Search.Serialization
                     }
                     else
                     {
-                        value = array.Select(t => t.Value<string>()).ToArray();
+                        value = ConvertArray(array, serializer);
                     }
                 }
                 else if (field.Value is JObject)
@@ -91,6 +91,15 @@ namespace Microsoft.Azure.Search.Serialization
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
+        }
+
+        private static object[] ConvertArray(JArray array, JsonSerializer serializer)
+        {
+            // There are two cases to consider: Either everything is a string, or it's not. If not, don't attempt
+            // any conversions and return everything in an object array.
+            return array.All(t => t.Type == JTokenType.String || t.Type == JTokenType.Null) ? 
+                array.Select(t => t.Value<string>()).ToArray() : 
+                array.Select(t => t.ToObject(typeof(object), serializer)).ToArray();
         }
     }
 }

--- a/src/Search/Search.Tests/Tests/Serialization/DocumentConverterTests.cs
+++ b/src/Search/Search.Tests/Tests/Serialization/DocumentConverterTests.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+namespace Microsoft.Azure.Search.Tests
+{
+    using Serialization;
+    using Models;
+    using Newtonsoft.Json;
+    using Xunit;
+    using System;
+    using Spatial;
+
+    public sealed class DocumentConverterTests
+    {
+        private const string TestDateString = "2016-10-10T17:41:05.123-07:00";
+
+        private static readonly DateTimeOffset TestDate = new DateTimeOffset(2016, 10, 10, 17, 41, 5, 123, TimeSpan.FromHours(-7));
+
+        // Use the same deserialization settings as JsonUtility so we're getting the right behavior for deserializing field values.
+        private readonly JsonSerializerSettings _settings =
+            new JsonSerializerSettings()
+            {
+                Converters = new JsonConverter[] { new DocumentConverter(), new GeographyPointConverter(), new DateTimeConverter() },
+                DateParseHandling = DateParseHandling.DateTimeOffset,
+                NullValueHandling = NullValueHandling.Include
+            };
+
+        [Fact]
+        public void AnnotationsAreExcludedFromDocument()
+        {
+            const string Json =
+@"{
+    ""@search.score"": 3.14,
+    ""field1"": ""value1"",
+    ""field2"": 123,
+    ""@search.someOtherAnnotation"": { ""a"": ""b"" },
+    ""field3"": 2.78
+}";
+
+            Document doc = JsonConvert.DeserializeObject<Document>(Json, _settings);
+
+            Assert.Equal(3, doc.Count);
+            Assert.Equal("value1", doc["field1"]);
+            Assert.Equal(123L, doc["field2"]);
+            Assert.Equal(2.78, doc["field3"]);
+        }
+
+        [Fact]
+        public void CanReadNullValues()
+        {
+            const string Json =
+@"{
+    ""field1"": null,
+    ""field2"": [ ""hello"", null ]
+}";
+
+            Document doc = JsonConvert.DeserializeObject<Document>(Json, _settings);
+
+            Assert.Equal(2, doc.Count);
+            Assert.Null(doc["field1"]);
+
+            string[] field2Values = Assert.IsType<string[]>(doc["field2"]);
+
+            Assert.Equal(2, field2Values.Length);
+            Assert.Equal("hello", field2Values[0]);
+            Assert.Null(field2Values[1]);
+        }
+
+        [Fact]
+        public void CanReadEmptyArrays()
+        {
+            Document doc = JsonConvert.DeserializeObject<Document>(@"{ ""field"": [] }", _settings);
+
+            Assert.Equal(1, doc.Count);
+            string[] fieldValues = Assert.IsType<string[]>(doc["field"]);
+            Assert.Equal(0, fieldValues.Length);
+        }
+
+        [Fact]
+        public void CanReadArraysOfStrings()
+        {
+            Document doc = JsonConvert.DeserializeObject<Document>(@"{ ""field"": [""hello"", ""goodbye""] }", _settings);
+
+            Assert.Equal(1, doc.Count);
+            string[] fieldValues = Assert.IsType<string[]>(doc["field"]);
+            Assert.Equal(2, fieldValues.Length);
+            Assert.Equal("hello", fieldValues[0]);
+            Assert.Equal("goodbye", fieldValues[1]);
+        }
+
+        [Fact]
+        public void CanReadGeoPoint()
+        {
+            const string Json = @"{ ""field"": { ""type"": ""Point"", ""coordinates"": [-122.131577, 47.678581] } }";
+            Document doc = JsonConvert.DeserializeObject<Document>(Json, _settings);
+
+            Assert.Equal(1, doc.Count);
+            GeographyPoint fieldValue = Assert.IsAssignableFrom<GeographyPoint>(doc["field"]);
+            Assert.Equal(-122.131577, fieldValue.Longitude);
+            Assert.Equal(47.678581, fieldValue.Latitude);
+        }
+
+        // This is a pinning test. It is not ideal behavior, but it's the best we can do without type information.
+        [Fact]
+        public void SpecialDoublesAreReadAsStrings()
+        {
+            const string Json =
+@"{
+    ""field1"": ""NaN"",
+    ""field2"": ""Infinity"",
+    ""field3"": ""-Infinity""
+}";
+
+            Document doc = JsonConvert.DeserializeObject<Document>(Json, _settings);
+
+            Assert.Equal(3, doc.Count);
+            Assert.Equal("NaN", doc["field1"]);
+            Assert.Equal("Infinity", doc["field2"]);
+            Assert.Equal("-Infinity", doc["field3"]);
+        }
+
+        // This is a pinning test. It is not ideal behavior, but it's the best we can do without type information.
+        [Fact]
+        public void DateTimeStringsAreReadAsDateTime()
+        {
+            string json = $@"{{ ""field"": ""{TestDateString}"" }}";
+
+            Document doc = JsonConvert.DeserializeObject<Document>(json, _settings);
+
+            Assert.Equal(1, doc.Count);
+            Assert.Equal(TestDate, doc["field"]);
+        }
+
+        // This is a pinning test. It is not ideal behavior, but it's the best we can do without type information.
+        [Fact]
+        public void CanReadArraysOfMixedTypes()
+        {
+            // Azure Search won't return payloads like this; This test is only for pinning purposes.
+            Document doc = JsonConvert.DeserializeObject<Document>(@"{ ""field"": [""hello"", 123, 3.14] }", _settings);
+
+            Assert.Equal(1, doc.Count);
+            object[] fieldValues = Assert.IsType<object[]>(doc["field"]);
+            Assert.Equal(3, fieldValues.Length);
+            Assert.Equal("hello", fieldValues[0]);
+            Assert.Equal(123L, fieldValues[1]);
+            Assert.Equal(3.14, fieldValues[2]);
+        }
+
+        // This is a pinning test. It is not ideal behavior, but it's the best we can do without type information.
+        [Fact]
+        public void DateTimeStringsInArraysAreReadAsDateTime()
+        {
+            string json = $@"{{ ""field"": [ ""hello"", ""{TestDateString}"", ""123"" ] }}";
+
+            Document doc = JsonConvert.DeserializeObject<Document>(json, _settings);
+
+            Assert.Equal(1, doc.Count);
+            object[] fieldValues = Assert.IsType<object[]>(doc["field"]);
+            Assert.Equal(3, fieldValues.Length);
+            Assert.Equal("hello", fieldValues[0]);
+            Assert.Equal(TestDate, fieldValues[1]);
+            Assert.Equal("123", fieldValues[2]);
+        }
+    }
+}


### PR DESCRIPTION
Fix for issue https://github.com/Azure/azure-sdk-for-net/issues/2434

Currently, document payloads containing arrays of strings where some of the strings are formatted as ISO datetime values cause exceptions to be thrown on deserialization. This is because JSON.NET automatically deserializes such values to `DateTimeOffset` in the absence of type information, and then we subsequently try to convert the `DateTimeOffset` value to `System.String`, which fails.

The fix for now is to be more tolerant of values that JSON.NET does not parse as strings. This is not a great solution since it doesn't guarantee full fidelity of all types (for example, if you try to round-trip a date time value, it might not work due to different precision in the fractional seconds part). However, a complete solution to this problem requires type information, which we'd need to add to the API responses. This is on our long-term radar, but it will be a while before we solve it.

I've also added new test coverage for DocumentConverter to pin the behavior around deserialization of responses in the absence of type information.
