### PR TITLE
[Fluent] Revert to IResource for batch create

### DIFF
--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineTests.cs
@@ -77,7 +77,7 @@ namespace Fluent.Tests.Compute
             }
         }
 
-        [Fact(Skip = "TODO: Convert to recorded tests")]
+        [Fact]
         public void CanCreateVirtualMachinesAndRelatedResourcesInParallel()
         {
             var resourceGroupName = ResourceNamer.RandomResourceName("rgvmtest-", 20);
@@ -172,6 +172,10 @@ namespace Fluent.Tests.Compute
                     Assert.NotNull(createdPublicIpAddress);
                     Assert.True(publicIpAddressNames.Contains(createdPublicIpAddress.Name));
                 }
+            }
+            catch(Exception exception)
+            {
+                Assert.True(false, exception.Message);
             }
             finally
             {

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineTests.cs
@@ -77,7 +77,7 @@ namespace Fluent.Tests.Compute
             }
         }
 
-        [Fact]
+        [Fact(Skip = "TODO: Convert to recorded tests")]
         public void CanCreateVirtualMachinesAndRelatedResourcesInParallel()
         {
             var resourceGroupName = ResourceNamer.RandomResourceName("rgvmtest-", 20);

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/CreatableResources.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/CreatableResources.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
     public abstract class CreatableResources<IFluentResourceT, FluentResourceT, InnerResourceT> :
         CreatableWrappers<IFluentResourceT, FluentResourceT, InnerResourceT>,
         ISupportsBatchCreation<IFluentResourceT>
-        where IFluentResourceT : class, IHasId
+        where IFluentResourceT : class, IResource
         where FluentResourceT : IFluentResourceT
     {
         public ICreatedResources<IFluentResourceT> Create(params ICreatable<IFluentResourceT>[] creatables)

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/CreatableUpdatableResourcesRoot.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/CreatableUpdatableResourcesRoot.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
         CreatableUpdatable<ICreatableUpdatableResourcesRoot<IFluentResourceT>,
             InnerResourceT,
             CreatableUpdatableResourcesRoot<IFluentResourceT, InnerResourceT>,
-            IHasId,
+            IResource,
             object>,
-        IHasId,
+        IResource,
         ICreatableUpdatableResourcesRoot<IFluentResourceT>
-        where IFluentResourceT : class, IHasId
+        where IFluentResourceT : class, IResource
     {
         private List<string> keys;
 
@@ -37,11 +37,11 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
             foreach (ICreatable<IFluentResourceT> item in creatables)
             {
                 this.keys.Add(item.Key);
-                this.AddCreatableDependency(item as IResourceCreator<IHasId>);
+                this.AddCreatableDependency(item as IResourceCreator<IResource>);
             }
         }
 
-        public IHasId CreatedRelatedResource(string key)
+        public IResource CreatedRelatedResource(string key)
         {
             return this.CreatorTaskGroup.CreatedResource(key);
         }
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
         }
         #endregion
 
-        #region IHasId empty Impl
+        #region IResource empty Impl
         public string Id
         {
             get
@@ -78,6 +78,54 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
                 return null;
             }
         }
+ 
+        public new string Key
+         {
+             get
+             {
+                 return null;
+             }
+         }
+ 
+         public new string Name
+         {
+             get
+             {
+                 return null;
+             }
+         }
+ 
+         public Region Region
+         {
+             get
+             {
+                 return default(Region);
+             }
+         }
+ 
+         public string RegionName
+         {
+             get
+             {
+                 return null;
+             }
+         }
+ 
+         public IDictionary<string, string> Tags
+         {
+             get
+             {
+                 return null;
+             }
+         }
+ 
+         public string Type
+         {
+             get
+             {
+                 return null;
+             }
+         }
         #endregion
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/CreatedResources.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/CreatedResources.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
     /// </summary>
     /// <typeparam name="ResourceT">the type of the resources in the batch</typeparam>
     internal class CreatedResources<ResourceT> : ICreatedResources<ResourceT>
-        where ResourceT : class, IHasId
+        where ResourceT : class, IResource
     {
         /// <summary>
         /// The dummy root resource for this batch.
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
 
         #region Implementation of ICreatedResources interface
 
-        public IHasId CreatedRelatedResource(string key)
+        public IResource CreatedRelatedResource(string key)
         {
             return this.creatableUpdatableResourcesRoot.CreatedRelatedResource(key);
         }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ICreatableUpdatableResourcesRoot.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ICreatableUpdatableResourcesRoot.cs
@@ -10,10 +10,10 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
     /// added via <see cref="ISupportsBatchCreation{IFluentResourceT}.CreateAsync(ICreatable{IFluentResourceT}[])">
     /// </summary>
     /// <typeparam name="IFluentResourceT">the type of resources in the batch</typeparam>
-    internal interface ICreatableUpdatableResourcesRoot<IFluentResourceT> : IHasId
-        where IFluentResourceT : IHasId
+    internal interface ICreatableUpdatableResourcesRoot<IFluentResourceT> : IResource
+        where IFluentResourceT : IResource
     {
         IEnumerable<IFluentResourceT> CreatedTopLevelResources();
-        IHasId CreatedRelatedResource(string key);
+        IResource CreatedRelatedResource(string key);
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsBatchCreation.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsBatchCreation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core.CollectionActions
     /// </summary>
     /// <typeparam name="IFluentResourceT">the top level Azure resource type</typeparam>
     public interface ISupportsBatchCreation<IFluentResourceT>
-        where IFluentResourceT : IHasId
+        where IFluentResourceT : IResource
     {
         /// <summary>
         /// Creates a set (batch) of resources.

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/ICreatedResources.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/ICreatedResources.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
     /// </summary>
     /// <typeparam name="ResourceT">the type of the resource in this batch</typeparam>
     public interface ICreatedResources<ResourceT> : IEnumerable<ResourceT>
-        where ResourceT : IHasId
+        where ResourceT : IResource
     {
         /// <summary>
         /// Gets a created resource with the given key.
         /// </summary>
         /// <param name="key">the key of the resource</param>
         /// <returns>the created resource</returns>
-        IHasId CreatedRelatedResource(string key);
+        IResource CreatedRelatedResource(string key);
     }
 }


### PR DESCRIPTION
@anudeepsharma it seems that using IHasId instead of IResource need more work, with IHasId we get NPE, this can be verified by running the unit test  https://github.com/Azure/azure-sdk-for-net/blob/Fluent/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineTests.cs#L81, reverting to IResource for now.