### PR TITLE
enable .net45 tests for clientruntime tests

### DIFF
--- a/src/ClientRuntime/Microsoft.Rest.ClientRuntime.Tests/ServiceClientTests.cs
+++ b/src/ClientRuntime/Microsoft.Rest.ClientRuntime.Tests/ServiceClientTests.cs
@@ -215,11 +215,10 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             Assert.True(testProduct.Product.Version.Equals(testProductVersion));
         }
 
-        #if net45
+#if NET451
         [Fact]
         public void VerifyOsInfoInUserAgent()
         {
-
             string osInfoProductName = "OSName";
 
             FakeServiceClient fakeClient = new FakeServiceClient(new FakeHttpHandler());
@@ -231,6 +230,6 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             Assert.NotEmpty(osProduct.Product.Name);
             Assert.NotEmpty(osProduct.Product.Version);
         }
-        #endif
+#endif
     }
 }

--- a/src/ClientRuntime/Microsoft.Rest.ClientRuntime.Tests/project.json
+++ b/src/ClientRuntime/Microsoft.Rest.ClientRuntime.Tests/project.json
@@ -13,18 +13,35 @@
   "frameworks": {
     "netcoreapp1.0": {
       "buildOptions": { "define": [ "PORTABLE" ] },
-      "imports": ["dnxcore50", "portable-net45+win8"]
+      "imports": [ "dnxcore50", "portable-net45+win8" ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        },
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "Microsoft.Rest.ClientRuntime.Azure": "[3.3.3,4.0.0)",
+        "Microsoft.Rest.ClientRuntime.Azure.Authentication": "[2.2.8-preview,3.0.0)",
+        "xunit": "2.2.0-beta2-build3300",
+        "dotnet-test-xunit": "2.2.0-preview2-build1029"
+      }
+    },
+    "net451": {
+      "imports": [ "net451", "dnxcore50" ],
+      "buildOptions": {
+        "debugType": "portable"
+      },
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1",
+        "xunit": "2.2.0-beta3-build3402",
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "Microsoft.Rest.ClientRuntime.Azure": "[3.3.3,4.0.0)",
+        "Microsoft.Rest.ClientRuntime.Azure.Authentication": "[2.2.8-preview,3.0.0)"
+      },
+      "frameworkAssemblies": {
+        "System": "",
+        "System.Runtime": ""
+      }
     }
-  },
-  "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0"
-    }, 
-    "Microsoft.NETCore.Platforms": "1.0.1",
-    "Microsoft.Rest.ClientRuntime.Azure": "[3.3.3,4.0.0)",
-    "Microsoft.Rest.ClientRuntime.Azure.Authentication": "[2.2.8-preview,3.0.0)",
-    "xunit": "2.2.0-beta2-build3300",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   }
 }

--- a/src/ClientRuntime/Microsoft.Rest.ClientRuntime/ServiceClient.cs
+++ b/src/ClientRuntime/Microsoft.Rest.ClientRuntime/ServiceClient.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Rest
         /// </summary>
         private string _fxVersion;
 
-#if net45
+#if NET45
         /// <summary>
         /// Indicates OS Name
         /// </summary>
@@ -409,7 +409,8 @@ namespace Microsoft.Rest
             HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(FXVERSION, FrameworkVersion));
 #if net45
             // If you want to log ProductName in userAgent, it has to be without spaces
-            HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(OsName, OsVersion));
+            HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(OSNAME, OsName));
+            HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(OSVERSION, OsVersion));
 #endif
         }
     }


### PR DESCRIPTION
Enable .NET 45 tests for client runtime.
Create .NET 451 target for the client runtime tests (as xunit console runner is only supported on .NET 4.5.1)
