### PR TITLE
Search SDK: Dropping rc suffix from management and data plane libraries

### DIFF
--- a/src/Search/Microsoft.Azure.Management.Search/Properties/AssemblyInfo.cs
+++ b/src/Search/Microsoft.Azure.Management.Search/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Makes it easy to manage Azure Search services from a .NET application.")]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/Search/Microsoft.Azure.Management.Search/project.json
+++ b/src/Search/Microsoft.Azure.Management.Search/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-rc",
+  "version": "1.0.1",
   "title": "Microsoft Azure Search Management Library",
   "description": "Makes it easy to manage Azure Search services and API keys from a .NET application.",
   "authors": [ "Microsoft" ],

--- a/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
+++ b/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Makes it easy to develop a .NET application that uses Azure Search.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/Search/Microsoft.Azure.Search/project.json
+++ b/src/Search/Microsoft.Azure.Search/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-rc",
+  "version": "3.0.1",
   "title": "Microsoft Azure Search Library",
   "description": "Makes it easy to develop a .NET application that uses Azure Search.",
   "authors": [ "Microsoft" ],
@@ -11,7 +11,7 @@
     "iconUrl": "http://go.microsoft.com/fwlink/?LinkID=288890",
     "tags": [ "Microsoft Azure Search", "REST HTTP client", "search", "azureofficial", "windowsazureofficial" ],
     "requireLicenseAcceptance": true,
-    "releaseNotes": "This is a release candidate of the next major version of the Azure Search .NET SDK, based on version 2016-09-01 of the Azure Search REST API. New in this version is support for indexing Azure Blob and Table storage, indexer field mappings, custom analyzers, and ETags. Also included is support for reflection-based field definitions via the FieldBuilder class, thanks to a contribution from Ian Griffiths (https://github.com/idg10). See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade."
+    "releaseNotes": "This is the next major version of the Azure Search .NET SDK, based on version 2016-09-01 of the Azure Search REST API. New in this version is support for indexing Azure Blob and Table storage, indexer field mappings, custom analyzers, and ETags. Also included is support for reflection-based field definitions via the FieldBuilder class, thanks to a contribution from Ian Griffiths (https://github.com/idg10). See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade."
   },
 
   "buildOptions": {

--- a/src/Search/Search.Management.Tests/project.json
+++ b/src/Search/Search.Management.Tests/project.json
@@ -32,8 +32,8 @@
     "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "[1.3.5-preview,2.0.0)",
     "Microsoft.Rest.ClientRuntime.Azure": "[3.3.*,4.0)",
     "Microsoft.Azure.Management.ResourceManager": "1.1.1-preview",
-    "Microsoft.Azure.Management.Search": "1.0.0-rc",
-    "Microsoft.Azure.Search": "3.0.0-rc",
+    "Microsoft.Azure.Management.Search": "1.0.1",
+    "Microsoft.Azure.Search": "3.0.1",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   }

--- a/src/Search/Search.Tests/project.json
+++ b/src/Search/Search.Tests/project.json
@@ -29,7 +29,7 @@
       "version": "1.0.0" 
     }, 
     "Search.Management.Tests": "1.0.0",
-    "Microsoft.Azure.Search": "3.0.0-rc",
+    "Microsoft.Azure.Search": "3.0.1",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0"
   }
 }


### PR DESCRIPTION
Microsoft.Azure.Search 3.0.0-rc -> 3.0.1
Microsoft.Azure.Management.Search 1.0.0-rc -> 1.0.1

FYI @chaosrealm @Yahnoosh @mhko @seansaleh 