### PR TITLE
Simplifying and hardening ExpandableStringEnum + some test and bug fixes

### DIFF
--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/AzureTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/AzureTests.cs
@@ -5,9 +5,11 @@ using Fluent.Tests.Common;
 using Microsoft.Azure.Management.Fluent;
 using Microsoft.Azure.Management.Resource.Fluent;
 using Microsoft.Azure.Management.Resource.Fluent.Authentication;
+using Microsoft.Azure.Management.Resource.Fluent.Core;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.Azure.Management.Resource.Fluent.Core.HttpLoggingDelegatingHandler;
+using System.Linq;
 
 namespace Azure.Tests
 {
@@ -46,6 +48,30 @@ namespace Azure.Tests
             new Network.ApplicationGateway.PublicMinimal(
                 azure.Networks)
                 .RunTest(azure.ApplicationGateways, azure.ResourceGroups);
+        }
+
+        public class ExpandableStringEnumFoo : ExpandableStringEnum<ExpandableStringEnumFoo>
+        {
+            public static readonly ExpandableStringEnumFoo Foo1 = Parse("value1");
+            public static readonly ExpandableStringEnumFoo Foo2 = Parse("value2");
+        }
+
+        public class ExpandableStringEnumBar : ExpandableStringEnum<ExpandableStringEnumBar>
+        {
+            public static readonly ExpandableStringEnumBar Bar1 = Parse("value1");
+            public static readonly ExpandableStringEnumBar Bar2 = Parse("value3");
+        }
+
+        [Fact(Skip = "TODO: Convert to recorded tests")]
+        public void TestExpandableEnums()
+        {
+            ExpandableStringEnumFoo foo = ExpandableStringEnumFoo.Foo1;
+            Assert.True(ExpandableStringEnumFoo.Foo1 == foo);
+
+            Assert.True(ExpandableStringEnumFoo.Foo1 == ExpandableStringEnumFoo.Parse(ExpandableStringEnumFoo.Foo1.ToString()));
+            Assert.True(ExpandableStringEnumFoo.Foo1 != ExpandableStringEnumFoo.Parse(ExpandableStringEnumFoo.Foo2.ToString()));
+            Assert.True(ExpandableStringEnumBar.Bar1 == ExpandableStringEnumBar.Parse(ExpandableStringEnumBar.Bar1.ToString()));
+            Assert.True(ExpandableStringEnumBar.Bar1 != ExpandableStringEnumBar.Parse(ExpandableStringEnumBar.Bar2.ToString()));
         }
 
         [Fact(Skip = "TODO: Convert to recorded tests")]

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/NSGTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/NSGTests.cs
@@ -72,6 +72,7 @@ namespace Fluent.Tests.Network
             Assert.True(resource.Tags.ContainsKey("tag1"));
 
             manager.NetworkSecurityGroups.DeleteById(resource.Id);
+            manager.ResourceManager.ResourceGroups.DeleteByName(resource.ResourceGroupName);
         }
 
 

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/NetworkInterfaceTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/NetworkInterfaceTests.cs
@@ -33,7 +33,7 @@ namespace Fluent.Tests.Network
             var resource = manager.NetworkInterfaces.GetByGroup("rg" + this.testId, "nic" + testId);
             resource = resource.Update()
                 .WithoutIpForwarding()
-                .UpdateIpConfiguration("primary-nic-config") // Updating the primary ip configuration
+                .UpdateIpConfiguration(resource.PrimaryIpConfiguration.Name) // Updating the primary ip configuration
                     .WithPrivateIpAddressDynamic() // Equivalent to ..update().withPrimaryPrivateIpAddressDynamic()
                     .WithoutPublicIpAddress()      // Equivalent to ..update().withoutPrimaryPublicIpAddress()
                     .Parent()
@@ -107,6 +107,7 @@ namespace Fluent.Tests.Network
             Assert.NotNull(resourceGroup);
             INetwork network = (INetwork)batchNics.CreatedRelatedResource(networkCreatable.Key);
             Assert.NotNull(network);
+            azure.ResourceGroups.DeleteByName(resourceGroup.Name);
         }
 
         public void print(INetworkInterface resource)

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/NetworkTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/NetworkTests.cs
@@ -4,7 +4,6 @@
 using Fluent.Tests.Common;
 using Microsoft.Azure.Management.Network.Fluent;
 using Microsoft.Azure.Management.Resource.Fluent.Core;
-using System;
 using System.Text;
 using Xunit;
 
@@ -60,6 +59,7 @@ namespace Fluent.Tests.Network
 
             manager.Networks.DeleteById(resource.Id);
             manager.NetworkSecurityGroups.DeleteById(nsg.Id);
+            manager.ResourceManager.ResourceGroups.DeleteByName(groupName);
         }
 
 

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/PublicIpAddressTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/PublicIpAddressTests.cs
@@ -43,7 +43,7 @@ namespace Fluent.Tests.Network
             Assert.True(resource.IdleTimeoutInMinutes == updatedIdleTimeout);
 
             manager.PublicIpAddresses.DeleteById(pip.Id);
-
+            manager.ResourceManager.ResourceGroups.DeleteByName(newRG);
         }
 
 

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:359B78C1848B4A526D723F29D8C8C558:7E3A196C87869BA2C348FE60F0D489C9
-        protected override async Task<VirtualMachineScaleSetInner> CreateInner()
+        protected override async Task<VirtualMachineScaleSetInner> CreateInnerAsync()
         {
             this.SetOSDiskAndOSProfileDefaults();
             this.SetPrimaryIpConfigurationSubnet();

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
@@ -850,13 +850,13 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:CBF523A860AE839D0C4D7384E636EA3A:FBFD113A504A5E7AC32C778EDF3C9726
         public VirtualMachineScaleSetImpl WithoutOverProvisioning()
         {
-            return this.WithOverProvision(true);
+            return this.WithOverProvision(false);
         }
 
         ///GENMHASH:D05B148D26960ED1D8EF344B16F36F78:00EC0F6EA3A819049F5C89068A74593C
         public VirtualMachineScaleSetImpl WithOverProvisioning()
         {
-            return this.WithOverProvision(false);
+            return this.WithOverProvision(true);
         }
 
         ///GENMHASH:085C052B5E99B190740EE6AF70CF4D53:4F450AB75A3E01A0CCB9AFBF4F23BE28

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayImpl.cs
@@ -1016,7 +1016,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:359B78C1848B4A526D723F29D8C8C558:257D937A0F04955A15D8633AF5E905F3
-        override protected async Task<ApplicationGatewayInner> CreateInner()
+        override protected async Task<ApplicationGatewayInner> CreateInnerAsync()
         {
             var tasks = new List<Task>();
 

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayOperationalState.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayOperationalState.cs
@@ -6,9 +6,9 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
 {
     public class ApplicationGatewayOperationalState : ExpandableStringEnum<ApplicationGatewayOperationalState>
     {
-        public static readonly ApplicationGatewayOperationalState Stopped = new ApplicationGatewayOperationalState() { Value = "Stopped" };
-        public static readonly ApplicationGatewayOperationalState Starting = new ApplicationGatewayOperationalState() { Value = "Starting" };
-        public static readonly ApplicationGatewayOperationalState Running = new ApplicationGatewayOperationalState() { Value = "Running" };
-        public static readonly ApplicationGatewayOperationalState Stopping = new ApplicationGatewayOperationalState() { Value = "Stopping" };
+        public static readonly ApplicationGatewayOperationalState Stopped = Parse("Stopped");
+        public static readonly ApplicationGatewayOperationalState Starting = Parse("Starting");
+        public static readonly ApplicationGatewayOperationalState Running = Parse("Running");
+        public static readonly ApplicationGatewayOperationalState Stopping = Parse("Stopping");
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayProtocol.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayProtocol.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
     /// </summary>
     public class ApplicationGatewayProtocol : ExpandableStringEnum<ApplicationGatewayProtocol>
     {
-        public static readonly ApplicationGatewayProtocol Http = new ApplicationGatewayProtocol() { Value = "Http" };
-        public static readonly ApplicationGatewayProtocol Https = new ApplicationGatewayProtocol() { Value = "Https" };
+        public static readonly ApplicationGatewayProtocol Http = Parse("Http");
+        public static readonly ApplicationGatewayProtocol Https = Parse("Https");
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayRequestRoutingRuleType.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayRequestRoutingRuleType.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
 {
     public class ApplicationGatewayRequestRoutingRuleType : ExpandableStringEnum<ApplicationGatewayRequestRoutingRuleType>
     {
-        public static readonly ApplicationGatewayRequestRoutingRuleType Basic = new ApplicationGatewayRequestRoutingRuleType() { Value = "Basic" };
-        public static readonly ApplicationGatewayRequestRoutingRuleType PathBasedRouting = new ApplicationGatewayRequestRoutingRuleType() { Value = "PathBasedRouting" };
+        public static readonly ApplicationGatewayRequestRoutingRuleType Basic = Parse("Basic");
+        public static readonly ApplicationGatewayRequestRoutingRuleType PathBasedRouting = Parse("PathBasedRouting");
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewaySkuName.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewaySkuName.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
 {
     public class ApplicationGatewaySkuName : ExpandableStringEnum<ApplicationGatewaySkuName>
     {
-        public static readonly ApplicationGatewaySkuName StandardSmall = new ApplicationGatewaySkuName() { Value = "Standard_Small" };
-        public static readonly ApplicationGatewaySkuName StandardMedium = new ApplicationGatewaySkuName() { Value = "Standard_Medium" };
-        public static readonly ApplicationGatewaySkuName StandardLarge = new ApplicationGatewaySkuName() { Value = "Standard_Large" };
+        public static readonly ApplicationGatewaySkuName StandardSmall = Parse("Standard_Small");
+        public static readonly ApplicationGatewaySkuName StandardMedium = Parse("Standard_Medium");
+        public static readonly ApplicationGatewaySkuName StandardLarge = Parse("Standard_Large");
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayTier.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayTier.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
 {
     public class ApplicationGatewayTier : ExpandableStringEnum<ApplicationGatewayTier>
     {
-        public static readonly ApplicationGatewayTier Standard = new ApplicationGatewayTier() { Value = "Standard" };
+        public static readonly ApplicationGatewayTier Standard = Parse("Standard");
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/IPAllocationMethod.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/IPAllocationMethod.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
     /// </summary>
     public class IPAllocationMethod : ExpandableStringEnum<IPAllocationMethod>
     {
-        public static readonly IPAllocationMethod Static = new IPAllocationMethod() { Value = "Static" };
-        public static readonly IPAllocationMethod Dynamic = new IPAllocationMethod() { Value = "Dynamic" };
+        public static readonly IPAllocationMethod Static = Parse("Static");
+        public static readonly IPAllocationMethod Dynamic = Parse("Dynamic");
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/IPVersion.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/IPVersion.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
     /// </summary>
     public class IPVersion : ExpandableStringEnum<IPVersion>
     {
-        public static readonly IPVersion IPv4 = new IPVersion() { Value = "IPv4" };
-        public static readonly IPVersion IPv6 = new IPVersion() { Value = "IPv6" };
+        public static readonly IPVersion IPv4 = Parse("IPv4");
+        public static readonly IPVersion IPv6 = Parse("IPv6");
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerImpl.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:359B78C1848B4A526D723F29D8C8C558:7501824DEE4570F3E78F9698BA2828B0
-        override protected Task<LoadBalancerInner> CreateInner()
+        override protected Task<LoadBalancerInner> CreateInnerAsync()
         {
             return innerCollection.CreateOrUpdateAsync(ResourceGroupName, Name, Inner);
         }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkImpl.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:359B78C1848B4A526D723F29D8C8C558:7501824DEE4570F3E78F9698BA2828B0
-        override protected Task<VirtualNetworkInner> CreateInner()
+        override protected Task<VirtualNetworkInner> CreateInnerAsync()
         {
             return innerCollection.CreateOrUpdateAsync(ResourceGroupName, Name, Inner);
         }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkInterfaceImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkInterfaceImpl.cs
@@ -463,7 +463,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:359B78C1848B4A526D723F29D8C8C558:7501824DEE4570F3E78F9698BA2828B0
-        override protected Task<NetworkInterfaceInner> CreateInner()
+        override protected Task<NetworkInterfaceInner> CreateInnerAsync()
         {
             return innerCollection.CreateOrUpdateAsync(ResourceGroupName, Name, Inner);
         }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkSecurityGroupImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkSecurityGroupImpl.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
 
         #region Helpers
         ///GENMHASH:359B78C1848B4A526D723F29D8C8C558:7501824DEE4570F3E78F9698BA2828B0
-        override protected Task<NetworkSecurityGroupInner> CreateInner()
+        override protected Task<NetworkSecurityGroupInner> CreateInnerAsync()
         {
             return innerCollection.CreateOrUpdateAsync(ResourceGroupName, Name, Inner);
         }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkUsageUnit.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkUsageUnit.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
 {
     public class NetworkUsageUnit : ExpandableStringEnum<NetworkUsageUnit>
     {
-        public static readonly NetworkUsageUnit Count = new NetworkUsageUnit() { Value = "Count" };
-        public static readonly NetworkUsageUnit Bytes = new NetworkUsageUnit() { Value = "Bytes" };
-        public static readonly NetworkUsageUnit Seconds = new NetworkUsageUnit() { Value = "Seconds" };
-        public static readonly NetworkUsageUnit Percent= new NetworkUsageUnit() { Value = "Percent" };
-        public static readonly NetworkUsageUnit CountsPerSecond = new NetworkUsageUnit() { Value = "CountsPerSecond" };
-        public static readonly NetworkUsageUnit BytesPerSecond = new NetworkUsageUnit() { Value = "BytesPerSecond" };
+        public static readonly NetworkUsageUnit Count = Parse("Count");
+        public static readonly NetworkUsageUnit Bytes = Parse("Bytes");
+        public static readonly NetworkUsageUnit Seconds = Parse("Seconds");
+        public static readonly NetworkUsageUnit Percent= Parse("Percent");
+        public static readonly NetworkUsageUnit CountsPerSecond = Parse("CountsPerSecond");
+        public static readonly NetworkUsageUnit BytesPerSecond = Parse("BytesPerSecond");
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ProbeProtocol.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ProbeProtocol.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
     /// </summary>
     public class ProbeProtocol : ExpandableStringEnum<ProbeProtocol>
     {
-        public static readonly ProbeProtocol Http = new ProbeProtocol() { Value = "Http" };
-        public static readonly ProbeProtocol Tcp = new ProbeProtocol() { Value = "Tcp" };
+        public static readonly ProbeProtocol Http = Parse("Http");
+        public static readonly ProbeProtocol Tcp = Parse("Tcp");
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/RouteNextHopType.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/RouteNextHopType.cs
@@ -10,10 +10,10 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
     /// </summary>
     public class RouteNextHopType : ExpandableStringEnum<RouteNextHopType>
     {
-        public static readonly RouteNextHopType VirtualNetworkGateway = new RouteNextHopType() { Value = "VirtualNetworkGateway" };
-        public static readonly RouteNextHopType VirtualNetworkLocal = new RouteNextHopType() { Value = "VnetLocal" };
-        public static readonly RouteNextHopType Internet = new RouteNextHopType() { Value = "Internet" };
-        public static readonly RouteNextHopType VirtualAppliance = new RouteNextHopType() { Value = "VirtualAppliance" };
-        public static readonly RouteNextHopType None = new RouteNextHopType() { Value = "None" };
+        public static readonly RouteNextHopType VirtualNetworkGateway = Parse("VirtualNetworkGateway");
+        public static readonly RouteNextHopType VirtualNetworkLocal = Parse("VnetLocal");
+        public static readonly RouteNextHopType Internet = Parse("Internet");
+        public static readonly RouteNextHopType VirtualAppliance = Parse("VirtualAppliance");
+        public static readonly RouteNextHopType None = Parse("None");
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/RouteTableImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/RouteTableImpl.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         private IDictionary<string, IRoute> routes;
 
         ///GENMHASH:359B78C1848B4A526D723F29D8C8C558:7501824DEE4570F3E78F9698BA2828B0
-        override protected Task<RouteTableInner> CreateInner()
+        override protected Task<RouteTableInner> CreateInnerAsync()
         {
             return innerCollection.CreateOrUpdateAsync(ResourceGroupName, Name, Inner);
         }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/SubnetImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/SubnetImpl.cs
@@ -50,8 +50,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:2E4015B29759BBD97527EBAE809B083C:8E698A4D3F26647C89221EE26B291774
         internal INetworkSecurityGroup GetNetworkSecurityGroup ()
         {
-            return (NetworkSecurityGroupId() != null)
-                ? Parent.Manager.NetworkSecurityGroups.GetById(RouteTableId())
+            var nsgId = NetworkSecurityGroupId();
+            return (nsgId != null)
+                ? Parent.Manager.NetworkSecurityGroups.GetById(nsgId)
                 : null;
         }
 

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/TransportProtocol.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/TransportProtocol.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
 {
     public class TransportProtocol : ExpandableStringEnum<TransportProtocol>
     {
-        public static readonly TransportProtocol Udp = new TransportProtocol() { Value = "Udp" };
-        public static readonly TransportProtocol Tcp = new TransportProtocol() { Value = "Tcp" };
+        public static readonly TransportProtocol Udp = Parse("Udp");
+        public static readonly TransportProtocol Tcp = Parse("Tcp");
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExpandableStringEnum.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExpandableStringEnum.cs
@@ -24,13 +24,9 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
         public string Value
         {
             get { return value; }
-            protected set
+            private set
             {
                 this.value = value;
-                if (values == null)
-                {
-                    values = new Dictionary<string, T>();
-                }
                 values[value.ToLower()] = (T)this;
             }
         }
@@ -61,13 +57,11 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
 
         public static T Parse(string value)
         {
+            T v;
             if (value == null)
             {
                 return null;
-            }
-
-            T v;
-            if (values.TryGetValue(value.ToLower(), out v))
+            } else if (values.TryGetValue(value.ToLower(), out v))
             {
                 return v;
             }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExpandableStringEnum.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExpandableStringEnum.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Microsoft.Azure.Management.Resource.Fluent.Core
 {
@@ -47,7 +48,10 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
             {
                 return ReferenceEquals(rhs, null);
             }
-            return lhs.Equals(rhs);
+            else
+            {
+                return lhs.Equals(rhs);
+            }
         }
 
         public static bool operator !=(ExpandableStringEnum<T> lhs, T rhs)
@@ -61,7 +65,8 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
             if (value == null)
             {
                 return null;
-            } else if (values.TryGetValue(value.ToLower(), out v))
+            }
+            else if (values.TryGetValue(value.ToLower(), out v))
             {
                 return v;
             }
@@ -86,6 +91,7 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
         public override bool Equals(object obj)
         {
             string value = ToString();
+            T rhs = (T)obj;
             if (!(obj is T))
             {
                 return false;
@@ -94,13 +100,14 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
             {
                 return true;
             }
-
-            T rhs = (T)obj;
-            if (value == null)
+            else if (value == null)
             {
                 return rhs.value == null;
             }
-            return value.Equals(rhs.value, StringComparison.OrdinalIgnoreCase);
+            else
+            {
+                return value.Equals(rhs.value, StringComparison.OrdinalIgnoreCase);
+            }
         }
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/GroupableParentResource.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/GroupableParentResource.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
             InitializeChildrenFromInner();
         }
 
-        protected abstract Task<InnerResourceT> CreateInner();
+        protected abstract Task<InnerResourceT> CreateInnerAsync();
 
         protected abstract void InitializeChildrenFromInner ();
 
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Management.Resource.Fluent.Core
         public override async Task<IFluentResourceT> CreateResourceAsync(CancellationToken cancellationToken)
         {
             BeforeCreating();
-            var inner = await CreateInner();
+            var inner = await CreateInnerAsync();
             SetInner(inner);
             InitializeChildrenFromInner();
             AfterCreating();


### PR DESCRIPTION
Further simplifying the use of the ExpandableStringEnum. To derive a new expandable single-string enum from it, all that is needed is this now:

```
public class ExpandableStringEnumFoo : ExpandableStringEnum<ExpandableStringEnumFoo>
{
    public static readonly ExpandableStringEnumFoo Foo1 = Parse("value1");
    public static readonly ExpandableStringEnumFoo Foo2 = Parse("value2");
}
```