### PR TITLE
Search SDK: Updating version and release notes

### DIFF
--- a/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
+++ b/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Makes it easy to develop a .NET application that uses Azure Search.")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.6.0")]
+[assembly: AssemblyFileVersion("2.0.7.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/Search/Microsoft.Azure.Search/project.json
+++ b/src/Search/Microsoft.Azure.Search/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.6-preview",
+  "version": "2.0.7-preview",
   "title": "Microsoft Azure Search Library",
   "description": "Makes it easy to develop a .NET application that uses Azure Search.",
   "authors": [ "Microsoft" ],
@@ -10,8 +10,8 @@
     "licenseUrl": "https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE",
     "iconUrl": "http://go.microsoft.com/fwlink/?LinkID=288890",
     "tags": [ "Microsoft Azure Search", "REST HTTP client", "search", "azureofficial", "windowsazureofficial" ],
-    "requireLicenseAcceptance":  true,
-    "releaseNotes": "This is a preview release of the Azure Search .NET SDK, based on version 2015-02-28-Preview of the Azure Search REST API. It includes support for indexing Azure Blob and Table storage, indexer field mappings, custom analyzers, and ETags. See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade."
+    "requireLicenseAcceptance": true,
+    "releaseNotes": "This is a preview release of the Azure Search .NET SDK, based on version 2015-02-28-Preview of the Azure Search REST API. New in this version is support for reflection-based field definitions via the FieldBuilder class, thanks to a contribution from Ian Griffiths (https://github.com/idg10). It also includes support for indexing Azure Blob and Table storage, indexer field mappings, custom analyzers, and ETags. See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade."
   },
 
   "buildOptions": {

--- a/src/Search/Search.Management.Tests/project.json
+++ b/src/Search/Search.Management.Tests/project.json
@@ -33,7 +33,7 @@
     "Microsoft.Rest.ClientRuntime.Azure": "[3.3.*,4.0)",
     "Microsoft.Azure.Management.ResourceManager": "1.1.1-preview",
     "Microsoft.Azure.Management.Search": "1.0.0-rc",
-    "Microsoft.Azure.Search": "2.0.6-preview",
+    "Microsoft.Azure.Search": "2.0.7-preview",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   }

--- a/src/Search/Search.Tests/project.json
+++ b/src/Search/Search.Tests/project.json
@@ -29,7 +29,7 @@
       "version": "1.0.0" 
     }, 
     "Search.Management.Tests": "1.0.0",
-    "Microsoft.Azure.Search": "2.0.6-preview",
+    "Microsoft.Azure.Search": "2.0.7-preview",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0"
   }
 }


### PR DESCRIPTION
This version includes a few more changes for indexers, plus the `FieldBuilder` class (which actually went out with the accidentally-published version 2.0.6-preview).

FYI @chaosrealm @idg10