### PR TITLE
Changing GUID to string for AccessPolicyEntry object id

### DIFF
--- a/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement.Tests/VaultOperationsTest.cs
+++ b/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement.Tests/VaultOperationsTest.cs
@@ -29,12 +29,12 @@ namespace KeyVault.Management.Tests
 
                 string vaultName = TestUtilities.GenerateName("sdktestvault");
                 var tenantIdGuid = Guid.Parse(testBase.tenantId);
-                var objectIdGuid = Guid.Parse(testBase.objectId);
+                var objectIdStr = testBase.objectId;
                 var tags = new Dictionary<string, string> { { "tag1", "value1" }, { "tag2", "value2" }, { "tag3", "value3" } };
                 var accPol = new AccessPolicyEntry
                                   {
                                       TenantId = tenantIdGuid,
-                                      ObjectId = objectIdGuid,
+                                      ObjectId = objectIdStr,
                                       PermissionsToKeys = new string[] { "all" },
                                       PermissionsToSecrets = null
                                   };
@@ -154,13 +154,13 @@ namespace KeyVault.Management.Tests
 
                 string vaultName = TestUtilities.GenerateName("sdktestvault");
                 var tenantIdGuid = Guid.Parse(testBase.tenantId);
-                var objectIdGuid = Guid.Parse(testBase.objectId);
+                var objectIdStr = testBase.objectId;
                 var applicationIdGuid = Guid.Parse(testBase.applicationId);
                 var tags = new Dictionary<string, string> { { "tag1", "value1" }, { "tag2", "value2" }, { "tag3", "value3" } };
                 var accPol = new AccessPolicyEntry
                 {
                     TenantId = tenantIdGuid,
-                    ObjectId = objectIdGuid,
+                    ObjectId = objectIdStr,
                     ApplicationId = applicationIdGuid,
                     PermissionsToKeys = new string[] { "all" },
                     PermissionsToSecrets = null
@@ -323,7 +323,7 @@ namespace KeyVault.Management.Tests
 
                 string rgName = TestUtilities.GenerateName("sdktestrg");
                 var tenantIdGuid = Guid.Parse(testBase.tenantId);
-                var objectIdGuid = Guid.Parse(testBase.objectId);
+                var objectIdStr = testBase.objectId;
 
                 var tags = new Dictionary<string, string> { { "tag1", "value1" }, { "tag2", "value2" }, { "tag3", "value3" } };
 
@@ -352,7 +352,7 @@ namespace KeyVault.Management.Tests
                                     new AccessPolicyEntry
                                     {
                                         TenantId = tenantIdGuid,
-                                        ObjectId = objectIdGuid,
+                                        ObjectId = objectIdStr,
                                         PermissionsToKeys = new string[]{"all"},
                                         PermissionsToSecrets = new string[]{"all"}
                                     }

--- a/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement/Customization/AccessPolicyEntry.cs
+++ b/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement/Customization/AccessPolicyEntry.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Management.KeyVault
         /// <summary>
         /// Object ID of the principal
         /// </summary>
-        public Guid ObjectId
+        public string ObjectId
         {
             get;
             set;

--- a/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement/Generated/VaultOperations.cs
+++ b/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement/Generated/VaultOperations.cs
@@ -209,7 +209,10 @@ namespace Microsoft.Azure.Management.KeyVault
                             
                             accessPolicyEntryValue["tenantId"] = accessPoliciesItem.TenantId.ToString();
                             
-                            accessPolicyEntryValue["objectId"] = accessPoliciesItem.ObjectId.ToString();
+                            if (accessPoliciesItem.ObjectId != null)  
+                            {  
+                                accessPolicyEntryValue["objectId"] = accessPoliciesItem.ObjectId;  
+                            }  
                             
                             if (accessPoliciesItem.ApplicationId != null)
                             {
@@ -359,7 +362,7 @@ namespace Microsoft.Azure.Management.KeyVault
                                         JToken objectIdValue = accessPoliciesValue["objectId"];
                                         if (objectIdValue != null && objectIdValue.Type != JTokenType.Null)
                                         {
-                                            Guid objectIdInstance = Guid.Parse(((string)objectIdValue));
+                                            string objectIdInstance = ((string)objectIdValue);
                                             accessPolicyEntryInstance.ObjectId = objectIdInstance;
                                         }
                                         
@@ -804,7 +807,7 @@ namespace Microsoft.Azure.Management.KeyVault
                                         JToken objectIdValue = accessPoliciesValue["objectId"];
                                         if (objectIdValue != null && objectIdValue.Type != JTokenType.Null)
                                         {
-                                            Guid objectIdInstance = Guid.Parse(((string)objectIdValue));
+                                            string objectIdInstance = ((string)objectIdValue);
                                             accessPolicyEntryInstance.ObjectId = objectIdInstance;
                                         }
                                         
@@ -1112,7 +1115,7 @@ namespace Microsoft.Azure.Management.KeyVault
                                                 JToken objectIdValue = accessPoliciesValue["objectId"];
                                                 if (objectIdValue != null && objectIdValue.Type != JTokenType.Null)
                                                 {
-                                                    Guid objectIdInstance = Guid.Parse(((string)objectIdValue));
+                                                    string objectIdInstance = ((string)objectIdValue);
                                                     accessPolicyEntryInstance.ObjectId = objectIdInstance;
                                                 }
                                                 
@@ -1394,7 +1397,7 @@ namespace Microsoft.Azure.Management.KeyVault
                                                 JToken objectIdValue = accessPoliciesValue["objectId"];
                                                 if (objectIdValue != null && objectIdValue.Type != JTokenType.Null)
                                                 {
-                                                    Guid objectIdInstance = Guid.Parse(((string)objectIdValue));
+                                                    string objectIdInstance = ((string)objectIdValue);
                                                     accessPolicyEntryInstance.ObjectId = objectIdInstance;
                                                 }
                                                 

--- a/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement/Microsoft.Azure.Management.KeyVault.nuget.proj
+++ b/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement/Microsoft.Azure.Management.KeyVault.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.KeyVault
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.KeyVault">
-      <PackageVersion>1.0.2</PackageVersion>
+      <PackageVersion>1.1.0-stack</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/KeyVaultManagement/KeyVaultManagement/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Key Vault management functions for managing key vaults.")]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Changing GUID to string for AccessPolicyEntry object id, This is against master with hydra specs
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/dev/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.
