### PR TITLE
Adding a way to publish single nuget package when a scope is provided…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ UpgradeLog*.XML
 # NuGet
 packages
 packages/repositories.config
+testPackages
 
 # Mac development
 .DS_Store

--- a/build.proj
+++ b/build.proj
@@ -1,399 +1,397 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
-  <!--
-  Available Targets:
+	<!--
+	Available Targets:
 
-  /t:Clean
-    Removes temporary build outputs.
+	/t:Clean
+	Removes temporary build outputs.
+
+	/t:Build
+	Builds assemblies.
+
+	/t:Package 
+	Builds NuGet packages using the binaries folder contents.
+	The packages will drop to .\binaries\packages.
+
+	/t:Test
+	Runs tests
+
+	/t:Publish
+	Publishes the built packages. You will need to include your
+	publishing key when running. Include: /p:NuGetKey=YOUR_PUBLISHING_KEY
+
+	Properties of interest:
+	/p:Scope 
+	'Common' : build Azure Common
+	'Subfolder under /src, with solution files, such as 'ResourceManagement\Compute'': build individual packages
+	'Authentication': build Authentication
+	By default, it builds all.
+
+	/P:CodeSign=True
+	Code sign binaries, mainly for official release. Default is false.
+
+	/p:CodeSign=True;DelaySign=True
+	Test the code sign workflow locally. 
+
+	/p:NuGetKey=NUGET_PUBLISHING_KEY
+	Provides the key used to publish to a NuGet or MyGet server.
+	This key should never be committed to source control.
+
+	/p:NuGetPublishingSource=Uri
+	The NuGet Server to push packages to.
+	-->  
+
+	<PropertyGroup>
+		<LibraryRoot>$(MSBuildThisFileDirectory)</LibraryRoot>
+		<LibrarySourceFolder>$(LibraryRoot)src</LibrarySourceFolder>
+		<LibraryToolsFolder>$(LibraryRoot)tools</LibraryToolsFolder>
+		<LibraryNugetPackageFolder>$(LibraryRoot)\packages</LibraryNugetPackageFolder>
+		<LibraryFriendlyName>Microsoft Azure Management Libraries</LibraryFriendlyName>
+		<AuthenticationSolution>src\Authentication\Authentication.sln</AuthenticationSolution>
+		<ManagementLibrariesSolution>AzureManagementLibraries.sln</ManagementLibrariesSolution>
+		<BinariesFolder>$(LibraryRoot)binaries</BinariesFolder>
+		<PackageOutputDir>$(BinariesFolder)\packages</PackageOutputDir>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<CodeSign Condition=" '$(CodeSign)' == '' ">false</CodeSign>
+		<!--Set this true only if you want to test the code sign workflow locally-->
+		<DelaySign Condition =" '$(DelaySign)' == '' ">false</DelaySign>
+		<Scope Condition=" '$(Scope)' == '' ">All</Scope>
+		<FxTargetList>portable;net40;net45</FxTargetList>
+		<FxTargetList Condition=" '$(Scope)' == 'authentication' ">net45</FxTargetList>
+		<ZipExeFolder>$(LibraryToolsFolder)\7-Zip</ZipExeFolder>
+		<ZipExe>$(ZipExeFolder)\7z.exe</ZipExe>
+		<NuGetCommand>&quot;$(LibraryToolsFolder)\nuget.exe&quot;</NuGetCommand>
+	</PropertyGroup>
+
+	<ItemGroup Condition="'$(PublishTestProjects)' == 'false' Or '$(PublishTestProjects)' == ''">
+		<LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\*.sln" Condition=" '$(Scope)' != 'all'  " />
+		<LibrariesToBuild Include="$(LibrarySourceFolder)\**\*.sln" Condition=" '$(Scope)' == 'all'  " />
+		<LibraryFxTargetList Include="$(FxTargetList)" />
+		<AutoRestLibraryFxTargetList Include="portable;net45" />
+		<ClientRuntimeProjects Include="$(LibrarySourceFolder)\ClientRuntime\**\*.xproj"/>
+		<ClientRuntimeTests Include="$(LibrarySourceFolder)\ClientRuntime\*.Tests\*.xproj"/>
+		<ClientRuntimeRootDir Include="%(ClientRuntimeProjects.RootDir)"/>
+	</ItemGroup>
+  
+	<Import Condition="$(PublishTestProjects) == 'true'" Project="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Build.Tasks.Tests\PublishNugetPackageTests.proj" />
+
+	<UsingTask TaskName="ValidateStrongNameSignatureTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
+	<UsingTask TaskName="FilterOutAutoRestLibraries" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
+	<UsingTask TaskName="BuildProjectTemplatesTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
+  
+	<!-- Building ClientRuntime projects -->
+	<Target Name="BuildClientRuntime" Condition="Exists($(ClientRuntimeRootDir))">
+	  <Exec Command="dotnet restore" WorkingDirectory="%(ClientRuntimeProjects.RootDir)\%(ClientRuntimeProjects.Directory)"/>
+	  <Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(ClientRuntimeProjects.RootDir)\%(ClientRuntimeProjects.Directory)"/>
+	</Target>
+
+	<Target Name="DisableSN" > 
+		<!-- Check for admin privs -->
+		<Exec Command="net session" IgnoreExitCode="true" StandardErrorImportance="Low">
+		<Output PropertyName="isadmin" TaskParameter="ExitCode" />
+		</Exec>
+
+		<!-- Disable strong name checking -->  
+		<Exec Command='"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\sn.exe" -Vr *' Condition="$(isadmin) == 0"/>
+		<Exec Command='"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\x64\sn.exe" -Vr *' Condition="$(isadmin) == 0"/>
+	</Target>
     
-  /t:Build
-    Builds assemblies.
+	<Target Name="EnableSN" > 
+		<!-- Check for admin privs -->
+		<Exec Command="net session" IgnoreExitCode="true" StandardErrorImportance="Low">
+		<Output PropertyName="isadmin" TaskParameter="ExitCode" />
+		</Exec>
 
-  /t:Package 
-    Builds NuGet packages using the binaries folder contents.
-    The packages will drop to .\binaries\packages.
+		<!-- Enable strong name checking -->  
+		<Exec Command='$(WindowsSDK_ExecutablePath_x86)\sn.exe -Vx *' Condition="$(isadmin) == 0"/>
+		<Exec Command='$(WindowsSDK_ExecutablePath_x64)\sn.exe -Vx *' Condition="$(isadmin) == 0"/>
+	</Target>
 
-  /t:Test
-    Runs tests
-
-  /t:Publish
-    Publishes the built packages. You will need to include your
-    publishing key when running. Include: /p:NuGetKey=YOUR_PUBLISHING_KEY
-
-  Properties of interest:
-  /p:Scope 
-    'Common' : build Azure Common
-    'Subfolder under /src, with solution files, such as 'ResourceManagement\Compute'': build individual packages
-    'Authentication': build Authentication
-    By default, it builds all.
-
-  /P:CodeSign=True
-    Code sign binaries, mainly for official release. Default is false.
-
-  /p:CodeSign=True;DelaySign=True
-    Test the code sign workflow locally. 
+	<!--
+	CI build related
+	-->
+	<PropertyGroup>
+		<!--OnPremiseBuildTasks is not a good name, but CI server is using that, will update across soon-->
+		<CIToolsPath>$(OnPremiseBuildTasks)</CIToolsPath>
+		<OnPremiseBuild Condition=" Exists($(OnPremiseBuildTasks)) ">true</OnPremiseBuild>
+		<OnPremiseBuild Condition=" ! Exists($(OnPremiseBuildTasks)) ">false</OnPremiseBuild>
+	</PropertyGroup>
+	<UsingTask Condition=" $(OnPremiseBuild) " TaskName="CodeSigningTask" AssemblyFile="$(CIToolsPath)\Microsoft.WindowsAzure.Tools.Build.Tasks.OnPremise.dll" />
+	<UsingTask Condition=" $(OnPremiseBuild) " TaskName="CorporateValidation" AssemblyFile="$(CIToolsPath)\Microsoft.WindowsAzure.Tools.Build.Tasks.OnPremise.dll" />
+	<Import Condition=" $(OnPremiseBuild) " Project="$(CIToolsPath)\Microsoft.WindowsAzure.Build.OnPremise.msbuild" />
   
-  /p:NuGetKey=NUGET_PUBLISHING_KEY
-    Provides the key used to publish to a NuGet or MyGet server.
-    This key should never be committed to source control.
-    
-  /p:NuGetPublishingSource=Uri
-    The NuGet Server to push packages to.
-  -->  
+	<Target Name="PrepareForAutoRestLibraries">
+		<FilterOutAutoRestLibraries AllLibraries="@(LibrariesToBuild)" AutoRestMark="AutoRestProjects" NugetPackagesToPublish="$(PackageName)">
+		  <Output TaskParameter="Non_NetCore_AutoRestLibraries" ItemName="Non_NetCore_AutoRestLibraries" />
+		  <Output TaskParameter="NetCore_AutoRestLibraries" ItemName="NetCore_AutoRestLibraries" />
+		</FilterOutAutoRestLibraries>
+		<Message Text="Non NetCore based AutoRest Libraries: @(Non_NetCore_AutoRestLibraries)" />
+		<Message Text="NetCore AutoRest Libraries: @(NetCore_AutoRestLibraries)" />
+
+		<!--Do not build old libraries except Authentication, which Azure PowerShell still uses-->
+		<ItemGroup>
+			<NonAutoRestLibraries Include="$(LibrarySourceFolder)\Authentication\Authentication.sln"	  
+								Condition=" '$(Scope)' == 'all' or '$(Scope)' == 'Authentication' " />    	
+		</ItemGroup>
+
+		<Message Text="Non-AutoRest Libraries: @(NonAutoRestLibraries)" />     
+		<Message Text="Ensure 7zip is available" />
+		<Exec
+		  Command="$(LibraryToolsFolder)\AzCopy\AzCopy.exe /Source:https://azuresdktools.blob.core.windows.net/7-zip  /S /Dest:$(ZipExeFolder) /Y"
+		  Condition="!Exists('$(ZipExe)')" />
+	</Target>
   
-  <PropertyGroup>
-    <LibraryRoot>$(MSBuildThisFileDirectory)</LibraryRoot>
-    <LibrarySourceFolder>$(LibraryRoot)src</LibrarySourceFolder>
-    <LibraryToolsFolder>$(LibraryRoot)tools</LibraryToolsFolder>
-    <LibraryNugetPackageFolder>$(LibraryRoot)\packages</LibraryNugetPackageFolder>
-    <LibraryFriendlyName>Microsoft Azure Management Libraries</LibraryFriendlyName>
-    <AuthenticationSolution>src\Authentication\Authentication.sln</AuthenticationSolution>
-    <ManagementLibrariesSolution>AzureManagementLibraries.sln</ManagementLibrariesSolution>
-    <BinariesFolder>$(LibraryRoot)binaries</BinariesFolder>
-    <PackageOutputDir>$(BinariesFolder)\packages</PackageOutputDir>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <CodeSign Condition=" '$(CodeSign)' == '' ">false</CodeSign>
-    <!--Set this true only if you want to test the code sign workflow locally-->
-    <DelaySign Condition =" '$(DelaySign)' == '' ">false</DelaySign>
-    <Scope Condition=" '$(Scope)' == '' ">All</Scope>
-    <FxTargetList>portable;net40;net45</FxTargetList>
-    <FxTargetList Condition=" '$(Scope)' == 'authentication' ">net45</FxTargetList>
-    <ZipExeFolder>$(LibraryToolsFolder)\7-Zip</ZipExeFolder>
-    <ZipExe>$(ZipExeFolder)\7z.exe</ZipExe>
-	<NuGetCommand>&quot;$(LibraryToolsFolder)\nuget.exe&quot;</NuGetCommand>
-  </PropertyGroup>
+	<Target Name="Build" DependsOnTargets="BuildClientRuntime;BuildMsBuildTask;PrepareForAutoRestLibraries;RestoreNugetPackages">
+		<PropertyGroup>
+		  <_ExtraPropertyList>CodeSign=$(CodeSign)</_ExtraPropertyList>
+		  <_TemporaryNetCoreFeeds>-s https://api.nuget.org/v3/index.json -s https://dotnet.myget.org/F/cli-deps/api/v3/index.json</_TemporaryNetCoreFeeds>
+		</PropertyGroup>
+		<CallTarget Targets="DisableSN" Condition=" '$(OS)' == 'Windows_NT'"/> 
+		<CallTarget Targets="BuildServerPreparation" Condition=" '$(CodeSign)' == 'true' " />
 
-  <ItemGroup Condition="'$(PublishTestProjects)' == 'false' Or '$(PublishTestProjects)' == ''">
-    <LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\*.sln" Condition=" '$(Scope)' != 'all'  " />
-    <LibrariesToBuild Include="$(LibrarySourceFolder)\**\*.sln" Condition=" '$(Scope)' == 'all'  " />
-    <LibraryFxTargetList Include="$(FxTargetList)" />
-    <AutoRestLibraryFxTargetList Include="portable;net45" />
-    <ClientRuntimeProjects Include="$(LibrarySourceFolder)\ClientRuntime\**\*.xproj"/>
-    <ClientRuntimeTests Include="$(LibrarySourceFolder)\ClientRuntime\*.Tests\*.xproj"/>
-	<ClientRuntimeRootDir Include="%(ClientRuntimeProjects.RootDir)"/>
-  </ItemGroup>
-  
-  <Import Condition="$(PublishTestProjects) == 'true'" Project="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Build.Tasks.Tests\PublishNugetPackageTests.proj" />
-  
-  <UsingTask TaskName="ValidateStrongNameSignatureTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
-  <UsingTask TaskName="FilterOutAutoRestLibraries" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
-  <UsingTask TaskName="BuildProjectTemplatesTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
-  
-  <!-- Building ClientRuntime projects -->
-  <Target Name="BuildClientRuntime" Condition="Exists($(ClientRuntimeRootDir))">
-      <Exec Command="dotnet restore" WorkingDirectory="%(ClientRuntimeProjects.RootDir)\%(ClientRuntimeProjects.Directory)"/>
-      <Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(ClientRuntimeProjects.RootDir)\%(ClientRuntimeProjects.Directory)"/>
-  </Target>
+		<MSBuild Projects="@(NonAutoRestLibraries)"
+				 Properties="Configuration=%(LibraryFxTargetList.Identity)-$(Configuration);Platform=Any CPU;$(_ExtraPropertyList)"
+				 Targets="Build" />
 
-  <Target Name="DisableSN" > 
-      <!-- Check for admin privs -->
-      <Exec Command="net session" IgnoreExitCode="true" StandardErrorImportance="Low">
-        <Output PropertyName="isadmin" TaskParameter="ExitCode" />
-      </Exec>
-  
-      <!-- Disable strong name checking -->  
-      <Exec Command='"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\sn.exe" -Vr *' Condition="$(isadmin) == 0"/>
-      <Exec Command='"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\x64\sn.exe" -Vr *' Condition="$(isadmin) == 0"/>
-    </Target>
-    
-    <Target Name="EnableSN" > 
-      <!-- Check for admin privs -->
-      <Exec Command="net session" IgnoreExitCode="true" StandardErrorImportance="Low">
-        <Output PropertyName="isadmin" TaskParameter="ExitCode" />
-      </Exec>
-  
-      <!-- Enable strong name checking -->  
-      <Exec Command='$(WindowsSDK_ExecutablePath_x86)\sn.exe -Vx *' Condition="$(isadmin) == 0"/>
-      <Exec Command='$(WindowsSDK_ExecutablePath_x64)\sn.exe -Vx *' Condition="$(isadmin) == 0"/>
-  </Target>
+		<MSBuild Projects="@(Non_NetCore_AutoRestLibraries)"
+				 Properties="Configuration=%(AutoRestLibraryFxTargetList.Identity)-$(Configuration);Platform=Any CPU;$(_ExtraPropertyList)"
+				 Targets="Build" />
 
-  <!--
-  CI build related
-  -->
-  <PropertyGroup>
-    <!--OnPremiseBuildTasks is not a good name, but CI server is using that, will update across soon-->
-    <CIToolsPath>$(OnPremiseBuildTasks)</CIToolsPath>
-    <OnPremiseBuild Condition=" Exists($(OnPremiseBuildTasks)) ">true</OnPremiseBuild>
-    <OnPremiseBuild Condition=" ! Exists($(OnPremiseBuildTasks)) ">false</OnPremiseBuild>
-  </PropertyGroup>
-  <UsingTask Condition=" $(OnPremiseBuild) " TaskName="CodeSigningTask" AssemblyFile="$(CIToolsPath)\Microsoft.WindowsAzure.Tools.Build.Tasks.OnPremise.dll" />
-  <UsingTask Condition=" $(OnPremiseBuild) " TaskName="CorporateValidation" AssemblyFile="$(CIToolsPath)\Microsoft.WindowsAzure.Tools.Build.Tasks.OnPremise.dll" />
-  <Import Condition=" $(OnPremiseBuild) " Project="$(CIToolsPath)\Microsoft.WindowsAzure.Build.OnPremise.msbuild" />
+		<!-- Restoring everyting from the root folder wipes out Storage nuget references and adds Storage project reference to all projects. -->
+		<!-- Restoring from root directory when publishing scope packages -->
+		<Exec Command="dotnet restore" WorkingDirectory="$(LibrarySourceFolder)\$(Scope)" Condition="Exists('$(LibrarySourceFolder)\$(Scope)') AND '$(Scope)' != 'all'"/>
 
-  <Target Name="PrepareForAutoRestLibraries">
-    <FilterOutAutoRestLibraries AllLibraries="@(LibrariesToBuild)" AutoRestMark="AutoRestProjects" NugetPackagesToPublish="$(PackageName)">
-      <Output TaskParameter="Non_NetCore_AutoRestLibraries" ItemName="Non_NetCore_AutoRestLibraries" />
-      <Output TaskParameter="NetCore_AutoRestLibraries" ItemName="NetCore_AutoRestLibraries" />
-    </FilterOutAutoRestLibraries>
-    <Message Text="Non NetCore based AutoRest Libraries: @(Non_NetCore_AutoRestLibraries)" />
-    <Message Text="NetCore AutoRest Libraries: @(NetCore_AutoRestLibraries)" />
-    
-    <!--Do not build old libraries except Authentication, which Azure PowerShell still uses-->
-    <ItemGroup>
-		<NonAutoRestLibraries Include="$(LibrarySourceFolder)\Authentication\Authentication.sln"	  
-                            Condition=" '$(Scope)' == 'all' or '$(Scope)' == 'Authentication' " />    	
-    </ItemGroup>
-	
-    <Message Text="Non-AutoRest Libraries: @(NonAutoRestLibraries)" />     
-    <Message Text="Ensure 7zip is available" />
-    <Exec
-      Command="$(LibraryToolsFolder)\AzCopy\AzCopy.exe /Source:https://azuresdktools.blob.core.windows.net/7-zip  /S /Dest:$(ZipExeFolder) /Y"
-      Condition="!Exists('$(ZipExe)')" />
-  </Target>
-  
-  <Target Name="Build" DependsOnTargets="BuildClientRuntime;BuildMsBuildTask;PrepareForAutoRestLibraries;RestoreNugetPackages">
-    <PropertyGroup>
-      <_ExtraPropertyList>CodeSign=$(CodeSign)</_ExtraPropertyList>
-      <_TemporaryNetCoreFeeds>-s https://api.nuget.org/v3/index.json -s https://dotnet.myget.org/F/cli-deps/api/v3/index.json</_TemporaryNetCoreFeeds>
-    </PropertyGroup>
-    <CallTarget Targets="DisableSN" Condition=" '$(OS)' == 'Windows_NT'"/> 
-    <CallTarget Targets="BuildServerPreparation" Condition=" '$(CodeSign)' == 'true' " />
+		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
+		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Test)" Condition=" @(NetCore_AutoRestLibraries) != '' and '%(NetCore_AutoRestLibraries.Test)' != '' and '$(Configuration)' != 'Release' "/>
 
-    <MSBuild Projects="@(NonAutoRestLibraries)"
-             Properties="Configuration=%(LibraryFxTargetList.Identity)-$(Configuration);Platform=Any CPU;$(_ExtraPropertyList)"
-             Targets="Build" />
+		<CallTarget Targets="BuildNetCoreLibraries" Condition=" @(NetCore_AutoRestLibraries) != '' " />
+		<CallTarget Targets="CodeSignBinaries" Condition=" '$(CodeSign)' == 'true' " />
+	</Target>
 
-    <MSBuild Projects="@(Non_NetCore_AutoRestLibraries)"
-             Properties="Configuration=%(AutoRestLibraryFxTargetList.Identity)-$(Configuration);Platform=Any CPU;$(_ExtraPropertyList)"
-             Targets="Build" />
-    
-    <!-- Restoring everyting from the root folder wipes out Storage nuget references and adds Storage project reference to all projects. -->
-    <Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
-    <Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Test)" Condition=" @(NetCore_AutoRestLibraries) != '' and '%(NetCore_AutoRestLibraries.Test)' != '' and '$(Configuration)' != 'Release' "/>
-
-    <CallTarget Targets="BuildNetCoreLibraries" Condition=" @(NetCore_AutoRestLibraries) != '' " />
-    <CallTarget Targets="CodeSignBinaries" Condition=" '$(CodeSign)' == 'true' " />
-  </Target>
-
-  <Target Name="BuildNetCoreLibraries">
-    <Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" '%(NetCore_AutoRestLibraries.Library)'!= '' "/>
-    <Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(NetCore_AutoRestLibraries.Test)" Condition=" '$(Configuration)' != 'Release' and '%(NetCore_AutoRestLibraries.Test)' != '' "/>
-  </Target>
+	<Target Name="BuildNetCoreLibraries">
+		<Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" '%(NetCore_AutoRestLibraries.Library)'!= '' "/>
+		<Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(NetCore_AutoRestLibraries.Test)" Condition=" '$(Configuration)' != 'Release' and '%(NetCore_AutoRestLibraries.Test)' != '' "/>
+	</Target>
  
-  <Target Name="Clean" DependsOnTargets="BuildMsBuildTask;PrepareForAutoRestLibraries;RestoreNugetPackages">
-    <!--<MSBuild Projects="@(NonAutoRestLibraries)"
-             Properties="Configuration=%(LibraryFxTargetList.Identity)-$(Configuration);Platform=Any CPU"
-             Targets="Clean" />-->
+	<Target Name="Clean" DependsOnTargets="BuildMsBuildTask;PrepareForAutoRestLibraries;RestoreNugetPackages">
+		<!--<MSBuild Projects="@(NonAutoRestLibraries)"
+				 Properties="Configuration=%(LibraryFxTargetList.Identity)-$(Configuration);Platform=Any CPU"
+				 Targets="Clean" />-->
 
-    <MSBuild Projects="@(Non_NetCore_AutoRestLibraries)"
-             Properties="Configuration=%(AutoRestLibraryFxTargetList.Identity)-$(Configuration);Platform=Any CPU;$(_ExtraPropertyList)"
-             Targets="Clean" />
+		<MSBuild Projects="@(Non_NetCore_AutoRestLibraries)"
+				 Properties="Configuration=%(AutoRestLibraryFxTargetList.Identity)-$(Configuration);Platform=Any CPU;$(_ExtraPropertyList)"
+				 Targets="Clean" />
 
-    <RemoveDir Directories="$(BinariesFolder)" />
-  </Target>
+		<RemoveDir Directories="$(BinariesFolder)" />
+	</Target>
 
-  <Target Name="Test" DependsOnTargets="PrepareForAutoRestLibraries">
-     <PropertyGroup>
-       <!--Extrat out service name from 'Scope' to use as test dll filter-->
-       <!--For example, from 'ServiceManagement\Storage', get 'Storage'.-->
-       <TestPartialName>$([System.IO.Path]::GetFileName($(Scope)))</TestPartialName>
-     </PropertyGroup>
-    <ItemGroup>
-      <!--TODO: improve the logic to be more explicit -->
-      <TestDlls Include=".\src\**\*.Tests\bin\net45-$(Configuration)\*.Tests.dll" Condition=" '$(Scope)' == 'All' " />
-      <TestDlls Include=".\src\$(Scope)\**\*.Tests\bin\net45-$(Configuration)\*.Tests.dll"
-                Condition=" '$(Scope)' != 'All' " />
-    </ItemGroup>
-    <MakeDir Directories="$(LibraryRoot)TestResults"/>
-    <Message Text="%(TestDlls.Filename)" />
-    <Exec Command="$(LibraryNugetPackageFolder)\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe &quot;%(TestDlls.Identity)&quot; -html &quot;$(MSBuildProjectDirectory)\TestResults\%(TestDlls.Filename).html&quot;"
-      Condition=" '@(TestDlls)' != '' "  
-      ContinueOnError="false"/>
-    
-    <!--Based on https://github.com/xunit/xunit/issues/653, only xml is supported -->
-    <Exec Command="dotnet test -xml &quot;$(MSBuildProjectDirectory)\TestResults\%(NetCore_AutoRestLibraries.Filename).xml&quot;" 
-          WorkingDirectory="%(NetCore_AutoRestLibraries.Test)"
-          Condition=" @(NetCore_AutoRestLibraries) != '' and '%(NetCore_AutoRestLibraries.Test)' != '' "/>
-    <Exec Command="dotnet test -xml &quot;$(MSBuildProjectDirectory)\TestResults\%(ClientRuntimeTests.Filename).xml&quot;" 
-          WorkingDirectory="%(ClientRuntimeTests.RootDir)\%(ClientRuntimeTests.Directory)"/>
+	<Target Name="Test" DependsOnTargets="PrepareForAutoRestLibraries">
+		<PropertyGroup>
+			<!--Extrat out service name from 'Scope' to use as test dll filter-->
+			<!--For example, from 'ServiceManagement\Storage', get 'Storage'.-->
+			<TestPartialName>$([System.IO.Path]::GetFileName($(Scope)))</TestPartialName>
+		</PropertyGroup>
+		<ItemGroup>
+		  <!--TODO: improve the logic to be more explicit -->
+		  <TestDlls Include=".\src\**\*.Tests\bin\net45-$(Configuration)\*.Tests.dll" Condition=" '$(Scope)' == 'All' " />
+		  <TestDlls Include=".\src\$(Scope)\**\*.Tests\bin\net45-$(Configuration)\*.Tests.dll"
+					Condition=" '$(Scope)' != 'All' " />
+		</ItemGroup>
+		<MakeDir Directories="$(LibraryRoot)TestResults"/>
+		<Message Text="%(TestDlls.Filename)" />
+		<Exec Command="$(LibraryNugetPackageFolder)\xunit.runner.console.2.0.0\tools\xunit.console.x86.exe &quot;%(TestDlls.Identity)&quot; -html &quot;$(MSBuildProjectDirectory)\TestResults\%(TestDlls.Filename).html&quot;"
+		  Condition=" '@(TestDlls)' != '' "  
+		  ContinueOnError="false"/>
+		
+		<!--Based on https://github.com/xunit/xunit/issues/653, only xml is supported -->
+		<Exec Command="dotnet test -xml &quot;$(MSBuildProjectDirectory)\TestResults\%(NetCore_AutoRestLibraries.Filename).xml&quot;" 
+			  WorkingDirectory="%(NetCore_AutoRestLibraries.Test)"
+			  Condition=" @(NetCore_AutoRestLibraries) != '' and '%(NetCore_AutoRestLibraries.Test)' != '' "/>
+		<Exec Command="dotnet test -xml &quot;$(MSBuildProjectDirectory)\TestResults\%(ClientRuntimeTests.Filename).xml&quot;" 
+			  WorkingDirectory="%(ClientRuntimeTests.RootDir)\%(ClientRuntimeTests.Directory)"/>
   </Target>
   
-  <PropertyGroup>
-    <!--This property is used by build script at CI server. Do not remove it unless you will update CI as well -->
-    <!--TODO: research to include all library folders but exlude test folders with huge recorded json files.
-      For now we run subset of folders to avoid long build delay and avoid errors reported on recorded json files-->
-    <CorporateScanPaths>$(LibrarySourceFolder)\Authentication</CorporateScanPaths>
-    <!--public token associated with MSSharedLibKey.snk-->
-    <StrongNameToken Condition=" '$(StrongNameToken)' == '' ">31bf3856ad364e35</StrongNameToken>
-  </PropertyGroup>
-  <Target Name="SignBinariesForAFxTarget">
- 
-    <GetFrameworkSdkPath>
-      <Output TaskParameter="Path" PropertyName="WindowsSdkPath"/>
-    </GetFrameworkSdkPath>
+	<PropertyGroup>
+		<!--This property is used by build script at CI server. Do not remove it unless you will update CI as well -->
+		<!--TODO: research to include all library folders but exlude test folders with huge recorded json files.
+		  For now we run subset of folders to avoid long build delay and avoid errors reported on recorded json files-->
+		<CorporateScanPaths>$(LibrarySourceFolder)\Authentication</CorporateScanPaths>
+		<!--public token associated with MSSharedLibKey.snk-->
+		<StrongNameToken Condition=" '$(StrongNameToken)' == '' ">31bf3856ad364e35</StrongNameToken>
+	</PropertyGroup>
+	<Target Name="SignBinariesForAFxTarget">
+		<GetFrameworkSdkPath>
+		  <Output TaskParameter="Path" PropertyName="WindowsSdkPath"/>
+		</GetFrameworkSdkPath>
 
-    <ItemGroup>
-      <DelaySignedAssembliesToValidate Include="binaries\$(LibraryFxTarget)\unsigned\*.dll" />
-    </ItemGroup>
-    
-    <Message Importance="high" Text="Binaries\$(LibraryFxTarget)\unsigned contains no files. Code sign will skip." 
-             Condition="'@(DelaySignedAssembliesToValidate)' == ''" />
-    
-    <ValidateStrongNameSignatureTask
-        WindowsSdkPath="$(WindowsSdkPath)"
-        Assembly="%(DelaySignedAssembliesToValidate.Identity)"
-        ExpectedTokenSignature="$(StrongNameToken)"
-        ExpectedDelaySigned="true"
-        ContinueOnError="false" 
-        Condition="'@(DelaySignedAssembliesToValidate)' != ''"/>
+		<ItemGroup>
+		  <DelaySignedAssembliesToValidate Include="binaries\$(LibraryFxTarget)\unsigned\*.dll" />
+		</ItemGroup>
 
-    <CodeSigningTask
-        Description="Microsoft Azure SDK"
-        Keywords="Microsoft Azure .NET SDK"
-        UnsignedFiles="@(DelaySignedAssembliesToValidate)"
-        DestinationPath="binaries\$(LibraryFxTarget)"
-        SigningLogPath="binaries\$(LibraryFxTarget)\signing.log"
-        ToolsPath="$(CIToolsPath)"
-        Condition="!$(DelaySign) and '@(DelaySignedAssembliesToValidate)' != ''"/>
-    <!--If we are testing locally then we copy the binaries and do not submit to the code sign server-->
-    <Copy SourceFiles="@(DelaySignedAssembliesToValidate)" DestinationFolder="binaries\$(LibraryFxTarget)" Condition="$(DelaySign)" />
-    
-    <ItemGroup>
-      <AfterSignedAssembliesToValidate Include="binaries\$(LibraryFxTarget)\*.dll" />
-    </ItemGroup>
-    <ValidateStrongNameSignatureTask
-        WindowsSdkPath="$(WindowsSdkPath)"
-        Assembly="%(AfterSignedAssembliesToValidate.Identity)"
-        ExpectedTokenSignature="$(StrongNameToken)"
-        ExpectedDelaySigned="false"
-        ContinueOnError="false" 
-        Condition="!$(DelaySign) and '@(DelaySignedAssembliesToValidate)' != ''"/>
-    
-    <RemoveDir Directories="binaries\$(LibraryFxTarget)\unsigned;" ContinueOnError="true" />
-  </Target>
+		<Message Importance="high" Text="Binaries\$(LibraryFxTarget)\unsigned contains no files. Code sign will skip." 
+				 Condition="'@(DelaySignedAssembliesToValidate)' == ''" />
+
+		<ValidateStrongNameSignatureTask
+			WindowsSdkPath="$(WindowsSdkPath)"
+			Assembly="%(DelaySignedAssembliesToValidate.Identity)"
+			ExpectedTokenSignature="$(StrongNameToken)"
+			ExpectedDelaySigned="true"
+			ContinueOnError="false" 
+			Condition="'@(DelaySignedAssembliesToValidate)' != ''"/>
+
+		<CodeSigningTask
+			Description="Microsoft Azure SDK"
+			Keywords="Microsoft Azure .NET SDK"
+			UnsignedFiles="@(DelaySignedAssembliesToValidate)"
+			DestinationPath="binaries\$(LibraryFxTarget)"
+			SigningLogPath="binaries\$(LibraryFxTarget)\signing.log"
+			ToolsPath="$(CIToolsPath)"
+			Condition="!$(DelaySign) and '@(DelaySignedAssembliesToValidate)' != ''"/>
+		<!--If we are testing locally then we copy the binaries and do not submit to the code sign server-->
+		<Copy SourceFiles="@(DelaySignedAssembliesToValidate)" DestinationFolder="binaries\$(LibraryFxTarget)" Condition="$(DelaySign)" />
+
+		<ItemGroup>
+		  <AfterSignedAssembliesToValidate Include="binaries\$(LibraryFxTarget)\*.dll" />
+		</ItemGroup>
+		<ValidateStrongNameSignatureTask
+			WindowsSdkPath="$(WindowsSdkPath)"
+			Assembly="%(AfterSignedAssembliesToValidate.Identity)"
+			ExpectedTokenSignature="$(StrongNameToken)"
+			ExpectedDelaySigned="false"
+			ContinueOnError="false" 
+			Condition="!$(DelaySign) and '@(DelaySignedAssembliesToValidate)' != ''"/>
+
+		<RemoveDir Directories="binaries\$(LibraryFxTarget)\unsigned;" ContinueOnError="true" />
+	</Target>
    
-  <Target Name="CodeSignBinaries">
+	<Target Name="CodeSignBinaries">
+		<Error Condition=" !$(OnPremiseBuild) and !$(DelaySign) " Text="No CI tools path available, the code sign will be unable to continue. $(CIToolsPath)" />
 
-    <Error Condition=" !$(OnPremiseBuild) and !$(DelaySign) " Text="No CI tools path available, the code sign will be unable to continue. $(CIToolsPath)" />
+		<Message Text="Code signing" Importance="high" />
+		<Message Text="Signing project: $(MSBuildProjectFullPath)" />
+		<MSBuild Projects="$(MSBuildProjectFullPath)"
+				 Targets="SignBinariesForAFxTarget"
+				 Properties="LibraryFxTarget=%(LibraryFxTargetList.Identity);StrongNameToken=$(StrongNameToken)">    
+		</MSBuild>
 
-    <Message Text="Code signing" Importance="high" />
+		<CallTarget Targets="ValidateCorporateCompliance" Condition="!$(DelaySign)"/>
+	</Target>
 
-    <Message Text="Signing project: $(MSBuildProjectFullPath)" />
-    
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Targets="SignBinariesForAFxTarget"
-             Properties="LibraryFxTarget=%(LibraryFxTargetList.Identity);StrongNameToken=$(StrongNameToken)">    
-    </MSBuild>
-    
-    <CallTarget Targets="ValidateCorporateCompliance" Condition="!$(DelaySign)"/>
-  </Target>
+	<!--
+	Pre-build the tasks file used for validating strong name signatures,
+	providing date-based build numbers, and processing regular expression
+	replacements in files such as NuGet specs.
+	-->
+	<Target Name="BuildMsBuildTask">
+		<Exec Command="$(NuGetCommand) restore $(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Microsoft.WindowsAzure.Build.Tasks.sln -PackagesDirectory $(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\packages"/>
+		<MSBuild Projects="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Microsoft.WindowsAzure.Build.Tasks.csproj"
+				 Targets="Build"
+				 Properties="Configuration=Debug;Platform=AnyCPU" />
+	</Target>
 
-  <!--
-  Pre-build the tasks file used for validating strong name signatures,
-  providing date-based build numbers, and processing regular expression
-  replacements in files such as NuGet specs.
-  -->
-  <Target Name="BuildMsBuildTask">
-	<Exec Command="$(NuGetCommand) restore $(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Microsoft.WindowsAzure.Build.Tasks.sln -PackagesDirectory $(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\packages"/>
-    <MSBuild Projects="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Microsoft.WindowsAzure.Build.Tasks.csproj"
-             Targets="Build"
-             Properties="Configuration=Debug;Platform=AnyCPU" />
-  </Target>
+	<Target Name="RestoreNugetPackages">
+		<PropertyGroup>
+			<NuGetRestoreConfigSwitch>-PackagesDirectory $(LibraryNugetPackageFolder)</NuGetRestoreConfigSwitch>
+		</PropertyGroup>
+		<Exec Command="$(NuGetCommand) restore %(Non_NetCore_AutoRestLibraries.Identity) $(NuGetRestoreConfigSwitch)" Condition=" @(Non_NetCore_AutoRestLibraries) != '' "/>
+		<Exec Command="$(NuGetCommand) restore %(NonAutoRestLibraries.Identity) $(NuGetRestoreConfigSwitch)" Condition=" @(NonAutoRestLibraries) != '' "/>
+		<Exec Command="$(NuGetCommand) install xunit.runner.console -Version 2.0.0 -o $(LibraryNugetPackageFolder)" />
+	</Target>
 
-  <Target Name="RestoreNugetPackages">
-    <PropertyGroup>
-      <NuGetRestoreConfigSwitch>-PackagesDirectory $(LibraryNugetPackageFolder)</NuGetRestoreConfigSwitch>
-    </PropertyGroup>
-    <Exec Command="$(NuGetCommand) restore %(Non_NetCore_AutoRestLibraries.Identity) $(NuGetRestoreConfigSwitch)" Condition=" @(Non_NetCore_AutoRestLibraries) != '' "/>
-    <Exec Command="$(NuGetCommand) restore %(NonAutoRestLibraries.Identity) $(NuGetRestoreConfigSwitch)" Condition=" @(NonAutoRestLibraries) != '' "/>
-    <Exec Command="$(NuGetCommand) install xunit.runner.console -Version 2.0.0 -o $(LibraryNugetPackageFolder)" />
-  </Target>
+	<!-- Task to build project templates -->  
+	<Target Name="BuildProjectTemplates">
+		<Message Text="Building Project Templates" />
+		<BuildProjectTemplatesTask>
+		  <Output TaskParameter="TaskErrorDetected" PropertyName="BuildTemplateTaskFailed" />
+		</BuildProjectTemplatesTask>
+		<Message Text="Building Project Templates Completed" />
+	</Target>
+	<!--
+	We have some important work to do when building our official Library bits.
+	-->
+	<Target Name="ValidateCorporateCompliance">
+		<Error Text="This target must be run in an on-premise build server." Condition=" '$(OnPremiseBuild)'=='false' " />
+		<CallTarget Targets="CorporateValidation" />
+	</Target>
 
-<!-- Task to build project templates -->  
-  <Target Name="BuildProjectTemplates">
-	<Message Text="Building Project Templates" />
-    <BuildProjectTemplatesTask>
-      <Output TaskParameter="TaskErrorDetected" PropertyName="BuildTemplateTaskFailed" />
-    </BuildProjectTemplatesTask>
-    <Message Text="Building Project Templates Completed" />
-  </Target>
-  <!--
-  We have some important work to do when building our official Library bits.
-  -->
-  <Target Name="ValidateCorporateCompliance">
-    <Error Text="This target must be run in an on-premise build server." Condition=" '$(OnPremiseBuild)'=='false' " />
-    <CallTarget Targets="CorporateValidation" />
-  </Target>
+	<!--
+	Tasks that should be performed on any build server before getting to work.
+	-->
+	<Target Name="BuildServerPreparation">
+		<!-- Log server information -->
+		<Message Text="Build Server Information" Importance="high" />
+		<Message Text="Hostname      : $(COMPUTERNAME)" />
+		<Message Text="Build Account : $(USERDOMAIN)\$(USERNAME)" />
 
-  <!--
-  Tasks that should be performed on any build server before getting to work.
-  -->
-  <Target Name="BuildServerPreparation">
-    <!-- Log server information -->
-    <Message Text="Build Server Information" Importance="high" />
-    <Message Text="Hostname      : $(COMPUTERNAME)" />
-    <Message Text="Build Account : $(USERDOMAIN)\$(USERNAME)" />
+		<!-- Useful variables to log -->
+		<Message Text="Build Properties and Variables" Importance="high" />
+		<Message Text="Libraries Solution : $(ManagementLibrariesSolution)" />
+		<Message Text="Library            : $(LibraryFriendlyName)" />
+		<Message Text="Source folder      : $(LibrarySourceFolder)" />
+	</Target>
 
-    <!-- Useful variables to log -->
-    <Message Text="Build Properties and Variables" Importance="high" />
-    <Message Text="Libraries Solution : $(ManagementLibrariesSolution)" />
-    <Message Text="Library            : $(LibraryFriendlyName)" />
-    <Message Text="Source folder      : $(LibrarySourceFolder)" />
-  </Target>
+	<Import Project="$(LibraryToolsFolder)\nuget.targets" />
 
-  <Import Project="$(LibraryToolsFolder)\nuget.targets" />
+	<Target Name="SignAssembliesInNetCorePackages">
+		<ItemGroup>
+			<_NetCorePackagesTemp Include="$(PackageOutputDir)\%(NetCore_AutoRestLibraries.PackageName)*.nupkg"/>
+		</ItemGroup>
+		
+		<RemoveDuplicates Inputs="@(_NetCorePackagesTemp)">
+			<Output TaskParameter="Filtered" ItemName="_NetCorePackages" />
+		</RemoveDuplicates>
+		<PropertyGroup>
+			<_UnsignedFolder>$(PackageOutputDir)\unsigned</_UnsignedFolder>
+			<_SignedFolder>$(PackageOutputDir)\signed</_SignedFolder>
+		</PropertyGroup>    
 
-  <Target Name="SignAssembliesInNetCorePackages">
-    <ItemGroup>
-      <_NetCorePackagesTemp Include="$(PackageOutputDir)\%(NetCore_AutoRestLibraries.PackageName)*.nupkg"/>
-    </ItemGroup>
-    <RemoveDuplicates Inputs="@(_NetCorePackagesTemp)">
-      <Output TaskParameter="Filtered" ItemName="_NetCorePackages" />
-    </RemoveDuplicates>
-    <PropertyGroup>
-      <_UnsignedFolder>$(PackageOutputDir)\unsigned</_UnsignedFolder>
-      <_SignedFolder>$(PackageOutputDir)\signed</_SignedFolder>
-    </PropertyGroup>    
-    
-    <Message Text="%(_NetCorePackages.Identity)" Importance="low" />
-    
-    <RemoveDir Directories="$(_UnsignedFolder);$(_SignedFolder)" ContinueOnError="false" />
-    <RemoveDir Directories="@(_NetCorePackages->'$(PackageOutputDir)\%(Filename)')" ContinueOnError="false" />
+		<Message Text="%(_NetCorePackages.Identity)" Importance="low" />
 
-    <MakeDir Directories="$(_UnsignedFolder);$(_SignedFolder)" />
-    
-    <Exec Command="$(ZipExe) x -y -scsUTF-8 -o@(_NetCorePackages->'$(PackageOutputDir)\%(Filename)') %(_NetCorePackages.Identity)" />
+		<RemoveDir Directories="$(_UnsignedFolder);$(_SignedFolder)" ContinueOnError="false" />
+		<RemoveDir Directories="@(_NetCorePackages->'$(PackageOutputDir)\%(Filename)')" ContinueOnError="false" />
 
-    <RemoveDir Directories="@(_NetCorePackages->'%(RootDir)%(Directory)\%(Filename)\_rels')" />
-    <Delete Files="@(_NetCorePackages->'%(RootDir)%(Directory)\%(Filename)\[Content_Types].xml')" />
+		<MakeDir Directories="$(_UnsignedFolder);$(_SignedFolder)" />
 
-    <ItemGroup>
-      <_TempBinaries Include="$(PackageOutputDir)\**\*.dll"/>
-      <_PackageBinaries Include="@(_TempBinaries)">
-        <!-- Flattened file for signing -->
-        <UnsignedFlatFileName>$(_UnsignedFolder)\$([System.String]::new('%(RecursiveDir)%(FileName)%(Extension)').Replace('\', '__'))</UnsignedFlatFileName>
-        <SignedFlatFileName>$(_SignedFolder)\$([System.String]::new('%(RecursiveDir)%(FileName)%(Extension)').Replace('\', '__'))</SignedFlatFileName>
-      </_PackageBinaries>
-    </ItemGroup>
+		<Exec Command="$(ZipExe) x -y -scsUTF-8 -o@(_NetCorePackages->'$(PackageOutputDir)\%(Filename)') %(_NetCorePackages.Identity)" />
 
-    <Copy SourceFiles="@(_PackageBinaries)" DestinationFiles="@(_PackageBinaries->'%(UnsignedFlatFileName)')"></Copy>
+		<RemoveDir Directories="@(_NetCorePackages->'%(RootDir)%(Directory)\%(Filename)\_rels')" />
+		<Delete Files="@(_NetCorePackages->'%(RootDir)%(Directory)\%(Filename)\[Content_Types].xml')" />
 
-    <CodeSigningTask
-      Description="Microsoft Azure SDK"
-      Keywords="Microsoft Azure .NET SDK"
-      UnsignedFiles="@(_PackageBinaries->'%(UnsignedFlatFileName)')"
-      DestinationPath="$(_SignedFolder)"
-      SigningLogPath="$(PackageOutputDir)\signing.log"
-      ToolsPath="$(CIToolsPath)"
-      Condition="!$(DelaySign)"/>
+		<ItemGroup>
+			<_TempBinaries Include="$(PackageOutputDir)\**\*.dll"/>
+			<_PackageBinaries Include="@(_TempBinaries)">
+			<!-- Flattened file for signing -->
+			<UnsignedFlatFileName>$(_UnsignedFolder)\$([System.String]::new('%(RecursiveDir)%(FileName)%(Extension)').Replace('\', '__'))</UnsignedFlatFileName>
+			<SignedFlatFileName>$(_SignedFolder)\$([System.String]::new('%(RecursiveDir)%(FileName)%(Extension)').Replace('\', '__'))</SignedFlatFileName>
+			</_PackageBinaries>
+		</ItemGroup>
 
-    <!--If we are testing locally then we copy the binaries and do not submit to the code sign server-->
-    <Copy SourceFiles="@(_PackageBinaries->'%(UnsignedFlatFileName)')" DestinationFolder="$(_SignedFolder)" Condition="$(DelaySign)" />
+		<Copy SourceFiles="@(_PackageBinaries)" DestinationFiles="@(_PackageBinaries->'%(UnsignedFlatFileName)')"></Copy>
 
-    <GetFrameworkSdkPath>
-      <Output TaskParameter="Path" PropertyName="WindowsSdkPath"/>
-    </GetFrameworkSdkPath>
-    <ValidateStrongNameSignatureTask
-        WindowsSdkPath="$(WindowsSdkPath)"
-        Assembly="%(_PackageBinaries.SignedFlatFileName)"
-        ExpectedTokenSignature="$(StrongNameToken)"
-        ExpectedDelaySigned="false"
-        ContinueOnError="false"
-        Condition="!$(DelaySign)"/>
+		<CodeSigningTask
+		  Description="Microsoft Azure SDK"
+		  Keywords="Microsoft Azure .NET SDK"
+		  UnsignedFiles="@(_PackageBinaries->'%(UnsignedFlatFileName)')"
+		  DestinationPath="$(_SignedFolder)"
+		  SigningLogPath="$(PackageOutputDir)\signing.log"
+		  ToolsPath="$(CIToolsPath)"
+		  Condition="!$(DelaySign)"/>
 
-    <Copy SourceFiles="@(_PackageBinaries->'%(SignedFlatFileName)')" DestinationFiles="@(_PackageBinaries->'%(FullPath)')"></Copy>
-    <Exec Command="$(ZipExe) a -tzip -mx9 -r -y $(PackageOutputDir)\%(_NetCorePackages.Filename).nupkg" WorkingDirectory="$(PackageOutputDir)\%(_NetCorePackages.Filename)" />
-  </Target>
-  
+		<!--If we are testing locally then we copy the binaries and do not submit to the code sign server-->
+		<Copy SourceFiles="@(_PackageBinaries->'%(UnsignedFlatFileName)')" DestinationFolder="$(_SignedFolder)" Condition="$(DelaySign)" />
+
+		<GetFrameworkSdkPath>
+			<Output TaskParameter="Path" PropertyName="WindowsSdkPath"/>
+		</GetFrameworkSdkPath>
+		<ValidateStrongNameSignatureTask
+			WindowsSdkPath="$(WindowsSdkPath)"
+			Assembly="%(_PackageBinaries.SignedFlatFileName)"
+			ExpectedTokenSignature="$(StrongNameToken)"
+			ExpectedDelaySigned="false"
+			ContinueOnError="false"
+			Condition="!$(DelaySign)"/>
+
+		<Copy SourceFiles="@(_PackageBinaries->'%(SignedFlatFileName)')" DestinationFiles="@(_PackageBinaries->'%(FullPath)')"></Copy>
+		<Exec Command="$(ZipExe) a -tzip -mx9 -r -y $(PackageOutputDir)\%(_NetCorePackages.Filename).nupkg" WorkingDirectory="$(PackageOutputDir)\%(_NetCorePackages.Filename)" />
+	</Target>
 </Project>

--- a/build.proj
+++ b/build.proj
@@ -288,7 +288,7 @@
   replacements in files such as NuGet specs.
   -->
   <Target Name="BuildMsBuildTask">
-	<Exec Command="$(NuGetCommand) restore $(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Microsoft.WindowsAzure.Build.Tasks.csproj"/>
+	<Exec Command="$(NuGetCommand) restore $(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Microsoft.WindowsAzure.Build.Tasks.sln -PackagesDirectory $(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\packages"/>
     <MSBuild Projects="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Microsoft.WindowsAzure.Build.Tasks.csproj"
              Targets="Build"
              Properties="Configuration=Debug;Platform=AnyCPU" />

--- a/build.proj
+++ b/build.proj
@@ -288,6 +288,7 @@
   replacements in files such as NuGet specs.
   -->
   <Target Name="BuildMsBuildTask">
+	<Exec Command="$(NuGetCommand) restore $(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Microsoft.WindowsAzure.Build.Tasks.csproj"/>
     <MSBuild Projects="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Microsoft.WindowsAzure.Build.Tasks.csproj"
              Targets="Build"
              Properties="Configuration=Debug;Platform=AnyCPU" />

--- a/build.proj
+++ b/build.proj
@@ -159,7 +159,7 @@
 
 		<!-- Restoring everyting from the root folder wipes out Storage nuget references and adds Storage project reference to all projects. -->
 		<!-- Restoring from root directory when publishing scope packages -->
-		<Exec Command="dotnet restore" WorkingDirectory="$(LibrarySourceFolder)\$(Scope)" Condition="Exists('$(LibrarySourceFolder)\$(Scope)') AND '$(Scope)' != 'all'"/>
+		<Exec Command="dotnet restore" WorkingDirectory="$(LibraryRoot)" />
 
 		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
 		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Test)" Condition=" @(NetCore_AutoRestLibraries) != '' and '%(NetCore_AutoRestLibraries.Test)' != '' and '$(Configuration)' != 'Release' "/>

--- a/build.proj
+++ b/build.proj
@@ -61,9 +61,10 @@
     <FxTargetList Condition=" '$(Scope)' == 'authentication' ">net45</FxTargetList>
     <ZipExeFolder>$(LibraryToolsFolder)\7-Zip</ZipExeFolder>
     <ZipExe>$(ZipExeFolder)\7z.exe</ZipExe>
+	<NuGetCommand>&quot;$(LibraryToolsFolder)\nuget.exe&quot;</NuGetCommand>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(PublishTestProjects)' == 'false' Or '$(PublishTestProjects)' == ''">
     <LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\*.sln" Condition=" '$(Scope)' != 'all'  " />
     <LibrariesToBuild Include="$(LibrarySourceFolder)\**\*.sln" Condition=" '$(Scope)' == 'all'  " />
     <LibraryFxTargetList Include="$(FxTargetList)" />
@@ -72,10 +73,8 @@
     <ClientRuntimeTests Include="$(LibrarySourceFolder)\ClientRuntime\*.Tests\*.xproj" />
   </ItemGroup>
   
-  <PropertyGroup>
-    <NuGetCommand>&quot;$(LibraryToolsFolder)\nuget.exe&quot;</NuGetCommand>
-  </PropertyGroup>
-
+  <Import Condition="$(PublishTestProjects) == 'true'" Project="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Build.Tasks.Tests\PublishNugetPackageTests.proj" />
+  
   <UsingTask TaskName="ValidateStrongNameSignatureTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
   <UsingTask TaskName="FilterOutAutoRestLibraries" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
   <UsingTask TaskName="BuildProjectTemplatesTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
@@ -122,7 +121,7 @@
   <Import Condition=" $(OnPremiseBuild) " Project="$(CIToolsPath)\Microsoft.WindowsAzure.Build.OnPremise.msbuild" />
 
   <Target Name="PrepareForAutoRestLibraries">
-    <FilterOutAutoRestLibraries AllLibraries="@(LibrariesToBuild)" AutoRestMark="AutoRestProjects">
+    <FilterOutAutoRestLibraries AllLibraries="@(LibrariesToBuild)" AutoRestMark="AutoRestProjects" NugetPackagesToPublish="$(PackageName)">
       <Output TaskParameter="Non_NetCore_AutoRestLibraries" ItemName="Non_NetCore_AutoRestLibraries" />
       <Output TaskParameter="NetCore_AutoRestLibraries" ItemName="NetCore_AutoRestLibraries" />
     </FilterOutAutoRestLibraries>
@@ -131,8 +130,13 @@
     
     <!--Do not build old libraries except Authentication, which Azure PowerShell still uses-->
     <ItemGroup>
-      <NonAutoRestLibraries Include="$(LibrarySourceFolder)\Authentication\Authentication.sln"
+	<NonAutoRestLibraries Include="$(LibrarySourceFolder)\Authentication\Authentication.sln"	  
                             Condition=" '$(Scope)' == 'all' or '$(Scope)' == 'Authentication' " />
+    <!--
+		<NonAutoRestLibraries Include="$(LibrarySourceFolder)\Authentication\Authentication.sln"
+                            Condition=" ('$(Scope)' == 'all' or '$(Scope)' == 'Authentication') and Exists('$(LibrarySourceFolder)\Authentication\Authentication.sln')" />
+	-->
+		
     </ItemGroup>
     <Message Text="Non-AutoRest Libraries: @(NonAutoRestLibraries)" />
      
@@ -140,7 +144,6 @@
     <Exec
       Command="$(LibraryToolsFolder)\AzCopy\AzCopy.exe /Source:https://azuresdktools.blob.core.windows.net/7-zip  /S /Dest:$(ZipExeFolder) /Y"
       Condition="!Exists('$(ZipExe)')" />
-    
   </Target>
   
   <Target Name="Build" DependsOnTargets="BuildClientRuntime;BuildMsBuildTask;PrepareForAutoRestLibraries;RestoreNugetPackages">

--- a/build.proj
+++ b/build.proj
@@ -69,8 +69,9 @@
     <LibrariesToBuild Include="$(LibrarySourceFolder)\**\*.sln" Condition=" '$(Scope)' == 'all'  " />
     <LibraryFxTargetList Include="$(FxTargetList)" />
     <AutoRestLibraryFxTargetList Include="portable;net45" />
-    <ClientRuntimeProjects Include="$(LibrarySourceFolder)\ClientRuntime\**\*.xproj" />
-    <ClientRuntimeTests Include="$(LibrarySourceFolder)\ClientRuntime\*.Tests\*.xproj" />
+    <ClientRuntimeProjects Include="$(LibrarySourceFolder)\ClientRuntime\**\*.xproj"/>
+    <ClientRuntimeTests Include="$(LibrarySourceFolder)\ClientRuntime\*.Tests\*.xproj"/>
+	<ClientRuntimeRootDir Include="%(ClientRuntimeProjects.RootDir)"/>
   </ItemGroup>
   
   <Import Condition="$(PublishTestProjects) == 'true'" Project="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Build.Tasks.Tests\PublishNugetPackageTests.proj" />
@@ -80,7 +81,7 @@
   <UsingTask TaskName="BuildProjectTemplatesTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
   
   <!-- Building ClientRuntime projects -->
-  <Target Name="BuildClientRuntime">
+  <Target Name="BuildClientRuntime" Condition="Exists($(ClientRuntimeRootDir))">
       <Exec Command="dotnet restore" WorkingDirectory="%(ClientRuntimeProjects.RootDir)\%(ClientRuntimeProjects.Directory)"/>
       <Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(ClientRuntimeProjects.RootDir)\%(ClientRuntimeProjects.Directory)"/>
   </Target>
@@ -130,16 +131,11 @@
     
     <!--Do not build old libraries except Authentication, which Azure PowerShell still uses-->
     <ItemGroup>
-	<NonAutoRestLibraries Include="$(LibrarySourceFolder)\Authentication\Authentication.sln"	  
-                            Condition=" '$(Scope)' == 'all' or '$(Scope)' == 'Authentication' " />
-    <!--
-		<NonAutoRestLibraries Include="$(LibrarySourceFolder)\Authentication\Authentication.sln"
-                            Condition=" ('$(Scope)' == 'all' or '$(Scope)' == 'Authentication') and Exists('$(LibrarySourceFolder)\Authentication\Authentication.sln')" />
-	-->
-		
+		<NonAutoRestLibraries Include="$(LibrarySourceFolder)\Authentication\Authentication.sln"	  
+                            Condition=" '$(Scope)' == 'all' or '$(Scope)' == 'Authentication' " />    	
     </ItemGroup>
-    <Message Text="Non-AutoRest Libraries: @(NonAutoRestLibraries)" />
-     
+	
+    <Message Text="Non-AutoRest Libraries: @(NonAutoRestLibraries)" />     
     <Message Text="Ensure 7zip is available" />
     <Exec
       Command="$(LibraryToolsFolder)\AzCopy\AzCopy.exe /Source:https://azuresdktools.blob.core.windows.net/7-zip  /S /Dest:$(ZipExeFolder) /Y"

--- a/build.proj
+++ b/build.proj
@@ -171,14 +171,15 @@
     <Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(NetCore_AutoRestLibraries.Test)" Condition=" '$(Configuration)' != 'Release' and '%(NetCore_AutoRestLibraries.Test)' != '' "/>
   </Target>
  
-  <Target Name="Clean" DependsOnTargets="BuildMsBuildTask;PrepareForAutoRestLibraries;RestoreNugetPackages;">
+  <Target Name="Clean" DependsOnTargets="BuildMsBuildTask;PrepareForAutoRestLibraries;RestoreNugetPackages">
     <!--<MSBuild Projects="@(NonAutoRestLibraries)"
              Properties="Configuration=%(LibraryFxTargetList.Identity)-$(Configuration);Platform=Any CPU"
              Targets="Clean" />-->
-    
+
     <MSBuild Projects="@(Non_NetCore_AutoRestLibraries)"
              Properties="Configuration=%(AutoRestLibraryFxTargetList.Identity)-$(Configuration);Platform=Any CPU;$(_ExtraPropertyList)"
              Targets="Clean" />
+
     <RemoveDir Directories="$(BinariesFolder)" />
   </Target>
 

--- a/build.proj
+++ b/build.proj
@@ -293,6 +293,7 @@
 		<PropertyGroup>
 			<NuGetRestoreConfigSwitch>-PackagesDirectory $(LibraryNugetPackageFolder)</NuGetRestoreConfigSwitch>
 		</PropertyGroup>
+		<Exec Command="$(NuGetCommand) restore $(LibrarySourceFolder)\$(Scope) $(NuGetRestoreConfigSwitch)" Condition=" '$(Scope)' != 'all' AND ('@(Non_NetCore_AutoRestLibraries)' != '' OR '@(NonAutoRestLibraries)' != '')"/>
 		<Exec Command="$(NuGetCommand) restore %(Non_NetCore_AutoRestLibraries.Identity) $(NuGetRestoreConfigSwitch)" Condition=" @(Non_NetCore_AutoRestLibraries) != '' "/>
 		<Exec Command="$(NuGetCommand) restore %(NonAutoRestLibraries.Identity) $(NuGetRestoreConfigSwitch)" Condition=" @(NonAutoRestLibraries) != '' "/>
 		<Exec Command="$(NuGetCommand) install xunit.runner.console -Version 2.0.0 -o $(LibraryNugetPackageFolder)" />

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="RunPublishTest" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<UsingTask TaskName="DebugTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
+	<PropertyGroup>		
+		<LibrarySourceFolder Condition="'$(PublishTestProjects)' == 'true'">$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Build.Tasks.Tests\TestPublishProjects</LibrarySourceFolder>
+		<LibraryNugetPackageFolder>$(LibraryRoot)\packages</LibraryNugetPackageFolder>
+		<FxTargetList>portable;net40;net45</FxTargetList>
+		<NuGetPublishingSource>$(USERPROFILE)\nugetPublish</NuGetPublishingSource>
+		<NuGetKey>1234</NuGetKey>
+	</PropertyGroup>
+	
+	<ItemGroup>
+		<!-- <LibrariesToBuild Remove="@(LibrariesToBuild)"/> -->
+		<LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\**\*.sln" Condition=" '$(Scope)' != 'All' Or '$(Scope)' == '' " />
+		<LibrariesToBuild Include="$(LibrarySourceFolder)\**\*.sln" Condition=" '$(Scope)' == 'All' Or '$(Scope)' == '' " />		
+		<LibraryFxTargetList Include="$(FxTargetList)" />
+		<AutoRestLibraryFxTargetList Include="portable;net45" />	
+	</ItemGroup>
+<!--
+	<Import Project="$(LibrarySourceFolder)\MultiProjectMultiSln\CSProjTestPublish\CSProjTestPublish.nuget.proj" />
+	-->
+	<Target Name="OnePackageInit">
+	<!-- Use Case: You have to provide scope here, the way msbuild builds it's build graph for imports
+		and the way we have authored our DynamicNuSpec targets
+		msbuild build.proj /p:PublishTestProjects=true /t:Publish_OnePackage /p:Scope=MultiProjectMultiSln
+	-->
+		<Message Text="Executing 'OnePackageInit'" />
+		<PropertyGroup>
+		  <Scope>MultiProjectMultiSln</Scope>
+		  <PackageName>CSProjTestPublish</PackageName>
+		</PropertyGroup>
+		<ItemGroup>
+			<LibrariesToBuild Remove="@(LibrariesToBuild)" Condition=" '@(LibrariesToBuild)' != '' " />
+			<LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\**\*.sln" />
+		</ItemGroup>
+		<Message Text="Scope: '$(Scope)', PackageName: '$(PackageName)'"/>
+		<Error Text="No Project found to be built." Condition=" '@(LibrariesToBuild)' == '' " />
+	</Target>
+
+	<Target Name="MultiPackageInit">
+		<Message Text="Executing 'MultiPackageInit'" />
+		<PropertyGroup>
+		  <Scope>MultiProjectSingleSln</Scope>
+		  <PackageName>Sdk RP1_MgmtPlane RP2_SDK.Test</PackageName>
+		</PropertyGroup>
+		<ItemGroup>
+			<LibrariesToBuild Remove="@(LibrariesToBuild)" Condition=" '@(LibrariesToBuild)' != '' " />
+			<LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\**\*.sln" />
+		</ItemGroup>
+		<Error Text="No Project found to be built." Condition=" '@(LibrariesToBuild)' == '' " />
+	</Target>
+
+	<Target Name="Publish_MultiplePackage" DependsOnTargets="MultiPackageInit;TestInit;CommonSteps">
+		<Message Text="'Publish_MutiplePackage' completed"/>
+	</Target>
+
+	<Target Name="Publish_OnePackage" DependsOnTargets="OnePackageInit;TestInit;CommonSteps">
+		<Message Text="'Publish_OnePackage' succeeded" Condition="Exists('$(NuGetPublishingSource)\CSProjTestPublish.0.0.1.nupkg')" />
+		<Error Text="'Publish_OnePackage' failed" Condition="!Exists('$(NuGetPublishingSource)\CSProjTestPublish.0.0.1.nupkg')" />
+	</Target>
+
+	<Target Name="CommonSteps" DependsOnTargets="prepareforautorestlibraries;BuildTestPackages;Package;Publish" />
+	
+	<Target Name="TestInit" >
+		<Message Text="Trying to Create directory $(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
+		<MakeDir Directories="$(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
+		<Message Text="Test Publishing directory detected $(NuGetPublishingSource)" Condition="Exists($(NuGetPublishingSource))" />
+		<Error Text="Directory creation failed for '$(NuGetPublishingSource)'" Condition="!Exists($(NuGetPublishingSource))" />
+	</Target>
+	
+	<Target  Name="BuildTestPackages">
+		<Message Text="Non-NetCore Test Packages Libs to be built:  @(Non_NetCore_AutoRestLibraries)" />
+		<MSBuild Projects="@(Non_NetCore_AutoRestLibraries)"             
+				 Targets="Build" />
+
+		<Message Text="NetCore Test Packages Libs to be built:  @(Non_NetCore_AutoRestLibraries)" />
+		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
+		<Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" '%(NetCore_AutoRestLibraries.Library)'!= '' "/>
+
+		<Message Text="Building packages completed. Publishing not done" />
+  </Target>
+</Project>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
@@ -78,6 +78,11 @@
   
   <!-- TEST CASES -->
   
+  <!-- Job commandline args
+  /t:Clean;Build;Package;Publish /p:CodeSign=true;Configuration=Release /p:NuGetKey=<key> 
+  /p:NuGetPublishingSource=https://www.nuget.org/api/v2/package/ /fl /flp:logfile=build.out;verbosity=normal 
+  /p:Scope=$Scope /p:PackageName="$PackageName" /p:PublishTestProjects=true
+  -->
   <!-- Use Case:
 		msbuild build.proj /p:PublishTestProjects=true /t:Publish_MultipleSelectedPackage /p:Scope=MultiProjectSingleSln /p:PackageName="Sdk RP1_MgmtPlane"
 	-->

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
@@ -5,7 +5,7 @@
 		<LibrarySourceFolder Condition="'$(PublishTestProjects)' == 'true'">$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Build.Tasks.Tests\TestPublishProjects</LibrarySourceFolder>
 		<LibraryNugetPackageFolder>$(LibraryRoot)\packages</LibraryNugetPackageFolder>
 		<FxTargetList>portable;net40;net45</FxTargetList>
-		<NuGetPublishingSource>$(USERPROFILE)\nugetPublish</NuGetPublishingSource>
+		<NuGetPublishingSource Condition="'$(NuGetPublishingSource)' == ''">$(LibraryRoot)\packages\nugetPublish</NuGetPublishingSource>
 		<NuGetKey>1234</NuGetKey>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
@@ -5,7 +5,7 @@
 		<LibrarySourceFolder Condition="'$(PublishTestProjects)' == 'true'">$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Build.Tasks.Tests\TestPublishProjects</LibrarySourceFolder>
 		<LibraryNugetPackageFolder>$(LibraryRoot)\packages</LibraryNugetPackageFolder>
 		<FxTargetList>portable;net40;net45</FxTargetList>
-		<NuGetPublishingSource Condition="'$(NuGetPublishingSource)' == ''">$(LibraryRoot)\packages\nugetPublish</NuGetPublishingSource>
+		<NuGetPublishingSource Condition="'$(NuGetPublishingSource)' == ''">$(LibraryRoot)\testPackages\nugetPublish</NuGetPublishingSource>
 		<NuGetKey>1234</NuGetKey>
 	</PropertyGroup>
 	<PropertyGroup>
@@ -85,6 +85,7 @@
   -->
   <!-- Use Case:
 		msbuild build.proj /p:PublishTestProjects=true /t:Publish_MultipleSelectedPackage /p:Scope=MultiProjectSingleSln /p:PackageName="Sdk RP1_MgmtPlane"
+    msbuild build.proj /t:Build;Package;Publish /p:PublishTestProjects=true /p:Scope=MultiProjectSingleSln /p:PackageName="Sdk RP1_MgmtPlane"
 	-->
 	<Target Name="Publish_MultipleSelectedPackage" DependsOnTargets="MultiSelectedPackagesInit;$(TestInit)">
 		<Message Text="'Publish_MultipleSelectedPackage' completed"/>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
@@ -1,29 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="RunPublishTest" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<UsingTask TaskName="DebugTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
-	<PropertyGroup>		
+	<PropertyGroup>
 		<LibrarySourceFolder Condition="'$(PublishTestProjects)' == 'true'">$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks\Build.Tasks.Tests\TestPublishProjects</LibrarySourceFolder>
 		<LibraryNugetPackageFolder>$(LibraryRoot)\packages</LibraryNugetPackageFolder>
 		<FxTargetList>portable;net40;net45</FxTargetList>
 		<NuGetPublishingSource>$(USERPROFILE)\nugetPublish</NuGetPublishingSource>
 		<NuGetKey>1234</NuGetKey>
 	</PropertyGroup>
-	
+	<PropertyGroup>
+		<TestInit>
+			CommonInit;
+			prepareforautorestlibraries;
+			BuildTestPackages;
+			Package;
+			Publish
+		</TestInit>
+	</PropertyGroup>
 	<ItemGroup>
-		<!-- <LibrariesToBuild Remove="@(LibrariesToBuild)"/> -->
 		<LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\**\*.sln" Condition=" '$(Scope)' != 'All' Or '$(Scope)' == '' " />
 		<LibrariesToBuild Include="$(LibrarySourceFolder)\**\*.sln" Condition=" '$(Scope)' == 'All' Or '$(Scope)' == '' " />		
 		<LibraryFxTargetList Include="$(FxTargetList)" />
 		<AutoRestLibraryFxTargetList Include="portable;net45" />	
 	</ItemGroup>
-<!--
-	<Import Project="$(LibrarySourceFolder)\MultiProjectMultiSln\CSProjTestPublish\CSProjTestPublish.nuget.proj" />
-	-->
-	<Target Name="OnePackageInit">
-	<!-- Use Case: You have to provide scope here, the way msbuild builds it's build graph for imports
-		and the way we have authored our DynamicNuSpec targets
-		msbuild build.proj /p:PublishTestProjects=true /t:Publish_OnePackage /p:Scope=MultiProjectMultiSln
-	-->
+	
+	<Target Name="OnePackageInit">	
 		<Message Text="Executing 'OnePackageInit'" />
 		<PropertyGroup>
 		  <Scope>MultiProjectMultiSln</Scope>
@@ -36,38 +37,33 @@
 		<Message Text="Scope: '$(Scope)', PackageName: '$(PackageName)'"/>
 		<Error Text="No Project found to be built." Condition=" '@(LibrariesToBuild)' == '' " />
 	</Target>
-
-	<Target Name="MultiPackageInit">
-		<Message Text="Executing 'MultiPackageInit'" />
+	<Target Name="AllPackageInit">
+		<Message Text="Executing 'AllPackageInit'" />
 		<PropertyGroup>
 		  <Scope>MultiProjectSingleSln</Scope>
-		  <PackageName>Sdk RP1_MgmtPlane RP2_SDK.Test</PackageName>
+		  <!-- <PackageName>Sdk RP1_MgmtPlane RP2_SDK.Test</PackageName> -->
 		</PropertyGroup>
 		<ItemGroup>
 			<LibrariesToBuild Remove="@(LibrariesToBuild)" Condition=" '@(LibrariesToBuild)' != '' " />
 			<LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\**\*.sln" />
 		</ItemGroup>
 		<Error Text="No Project found to be built." Condition=" '@(LibrariesToBuild)' == '' " />
-	</Target>
-
-	<Target Name="Publish_MultiplePackage" DependsOnTargets="MultiPackageInit;TestInit;CommonSteps">
-		<Message Text="'Publish_MutiplePackage' completed"/>
-	</Target>
-
-	<Target Name="Publish_OnePackage" DependsOnTargets="OnePackageInit;TestInit;CommonSteps">
-		<Message Text="'Publish_OnePackage' succeeded" Condition="Exists('$(NuGetPublishingSource)\CSProjTestPublish.0.0.1.nupkg')" />
-		<Error Text="'Publish_OnePackage' failed" Condition="!Exists('$(NuGetPublishingSource)\CSProjTestPublish.0.0.1.nupkg')" />
-	</Target>
-
-	<Target Name="CommonSteps" DependsOnTargets="prepareforautorestlibraries;BuildTestPackages;Package;Publish" />
-	
-	<Target Name="TestInit" >
+	</Target>	
+	<Target Name="MultiSelectedPackagesInit">
+		<Message Text="Executing 'MultiSelectedPackagesInit'" />
+		<ItemGroup>
+			<LibrariesToBuild Remove="@(LibrariesToBuild)" Condition=" '@(LibrariesToBuild)' != '' " />
+			<LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\**\*.sln" />
+		</ItemGroup>
+		<Error Text="No Project found to be built." Condition=" '@(LibrariesToBuild)' == '' " />
+	</Target>	
+	<Target Name="CommonInit" >
+		<Message Text="Executing 'CommonInit'" />
 		<Message Text="Trying to Create directory $(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
 		<MakeDir Directories="$(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
 		<Message Text="Test Publishing directory detected $(NuGetPublishingSource)" Condition="Exists($(NuGetPublishingSource))" />
 		<Error Text="Directory creation failed for '$(NuGetPublishingSource)'" Condition="!Exists($(NuGetPublishingSource))" />
-	</Target>
-	
+	</Target>	
 	<Target  Name="BuildTestPackages">
 		<Message Text="Non-NetCore Test Packages Libs to be built:  @(Non_NetCore_AutoRestLibraries)" />
 		<MSBuild Projects="@(Non_NetCore_AutoRestLibraries)"             
@@ -79,4 +75,31 @@
 
 		<Message Text="Building packages completed. Publishing not done" />
   </Target>
-</Project>
+  
+  <!-- TEST CASES -->
+  
+  <!-- Use Case:
+		msbuild build.proj /p:PublishTestProjects=true /t:Publish_MultipleSelectedPackage /p:Scope=MultiProjectSingleSln /p:PackageName="Sdk RP1_MgmtPlane"
+	-->
+	<Target Name="Publish_MultipleSelectedPackage" DependsOnTargets="MultiSelectedPackagesInit;$(TestInit)">
+		<Message Text="'Publish_MultipleSelectedPackage' completed"/>
+	</Target>
+	
+	<!-- Use Case:
+		msbuild build.proj /p:PublishTestProjects=true /t:Publish_AllPackage
+	-->
+	<Target Name="Publish_AllPackage" DependsOnTargets="AllPackageInit;$(TestInit)">
+		<Message Text="'Publish_MultiplePackage' completed"/>
+	</Target>
+
+	<!-- Use Case: You have to provide scope here, the way msbuild builds it's build graph for imports
+		and the way we have authored our DynamicNuSpec targets
+		msbuild build.proj /p:PublishTestProjects=true /t:Publish_OnePackage /p:Scope=MultiProjectMultiSln
+	-->
+	<Target Name="Publish_OnePackage" DependsOnTargets="OnePackageInit;$(TestInit)">
+		<Message Text="'Publish_OnePackage' succeeded" Condition="Exists('$(NuGetPublishingSource)\CSProjTestPublish.0.0.1.nupkg')" />
+		<Error Text="'Publish_OnePackage' failed" Condition="!Exists('$(NuGetPublishingSource)\CSProjTestPublish.0.0.1.nupkg')" />
+	</Target>
+  
+  <!-- END OF TEST CASES -->
+  </Project>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/CSProjTestPublish.csproj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/CSProjTestPublish.csproj
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>424ee98f-19b5-4c8d-81a0-9e2891a20b36</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CSProjTestPublish</RootNamespace>
+    <AssemblyName>CSProjTestPublish</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoRestProjects>true</AutoRestProjects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <Import Project="..\..\..\..\..\Library.Settings.targets" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System"/>    
+    <Reference Include="System.Core"/>
+    <Reference Include="System.Xml.Linq"/>
+    <Reference Include="System.Data.DataSetExtensions"/>
+    <Reference Include="Microsoft.CSharp"/>    
+    <Reference Include="System.Data"/>    
+    <Reference Include="System.Net.Http"/>    
+    <Reference Include="System.Xml"/>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>  
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+ </Project>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/CSProjTestPublish.csproj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/CSProjTestPublish.csproj
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>424ee98f-19b5-4c8d-81a0-9e2891a20b36</ProjectGuid>
+    <ProjectGuid>{424EE98F-19B5-4C8D-81A0-9E2891A20B36}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CSProjTestPublish</RootNamespace>
@@ -32,18 +32,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System"/>    
-    <Reference Include="System.Core"/>
-    <Reference Include="System.Xml.Linq"/>
-    <Reference Include="System.Data.DataSetExtensions"/>
-    <Reference Include="Microsoft.CSharp"/>    
-    <Reference Include="System.Data"/>    
-    <Reference Include="System.Net.Http"/>    
-    <Reference Include="System.Xml"/>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Class1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\..\..\MSSharedLibKey.snk">
+      <Link>MSSharedLibKey.snk</Link>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
@@ -53,4 +58,4 @@
   <Target Name="AfterBuild">
   </Target>
   -->
- </Project>
+</Project>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/CSProjTestPublish.nuget.proj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/CSProjTestPublish.nuget.proj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <SdkNuGetPackage Include="CSProjTestPublish">
+      <PackageVersion>0.0.1</PackageVersion>
+      <Folder>$(MSBuildThisFileDirectory)</Folder>
+    </SdkNuGetPackage>
+  </ItemGroup>
+</Project>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/CSProjTestPublish.nuspec
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/CSProjTestPublish.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>CSProjTestPublish</id>
+    <version>$version$</version>
+    <title>CSProjTestPublish</title>
+    <authors>CSProjTestPublish</authors>
+    <owners>CSProjTestPublish</owners>
+    <licenseUrl>http://aka.ms/windowsazureapache2</licenseUrl>
+    <projectUrl>http://aka.ms/windowsazureapache2</projectUrl>
+    <iconUrl>http://aka.ms/windowsazureapache2</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>This is a test library used to test publish process to nuget</description>
+    <summary>This is a test library used to test publish process to nuget.</summary>
+    <releaseNotes/>
+    <tags>CSProjTestPublish</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5">
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\binaries\net45\CSProjTestPublish.dll" target="lib\net45" />
+	<file src="..\binaries\net45\CSProjTestPublish.pdb" target="lib\net45" />
+  </files>
+</package>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/CSProjTestPublish.sln
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/CSProjTestPublish.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSProjTestPublish", "CSProjTestPublish.csproj", "{424EE98F-19B5-4C8D-81A0-9E2891A20B36}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Net40-Debug|Any CPU = Net40-Debug|Any CPU
+		Net40-Release|Any CPU = Net40-Release|Any CPU
+		Net45-Debug|Any CPU = Net45-Debug|Any CPU
+		Net45-Release|Any CPU = Net45-Release|Any CPU
+		Portable-Debug|Any CPU = Portable-Debug|Any CPU
+		Portable-Release|Any CPU = Portable-Release|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Net40-Debug|Any CPU.ActiveCfg = Net40-Debug|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Net40-Debug|Any CPU.Build.0 = Net40-Debug|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Net40-Release|Any CPU.ActiveCfg = Net40-Release|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Net40-Release|Any CPU.Build.0 = Net40-Release|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Net45-Debug|Any CPU.ActiveCfg = Net45-Debug|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Net45-Debug|Any CPU.Build.0 = Net45-Debug|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Net45-Release|Any CPU.ActiveCfg = Net45-Release|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Net45-Release|Any CPU.Build.0 = Net45-Release|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Portable-Debug|Any CPU.ActiveCfg = Portable-Debug|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Portable-Debug|Any CPU.Build.0 = Portable-Debug|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Portable-Release|Any CPU.ActiveCfg = Portable-Release|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Portable-Release|Any CPU.Build.0 = Portable-Release|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{424EE98F-19B5-4C8D-81A0-9E2891A20B36}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Class1.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Class1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSProjTestPublish
+{
+    public class Class1
+    {
+    }
+}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Class1.cs
@@ -23,5 +23,7 @@ namespace CSProjTestPublish
 {
     public class Class1
     {
+        public void TestMethod1() { }
+
     }
 }

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Properties/AssemblyInfo.cs
@@ -1,3 +1,18 @@
+//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -32,5 +47,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.*")]
 [assembly: AssemblyFileVersion("0.0.1.0")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CSProjTestPublish")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CSProjTestPublish")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("424ee98f-19b5-4c8d-81a0-9e2891a20b36")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.1.0")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/CSProjTestPublish/Properties/AssemblyInfo.cs
@@ -48,4 +48,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.*")]
-[assembly: AssemblyFileVersion("0.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/Class1.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/Class1.cs
@@ -23,7 +23,9 @@ namespace NetCoreTestPublish
     public class Class1
     {
         public Class1()
-        {
+        {   
         }
+
+        public void TestMethod1() { }
     }
 }

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/Class1.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NetCoreTestPublish
+{
+    public class Class1
+    {
+        public Class1()
+        {
+        }
+    }
+}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/NetCoreTestPublish.sln
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/NetCoreTestPublish.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NetCoreTestPublish", "NetCoreTestPublish.xproj", "{4E25F50B-E3E9-4D84-AF23-629694F3FBB9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4E25F50B-E3E9-4D84-AF23-629694F3FBB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E25F50B-E3E9-4D84-AF23-629694F3FBB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E25F50B-E3E9-4D84-AF23-629694F3FBB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E25F50B-E3E9-4D84-AF23-629694F3FBB9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/NetCoreTestPublish.xproj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/NetCoreTestPublish.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>4e25f50b-e3e9-4d84-af23-629694f3fbb9</ProjectGuid>
+    <RootNamespace>NetCoreTestPublish</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/Properties/AssemblyInfo.cs
@@ -1,4 +1,19 @@
-﻿using System.Reflection;
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -17,3 +32,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("4e25f50b-e3e9-4d84-af23-629694f3fbb9")]
+
+[assembly: AssemblyVersion("1.0.0.*")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NetCoreTestPublish")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4e25f50b-e3e9-4d84-af23-629694f3fbb9")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/project.json
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/project.json
@@ -1,0 +1,13 @@
+﻿{
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "NETStandard.Library": "1.6.0"
+  },
+
+  "frameworks": {
+    "netstandard1.6": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/project.json
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectMultiSln/NetCoreTestPublish/project.json
@@ -1,13 +1,19 @@
 ﻿{
   "version": "1.0.0-*",
 
-  "dependencies": {
-    "NETStandard.Library": "1.6.0"
+  "buildOptions": {
+    "delaySign": true,
+    "publicSign": false,
+    "keyFile": "../../../../../MSSharedLibKey.snk"
   },
 
-  "frameworks": {
-    "netstandard1.6": {
-      "imports": "dnxcore50"
+    "dependencies": {
+      "NETStandard.Library": "1.6.0"
+    },
+
+    "frameworks": {
+      "netstandard1.6": {
+        "imports": "dnxcore50"
+      }
     }
   }
-}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/MultiProjectSingleSolution.sln
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/MultiProjectSingleSolution.sln
@@ -1,0 +1,40 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RP1_MgmtPlane", "RP1_MgmtPlane\RP1_MgmtPlane.xproj", "{98DF3CCC-731E-436A-ABAE-41D3BEAA9B5D}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RP1_DataPlane", "RP1_DataPlane\RP1_DataPlane.xproj", "{A74B90B5-57AF-4E7F-8FD0-CA1F9BFAE6D1}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RP2_SDK.Test", "RP2_Sdk\RP2_SDK.Test\RP2_SDK.Test.xproj", "{3D2CD7FB-D1CE-48F2-800E-8B63F7767734}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RP2_Sdk", "RP2_Sdk\Sdk\RP2_Sdk.xproj", "{E84C518F-6F25-415A-8E54-443CD6FDAB26}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{98DF3CCC-731E-436A-ABAE-41D3BEAA9B5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98DF3CCC-731E-436A-ABAE-41D3BEAA9B5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98DF3CCC-731E-436A-ABAE-41D3BEAA9B5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98DF3CCC-731E-436A-ABAE-41D3BEAA9B5D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A74B90B5-57AF-4E7F-8FD0-CA1F9BFAE6D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A74B90B5-57AF-4E7F-8FD0-CA1F9BFAE6D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A74B90B5-57AF-4E7F-8FD0-CA1F9BFAE6D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A74B90B5-57AF-4E7F-8FD0-CA1F9BFAE6D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D2CD7FB-D1CE-48F2-800E-8B63F7767734}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D2CD7FB-D1CE-48F2-800E-8B63F7767734}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D2CD7FB-D1CE-48F2-800E-8B63F7767734}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D2CD7FB-D1CE-48F2-800E-8B63F7767734}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E84C518F-6F25-415A-8E54-443CD6FDAB26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E84C518F-6F25-415A-8E54-443CD6FDAB26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E84C518F-6F25-415A-8E54-443CD6FDAB26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E84C518F-6F25-415A-8E54-443CD6FDAB26}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/Class1.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/Class1.cs
@@ -25,5 +25,7 @@ namespace RP1_DataPlane
         public Class1()
         {
         }
+
+        public void TestMethod1() { }
     }
 }

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/Class1.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace RP1_DataPlane
+{
+    public class Class1
+    {
+        public Class1()
+        {
+        }
+    }
+}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RP1_DataPlane")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a74b90b5-57af-4e7f-8fd0-ca1f9bfae6d1")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/Properties/AssemblyInfo.cs
@@ -1,4 +1,19 @@
-﻿using System.Reflection;
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -17,3 +32,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a74b90b5-57af-4e7f-8fd0-ca1f9bfae6d1")]
+
+[assembly: AssemblyVersion("1.0.0.*")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/RP1_DataPlane.xproj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/RP1_DataPlane.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>a74b90b5-57af-4e7f-8fd0-ca1f9bfae6d1</ProjectGuid>
+    <RootNamespace>RP1_DataPlane</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/project.json
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/project.json
@@ -1,0 +1,13 @@
+﻿{
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "NETStandard.Library": "1.6.0"
+  },
+
+  "frameworks": {
+    "netstandard1.6": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/project.json
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_DataPlane/project.json
@@ -1,6 +1,12 @@
 ﻿{
   "version": "1.0.0-*",
 
+  "buildOptions": {
+    "delaySign": true,
+    "publicSign": false,
+    "keyFile": "../../../../../MSSharedLibKey.snk"
+  },
+
   "dependencies": {
     "NETStandard.Library": "1.6.0"
   },

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/Class1.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/Class1.cs
@@ -25,5 +25,7 @@ namespace RP1_MgmtPlane
         public Class1()
         {
         }
+
+        public void TestMethod1() { }
     }
 }

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/Class1.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace RP1_MgmtPlane
+{
+    public class Class1
+    {
+        public Class1()
+        {
+        }
+    }
+}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/Properties/AssemblyInfo.cs
@@ -1,4 +1,19 @@
-﻿using System.Reflection;
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -17,3 +32,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("98df3ccc-731e-436a-abae-41d3beaa9b5d")]
+
+[assembly: AssemblyVersion("1.0.0.*")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RP1_MgmtPlane")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("98df3ccc-731e-436a-abae-41d3beaa9b5d")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/RP1_MgmtPlane.xproj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/RP1_MgmtPlane.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>98df3ccc-731e-436a-abae-41d3beaa9b5d</ProjectGuid>
+    <RootNamespace>RP1_MgmtPlane</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/project.json
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/project.json
@@ -1,0 +1,13 @@
+﻿{
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "NETStandard.Library": "1.6.0"
+  },
+
+  "frameworks": {
+    "netstandard1.6": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/project.json
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP1_MgmtPlane/project.json
@@ -1,6 +1,12 @@
 ﻿{
   "version": "1.0.0-*",
 
+  "buildOptions": {
+    "delaySign": true,
+    "publicSign": false,
+    "keyFile": "../../../../../MSSharedLibKey.snk"
+  },
+
   "dependencies": {
     "NETStandard.Library": "1.6.0"
   },

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/Class1.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/Class1.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace RP2_SDK.Test
+{
+    public class Class1
+    {
+        public Class1()
+        {
+        }
+    }
+}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/Class1.cs
@@ -25,5 +25,7 @@ namespace RP2_SDK.Test
         public Class1()
         {
         }
+
+        public void TestMethod1() { }
     }
 }

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RP2_SDK.Test")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3d2cd7fb-d1ce-48f2-800e-8b63f7767734")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/Properties/AssemblyInfo.cs
@@ -1,4 +1,19 @@
-﻿using System.Reflection;
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -17,3 +32,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3d2cd7fb-d1ce-48f2-800e-8b63f7767734")]
+
+[assembly: AssemblyVersion("1.0.0.*")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/RP2_SDK.Test.xproj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/RP2_SDK.Test.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>3d2cd7fb-d1ce-48f2-800e-8b63f7767734</ProjectGuid>
+    <RootNamespace>RP2_SDK.Test</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/project.json
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/RP2_SDK.Test/project.json
@@ -1,0 +1,13 @@
+﻿{
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "NETStandard.Library": "1.6.0"
+  },
+
+  "frameworks": {
+    "netstandard1.6": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/Class1.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/Class1.cs
@@ -25,5 +25,7 @@ namespace RP2_Sdk
         public Class1()
         {
         }
+
+        public void TestMethod1() { }
     }
 }

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/Class1.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/Class1.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace RP2_Sdk
+{
+    public class Class1
+    {
+        public Class1()
+        {
+        }
+    }
+}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/Properties/AssemblyInfo.cs
@@ -1,4 +1,19 @@
-﻿using System.Reflection;
+﻿//
+// Copyright (c) Microsoft.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -17,3 +32,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e84c518f-6f25-415a-8e54-443cd6fdab26")]
+
+[assembly: AssemblyVersion("1.0.0.*")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RP2_Sdk")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e84c518f-6f25-415a-8e54-443cd6fdab26")]

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/RP2_Sdk.xproj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/RP2_Sdk.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>e84c518f-6f25-415a-8e54-443cd6fdab26</ProjectGuid>
+    <RootNamespace>RP2_Sdk</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/project.json
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/project.json
@@ -1,0 +1,13 @@
+﻿{
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "NETStandard.Library": "1.6.0"
+  },
+
+  "frameworks": {
+    "netstandard1.6": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/project.json
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/TestPublishProjects/MultiProjectSingleSln/RP2_Sdk/Sdk/project.json
@@ -1,6 +1,12 @@
 ﻿{
   "version": "1.0.0-*",
 
+  "buildOptions": {
+    "delaySign": true,
+    "publicSign": false,
+    "keyFile": "../../../../../../MSSharedLibKey.snk"
+  },
+
   "dependencies": {
     "NETStandard.Library": "1.6.0"
   },

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
@@ -51,6 +51,14 @@ namespace Microsoft.WindowsAzure.Build.Tasks
 
         public override bool Execute()
         {
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            foreach (ITaskItem sln in AllLibraries)
+            {   
+                sb.AppendFormat("{0},", sln.GetMetadata("FullPath"));
+            }
+
+            Log.LogMessage(MessageImportance.High, "We have found {0}", sb.ToString());
+
             var nonNetCoreAutoRestLibraries = new List<ITaskItem>();
             var netCoreAutoRestLibraries = new List<ITaskItem>();
             var netCoreLibraryTestOnes = new List<ITaskItem>();
@@ -95,9 +103,11 @@ namespace Microsoft.WindowsAzure.Build.Tasks
                     if (nPkgsList != null)
                     {
                         //We need to filter out projects from the final output to build and publish limited set of projects
-                        string projectDirPath = Path.GetDirectoryName(nugetProjects[0]);
-                        string projectDirName = Path.GetFileName(projectDirPath);
-                        string match = nPkgsList.Find((pn) => pn.Equals(projectDirName, System.StringComparison.OrdinalIgnoreCase));
+                        //Here we need to get to the name of the nuget.proj file with .nuget.proj
+                        string nugetProjName = Path.GetFileName(nugetProjects[0]);
+                        string projNameWithoutExt = Path.GetFileNameWithoutExtension(nugetProjName);
+                        projNameWithoutExt = Path.GetFileNameWithoutExtension(projNameWithoutExt);
+                        string match = nPkgsList.Find((pn) => pn.Equals(projNameWithoutExt, System.StringComparison.OrdinalIgnoreCase));
                         if (!string.IsNullOrEmpty(match))
                         {
                             nonNetCoreAutoRestLibraries.Add(solution);

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Framework;
@@ -61,9 +62,10 @@ namespace Microsoft.WindowsAzure.Build.Tasks
 
                 if (!string.IsNullOrEmpty(NugetPackagesToPublish))
                 {   
-                    nPkgsList = NugetPackagesToPublish.Split(' ').ToList<string>();
+                    nPkgsList = NugetPackagesToPublish.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries).ToList<string>();
                 }
             }
+
             foreach (ITaskItem solution in AllLibraries)
             {
                 bool isAutoRestLibrary = false;

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
@@ -31,10 +31,12 @@ namespace Microsoft.WindowsAzure.Build.Tasks
         public string AutoRestMark { get; set; }
 
         /// <summary>
-        /// Name of packages that needs to be published. Currently for ease of user, it will be space delimited list of NetCore projects
+        /// Name of packages that needs to be published. Currently for ease for the user, it will be space delimited list of NetCore projects
         /// Non-NetCore projects cannot be published more than one package due to MSBuild limitation as well as our existing architecture of nuget.proj files
-        /// Plus once we are very limited set of non-netCore projects, so the effort is not worth. Worse case, each job to publish 1 package at a time
-        /// E.g. /p:PackageName="PackageName1 PackageName2" string can be passed to publish PacakgeName1 and PackageName2
+        /// Plus as we have very limited set of non-netCore projects, so the effort is not worth it. Worse case for publishing non-netCore projects, each job 
+        /// to publish 1 package at a time
+        /// 
+        /// E.g. for NetCore projects /p:PackageName="PackageName1 PackageName2" string can be passed to publish PacakgeName1 and PackageName2
         /// </summary>
         public string NugetPackagesToPublish { get; set; }
 
@@ -56,14 +58,9 @@ namespace Microsoft.WindowsAzure.Build.Tasks
             
             List<string> nPkgsList = null;
 
-            if (NugetPackagesToPublish != null)
+            if (!string.IsNullOrWhiteSpace(NugetPackagesToPublish))
             {
-                NugetPackagesToPublish = NugetPackagesToPublish.Trim();
-
-                if (!string.IsNullOrEmpty(NugetPackagesToPublish))
-                {   
-                    nPkgsList = NugetPackagesToPublish.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries).ToList<string>();
-                }
+                nPkgsList = NugetPackagesToPublish.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries).ToList<string>();
             }
 
             foreach (ITaskItem solution in AllLibraries)
@@ -102,7 +99,9 @@ namespace Microsoft.WindowsAzure.Build.Tasks
                         string projectDirName = Path.GetFileName(projectDirPath);
                         string match = nPkgsList.Find((pn) => pn.Equals(projectDirName, System.StringComparison.OrdinalIgnoreCase));
                         if (!string.IsNullOrEmpty(match))
+                        {
                             nonNetCoreAutoRestLibraries.Add(solution);
+                        }
                     }
                     else
                     {
@@ -158,6 +157,15 @@ namespace Microsoft.WindowsAzure.Build.Tasks
                     {
                         others.Add(solution);
                     }
+                }
+            }
+
+            if(nPkgsList != null)
+            {
+                if (nPkgsList.Any<string>())
+                {
+                    string pkgNames = string.Join(",", nPkgsList);
+                    Log.LogMessage(MessageImportance.High, "Trying to publish packages: {0}", pkgNames);
                 }
             }
 

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Microsoft.WindowsAzure.Build.Tasks.csproj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Microsoft.WindowsAzure.Build.Tasks.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Microsoft.WindowsAzure.Build.Tasks.csproj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Microsoft.WindowsAzure.Build.Tasks.csproj
@@ -62,6 +62,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Build.Tasks.Tests\BuildTasksTest.BuildProjectTemplates.proj" />
+    <None Include="Build.Tasks.Tests\PublishNugetPackageTests.proj">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tools/nuget.targets
+++ b/tools/nuget.targets
@@ -95,7 +95,9 @@
  
   <Target Name="Publish" DependsOnTargets="PrepareForAutoRestLibraries">
     <Error Condition=" '$(NuGetKey)' == '' " Text="You must provide the NuGetKey parameter to the build: /p:NuGetKey=YOUR_PUBLISHING_KEY" />
-
+	<Message Text="Trying to Create directory $(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
+	<MakeDir Directories="$(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource)) AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$(NuGetPublishingSource)', '^(?i)http'))" />
+	<Message Text="Publishing directory detected $(NuGetPublishingSource)" Condition="Exists($(NuGetPublishingSource))" />
     <PropertyGroup>
       <ActualSource Condition=" '$(NuGetPublishingSource)' == '' "></ActualSource>
       <ActualSource Condition=" '$(NuGetPublishingSource)' != '' "> -Source $(NuGetPublishingSource)</ActualSource>

--- a/tools/nuget.targets
+++ b/tools/nuget.targets
@@ -1,136 +1,138 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <BaselineReleaseNotes>PREVIEW RELEASE</BaselineReleaseNotes>
-  </PropertyGroup>
-  
-  <Import Project="$(LibrarySourceFolder)\$(Scope)\**\*$(PackageName).nuget.proj"
-          Condition=" '$(Scope)' != 'all' " />
+	<PropertyGroup>
+	<BaselineReleaseNotes>PREVIEW RELEASE</BaselineReleaseNotes>
+	</PropertyGroup>
 
-  <!--TODO: remove when we convert them to be NetCore based-->
-  <Import Project="$(LibrarySourceFolder)\Authentication\Common.Authentication\*.nuget.proj"
-          Condition=" '$(Scope)' == 'all' "/>
-  <Import Project="$(LibrarySourceFolder)\Batch\Client\Src\*.nuget.proj"
-          Condition=" '$(Scope)' == 'all' "/>
-  <Import Project="$(LibrarySourceFolder)\Batch\FileConventions\Src\AzureBatchFileConventions\*.nuget.proj"
-          Condition=" '$(Scope)' == 'all' "/>
-  
-  <PropertyGroup>
-    <NuGetVerbosity>normal</NuGetVerbosity>
-  </PropertyGroup>
+	<Import Project="$(LibrarySourceFolder)\$(Scope)\**\*$(PackageName).nuget.proj"
+		  Condition=" '$(Scope)' != 'all' " />
 
-  <ItemGroup>
-    <NuSpecReplacementTokens Include="BASELINE_RELEASE_NOTES">
-      <Value>$(BaselineReleaseNotes)</Value>
-    </NuSpecReplacementTokens>
-  </ItemGroup>
-  
-  <Target Name="EnsureBinariesFolderExists">
-    <MakeDir Directories="binaries" Condition="!Exists('binaries')" />
-    <MakeDir Directories="binaries\packages" Condition="!Exists('binaries\packages')" />
-    <MakeDir Directories="binaries\packages\specs" Condition="!Exists('binaries\packages\specs')" />
-  </Target>
-  
-  <UsingTask TaskName="RegexReplacementTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll" />
-  <!-- Replacing version token dependency. -->
-  <Target Name="BuildDynamicNuSpecs"
-          DependsOnTargets="EnsureBinariesFolderExists">
-    <!-- First we copy nuspec files to binaries folder -->
-    <ItemGroup>
-      <NuspecFilesToUpdate Include="%(SdkNuGetPackage.Folder)%(SdkNuGetPackage.Identity).nuspec" />
-    </ItemGroup>
-	
-    <PropertyGroup>
-      <PowerShellExe Condition=" '$(PowerShellExe)'=='' ">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>   
-      <NuSpecSyncScript>$(MSBuildProjectDirectory)\tools\Sync-NuspecDependencies.ps1</NuSpecSyncScript>	  
-    </PropertyGroup>
-	
-    <Error Text="NuGet specification %(NuspecFilesToUpdate.Identity) not found."
-           Condition="!Exists(%(NuspecFilesToUpdate.Identity))" />
+	<!--TODO: remove when we convert them to be NetCore based-->
+	<Import Project="$(LibrarySourceFolder)\Authentication\Common.Authentication\*.nuget.proj"
+		  Condition=" '$(Scope)' == 'all' "/>
+	<Import Project="$(LibrarySourceFolder)\Batch\Client\Src\*.nuget.proj"
+		  Condition=" '$(Scope)' == 'all' "/>
+	<Import Project="$(LibrarySourceFolder)\Batch\FileConventions\Src\AzureBatchFileConventions\*.nuget.proj"
+		  Condition=" '$(Scope)' == 'all' "/>
 
-    <!-- First replace any string tokens, storing the output in the binaries 
-         folder instead of doing a destructive replacement. -->
-    <RegexReplacementTask Files="@(NuspecFilesToUpdate)"
-                          OutputDir="binaries\packages\specs\"
-                          Find="__%(NuSpecReplacementTokens.Identity)__"
-                          Replace="%(NuSpecReplacementTokens.Value)"
-                          LogReplacement="false" />
+	<PropertyGroup>
+		<NuGetVerbosity>normal</NuGetVerbosity>
+	</PropertyGroup>
 
-    <!-- Update all explicit references to dependent versions. -->
-    <Exec Command="$(PowerShellExe) -NonInteractive -ExecutionPolicy bypass -Command &quot;&amp; { &amp;&apos;$(NuSpecSyncScript)&apos; &apos;%(NuspecFilesToUpdate.RootDir)%(NuspecFilesToUpdate.Directory)&apos; }&quot;" />
+	<ItemGroup>
+		<NuSpecReplacementTokens Include="BASELINE_RELEASE_NOTES">
+		  <Value>$(BaselineReleaseNotes)</Value>
+		</NuSpecReplacementTokens>
+	</ItemGroup>
 
-    <!-- Second, use the new files as destructive replacement targets. -->
-    <ItemGroup>
-      <NuspecFilesToUpdate2 Include="binaries\packages\specs\*.nuspec" />
-    </ItemGroup>
-    <RegexReplacementTask Files="@(NuspecFilesToUpdate2)"
-                          Find="__VERSION_%(SdkNuGetPackage.Identity)__"
-                          Replace="%(SdkNuGetPackage.PackageVersion)"
-                          LogReplacement="false" />
+	<Target Name="EnsureBinariesFolderExists">
+		<MakeDir Directories="binaries" Condition="!Exists('binaries')" />
+		<MakeDir Directories="binaries\packages" Condition="!Exists('binaries\packages')" />
+		<MakeDir Directories="binaries\packages\specs" Condition="!Exists('binaries\packages\specs')" />
+	</Target> 
 
-    <Message Text="Created dynamic nuspec %(NuspecFilesToUpdate2.Identity)" />
-  </Target>
+	<UsingTask TaskName="RegexReplacementTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll" />
+	<UsingTask TaskName="DebugTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
 
-  <Target Name="ListPackages">
-    <Message Text="%(SdkNuGetPackage.Identity) %(SdkNuGetPackage.PackageVersion) %(SdkNuGetPackage.Folder)" />
-  </Target>
+	<!-- Replacing version token dependency. -->
+	<Target Name="BuildDynamicNuSpecs"
+		  DependsOnTargets="EnsureBinariesFolderExists">
+		<!-- First we copy nuspec files to binaries folder -->
+		<ItemGroup>
+		<NuspecFilesToUpdate Include="%(SdkNuGetPackage.Folder)%(SdkNuGetPackage.Identity).nuspec" />
+		</ItemGroup>
 
-  <!--
-  Build NuGet packages
-  -->
-  <Target Name="Package" DependsOnTargets="PrepareForAutoRestLibraries">
-    <CallTarget Targets="BuildDynamicNuSpecs" Condition=" @(Non_NetCore_AutoRestLibraries) != '' or @(NonAutoRestLibraries) != ''" />
-    
-    <Message Text="Generating NuGet library" Importance="high" />
-    <Exec Condition=" '%(SdkNuGetPackage.Identity)' != '' "
-          Command="$(NuGetCommand) pack -BasePath .\src\ -Verbosity $(NuGetVerbosity) &quot;binaries\packages\specs\%(SdkNuGetPackage.Identity).nuspec&quot; -Version %(SdkNuGetPackage.PackageVersion) -OutputDirectory &quot;$(PackageOutputDir)&quot; -Symbols" />
+		<PropertyGroup>
+		  <PowerShellExe Condition=" '$(PowerShellExe)'=='' ">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>   
+		  <NuSpecSyncScript>$(MSBuildProjectDirectory)\tools\Sync-NuspecDependencies.ps1</NuSpecSyncScript>	  
+		</PropertyGroup>
 
-    <Exec Command="dotnet pack --configuration $(Configuration)" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
-    <ItemGroup>
-      <_NetCorePackages Include="%(NetCore_AutoRestLibraries.Library)\bin\$(Configuration)\%(NetCore_AutoRestLibraries.PackageName)*.nupkg" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_NetCorePackages)" DestinationFolder="$(PackageOutputDir)" Condition=" @(NetCore_AutoRestLibraries) != '' " />
-    <CallTarget Targets="SignAssembliesInNetCorePackages" Condition=" @(NetCore_AutoRestLibraries) != '' and '$(CodeSign)' == 'true' " />
-  </Target>
- 
-  <Target Name="Publish" DependsOnTargets="PrepareForAutoRestLibraries">
-    <Error Condition=" '$(NuGetKey)' == '' " Text="You must provide the NuGetKey parameter to the build: /p:NuGetKey=YOUR_PUBLISHING_KEY" />
-	<Message Text="Trying to Create directory $(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
-	<MakeDir Directories="$(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource)) AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$(NuGetPublishingSource)', '^(?i)http'))" />
-	<Message Text="Publishing directory detected $(NuGetPublishingSource)" Condition="Exists($(NuGetPublishingSource))" />
-    <PropertyGroup>
-      <ActualSource Condition=" '$(NuGetPublishingSource)' == '' "></ActualSource>
-      <ActualSource Condition=" '$(NuGetPublishingSource)' != '' "> -Source $(NuGetPublishingSource)</ActualSource>
-    </PropertyGroup>
+		<Error Text="NuGet specification %(NuspecFilesToUpdate.Identity) not found."
+			   Condition="!Exists(%(NuspecFilesToUpdate.Identity))" />
 
-    <!--Ran 'nuget push' on the main package, will automatically push the symbol package at the same time-->
-    <Message Importance="high" Text="Publishing main and symbols packages to the cloud at $(NuGetPublishingSource)" />
-    <Exec Command="$(NuGetCommand) push &quot;$(PackageOutputDir)\%(SdkNuGetPackage.Identity).%(SdkNuGetPackage.PackageVersion).nupkg&quot; $(NuGetKey)$(ActualSource)"
-          IgnoreExitCode="true"
-          Condition=" '%(SdkNuGetPackage.Publish)' != 'false' " />
+		<!-- First replace any string tokens, storing the output in the binaries 
+			 folder instead of doing a destructive replacement. -->
+		<RegexReplacementTask Files="@(NuspecFilesToUpdate)"
+							  OutputDir="binaries\packages\specs\"
+							  Find="__%(NuSpecReplacementTokens.Identity)__"
+							  Replace="%(NuSpecReplacementTokens.Value)"
+							  LogReplacement="false" />
 
-    <Message Text="Not publishing package %(SdkNuGetPackage.Identity) as Publish is set to 'false' for the component."
-             Condition=" '%(SdkNuGetPackage.Publish)' == 'false' " />
+		<!-- Update all explicit references to dependent versions. -->
+		<Exec Command="$(PowerShellExe) -NonInteractive -ExecutionPolicy bypass -Command &quot;&amp; { &amp;&apos;$(NuSpecSyncScript)&apos; &apos;%(NuspecFilesToUpdate.RootDir)%(NuspecFilesToUpdate.Directory)&apos; }&quot;" />
 
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Properties="NuGetKey=$(NuGetKey);NetCorePackageName=%(NetCore_AutoRestLibraries.PackageName);PackageOutputDir=$(PackageOutputDir)"
-             Targets="PublishNetCorePackage" Condition=" %(NetCore_AutoRestLibraries.PackageName) != '' " />
-  </Target>
+		<!-- Second, use the new files as destructive replacement targets. -->
+		<ItemGroup>
+		  <NuspecFilesToUpdate2 Include="binaries\packages\specs\*.nuspec" />
+		</ItemGroup>
+		<RegexReplacementTask Files="@(NuspecFilesToUpdate2)"
+							  Find="__VERSION_%(SdkNuGetPackage.Identity)__"
+							  Replace="%(SdkNuGetPackage.PackageVersion)"
+							  LogReplacement="false" />
 
-  <Target Name="PublishNetCorePackage">
-    <ItemGroup>
-      <_NetCorePackagesToPublish Include="$(PackageOutputDir)\$(NetCorePackageName)*.nupkg"
+		<Message Text="Created dynamic nuspec %(NuspecFilesToUpdate2.Identity)" />
+	</Target>
+
+	<Target Name="ListPackages">
+		<Message Text="%(SdkNuGetPackage.Identity) %(SdkNuGetPackage.PackageVersion) %(SdkNuGetPackage.Folder)" />
+	</Target>
+
+	<!--
+	Build NuGet packages
+	-->
+	<Target Name="Package" DependsOnTargets="PrepareForAutoRestLibraries">
+		<CallTarget Targets="BuildDynamicNuSpecs" Condition=" @(Non_NetCore_AutoRestLibraries) != '' or @(NonAutoRestLibraries) != ''" />
+
+		<Message Text="Generating NuGet library" Importance="high" />
+		<Exec Condition=" '%(SdkNuGetPackage.Identity)' != '' "
+			  Command="$(NuGetCommand) pack -BasePath .\src\ -Verbosity $(NuGetVerbosity) &quot;binaries\packages\specs\%(SdkNuGetPackage.Identity).nuspec&quot; -Version %(SdkNuGetPackage.PackageVersion) -OutputDirectory &quot;$(PackageOutputDir)&quot; -Symbols" />
+		<Exec Command="dotnet pack --configuration $(Configuration)" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
+
+		<ItemGroup>
+			<_NetCorePackages Include="%(NetCore_AutoRestLibraries.Library)\bin\$(Configuration)\%(NetCore_AutoRestLibraries.PackageName)*.nupkg" />
+		</ItemGroup>
+		<Copy SourceFiles="@(_NetCorePackages)" DestinationFolder="$(PackageOutputDir)" Condition=" @(NetCore_AutoRestLibraries) != '' " />
+		<CallTarget Targets="SignAssembliesInNetCorePackages" Condition=" @(NetCore_AutoRestLibraries) != '' and '$(CodeSign)' == 'true' " />
+	</Target>
+
+	<Target Name="Publish" DependsOnTargets="PrepareForAutoRestLibraries">
+		<Error Condition=" '$(NuGetKey)' == '' " Text="You must provide the NuGetKey parameter to the build: /p:NuGetKey=YOUR_PUBLISHING_KEY" />
+		<Message Text="Trying to Create directory $(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
+		<MakeDir Directories="$(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource)) AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$(NuGetPublishingSource)', '^(?i)http'))" />
+		<Message Text="Publishing directory detected $(NuGetPublishingSource)" Condition="Exists($(NuGetPublishingSource))" />
+		<PropertyGroup>
+			<ActualSource Condition=" '$(NuGetPublishingSource)' == '' "></ActualSource>
+			<ActualSource Condition=" '$(NuGetPublishingSource)' != '' "> -Source $(NuGetPublishingSource)</ActualSource>
+		</PropertyGroup>
+
+		<!--Ran 'nuget push' on the main package, will automatically push the symbol package at the same time-->
+		<Message Importance="high" Text="Publishing main and symbols packages to the cloud at $(NuGetPublishingSource)" />
+		<Exec Command="$(NuGetCommand) push &quot;$(PackageOutputDir)\%(SdkNuGetPackage.Identity).%(SdkNuGetPackage.PackageVersion).nupkg&quot; $(NuGetKey)$(ActualSource)"
+			  IgnoreExitCode="true"
+			  Condition=" '%(SdkNuGetPackage.Publish)' != 'false' " />
+
+		<Message Text="Not publishing package %(SdkNuGetPackage.Identity) as Publish is set to 'false' for the component."
+				 Condition=" '%(SdkNuGetPackage.Publish)' == 'false' " />
+
+		<MSBuild Projects="$(MSBuildProjectFullPath)"
+				 Properties="NuGetKey=$(NuGetKey);NetCorePackageName=%(NetCore_AutoRestLibraries.PackageName);PackageOutputDir=$(PackageOutputDir)"
+				 Targets="PublishNetCorePackage" Condition=" %(NetCore_AutoRestLibraries.PackageName) != '' " />
+	</Target>
+
+	<Target Name="PublishNetCorePackage">
+		<ItemGroup>
+			<_NetCorePackagesToPublish Include="$(PackageOutputDir)\$(NetCorePackageName)*.nupkg"
                              Exclude="$(PackageOutputDir)\$(NetCorePackageName)*.symbols.nupkg">
-      </_NetCorePackagesToPublish>
-    </ItemGroup>
+			</_NetCorePackagesToPublish>
+		</ItemGroup>
 
-    <PropertyGroup>
-      <ActualSource Condition=" '$(NuGetPublishingSource)' == '' "></ActualSource>
-      <ActualSource Condition=" '$(NuGetPublishingSource)' != '' "> -Source $(NuGetPublishingSource)</ActualSource>
-    </PropertyGroup>
+		<PropertyGroup>
+		  <ActualSource Condition=" '$(NuGetPublishingSource)' == '' "></ActualSource>
+		  <ActualSource Condition=" '$(NuGetPublishingSource)' != '' "> -Source $(NuGetPublishingSource)</ActualSource>
+		</PropertyGroup>
     
-    <Exec Command="$(NuGetCommand) push &quot;%(_NetCorePackagesToPublish.Identity)&quot; $(NuGetKey)$(ActualSource)"
-          IgnoreExitCode="true" />
+		<Exec Command="$(NuGetCommand) push &quot;%(_NetCorePackagesToPublish.Identity)&quot; $(NuGetKey)$(ActualSource)"
+			  IgnoreExitCode="true" />
   </Target>
   
 </Project>


### PR DESCRIPTION
1) Adding a way to publish single nuget package when a scope is provided.
2) This change will also allow publishing multiple packages from the same scope (only NetCore projects are supported as this stage). Due to restrictions on how we have enabled non-NetCore project imports and the way msbuild builds it's build graph.
3) Adding test collateral and tests to test publishing one project