### PR TITLE
Remove net45 dependency that is causing package download error.

### DIFF
--- a/src/KeyVault/Microsoft.Azure.KeyVault.Cryptography.Tests/project.json
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Cryptography.Tests/project.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Microsoft.Azure.KeyVault.Core": "[2.0.4, 3.0)",
-    "Microsoft.Azure.KeyVault.Cryptography": "[2.0.4, 3.0)",
+    "Microsoft.Azure.KeyVault.Cryptography": "[2.0.5, 3.0)",
     "Microsoft.Azure.KeyVault.WebKey": "[2.0.4, 3.0)",
     "xunit": "2.2.0-beta2-build3300"
   }

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Cryptography/Properties/AssemblyInfo.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Cryptography/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 [assembly: AssemblyDescription("Microsoft Azure Key Vault Cryptography Class Library.")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.4.0")]
+[assembly: AssemblyFileVersion("2.0.5.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Cryptography/project.json
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Cryptography/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.4",
+  "version": "2.0.5",
   "title": "Microsoft Azure Key Vault Cryptography",
   "description": "Microsoft Azure Key Vault Cryptography Class Library",
   "authors": [ "Microsoft" ],
@@ -29,7 +29,6 @@
         "debugType": "portable"
       },
       "frameworkAssemblies": {
-        "System.Diagnostics.Tools": "4.0.0.0"
       }
     },
     "netstandard1.5": {

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions.Tests/project.json
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions.Tests/project.json
@@ -35,8 +35,8 @@
 
   "dependencies": {
     "Microsoft.Azure.KeyVault": "[2.0.6, 3.0)",
-    "Microsoft.Azure.KeyVault.Cryptography": "[2.0.4, 3.0)",
-    "Microsoft.Azure.KeyVault.Extensions": "[2.0.4, 3.0)",
+    "Microsoft.Azure.KeyVault.Cryptography": "[2.0.5, 3.0)",
+    "Microsoft.Azure.KeyVault.Extensions": "[2.0.5, 3.0)",
     "Microsoft.Azure.KeyVault.Core": "[2.0.4, 3.0)",
     "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "[1.3.5-preview, 2.0.0)",
     "Microsoft.Azure.KeyVault.TestFramework": "[2.0.2-preview, 3.0)",

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Properties/AssemblyInfo.cs
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Microsoft Azure Key Vault Extensions Class Library")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.4.0")]
+[assembly: AssemblyFileVersion("2.0.5.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/project.json
+++ b/src/KeyVault/Microsoft.Azure.KeyVault.Extensions/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.4",
+  "version": "2.0.5",
   "title": "Microsoft Azure Key Vault Extensions",
   "description": "Microsoft Azure Key Vault Extensions Class Library",
   "authors": [ "Microsoft" ],
@@ -21,7 +21,7 @@
   "dependencies": {
     "Microsoft.Azure.KeyVault": "[2.0.6, 3.0)",
     "Microsoft.Azure.KeyVault.Core": "[2.0.4, 3.0)",
-    "Microsoft.Azure.KeyVault.Cryptography": "[2.0.4, 3.0)",
+    "Microsoft.Azure.KeyVault.Cryptography": "[2.0.5, 3.0)",
     "Microsoft.Azure.KeyVault.WebKey": "[2.0.4, 3.0)"
   },
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Fix for issue: https://github.com/Azure/azure-sdk-for-net/issues/2681

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/dev/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [x] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.