### PR TITLE
Initialize TenantId with a default value of MSFT tenantId if not specified

### DIFF
--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ConnectionString.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ConnectionString.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         private Dictionary<string, string> _keyValuePairs;
         private string _connString;
         private StringBuilder _parseErrorSb;
-        private string DEFAULT_TENANTID = "microsoft.onmicrosoft.com";
+        private string DEFAULT_TENANTID = "72f988bf-86f1-41af-91ab-2d7cd011db47";
 
         #endregion
 

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ConnectionString.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ConnectionString.cs
@@ -20,8 +20,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         private Dictionary<string, string> _keyValuePairs;
         private string _connString;
         private StringBuilder _parseErrorSb;
-        private string DEFAULT_TENANTID = "72f988bf-86f1-41af-91ab-2d7cd011db47";
-        private string DEFAULT_CLIENTID = "1950a258-227b-4e31-a9cf-717495945fc2";
+        private string DEFAULT_TENANTID = "microsoft.onmicrosoft.com";
 
         #endregion
 

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ConnectionString.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/ConnectionString.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         private Dictionary<string, string> _keyValuePairs;
         private string _connString;
         private StringBuilder _parseErrorSb;
+        private string DEFAULT_TENANTID = "72f988bf-86f1-41af-91ab-2d7cd011db47";
+        private string DEFAULT_CLIENTID = "1950a258-227b-4e31-a9cf-717495945fc2";
+
         #endregion
 
         #region Properties
@@ -103,13 +106,14 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         /// </summary>
         private void NormalizeKeyValuePairs()
         {
-            string clientId, spn, password, spnSecret, userId;
+            string clientId, spn, password, spnSecret, userId, aadTenantId;
             KeyValuePairs.TryGetValue(ConnectionStringKeys.AADClientIdKey, out clientId);
             KeyValuePairs.TryGetValue(ConnectionStringKeys.ServicePrincipalKey, out spn);
 
             KeyValuePairs.TryGetValue(ConnectionStringKeys.UserIdKey, out userId);
             KeyValuePairs.TryGetValue(ConnectionStringKeys.PasswordKey, out password);
             KeyValuePairs.TryGetValue(ConnectionStringKeys.ServicePrincipalSecretKey, out spnSecret);
+            KeyValuePairs.TryGetValue(ConnectionStringKeys.AADTenantKey, out aadTenantId);
 
             //ClientId was provided and servicePrincipal was empty, we want ServicePrincipal to be initialized
             //At some point we will deprecate ClientId keyName
@@ -124,11 +128,11 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
             {
                 KeyValuePairs[ConnectionStringKeys.ServicePrincipalSecretKey] = password;
             }
-
-            //Initialize default values if found empty
-            if (string.IsNullOrEmpty(clientId) && (string.IsNullOrEmpty(spn)))
+            
+            //Initialize default value for AADTenent
+            if(string.IsNullOrEmpty(aadTenantId))
             {
-                KeyValuePairs[ConnectionStringKeys.ServicePrincipalKey] = "1950a258-227b-4e31-a9cf-717495945fc2";
+                KeyValuePairs[ConnectionStringKeys.AADTenantKey] = DEFAULT_TENANTID;
             }
 
             //Initialize raw tokens to a non-null/non-empty strings

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/Properties/AssemblyInfo.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/Properties/AssemblyInfo.cs
@@ -16,5 +16,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6eb355e3-e1e1-4f46-bcfa-737812ccff87")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/project.json
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.4.0-preview",
+  "version": "1.5.0-preview",
   "copyright": "Copyright (c) Microsoft Corporation",
   "title": "Test framework for Microsoft AutoRest Generated Clients",
   "description": "Microsoft.Rest.ClientRuntime.Azure.TestFramework",

--- a/src/TestFramework/TestFramework.Tests/TestEnvironment/TestEnvironmentTests.cs
+++ b/src/TestFramework/TestFramework.Tests/TestEnvironment/TestEnvironmentTests.cs
@@ -5,6 +5,8 @@ namespace TestFramework.Tests.TestEnvironment
 {
     using Xunit;
     using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
+    using System;
+    using Microsoft.Azure.Test.HttpRecorder;
 
     public class TestEnvironmentTests
     {
@@ -14,5 +16,17 @@ namespace TestFramework.Tests.TestEnvironment
             TestEnvironment env = new TestEnvironment();
             Assert.Equal<int>(4, env.EnvEndpoints.Count);
         }
+
+        [Fact]
+        public void DefaultTenantInTestEnvironment()
+        {
+            Environment.SetEnvironmentVariable("TEST_CSM_ORGID_AUTHENTICATION", "SubscriptionId=2c224e7e-57b-e71f4662e3a6;ServicePrincipal=4c9b80e8e4-7c2233383b4e;ServicePrincipalSecret=kzSj3+tSXIdRsX8mxuQe7yZY=;Environment=Prod");
+            HttpMockServer.Mode = HttpRecorderMode.Playback;
+            TestEnvironment env = TestEnvironmentFactory.GetTestEnvironment();
+            string tenantId = env.ConnectionString.KeyValuePairs[ConnectionStringKeys.AADTenantKey];
+            Assert.False(string.IsNullOrEmpty(tenantId));
+            Assert.Equal<string>("72f988bf-86f1-41af-91ab-2d7cd011db47", tenantId);
+        }
+
     }
 }


### PR DESCRIPTION
Initialize Tenant ID with a default value of MSFT tenant ID if not specified in connection string
No longer initializing clientId with a default value if not specified.