### PR TITLE
Key Vault bug fixes, sample code license changed to MIT

### DIFF
--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/ConsoleTracingInterceptor.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/ConsoleTracingInterceptor.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System;
 using System.Collections.Generic;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/InjectHostHeaderHttpMessageHandler.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/InjectHostHeaderHttpMessageHandler.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System;
 using System.Threading.Tasks;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/InputValidator.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/InputValidator.cs
@@ -1,19 +1,8 @@
 ﻿//
-// Copyright © Microsoft Corporation, All Rights Reserved
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System;
 using System.Collections.Generic;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/KeyOperationType.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/KeyOperationType.cs
@@ -1,20 +1,8 @@
 ﻿//
-// Copyright © Microsoft Corporation, All Rights Reserved
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
-
 namespace Sample.Microsoft.HelloKeyVault
 {
     enum KeyOperationType

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/Program.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/HelloKeyVault/Program.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System;
 using System.Collections.Generic;
@@ -1011,20 +1000,31 @@ namespace Sample.Microsoft.HelloKeyVault
             if (certificateThumbprint == null)
                 throw new System.ArgumentNullException("certificateThumbprint");
 
-            X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
-            try
+            foreach (StoreLocation storeLocation in (StoreLocation[])
+                Enum.GetValues(typeof(StoreLocation)))
             {
-                store.Open(OpenFlags.ReadOnly);
-                X509Certificate2Collection col = store.Certificates.Find(X509FindType.FindByThumbprint, certificateThumbprint, false); // Don't validate certs, since the test root isn't installed.
-                if (col == null || col.Count == 0)
-                    throw new System.Exception(
-                        string.Format("Could not find the certificate with thumbprint {0} in the Local Machine's Personal certificate store.", certificateThumbprint));
-                return col[0];
+                foreach (StoreName storeName in (StoreName[])
+                    Enum.GetValues(typeof(StoreName)))
+                {
+                    X509Store store = new X509Store(storeName, storeLocation);
+
+                    store.Open(OpenFlags.ReadOnly);
+                    X509Certificate2Collection col = store.Certificates.Find(X509FindType.FindByThumbprint, certificateThumbprint, false); // Don't validate certs, since the test root isn't installed.
+                    if (col != null && col.Count != 0)
+                    {
+                        foreach (X509Certificate2 cert in col)
+                        {
+                            if (cert.HasPrivateKey)
+                            {
+                                store.Close();
+                                return cert;
+                            }
+                        }
+                    }
+                }
             }
-            finally
-            {
-                store.Close();
-            }
+            throw new System.Exception(
+                    string.Format("Could not find the certificate with thumbprint {0} in any certificate store.", certificateThumbprint));
         }
 
         /// <summary>

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/App_Start/BundleConfig.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/App_Start/BundleConfig.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System.Web;
 using System.Web.Optimization;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/App_Start/FilterConfig.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/App_Start/FilterConfig.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System.Web.Mvc;
 

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/App_Start/RouteConfig.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/App_Start/RouteConfig.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System.Web.Mvc;
 using System.Web.Routing;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/CertificateHelper.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/CertificateHelper.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System;
 using System.Security.Cryptography.X509Certificates;
@@ -42,8 +31,14 @@ namespace SampleKeyVaultClientWebRole
                     X509Certificate2Collection col = store.Certificates.Find(X509FindType.FindByThumbprint, certificateThumbprint, false); // Don't validate certs, since the test root isn't installed.
                     if (col != null && col.Count != 0)
                     {
-                        store.Close();
-                        return col[0];
+                        foreach (X509Certificate2 cert in col)
+                        {
+                            if (cert.HasPrivateKey)
+                            {
+                                store.Close();
+                                return cert;
+                            }
+                        }
                     }
                 }
             }

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Constants.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Constants.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 namespace SampleKeyVaultClientWebRole
 {

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Controllers/HomeController.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Controllers/HomeController.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Auth;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Global.asax.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Global.asax.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System;
 using System.Threading.Tasks;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Models/Message.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Models/Message.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System;
 using Microsoft.WindowsAzure.Storage.Table;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Models/MessageBoardModel.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Models/MessageBoardModel.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System;
 using System.Collections.Generic;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Properties/AssemblyInfo.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/Properties/AssemblyInfo.cs
@@ -1,16 +1,7 @@
 ﻿//
-// Copyright (c) Microsoft.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
 
 using System.Reflection;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/StorageTableAccessor.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultClientWebRole/StorageTableAccessor.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultConfigurationManager/ConfigurationManager.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultConfigurationManager/ConfigurationManager.cs
@@ -1,19 +1,8 @@
-﻿// 
-// Copyright © Microsoft Corporation, All Rights Reserved
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
-// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
-// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
-// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
-//
-// See the Apache License, Version 2.0 for the specific language
-// governing permissions and limitations under the License.
 
 using System;
 using System.Runtime.Caching;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultConfigurationManager/Properties/AssemblyInfo.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/samples/SampleAzureWebService/SampleKeyVaultConfigurationManager/Properties/AssemblyInfo.cs
@@ -1,16 +1,7 @@
 ﻿//
-// Copyright (c) Microsoft.  All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
 //
 
 using System.Reflection;

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/scripts/GetAppConfigSettings.ps1
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/scripts/GetAppConfigSettings.ps1
@@ -38,6 +38,8 @@ $certificateName = "$applicationName" + "cert"
 $myCertThumbprint = (New-SelfSignedCertificate -Type Custom -Subject "$certificateName"-KeyUsage DigitalSignature -KeyAlgorithm RSA -KeyLength 2048 -CertStoreLocation "Cert:\CurrentUser\My" -Provider "Microsoft Enhanced Cryptographic Provider v1.0" ).Thumbprint
 $x509 = (Get-ChildItem -Path cert:\CurrentUser\My\$myCertthumbprint)
 $password = Read-Host -Prompt "Please enter the certificate password." -AsSecureString
+
+# Saving the self-signed cert and pfx (private key) in case it's needed later
 Export-Certificate -cert $x509 -FilePath ".\$certificateName.cer"
 Export-PfxCertificate -Cert $x509 -FilePath ".\$certificateName.pfx" -Password $password
 

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Samples/scripts/GetServiceConfigSettings.ps1
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Samples/scripts/GetServiceConfigSettings.ps1
@@ -43,6 +43,8 @@ $certificateName = "$applicationName" + "cert"
 $myCertThumbprint = (New-SelfSignedCertificate -Type Custom -Subject "$certificateName"-KeyUsage DigitalSignature -KeyAlgorithm RSA -KeyLength 2048 -CertStoreLocation "Cert:\CurrentUser\My" -Provider "Microsoft Enhanced Cryptographic Provider v1.0" ).Thumbprint
 $x509 = (Get-ChildItem -Path cert:\CurrentUser\My\$myCertthumbprint)
 $password = Read-Host -Prompt "Please enter the certificate password." -AsSecureString
+
+# Saving the self-signed cert and pfx (private key) in case it's needed later
 Export-Certificate -cert $x509 -FilePath ".\$certificateName.cer"
 Export-PfxCertificate -Cert $x509 -FilePath ".\$certificateName.pfx" -Password $password
 


### PR DESCRIPTION
Sample code license changed to MIT
FindCertificateByThumbprint changed to return matching cert only if it has private key.


