### PR TITLE
change object id type to string and change return type of keyvault list

### DIFF
--- a/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement.Tests/VaultOperationsTest.cs
+++ b/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement.Tests/VaultOperationsTest.cs
@@ -31,7 +31,7 @@ namespace KeyVault.Management.Tests
 
                 string vaultName = TestUtilities.GenerateName("sdktestvault");
                 var tenantIdGuid = Guid.Parse(testBase.tenantId);
-                var objectIdGuid = Guid.Parse(testBase.objectId);
+                var objectIdGuid = testBase.objectId;
                 var tags = new Dictionary<string, string> { { "tag1", "value1" }, { "tag2", "value2" }, { "tag3", "value3" } };
                 var accPol = new AccessPolicyEntry
                 {
@@ -158,7 +158,7 @@ namespace KeyVault.Management.Tests
 
                 string vaultName = TestUtilities.GenerateName("sdktestvault");
                 var tenantIdGuid = Guid.Parse(testBase.tenantId);
-                var objectIdGuid = Guid.Parse(testBase.objectId);
+                var objectIdGuid = testBase.objectId;
                 var applicationId = Guid.Parse(testBase.applicationId);
                 var tags = new Dictionary<string, string> { { "tag1", "value1" }, { "tag2", "value2" }, { "tag3", "value3" } };
                 var accPol = new AccessPolicyEntry
@@ -326,7 +326,7 @@ namespace KeyVault.Management.Tests
 
                 string rgName = TestUtilities.GenerateName("sdktestrg");
                 var tenantIdGuid = Guid.Parse(testBase.tenantId);
-                var objectIdGuid = Guid.Parse(testBase.objectId);
+                var objectIdGuid = testBase.objectId;
 
                 var tags = new Dictionary<string, string> { { "tag1", "value1" }, { "tag2", "value2" }, { "tag3", "value3" } };
 
@@ -384,7 +384,7 @@ namespace KeyVault.Management.Tests
 
                 while (vaults.NextPageLink != null)
                 {
-                    vaults = client.Vaults.ListNext(vaults.NextPageLink);
+                    vaults = client.Vaults.ListByResourceGroupNext(vaults.NextPageLink);
                     Assert.NotNull(vaults);
                     foreach (var v in vaults)
                     {

--- a/src/ResourceManagement/KeyVaultManagement/Microsoft.Azure.Management.KeyVault/Generated/IVaultsOperations.cs
+++ b/src/ResourceManagement/KeyVaultManagement/Microsoft.Azure.Management.KeyVault/Generated/IVaultsOperations.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Management.KeyVault
         /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<AzureOperationResponse<IPage<Vault>>> ListWithHttpMessagesAsync(int? top = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<AzureOperationResponse<IPage<Resource>>> ListWithHttpMessagesAsync(int? top = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// The List operation gets information about the vaults associated
         /// with the subscription and within the specified resource group.
@@ -191,6 +191,6 @@ namespace Microsoft.Azure.Management.KeyVault
         /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<AzureOperationResponse<IPage<Vault>>> ListNextWithHttpMessagesAsync(string nextPageLink, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<AzureOperationResponse<IPage<Resource>>> ListNextWithHttpMessagesAsync(string nextPageLink, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/ResourceManagement/KeyVaultManagement/Microsoft.Azure.Management.KeyVault/Generated/Models/AccessPolicyEntry.cs
+++ b/src/ResourceManagement/KeyVaultManagement/Microsoft.Azure.Management.KeyVault/Generated/Models/AccessPolicyEntry.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Management.KeyVault.Models
         /// secrets and certificates.</param>
         /// <param name="applicationId"> Application ID of the client making
         /// request on behalf of a principal</param>
-        public AccessPolicyEntry(Guid tenantId, Guid objectId, Permissions permissions, Guid? applicationId = default(Guid?))
+        public AccessPolicyEntry(Guid tenantId, string objectId, Permissions permissions, Guid? applicationId = default(Guid?))
         {
             TenantId = tenantId;
             ObjectId = objectId;
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Management.KeyVault.Models
         /// policies.
         /// </summary>
         [JsonProperty(PropertyName = "objectId")]
-        public Guid ObjectId { get; set; }
+        public string ObjectId { get; set; }
 
         /// <summary>
         /// Gets or sets  Application ID of the client making request on
@@ -87,6 +87,10 @@ namespace Microsoft.Azure.Management.KeyVault.Models
         /// </exception>
         public virtual void Validate()
         {
+            if (ObjectId == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "ObjectId");
+            }
             if (Permissions == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "Permissions");

--- a/src/ResourceManagement/KeyVaultManagement/Microsoft.Azure.Management.KeyVault/Generated/VaultsOperations.cs
+++ b/src/ResourceManagement/KeyVaultManagement/Microsoft.Azure.Management.KeyVault/Generated/VaultsOperations.cs
@@ -859,7 +859,7 @@ namespace Microsoft.Azure.Management.KeyVault
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<AzureOperationResponse<IPage<Vault>>> ListWithHttpMessagesAsync(int? top = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<AzureOperationResponse<IPage<Resource>>> ListWithHttpMessagesAsync(int? top = default(int?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (this.Client.SubscriptionId == null)
             {
@@ -988,7 +988,7 @@ namespace Microsoft.Azure.Management.KeyVault
                 throw ex;
             }
             // Create Result
-            var _result = new AzureOperationResponse<IPage<Vault>>();
+            var _result = new AzureOperationResponse<IPage<Resource>>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("x-ms-request-id"))
@@ -1001,7 +1001,7 @@ namespace Microsoft.Azure.Management.KeyVault
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = SafeJsonConvert.DeserializeObject<Page<Vault>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<Resource>>(_responseContent, this.Client.DeserializationSettings);
                 }
                 catch (JsonException ex)
                 {
@@ -1214,7 +1214,7 @@ namespace Microsoft.Azure.Management.KeyVault
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<AzureOperationResponse<IPage<Vault>>> ListNextWithHttpMessagesAsync(string nextPageLink, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<AzureOperationResponse<IPage<Resource>>> ListNextWithHttpMessagesAsync(string nextPageLink, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
@@ -1326,7 +1326,7 @@ namespace Microsoft.Azure.Management.KeyVault
                 throw ex;
             }
             // Create Result
-            var _result = new AzureOperationResponse<IPage<Vault>>();
+            var _result = new AzureOperationResponse<IPage<Resource>>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("x-ms-request-id"))
@@ -1339,7 +1339,7 @@ namespace Microsoft.Azure.Management.KeyVault
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = SafeJsonConvert.DeserializeObject<Page<Vault>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<Resource>>(_responseContent, this.Client.DeserializationSettings);
                 }
                 catch (JsonException ex)
                 {

--- a/src/ResourceManagement/KeyVaultManagement/Microsoft.Azure.Management.KeyVault/Generated/VaultsOperationsExtensions.cs
+++ b/src/ResourceManagement/KeyVaultManagement/Microsoft.Azure.Management.KeyVault/Generated/VaultsOperationsExtensions.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.Management.KeyVault
             /// <param name='top'>
             /// Maximum number of results to return.
             /// </param>
-            public static IPage<Vault> List(this IVaultsOperations operations, int? top = default(int?))
+            public static IPage<Resource> List(this IVaultsOperations operations, int? top = default(int?))
             {
                 return Task.Factory.StartNew(s => ((IVaultsOperations)s).ListAsync(top), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Management.KeyVault
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<IPage<Vault>> ListAsync(this IVaultsOperations operations, int? top = default(int?), CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<IPage<Resource>> ListAsync(this IVaultsOperations operations, int? top = default(int?), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListWithHttpMessagesAsync(top, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.Management.KeyVault
             /// <param name='nextPageLink'>
             /// The NextLink from the previous successful call to List operation.
             /// </param>
-            public static IPage<Vault> ListNext(this IVaultsOperations operations, string nextPageLink)
+            public static IPage<Resource> ListNext(this IVaultsOperations operations, string nextPageLink)
             {
                 return Task.Factory.StartNew(s => ((IVaultsOperations)s).ListNextAsync(nextPageLink), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
             }
@@ -287,7 +287,7 @@ namespace Microsoft.Azure.Management.KeyVault
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<IPage<Vault>> ListNextAsync(this IVaultsOperations operations, string nextPageLink, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<IPage<Resource>> ListNextAsync(this IVaultsOperations operations, string nextPageLink, CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListNextWithHttpMessagesAsync(nextPageLink, null, cancellationToken).ConfigureAwait(false))
                 {


### PR DESCRIPTION
change object id type to string and change return type of keyvault list to resources to represent the rest API.

Swagger change is in this PR: https://github.com/Azure/azure-rest-api-specs/pull/800