### PR TITLE
Cosmetic fixes in tests: naming/capitalization conventions

### DIFF
--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/ApplicationGatewayHelper.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/ApplicationGatewayHelper.cs
@@ -15,34 +15,30 @@ namespace Azure.Tests.Common
 {
     public static class ApplicationGatewayHelper
     {
-        public static readonly string ID_TEMPLATE = "/subscriptions/${subId}/resourceGroups/${rgName}/providers/Microsoft.Network/applicationGateways/${resourceName}";
-        public static readonly Region REGION = Region.US_WEST;
-        public static readonly long TEST_ID = DateTime.Now.Millisecond;
-        public static readonly string GROUP_NAME = "rg" + TEST_ID;
-        public static readonly string APP_GATEWAY_NAME = "ag" + TEST_ID;
-        public static readonly string[] PIP_NAMES = { "pipa" + TEST_ID, "pipb" + TEST_ID };
-        public static readonly string[] VM_IDS = {
-                "/subscriptions/9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef/resourceGroups/marcinslbtest/providers/Microsoft.Compute/virtualMachines/marcinslbtest1",
-                "/subscriptions/9657ab5d-4a4a-4fd2-ae7a-4cd9fbd030ef/resourceGroups/marcinslbtest/providers/Microsoft.Compute/virtualMachines/marcinslbtest3"
-        };
+        public static readonly string IdTemplate = "/subscriptions/${subId}/resourceGroups/${rgName}/providers/Microsoft.Network/applicationGateways/${resourceName}";
+        public static readonly Region Region = Region.US_WEST;
+        public static readonly long TestId = DateTime.Now.Millisecond;
+        public static readonly string GroupName = "rg" + TestId;
+        public static readonly string AppGatewayName = "ag" + TestId;
+        public static readonly string[] PipNames = { "pipa" + TestId, "pipb" + TestId };
 
         public static string CreateResourceId(string subscriptionId)
         {
-            return ID_TEMPLATE
+            return IdTemplate
                     .Replace("${subId}", subscriptionId)
-                    .Replace("${rgName}", GROUP_NAME)
-                    .Replace("${resourceName}", APP_GATEWAY_NAME);
+                    .Replace("${rgName}", GroupName)
+                    .Replace("${resourceName}", AppGatewayName);
         }
 
         // Create VNet for the LB
         public static IEnumerable<IPublicIpAddress> EnsurePIPs(IPublicIpAddresses pips)
         {
             var creatablePips = new List<ICreatable<IPublicIpAddress>>();
-            for (int i = 0; i<PIP_NAMES.Length; i++)
+            for (int i = 0; i<PipNames.Length; i++)
             {
-                creatablePips.Add(pips.Define(PIP_NAMES[i])
-                                  .WithRegion(REGION)
-                                  .WithNewResourceGroup(GROUP_NAME));
+                creatablePips.Add(pips.Define(PipNames[i])
+                                  .WithRegion(Region)
+                                  .WithNewResourceGroup(GroupName));
             }
 
             return pips.Create(creatablePips.ToArray());
@@ -57,8 +53,8 @@ namespace Azure.Tests.Common
             var createdVMs = new List<IVirtualMachine>();
             INetwork network = null;
             Region region = Region.US_WEST;
-            string userName = "testuser" + TEST_ID;
-            string availabilitySetName = "as" + TEST_ID;
+            string userName = "testuser" + TestId;
+            string availabilitySetName = "as" + TestId;
 
             foreach (var vmId in vmIds)
             {
@@ -70,13 +66,13 @@ namespace Azure.Tests.Common
                 {
                     // Creating a new VM
                     vm = null;
-                    groupName = "rg" + TEST_ID;
-                    vmName = "vm" + TEST_ID;
+                    groupName = "rg" + TestId;
+                    vmName = "vm" + TestId;
 
                     if (network == null)
                     {
                         // Create a VNet for the VM
-                        network = networks.Define("net" + TEST_ID)
+                        network = networks.Define("net" + TestId)
                             .WithRegion(region)
                             .WithNewResourceGroup(groupName)
                             .WithAddressSpace("10.0.0.0/28")

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/LoadBalancerHelper.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/LoadBalancerHelper.cs
@@ -17,22 +17,22 @@ namespace Azure.Tests.Common
 {
     public static class LoadBalancerHelper
     {
-        public static readonly long TEST_ID = DateTime.Now.Millisecond;
-        public static readonly Region REGION = Region.US_WEST;
-        public static readonly string GROUP_NAME = "rg" + TEST_ID;
-        public static readonly string LB_NAME = "lb" + TEST_ID;
-        public static readonly string[] PIP_NAMES = { "pipa" + TEST_ID, "pipb" + TEST_ID };
+        public static readonly long TestId = DateTime.Now.Millisecond;
+        public static readonly Region Region = Region.US_WEST;
+        public static readonly string GroupName = "rg" + TestId;
+        public static readonly string LoadBalancerName = "lb" + TestId;
+        public static readonly string[] PipNames = { "pipa" + TestId, "pipb" + TestId };
 
         // Create VNet for the LB
         public static IEnumerable<IPublicIpAddress> EnsurePIPs(IPublicIpAddresses pips)
         {
             var creatablePips = new List<ICreatable<IPublicIpAddress>>();
-            for (int i = 0; i<PIP_NAMES.Length; i++)
+            for (int i = 0; i<PipNames.Length; i++)
             {
-                creatablePips.Add(pips.Define(PIP_NAMES[i])
-                                  .WithRegion(REGION)
-                                  .WithNewResourceGroup(GROUP_NAME)
-                                  .WithLeafDomainLabel(PIP_NAMES[i]));
+                creatablePips.Add(pips.Define(PipNames[i])
+                                  .WithRegion(Region)
+                                  .WithNewResourceGroup(GroupName)
+                                  .WithLeafDomainLabel(PipNames[i]));
             }
 
             return pips.Create(creatablePips.ToArray());
@@ -46,21 +46,21 @@ namespace Azure.Tests.Common
             int count)
         {
             // Create a network for the VMs
-            INetwork network = networks.Define("net" + TEST_ID)
-                .WithRegion(REGION)
-                .WithNewResourceGroup(GROUP_NAME)
+            INetwork network = networks.Define("net" + TestId)
+                .WithRegion(Region)
+                .WithNewResourceGroup(GroupName)
                 .WithAddressSpace("10.0.0.0/28")
                 .WithSubnet("subnet1", "10.0.0.0/29")
                 .WithSubnet("subnet2", "10.0.0.8/29")
                 .Create();
 
             // Define an availability set for the VMs
-            var availabilitySetDefinition = availabilitySets.Define("as" + TEST_ID)
-                .WithRegion(REGION)
-                .WithExistingResourceGroup(GROUP_NAME);
+            var availabilitySetDefinition = availabilitySets.Define("as" + TestId)
+                .WithRegion(Region)
+                .WithExistingResourceGroup(GroupName);
 
             // Create the requested number of VM definitions
-            string userName = "testuser" + TEST_ID;
+            string userName = "testuser" + TestId;
             List<ICreatable<IVirtualMachine>> vmDefinitions = new List<ICreatable<IVirtualMachine>>();
 
             for (int i = 0; i < count; i++)
@@ -68,8 +68,8 @@ namespace Azure.Tests.Common
                 string vmName = ResourceNamer.RandomResourceName("vm", 15);
 
                 var vm = vms.Define(vmName)
-                    .WithRegion(REGION)
-                    .WithExistingResourceGroup(GROUP_NAME)
+                    .WithRegion(Region)
+                    .WithExistingResourceGroup(GroupName)
                     .WithExistingPrimaryNetwork(network)
                     .WithSubnet(network.Subnets.Values.First().Name)
                     .WithPrimaryPrivateIpAddressDynamic()

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/TestTemplate.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/TestTemplate.cs
@@ -43,7 +43,7 @@ namespace Azure.Tests.Common
          */
         public int VerifyListing()
         {
-            var resources = this.collection.List();
+            var resources = collection.List();
             foreach (T r in resources)
             {
                 TestHelper.WriteLine("resource id: " + r.Id);
@@ -60,8 +60,8 @@ namespace Azure.Tests.Common
          */
         public T VerifyGetting()
         {
-            T resourceByGroup = this.collection.GetByGroup(this.resource.ResourceGroupName, this.resource.Name);
-            T resourceById = this.collection.GetById(resourceByGroup.Id);
+            T resourceByGroup = collection.GetByGroup(resource.ResourceGroupName, resource.Name);
+            T resourceById = collection.GetById(resourceByGroup.Id);
             Assert.True(resourceById.Id.Equals(resourceByGroup.Id, StringComparison.OrdinalIgnoreCase));
             return resourceById;
         }
@@ -72,9 +72,9 @@ namespace Azure.Tests.Common
          */
         public void VerifyDeleting()
         {
-            var groupName = this.resource.ResourceGroupName;
-            this.collection.DeleteById(this.resource.Id);
-            this.resourceGroups.DeleteByName(groupName);
+            var groupName = resource.ResourceGroupName;
+            collection.DeleteById(resource.Id);
+            resourceGroups.DeleteByName(groupName);
         }
 
         /**
@@ -99,7 +99,7 @@ namespace Azure.Tests.Common
             int initialCount = VerifyListing();
 
             // Verify creation
-            this.resource = CreateResource(collection);
+            resource = CreateResource(collection);
             TestHelper.WriteLine("\n------------\nAfter creation:\n");
             Print(resource);
 
@@ -107,16 +107,16 @@ namespace Azure.Tests.Common
             VerifyListing();
 
             // Verify getting
-            this.resource = VerifyGetting();
-            Assert.NotNull(this.resource);
+            resource = VerifyGetting();
+            Assert.NotNull(resource);
             TestHelper.WriteLine("\n------------\nRetrieved resource:\n");
-            Print(this.resource);
+            Print(resource);
 
             // Verify update
-            this.resource = UpdateResource(this.resource);
-            Assert.NotNull(this.resource);
+            resource = UpdateResource(resource);
+            Assert.NotNull(resource);
             TestHelper.WriteLine("\n------------\nUpdated resource:\n");
-            Print(this.resource);
+            Print(resource);
 
             // Verify deletion
             VerifyDeleting();

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineTests.cs
@@ -9,8 +9,6 @@ using System;
 using System.Linq;
 using Xunit;
 using Microsoft.Azure.Management.Resource.Fluent.Core;
-using Microsoft.Azure.Management.Storage.Fluent;
-using Microsoft.Azure.Management.Fluent;
 using System.Collections.Generic;
 using Microsoft.Azure.Management.Resource.Fluent.Core.ResourceActions;
 using Microsoft.Azure.Management.Network.Fluent;
@@ -22,9 +20,9 @@ namespace Fluent.Tests.Compute
 {
     public class VirtualMachineTests
     {
-        private readonly string RG_NAME = ResourceNamer.RandomResourceName("rgfluentchash-", 20);
-        private const string LOCATION = "southcentralus";
-        private const string VMNAME = "chashvm";
+        private readonly string GroupName = ResourceNamer.RandomResourceName("rgfluentchash-", 20);
+        private const string Location = "southcentralus";
+        private const string VMName = "chashvm";
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
         public void CanCreateVirtualMachine()
@@ -36,9 +34,9 @@ namespace Fluent.Tests.Compute
             {
                 // Create
                 var vm = computeManager.VirtualMachines
-                    .Define(VMNAME)
-                    .WithRegion(LOCATION)
-                    .WithNewResourceGroup(RG_NAME)
+                    .Define(VMName)
+                    .WithRegion(Location)
+                    .WithNewResourceGroup(GroupName)
                     .WithNewPrimaryNetwork("10.0.0.0/28")
                     .WithPrimaryPrivateIpAddressDynamic()
                     .WithoutPrimaryPublicIpAddress()
@@ -50,15 +48,15 @@ namespace Fluent.Tests.Compute
                     .WithOsDiskName("javatest")
                     .Create();
 
-                var foundedVM = computeManager.VirtualMachines.ListByGroup(RG_NAME)
-                    .FirstOrDefault(v => v.Name.Equals(VMNAME, StringComparison.OrdinalIgnoreCase));
+                var foundedVM = computeManager.VirtualMachines.ListByGroup(GroupName)
+                    .FirstOrDefault(v => v.Name.Equals(VMName, StringComparison.OrdinalIgnoreCase));
 
                 Assert.NotNull(foundedVM);
-                Assert.Equal(LOCATION, foundedVM.RegionName);
+                Assert.Equal(Location, foundedVM.RegionName);
                 // Get
-                foundedVM = computeManager.VirtualMachines.GetByGroup(RG_NAME, VMNAME);
+                foundedVM = computeManager.VirtualMachines.GetByGroup(GroupName, VMName);
                 Assert.NotNull(foundedVM);
-                Assert.Equal(LOCATION, foundedVM.RegionName);
+                Assert.Equal(Location, foundedVM.RegionName);
 
                 // Fetch instance view
                 PowerState powerState = foundedVM.PowerState;
@@ -76,7 +74,7 @@ namespace Fluent.Tests.Compute
                 // Delete VM
                 computeManager.VirtualMachines.DeleteById(foundedVM.Id);
             } finally {
-                resourceManager.ResourceGroups.DeleteByName(RG_NAME);
+                resourceManager.ResourceGroups.DeleteByName(GroupName);
             }
         }
 

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/ApplicationGateway/PrivateComplex.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/ApplicationGateway/PrivateComplex.cs
@@ -33,9 +33,9 @@ namespace Azure.Tests.Network.ApplicationGateway
 
         public override IApplicationGateway CreateResource(IApplicationGateways resources)
         {
-            INetwork vnet = networks.Define("net" + ApplicationGatewayHelper.TEST_ID)
-                .WithRegion(ApplicationGatewayHelper.REGION)
-                .WithNewResourceGroup(ApplicationGatewayHelper.GROUP_NAME)
+            INetwork vnet = networks.Define("net" + ApplicationGatewayHelper.TestId)
+                .WithRegion(ApplicationGatewayHelper.Region)
+                .WithNewResourceGroup(ApplicationGatewayHelper.GroupName)
                 .WithAddressSpace("10.0.0.0/28")
                 .WithSubnet("subnet1", "10.0.0.0/29")
                 .WithSubnet("subnet2", "10.0.0.8/29")
@@ -46,9 +46,9 @@ namespace Azure.Tests.Network.ApplicationGateway
                 Thread.CurrentThread.IsBackground = true;
                 // Create an application gateway
                 try {
-                    resources.Define(ApplicationGatewayHelper.APP_GATEWAY_NAME)
-                        .WithRegion(ApplicationGatewayHelper.REGION)
-                        .WithExistingResourceGroup(ApplicationGatewayHelper.GROUP_NAME)
+                    resources.Define(ApplicationGatewayHelper.AppGatewayName)
+                        .WithRegion(ApplicationGatewayHelper.Region)
+                        .WithExistingResourceGroup(ApplicationGatewayHelper.GroupName)
 
                         // Request routing rules
                         .DefineRequestRoutingRule("rule80")

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/ApplicationGateway/PrivateMinimal.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/ApplicationGateway/PrivateMinimal.cs
@@ -30,9 +30,9 @@ namespace Azure.Tests.Network.ApplicationGateway
         {
 
             // Create an app gateway
-            resources.Define(ApplicationGatewayHelper.APP_GATEWAY_NAME)
-                .WithRegion(ApplicationGatewayHelper.REGION)
-                .WithNewResourceGroup(ApplicationGatewayHelper.GROUP_NAME)
+            resources.Define(ApplicationGatewayHelper.AppGatewayName)
+                .WithRegion(ApplicationGatewayHelper.Region)
+                .WithNewResourceGroup(ApplicationGatewayHelper.GroupName)
 
                 // Request routing rule
                 .DefineRequestRoutingRule("rule1")

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/ApplicationGateway/PublicComplex.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/ApplicationGateway/PublicComplex.cs
@@ -33,9 +33,9 @@ namespace Azure.Tests.Network.ApplicationGateway
             // Create an application gateway
             try
             {
-                resources.Define(ApplicationGatewayHelper.APP_GATEWAY_NAME)
-                    .WithRegion(ApplicationGatewayHelper.REGION)
-                    .WithExistingResourceGroup(ApplicationGatewayHelper.GROUP_NAME)
+                resources.Define(ApplicationGatewayHelper.AppGatewayName)
+                    .WithRegion(ApplicationGatewayHelper.Region)
+                    .WithExistingResourceGroup(ApplicationGatewayHelper.GroupName)
 
                     // Request routing rules
                     .DefineRequestRoutingRule("rule80")

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/ApplicationGateway/PublicMinimal.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/ApplicationGateway/PublicMinimal.cs
@@ -30,9 +30,9 @@ namespace Azure.Tests.Network.ApplicationGateway
         {
             try
             {
-                resources.Define(ApplicationGatewayHelper.APP_GATEWAY_NAME)
-                    .WithRegion(ApplicationGatewayHelper.REGION)
-                    .WithNewResourceGroup(ApplicationGatewayHelper.GROUP_NAME)
+                resources.Define(ApplicationGatewayHelper.AppGatewayName)
+                    .WithRegion(ApplicationGatewayHelper.Region)
+                    .WithNewResourceGroup(ApplicationGatewayHelper.GroupName)
 
                     // Request routing rules
                     .DefineRequestRoutingRule("rule1")

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/LoadBalancer/InternalMinimal.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/LoadBalancer/InternalMinimal.cs
@@ -44,9 +44,9 @@ namespace Azure.Tests.Network.LoadBalancer
             network = existingVMs.First().GetPrimaryNetworkInterface().PrimaryIpConfiguration.GetNetwork();
 
             // Create a load balancer
-            var lb = resources.Define(LoadBalancerHelper.LB_NAME)
-                        .WithRegion(LoadBalancerHelper.REGION)
-                        .WithExistingResourceGroup(LoadBalancerHelper.GROUP_NAME)
+            var lb = resources.Define(LoadBalancerHelper.LoadBalancerName)
+                        .WithRegion(LoadBalancerHelper.Region)
+                        .WithExistingResourceGroup(LoadBalancerHelper.GroupName)
                         // Frontend (default)
                         .WithFrontendSubnet(network, "subnet1")
                         // Backend (default)

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/LoadBalancer/InternetMinimal.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/LoadBalancer/InternetMinimal.cs
@@ -44,9 +44,9 @@ namespace Azure.Tests.Network.LoadBalancer
             var existingPips = LoadBalancerHelper.EnsurePIPs(pips);
 
             // Create a load balancer
-            var lb = resources.Define(LoadBalancerHelper.LB_NAME)
-                        .WithRegion(LoadBalancerHelper.REGION)
-                        .WithExistingResourceGroup(LoadBalancerHelper.GROUP_NAME)
+            var lb = resources.Define(LoadBalancerHelper.LoadBalancerName)
+                        .WithRegion(LoadBalancerHelper.Region)
+                        .WithExistingResourceGroup(LoadBalancerHelper.GroupName)
                         // Frontend (default)
                         .WithExistingPublicIpAddress(existingPips.ElementAt(0))
                         // Backend (default)

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/LoadBalancer/InternetWithNatPool.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/LoadBalancer/InternetWithNatPool.cs
@@ -47,9 +47,9 @@ namespace Azure.Tests.Network.LoadBalancer
             var existingPips = LoadBalancerHelper.EnsurePIPs(pips);
 
             // Create a load balancer
-            var lb = resources.Define(LoadBalancerHelper.LB_NAME)
-                .WithRegion(LoadBalancerHelper.REGION)
-                .WithExistingResourceGroup(LoadBalancerHelper.GROUP_NAME)
+            var lb = resources.Define(LoadBalancerHelper.LoadBalancerName)
+                .WithRegion(LoadBalancerHelper.Region)
+                .WithExistingResourceGroup(LoadBalancerHelper.GroupName)
 
                 // Frontends
                 .WithExistingPublicIpAddress(existingPips.ElementAt(0))

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/LoadBalancer/InternetWithNatRule.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Network/LoadBalancer/InternetWithNatRule.cs
@@ -47,9 +47,9 @@ namespace Azure.Tests.Network.LoadBalancer
             var nic2 = existingVMs.ElementAt(1).GetPrimaryNetworkInterface();
 
             // Create a load balancer
-            var lb = resources.Define(LoadBalancerHelper.LB_NAME)
-                        .WithRegion(LoadBalancerHelper.REGION)
-                        .WithExistingResourceGroup(LoadBalancerHelper.GROUP_NAME)
+            var lb = resources.Define(LoadBalancerHelper.LoadBalancerName)
+                        .WithRegion(LoadBalancerHelper.Region)
+                        .WithExistingResourceGroup(LoadBalancerHelper.GroupName)
 
                         // Frontends
                         .DefinePublicFrontend("frontend1")

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Redis/RedisCacheTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Redis/RedisCacheTests.cs
@@ -17,12 +17,11 @@ namespace Azure.Tests.Redis
 {
     public class RedisCacheTests
     {
-        private const string RG_NAME = "javacsmrg375";
-        private const string RG_NAME_SECOND = "javacsmrg375Second";
-        private const string RR_NAME = "javacsmrc375";
-        private const string RR_NAME_SECOND = "javacsmrc375Second";
-        private const string RR_NAME_THIRD = "javacsmrc375Third";
-        private const string SA_NAME = "javacsmsa375";
+        private const string GroupName = "javacsmrg375";
+        private const string GroupName2 = "javacsmrg375Second";
+        private const string CacheName = "javacsmrc375";
+        private const string CacheName2 = "javacsmrc375Second";
+        private const string CacheName3 = "javacsmrc375Third";
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
         public void CanCRUDRedisCache()
@@ -33,19 +32,19 @@ namespace Azure.Tests.Redis
 
                 // Create
                 var resourceGroup = redisManager.ResourceManager.ResourceGroups
-                                        .Define(RG_NAME_SECOND)
+                                        .Define(GroupName2)
                                         .WithRegion(Region.US_CENTRAL)
                                         .Create();
 
                 var redisCacheDefinition1 = redisManager.RedisCaches
-                        .Define(RR_NAME)
+                        .Define(CacheName)
                         .WithRegion(Region.ASIA_EAST)
-                        .WithNewResourceGroup(RG_NAME)
+                        .WithNewResourceGroup(GroupName)
                         .WithBasicSku()
                         .Create();
 
                 var redisCacheDefinition2 = redisManager.RedisCaches
-                        .Define(RR_NAME_SECOND)
+                        .Define(CacheName2)
                         .WithRegion(Region.US_CENTRAL)
                         .WithExistingResourceGroup(resourceGroup)
                         .WithPremiumSku()
@@ -54,7 +53,7 @@ namespace Azure.Tests.Redis
                         .Create();
 
                 var redisCacheDefinition3 = redisManager.RedisCaches
-                        .Define(RR_NAME_THIRD)
+                        .Define(CacheName3)
                         .WithRegion(Region.US_CENTRAL)
                         .WithExistingResourceGroup(resourceGroup)
                         .WithPremiumSku(2)
@@ -64,13 +63,13 @@ namespace Azure.Tests.Redis
 
                 var redisCache = redisCacheDefinition1;
                 var redisCachePremium = redisCacheDefinition3;
-                Assert.Equal(RG_NAME, redisCache.ResourceGroupName);
+                Assert.Equal(GroupName, redisCache.ResourceGroupName);
                 Assert.Equal(SkuName.Basic, redisCache.Sku.Name);
 
                 // List by Resource Group
-                var redisCaches = redisManager.RedisCaches.ListByGroup(RG_NAME);
+                var redisCaches = redisManager.RedisCaches.ListByGroup(GroupName);
 
-                if (!redisCaches.Any(r => r.Name.Equals(RR_NAME, StringComparison.OrdinalIgnoreCase)))
+                if (!redisCaches.Any(r => r.Name.Equals(CacheName, StringComparison.OrdinalIgnoreCase)))
                 {
                     Assert.True(false);
                 }
@@ -79,14 +78,14 @@ namespace Azure.Tests.Redis
                 // List all Redis resources
                 redisCaches = redisManager.RedisCaches.List();
 
-                if (!redisCaches.Any(r => r.Name.Equals(RR_NAME, StringComparison.OrdinalIgnoreCase)))
+                if (!redisCaches.Any(r => r.Name.Equals(CacheName, StringComparison.OrdinalIgnoreCase)))
                 {
                     Assert.True(false);
                 }
                 Assert.Equal(3, redisCaches.Count);
 
                 // Get
-                var redisCacheGet = redisManager.RedisCaches.GetByGroup(RG_NAME, RR_NAME);
+                var redisCacheGet = redisManager.RedisCaches.GetByGroup(GroupName, CacheName);
                 Assert.NotNull(redisCacheGet);
                 Assert.Equal(redisCache.Id, redisCacheGet.Id);
                 Assert.Equal(redisCache.ProvisioningState, redisCacheGet.ProvisioningState);
@@ -184,13 +183,13 @@ namespace Azure.Tests.Redis
             {
                 try
                 {
-                    CreateResourceManager().ResourceGroups.DeleteByName(RG_NAME);
+                    CreateResourceManager().ResourceGroups.DeleteByName(GroupName);
                 }
                 catch
                 { }
                 try
                 {
-                    CreateResourceManager().ResourceGroups.DeleteByName(RG_NAME_SECOND);
+                    CreateResourceManager().ResourceGroups.DeleteByName(GroupName2);
                 }
                 catch
                 { }

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Sql/SqlTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Sql/SqlTests.cs
@@ -17,25 +17,25 @@ namespace Azure.Tests.Sql
 {
     public class SqlTests : IDisposable
     {
-        private static string RG_NAME = null;
-        private static string SQL_SERVER_NAME = null;
-        private static readonly string SQL_DATABASE_NAME = "myTestDatabase2";
-        private static readonly string COLLATION = "SQL_Latin1_General_CP1_CI_AS";
-        private static readonly string SQL_ELASTIC_POOL_NAME = "testElasticPool";
-        private static readonly string SQL_FIREWALLRULE_NAME = "firewallrule1";
-        private static readonly string START_IPADDRESS = "10.102.1.10";
-        private static readonly string END_IPADDRESS = "10.102.1.12";
+        private static string GroupName = null;
+        private static string SqlServerName = null;
+        private static readonly string SqlDatabaseName = "myTestDatabase2";
+        private static readonly string Collation = "SQL_Latin1_General_CP1_CI_AS";
+        private static readonly string SqlElasticPoolName = "testElasticPool";
+        private static readonly string SqlFirewallRuleName = "firewallrule1";
+        private static readonly string StartIPAddress = "10.102.1.10";
+        private static readonly string EndIPAddress = "10.102.1.12";
         private static ISqlManager sqlServerManager = TestHelper.CreateSqlManager();
 
         private static void  GenerateNewRGAndSqlServerNameForTest()
         {
-            RG_NAME = ResourceNamer.RandomResourceName("netsqlserver", 20);
-            SQL_SERVER_NAME = RG_NAME;
+            GroupName = ResourceNamer.RandomResourceName("netsqlserver", 20);
+            SqlServerName = GroupName;
         }
 
         public void Dispose()
         {
-            DeleteResourceGroup(RG_NAME);
+            DeleteResourceGroup(GroupName);
         }
 
         private void DeleteResourceGroup(string resourceGroup)
@@ -55,16 +55,16 @@ namespace Azure.Tests.Sql
         {
             GenerateNewRGAndSqlServerNameForTest();
             var rollUpClient = TestHelper.CreateRollupClient();
-            var sqlServer = rollUpClient.SqlServers.Define(SQL_SERVER_NAME)
+            var sqlServer = rollUpClient.SqlServers.Define(SqlServerName)
                     .WithRegion(Region.US_CENTRAL)
-                    .WithNewResourceGroup(RG_NAME)
+                    .WithNewResourceGroup(GroupName)
                     .WithAdministratorLogin("userName")
                     .WithAdministratorPassword("loepop77ejk~13@@")
                     .Create();
             Assert.NotNull(sqlServer.Databases.List());
             rollUpClient.SqlServers.DeleteById(sqlServer.Id);
 
-            DeleteResourceGroup(RG_NAME);
+            DeleteResourceGroup(GroupName);
         }
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
@@ -96,18 +96,18 @@ namespace Azure.Tests.Sql
             sqlServer.Update().WithAdministratorPassword("loepop77ejk~13@@").Apply();
 
             // List
-            var sqlServers = sqlServerManager.SqlServers.ListByGroup(RG_NAME);
+            var sqlServers = sqlServerManager.SqlServers.ListByGroup(GroupName);
             var found = false;
             foreach (var server in sqlServers)
             {
-                if (StringComparer.OrdinalIgnoreCase.Equals(server.Name, SQL_SERVER_NAME))
+                if (StringComparer.OrdinalIgnoreCase.Equals(server.Name, SqlServerName))
                 {
                     found = true;
                 }
             }
             Assert.True(found);
             // Get
-            sqlServer = sqlServerManager.SqlServers.GetByGroup(RG_NAME, SQL_SERVER_NAME);
+            sqlServer = sqlServerManager.SqlServers.GetByGroup(GroupName, SqlServerName);
             Assert.NotNull(sqlServer);
 
             sqlServerManager.SqlServers.DeleteByGroup(sqlServer.ResourceGroupName, sqlServer.Name);
@@ -125,26 +125,26 @@ namespace Azure.Tests.Sql
             var database2InEPName = "database2InEP";
             var elasticPool2Name = "elasticPool2";
             var elasticPool3Name = "elasticPool3";
-            var elasticPool1Name = SQL_ELASTIC_POOL_NAME;
+            var elasticPool1Name = SqlElasticPoolName;
 
             // Create
-            var sqlServer = sqlServerManager.SqlServers.Define(SQL_SERVER_NAME)
+            var sqlServer = sqlServerManager.SqlServers.Define(SqlServerName)
                 .WithRegion(Region.US_CENTRAL)
-                .WithNewResourceGroup(RG_NAME)
+                .WithNewResourceGroup(GroupName)
                 .WithAdministratorLogin("userName")
                 .WithAdministratorPassword("loepopfuejk~13@@")
-                .WithNewDatabase(SQL_DATABASE_NAME)
+                .WithNewDatabase(SqlDatabaseName)
                 .WithNewDatabase(database2Name)
                 .WithNewElasticPool(elasticPool1Name, ElasticPoolEditions.Standard)
                 .WithNewElasticPool(elasticPool2Name, ElasticPoolEditions.Premium, database1InEPName, database2InEPName)
                 .WithNewElasticPool(elasticPool3Name, ElasticPoolEditions.Standard)
-                .WithNewFirewallRule(START_IPADDRESS, END_IPADDRESS, SQL_FIREWALLRULE_NAME)
-                .WithNewFirewallRule(START_IPADDRESS, END_IPADDRESS)
-                .WithNewFirewallRule(START_IPADDRESS)
+                .WithNewFirewallRule(StartIPAddress, EndIPAddress, SqlFirewallRuleName)
+                .WithNewFirewallRule(StartIPAddress, EndIPAddress)
+                .WithNewFirewallRule(StartIPAddress)
                 .Create();
 
             ValidateMultiCreation(database2Name, database1InEPName, database2InEPName, elasticPool1Name, elasticPool2Name, elasticPool3Name, sqlServer, false);
-            elasticPool1Name = SQL_ELASTIC_POOL_NAME + " U";
+            elasticPool1Name = SqlElasticPoolName + " U";
             database2Name = "database2U";
             database1InEPName = "database1InEPU";
             database2InEPName = "database2InEPU";
@@ -153,13 +153,13 @@ namespace Azure.Tests.Sql
 
             // Update
             sqlServer = sqlServer.Update()
-                .WithNewDatabase(SQL_DATABASE_NAME).WithNewDatabase(database2Name)
+                .WithNewDatabase(SqlDatabaseName).WithNewDatabase(database2Name)
                 .WithNewElasticPool(elasticPool1Name, ElasticPoolEditions.Standard)
                 .WithNewElasticPool(elasticPool2Name, ElasticPoolEditions.Premium, database1InEPName, database2InEPName)
                 .WithNewElasticPool(elasticPool3Name, ElasticPoolEditions.Standard)
-                .WithNewFirewallRule(START_IPADDRESS, END_IPADDRESS, SQL_FIREWALLRULE_NAME)
-                .WithNewFirewallRule(START_IPADDRESS, END_IPADDRESS)
-                .WithNewFirewallRule(START_IPADDRESS)
+                .WithNewFirewallRule(StartIPAddress, EndIPAddress, SqlFirewallRuleName)
+                .WithNewFirewallRule(StartIPAddress, EndIPAddress)
+                .WithNewFirewallRule(StartIPAddress)
                 .Apply();
 
             ValidateMultiCreation(database2Name, database1InEPName, database2InEPName, elasticPool1Name, elasticPool2Name, elasticPool3Name, sqlServer, true);
@@ -168,11 +168,11 @@ namespace Azure.Tests.Sql
             Assert.Equal(sqlServer.ElasticPools.List().Count(), 0);
 
             // List
-            var sqlServers = sqlServerManager.SqlServers.ListByGroup(RG_NAME);
+            var sqlServers = sqlServerManager.SqlServers.ListByGroup(GroupName);
             var found = false;
             foreach (var server in sqlServers)
             {
-                if (StringComparer.OrdinalIgnoreCase.Equals(server.Name, SQL_SERVER_NAME))
+                if (StringComparer.OrdinalIgnoreCase.Equals(server.Name, SqlServerName))
                 {
                     found = true;
                 }
@@ -180,7 +180,7 @@ namespace Azure.Tests.Sql
 
             Assert.True(found);
             // Get
-            sqlServer = sqlServerManager.SqlServers.GetByGroup(RG_NAME, SQL_SERVER_NAME);
+            sqlServer = sqlServerManager.SqlServers.GetByGroup(GroupName, SqlServerName);
             Assert.NotNull(sqlServer);
 
             sqlServerManager.SqlServers.DeleteByGroup(sqlServer.ResourceGroupName, sqlServer.Name);
@@ -199,9 +199,9 @@ namespace Azure.Tests.Sql
                 bool deleteUsingUpdate)
         {
             ValidateSqlServer(sqlServer);
-            ValidateSqlServer(sqlServerManager.SqlServers.GetByGroup(RG_NAME, SQL_SERVER_NAME));
-            ValidateSqlDatabase(sqlServer.Databases.Get(SQL_DATABASE_NAME), SQL_DATABASE_NAME);
-            ValidateSqlFirewallRule(sqlServer.FirewallRules.Get(SQL_FIREWALLRULE_NAME), SQL_FIREWALLRULE_NAME);
+            ValidateSqlServer(sqlServerManager.SqlServers.GetByGroup(GroupName, SqlServerName));
+            ValidateSqlDatabase(sqlServer.Databases.Get(SqlDatabaseName), SqlDatabaseName);
+            ValidateSqlFirewallRule(sqlServer.FirewallRules.Get(SqlFirewallRuleName), SqlFirewallRuleName);
 
             var firewalls = sqlServer.FirewallRules.List();
             Assert.Equal(3, firewalls.Count());
@@ -211,14 +211,14 @@ namespace Azure.Tests.Sql
 
             foreach (ISqlFirewallRule firewall in firewalls)
             {
-                if (!StringComparer.OrdinalIgnoreCase.Equals(firewall.Name, SQL_FIREWALLRULE_NAME))
+                if (!StringComparer.OrdinalIgnoreCase.Equals(firewall.Name, SqlFirewallRuleName))
                 {
-                    Assert.Equal(firewall.StartIpAddress, START_IPADDRESS);
-                    if (StringComparer.OrdinalIgnoreCase.Equals(firewall.EndIpAddress, START_IPADDRESS))
+                    Assert.Equal(firewall.StartIpAddress, StartIPAddress);
+                    if (StringComparer.OrdinalIgnoreCase.Equals(firewall.EndIpAddress, StartIPAddress))
                     {
                         startIpAddress++;
                     }
-                    else if (StringComparer.OrdinalIgnoreCase.Equals(firewall.EndIpAddress, END_IPADDRESS))
+                    else if (StringComparer.OrdinalIgnoreCase.Equals(firewall.EndIpAddress, EndIPAddress))
                     {
                         endIpAddress++;
                     }
@@ -252,7 +252,7 @@ namespace Azure.Tests.Sql
                 sqlServer.Databases.Delete(database2Name);
                 sqlServer.Databases.Delete(database1InEPName);
                 sqlServer.Databases.Delete(database2InEPName);
-                sqlServer.Databases.Delete(SQL_DATABASE_NAME);
+                sqlServer.Databases.Delete(SqlDatabaseName);
 
                 Assert.Equal(ep1.ListDatabases().Count(), 0);
                 Assert.Equal(ep2.ListDatabases().Count(), 0);
@@ -278,9 +278,9 @@ namespace Azure.Tests.Sql
                         .WithoutElasticPool(elasticPool3Name)
                         .WithoutElasticPool(elasticPool1Name)
                         .WithoutDatabase(database1InEPName)
-                        .WithoutDatabase(SQL_DATABASE_NAME)
+                        .WithoutDatabase(SqlDatabaseName)
                         .WithoutDatabase(database2InEPName)
-                        .WithoutFirewallRule(SQL_FIREWALLRULE_NAME)
+                        .WithoutFirewallRule(SqlFirewallRuleName)
                         .Apply();
 
                 Assert.Equal(sqlServer.ElasticPools.List().Count(), 0);
@@ -307,12 +307,12 @@ namespace Azure.Tests.Sql
             var sqlServer = CreateSqlServer();
 
             var sqlDatabase = sqlServer.Databases
-                .Define(SQL_DATABASE_NAME)
-                .WithCollation(COLLATION)
+                .Define(SqlDatabaseName)
+                .WithCollation(Collation)
                 .WithEdition(DatabaseEditions.Standard)
                 .Create();
 
-            ValidateSqlDatabase(sqlDatabase, SQL_DATABASE_NAME);
+            ValidateSqlDatabase(sqlDatabase, SqlDatabaseName);
 
             // Test transparent data encryption settings.
             var transparentDataEncryption = sqlDatabase.GetTransparentDataEncryption();
@@ -332,8 +332,8 @@ namespace Azure.Tests.Sql
             transparentDataEncryption = sqlDatabase.GetTransparentDataEncryption().UpdateStatus(TransparentDataEncryptionStates.Disabled);
             Assert.NotNull(transparentDataEncryption);
             Assert.Equal(transparentDataEncryption.Status, TransparentDataEncryptionStates.Disabled);
-            Assert.Equal(transparentDataEncryption.SqlServerName, SQL_SERVER_NAME);
-            Assert.Equal(transparentDataEncryption.DatabaseName, SQL_DATABASE_NAME);
+            Assert.Equal(transparentDataEncryption.SqlServerName, SqlServerName);
+            Assert.Equal(transparentDataEncryption.DatabaseName, SqlDatabaseName);
             Assert.NotNull(transparentDataEncryption.Name);
             Assert.NotNull(transparentDataEncryption.Id);
             // Done testing with encryption settings.
@@ -350,12 +350,12 @@ namespace Azure.Tests.Sql
             Assert.NotNull(serviceTierAdvisors.Values.First().ServiceLevelObjectiveUsageMetrics);
             // End of testing service tier advisors.
 
-            sqlServer = sqlServerManager.SqlServers.GetByGroup(RG_NAME, SQL_SERVER_NAME);
+            sqlServer = sqlServerManager.SqlServers.GetByGroup(GroupName, SqlServerName);
             ValidateSqlServer(sqlServer);
 
             // Create another database with above created database as source database.
             var sqlElasticPoolCreatable = sqlServer.ElasticPools
-                .Define(SQL_ELASTIC_POOL_NAME)
+                .Define(SqlElasticPoolName)
                 .WithEdition(ElasticPoolEditions.Standard);
             var anotherDatabaseName = "anotherDatabase";
             var anotherDatabase = sqlServer.Databases
@@ -369,19 +369,19 @@ namespace Azure.Tests.Sql
             sqlServer.Databases.Delete(anotherDatabase.Name);
 
             // Get
-            ValidateSqlDatabase(sqlServer.Databases.Get(SQL_DATABASE_NAME), SQL_DATABASE_NAME);
+            ValidateSqlDatabase(sqlServer.Databases.Get(SqlDatabaseName), SqlDatabaseName);
 
             // List
             ValidateListSqlDatabase(sqlServer.Databases.List());
 
             // Delete
-            sqlServer.Databases.Delete(SQL_DATABASE_NAME);
-            ValidateSqlDatabaseNotFound(SQL_DATABASE_NAME);
+            sqlServer.Databases.Delete(SqlDatabaseName);
+            ValidateSqlDatabaseNotFound(SqlDatabaseName);
 
             // Add another database to the server
             sqlDatabase = sqlServer.Databases
                     .Define("newDatabase")
-                    .WithCollation(COLLATION)
+                    .WithCollation(Collation)
                     .WithEdition(DatabaseEditions.Standard)
                     .Create();
             sqlServer.Databases.Delete(sqlDatabase.Name);
@@ -396,19 +396,19 @@ namespace Azure.Tests.Sql
             GenerateNewRGAndSqlServerNameForTest();
 
             // Create
-            var anotherSqlServerName = SQL_SERVER_NAME + "another";
+            var anotherSqlServerName = SqlServerName + "another";
             var sqlServer1 = CreateSqlServer();
             var sqlServer2 = CreateSqlServer(anotherSqlServerName);
 
             var databaseInServer1 = sqlServer1.Databases
-                .Define(SQL_DATABASE_NAME)
-                .WithCollation(COLLATION)
+                .Define(SqlDatabaseName)
+                .WithCollation(Collation)
                 .WithEdition(DatabaseEditions.Standard)
                 .Create();
 
-            ValidateSqlDatabase(databaseInServer1, SQL_DATABASE_NAME);
+            ValidateSqlDatabase(databaseInServer1, SqlDatabaseName);
             var databaseInServer2 = sqlServer2.Databases
-                .Define(SQL_DATABASE_NAME)
+                .Define(SqlDatabaseName)
                 .WithSourceDatabase(databaseInServer1.Id)
                 .WithMode(CreateMode.OnlineSecondary)
                 .Create();
@@ -465,20 +465,20 @@ namespace Azure.Tests.Sql
             Assert.NotNull(sqlServer.ListUsages());
 
             var sqlDatabase = sqlServer.Databases
-                    .Define(SQL_DATABASE_NAME)
-                    .WithCollation(COLLATION)
+                    .Define(SqlDatabaseName)
+                    .WithCollation(Collation)
                     .WithEdition(DatabaseEditions.DataWarehouse)
                     .Create();
 
-            sqlDatabase = sqlServer.Databases.Get(SQL_DATABASE_NAME);
+            sqlDatabase = sqlServer.Databases.Get(SqlDatabaseName);
             Assert.NotNull(sqlDatabase);
             Assert.True(sqlDatabase.IsDataWarehouse);
 
             // Get
-            var dataWarehouse = sqlServer.Databases.Get(SQL_DATABASE_NAME).AsWarehouse();
+            var dataWarehouse = sqlServer.Databases.Get(SqlDatabaseName).AsWarehouse();
 
             Assert.NotNull(dataWarehouse);
-            Assert.Equal(dataWarehouse.Name, SQL_DATABASE_NAME);
+            Assert.Equal(dataWarehouse.Name, SqlDatabaseName);
             Assert.Equal(dataWarehouse.Edition, DatabaseEditions.DataWarehouse);
 
             // List Restore points.
@@ -492,7 +492,7 @@ namespace Azure.Tests.Sql
             // Resume warehouse
             dataWarehouse.ResumeDataWarehouse();
 
-            sqlServer.Databases.Delete(SQL_DATABASE_NAME);
+            sqlServer.Databases.Delete(SqlDatabaseName);
 
             sqlServerManager.SqlServers.DeleteByGroup(sqlServer.ResourceGroupName, sqlServer.Name);
             ValidateSqlServerNotFound(sqlServer);
@@ -508,26 +508,26 @@ namespace Azure.Tests.Sql
             var sqlServer = CreateSqlServer();
 
             var sqlElasticPoolCreatable = sqlServer.ElasticPools
-                    .Define(SQL_ELASTIC_POOL_NAME)
+                    .Define(SqlElasticPoolName)
                     .WithEdition(ElasticPoolEditions.Standard);
 
             var sqlDatabase = sqlServer.Databases
-                    .Define(SQL_DATABASE_NAME)
+                    .Define(SqlDatabaseName)
                     .WithNewElasticPool(sqlElasticPoolCreatable)
-                    .WithCollation(COLLATION)
+                    .WithCollation(Collation)
                     .Create();
 
-            ValidateSqlDatabase(sqlDatabase, SQL_DATABASE_NAME);
+            ValidateSqlDatabase(sqlDatabase, SqlDatabaseName);
 
-            sqlServer = sqlServerManager.SqlServers.GetByGroup(RG_NAME, SQL_SERVER_NAME);
+            sqlServer = sqlServerManager.SqlServers.GetByGroup(GroupName, SqlServerName);
             ValidateSqlServer(sqlServer);
 
             // Get Elastic pool
-            var elasticPool = sqlServer.ElasticPools.Get(SQL_ELASTIC_POOL_NAME);
+            var elasticPool = sqlServer.ElasticPools.Get(SqlElasticPoolName);
             ValidateSqlElasticPool(elasticPool);
 
             // Get
-            ValidateSqlDatabaseWithElasticPool(sqlServer.Databases.Get(SQL_DATABASE_NAME), SQL_DATABASE_NAME);
+            ValidateSqlDatabaseWithElasticPool(sqlServer.Databases.Get(SqlDatabaseName), SqlDatabaseName);
 
             // List
             ValidateListSqlDatabase(sqlServer.Databases.List());
@@ -538,7 +538,7 @@ namespace Azure.Tests.Sql
                     .WithEdition(DatabaseEditions.Standard)
                     .WithServiceObjective(ServiceObjectiveName.S3)
                 .Apply();
-            sqlDatabase = sqlServer.Databases.Get(SQL_DATABASE_NAME);
+            sqlDatabase = sqlServer.Databases.Get(SqlDatabaseName);
             Assert.Null(sqlDatabase.ElasticPoolName);
 
             // Update edition of the SQL database
@@ -546,13 +546,13 @@ namespace Azure.Tests.Sql
                     .WithEdition(DatabaseEditions.Premium)
                     .WithServiceObjective(ServiceObjectiveName.P1)
                     .Apply();
-            sqlDatabase = sqlServer.Databases.Get(SQL_DATABASE_NAME);
+            sqlDatabase = sqlServer.Databases.Get(SqlDatabaseName);
             Assert.Equal(sqlDatabase.Edition, DatabaseEditions.Premium);
             Assert.Equal(sqlDatabase.ServiceLevelObjective, ServiceObjectiveName.P1);
 
             // Update just the service level objective for database.
             sqlDatabase.Update().WithServiceObjective(ServiceObjectiveName.P2).Apply();
-            sqlDatabase = sqlServer.Databases.Get(SQL_DATABASE_NAME);
+            sqlDatabase = sqlServer.Databases.Get(SqlDatabaseName);
             Assert.Equal(sqlDatabase.ServiceLevelObjective, ServiceObjectiveName.P2);
             Assert.Equal(sqlDatabase.RequestedServiceObjectiveName, ServiceObjectiveName.P2);
 
@@ -561,16 +561,16 @@ namespace Azure.Tests.Sql
                     .WithMaxSizeBytes(268435456000L)
                     .Apply();
 
-            sqlDatabase = sqlServer.Databases.Get(SQL_DATABASE_NAME);
+            sqlDatabase = sqlServer.Databases.Get(SqlDatabaseName);
             Assert.Equal(sqlDatabase.MaxSizeBytes, 268435456000L);
 
             // Put the database back in elastic pool.
             sqlDatabase.Update()
-                    .WithExistingElasticPool(SQL_ELASTIC_POOL_NAME)
+                    .WithExistingElasticPool(SqlElasticPoolName)
                     .Apply();
 
-            sqlDatabase = sqlServer.Databases.Get(SQL_DATABASE_NAME);
-            Assert.Equal(sqlDatabase.ElasticPoolName, SQL_ELASTIC_POOL_NAME);
+            sqlDatabase = sqlServer.Databases.Get(SqlDatabaseName);
+            Assert.Equal(sqlDatabase.ElasticPoolName, SqlElasticPoolName);
 
             // List Activity in elastic pool
             Assert.NotNull(elasticPool.ListActivities());
@@ -584,8 +584,8 @@ namespace Azure.Tests.Sql
             Assert.Equal(databasesInElasticPool.Count(), 1);
 
             // Get a particular database in elastic pool.
-            var databaseInElasticPool = elasticPool.GetDatabase(SQL_DATABASE_NAME);
-            ValidateSqlDatabase(databaseInElasticPool, SQL_DATABASE_NAME);
+            var databaseInElasticPool = elasticPool.GetDatabase(SqlDatabaseName);
+            ValidateSqlDatabase(databaseInElasticPool, SqlDatabaseName);
 
             // Refresh works on the database got from elastic pool.
             databaseInElasticPool.Refresh();
@@ -601,21 +601,21 @@ namespace Azure.Tests.Sql
             }
 
             // Delete
-            sqlServer.Databases.Delete(SQL_DATABASE_NAME);
-            ValidateSqlDatabaseNotFound(SQL_DATABASE_NAME);
+            sqlServer.Databases.Delete(SqlDatabaseName);
+            ValidateSqlDatabaseNotFound(SqlDatabaseName);
 
-            var sqlElasticPool = sqlServer.ElasticPools.Get(SQL_ELASTIC_POOL_NAME);
+            var sqlElasticPool = sqlServer.ElasticPools.Get(SqlElasticPoolName);
 
             // Add another database to the server and pool.
             sqlDatabase = sqlServer.Databases
                     .Define("newDatabase")
                     .WithExistingElasticPool(sqlElasticPool)
-                    .WithCollation(COLLATION)
+                    .WithCollation(Collation)
                     .Create();
             sqlServer.Databases.Delete(sqlDatabase.Name);
             ValidateSqlDatabaseNotFound("newDatabase");
 
-            sqlServer.ElasticPools.Delete(SQL_ELASTIC_POOL_NAME);
+            sqlServer.ElasticPools.Delete(SqlElasticPoolName);
             sqlServerManager.SqlServers.DeleteByGroup(sqlServer.ResourceGroupName, sqlServer.Name);
             ValidateSqlServerNotFound(sqlServer);
             DeleteResourceGroup(sqlServer.ResourceGroupName);
@@ -629,11 +629,11 @@ namespace Azure.Tests.Sql
             // Create
             var sqlServer = CreateSqlServer();
 
-            sqlServer = sqlServerManager.SqlServers.GetByGroup(RG_NAME, SQL_SERVER_NAME);
+            sqlServer = sqlServerManager.SqlServers.GetByGroup(GroupName, SqlServerName);
             ValidateSqlServer(sqlServer);
 
             var sqlElasticPool = sqlServer.ElasticPools
-                    .Define(SQL_ELASTIC_POOL_NAME)
+                    .Define(SqlElasticPoolName)
                     .WithEdition(ElasticPoolEditions.Standard)
                     .Create();
             ValidateSqlElasticPool(sqlElasticPool);
@@ -644,22 +644,22 @@ namespace Azure.Tests.Sql
                     .WithDatabaseDtuMax(20)
                     .WithDatabaseDtuMin(10)
                     .WithStorageCapacity(102400)
-                    .WithNewDatabase(SQL_DATABASE_NAME)
+                    .WithNewDatabase(SqlDatabaseName)
                     .Apply();
 
             ValidateSqlElasticPool(sqlElasticPool);
             Assert.Equal(sqlElasticPool.ListDatabases().Count(), 1);
 
             // Get
-            ValidateSqlElasticPool(sqlServer.ElasticPools.Get(SQL_ELASTIC_POOL_NAME));
+            ValidateSqlElasticPool(sqlServer.ElasticPools.Get(SqlElasticPoolName));
 
             // List
             ValidateListSqlElasticPool(sqlServer.ElasticPools.List());
 
             // Delete
-            sqlServer.Databases.Delete(SQL_DATABASE_NAME);
-            sqlServer.ElasticPools.Delete(SQL_ELASTIC_POOL_NAME);
-            ValidateSqlElasticPoolNotFound(sqlServer, SQL_ELASTIC_POOL_NAME);
+            sqlServer.Databases.Delete(SqlDatabaseName);
+            sqlServer.ElasticPools.Delete(SqlElasticPoolName);
+            ValidateSqlElasticPoolNotFound(sqlServer, SqlElasticPoolName);
 
             // Add another database to the server
             sqlElasticPool = sqlServer.ElasticPools
@@ -683,43 +683,43 @@ namespace Azure.Tests.Sql
             // Create
             var sqlServer = CreateSqlServer();
 
-            sqlServer = sqlServerManager.SqlServers.GetByGroup(RG_NAME, SQL_SERVER_NAME);
+            sqlServer = sqlServerManager.SqlServers.GetByGroup(GroupName, SqlServerName);
             ValidateSqlServer(sqlServer);
 
             var sqlFirewallRule = sqlServer.FirewallRules
-                    .Define(SQL_FIREWALLRULE_NAME)
-                    .WithIpAddressRange(START_IPADDRESS, END_IPADDRESS)
+                    .Define(SqlFirewallRuleName)
+                    .WithIpAddressRange(StartIPAddress, EndIPAddress)
                     .Create();
 
-            ValidateSqlFirewallRule(sqlFirewallRule, SQL_FIREWALLRULE_NAME);
-            ValidateSqlFirewallRule(sqlServer.FirewallRules.Get(SQL_FIREWALLRULE_NAME), SQL_FIREWALLRULE_NAME);
+            ValidateSqlFirewallRule(sqlFirewallRule, SqlFirewallRuleName);
+            ValidateSqlFirewallRule(sqlServer.FirewallRules.Get(SqlFirewallRuleName), SqlFirewallRuleName);
 
             var secondFirewallRuleName = "secondFireWallRule";
             var secondFirewallRule = sqlServer.FirewallRules
                     .Define(secondFirewallRuleName)
-                    .WithIpAddress(START_IPADDRESS)
+                    .WithIpAddress(StartIPAddress)
                     .Create();
 
             secondFirewallRule = sqlServer.FirewallRules.Get(secondFirewallRuleName);
 
             Assert.NotNull(secondFirewallRule);
-            Assert.Equal(START_IPADDRESS, secondFirewallRule.EndIpAddress);
+            Assert.Equal(StartIPAddress, secondFirewallRule.EndIpAddress);
 
-            secondFirewallRule = secondFirewallRule.Update().WithEndIpAddress(END_IPADDRESS).Apply();
+            secondFirewallRule = secondFirewallRule.Update().WithEndIpAddress(EndIPAddress).Apply();
 
             ValidateSqlFirewallRule(secondFirewallRule, secondFirewallRuleName);
             sqlServer.FirewallRules.Delete(secondFirewallRuleName);
             AssertIfFound(() => sqlServer.FirewallRules.Get(secondFirewallRuleName));
 
             // Get
-            sqlFirewallRule = sqlServer.FirewallRules.Get(SQL_FIREWALLRULE_NAME);
-            ValidateSqlFirewallRule(sqlFirewallRule, SQL_FIREWALLRULE_NAME);
+            sqlFirewallRule = sqlServer.FirewallRules.Get(SqlFirewallRuleName);
+            ValidateSqlFirewallRule(sqlFirewallRule, SqlFirewallRuleName);
 
             // Update
             // Making start and end IP address same.
-            sqlFirewallRule.Update().WithEndIpAddress(START_IPADDRESS).Apply();
-            sqlFirewallRule = sqlServer.FirewallRules.Get(SQL_FIREWALLRULE_NAME);
-            Assert.Equal(sqlFirewallRule.EndIpAddress, START_IPADDRESS);
+            sqlFirewallRule.Update().WithEndIpAddress(StartIPAddress).Apply();
+            sqlFirewallRule = sqlServer.FirewallRules.Get(SqlFirewallRuleName);
+            Assert.Equal(sqlFirewallRule.EndIpAddress, StartIPAddress);
 
             // List
             ValidateListSqlFirewallRule(sqlServer.FirewallRules.List());
@@ -736,7 +736,7 @@ namespace Azure.Tests.Sql
 
         private static void ValidateSqlFirewallRuleNotFound()
         {
-            AssertIfFound(() => sqlServerManager.SqlServers.GetByGroup(RG_NAME, SQL_SERVER_NAME).FirewallRules.Get(SQL_FIREWALLRULE_NAME));
+            AssertIfFound(() => sqlServerManager.SqlServers.GetByGroup(GroupName, SqlServerName).FirewallRules.Get(SqlFirewallRuleName));
         }
 
         private static void ValidateSqlElasticPoolNotFound(ISqlServer sqlServer, string elasticPoolName)
@@ -746,7 +746,7 @@ namespace Azure.Tests.Sql
 
         private static void ValidateSqlDatabaseNotFound(String newDatabase)
         {
-            AssertIfFound(() => sqlServerManager.SqlServers.GetByGroup(RG_NAME, SQL_SERVER_NAME).Databases.Get(newDatabase));
+            AssertIfFound(() => sqlServerManager.SqlServers.GetByGroup(GroupName, SqlServerName).Databases.Get(newDatabase));
         }
 
         private static void ValidateSqlServerNotFound(ISqlServer sqlServer)
@@ -775,7 +775,7 @@ namespace Azure.Tests.Sql
 
         private static ISqlServer CreateSqlServer()
         {
-            return CreateSqlServer(SQL_SERVER_NAME);
+            return CreateSqlServer(SqlServerName);
         }
 
         private static ISqlServer CreateSqlServer(String SQL_SERVER_NAME)
@@ -783,7 +783,7 @@ namespace Azure.Tests.Sql
             return sqlServerManager.SqlServers
                     .Define(SQL_SERVER_NAME)
                     .WithRegion(Region.US_CENTRAL)
-                    .WithNewResourceGroup(RG_NAME)
+                    .WithNewResourceGroup(GroupName)
                     .WithAdministratorLogin("userName")
                     .WithAdministratorPassword("loepopfuejk~13@@")
                     .Create();
@@ -791,37 +791,37 @@ namespace Azure.Tests.Sql
 
         private static void ValidateListSqlFirewallRule(IList<ISqlFirewallRule> sqlFirewallRules)
         {
-            Assert.True(sqlFirewallRules.Any(firewallRule => StringComparer.OrdinalIgnoreCase.Equals(firewallRule.Name, SQL_FIREWALLRULE_NAME)));
+            Assert.True(sqlFirewallRules.Any(firewallRule => StringComparer.OrdinalIgnoreCase.Equals(firewallRule.Name, SqlFirewallRuleName)));
         }
 
         private static void ValidateSqlFirewallRule(ISqlFirewallRule sqlFirewallRule, string firewallName)
         {
             Assert.NotNull(sqlFirewallRule);
             Assert.Equal(firewallName, sqlFirewallRule.Name);
-            Assert.Equal(SQL_SERVER_NAME, sqlFirewallRule.SqlServerName);
-            Assert.Equal(START_IPADDRESS, sqlFirewallRule.StartIpAddress);
-            Assert.Equal(END_IPADDRESS, sqlFirewallRule.EndIpAddress);
-            Assert.Equal(RG_NAME, sqlFirewallRule.ResourceGroupName);
-            Assert.Equal(SQL_SERVER_NAME, sqlFirewallRule.SqlServerName);
+            Assert.Equal(SqlServerName, sqlFirewallRule.SqlServerName);
+            Assert.Equal(StartIPAddress, sqlFirewallRule.StartIpAddress);
+            Assert.Equal(EndIPAddress, sqlFirewallRule.EndIpAddress);
+            Assert.Equal(GroupName, sqlFirewallRule.ResourceGroupName);
+            Assert.Equal(SqlServerName, sqlFirewallRule.SqlServerName);
             Assert.Equal(Region.US_CENTRAL, sqlFirewallRule.Region);
         }
 
         private static void ValidateListSqlElasticPool(IList<ISqlElasticPool> sqlElasticPools)
         {
-            Assert.True(sqlElasticPools.Any(elasticPool => StringComparer.OrdinalIgnoreCase.Equals(elasticPool.Name, SQL_ELASTIC_POOL_NAME)));
+            Assert.True(sqlElasticPools.Any(elasticPool => StringComparer.OrdinalIgnoreCase.Equals(elasticPool.Name, SqlElasticPoolName)));
         }
 
         private static void ValidateSqlElasticPool(ISqlElasticPool sqlElasticPool)
         {
-            ValidateSqlElasticPool(sqlElasticPool, SQL_ELASTIC_POOL_NAME);
+            ValidateSqlElasticPool(sqlElasticPool, SqlElasticPoolName);
         }
 
         private static void ValidateSqlElasticPool(ISqlElasticPool sqlElasticPool, string elasticPoolName)
         {
             Assert.NotNull(sqlElasticPool);
-            Assert.Equal(RG_NAME, sqlElasticPool.ResourceGroupName);
+            Assert.Equal(GroupName, sqlElasticPool.ResourceGroupName);
             Assert.Equal(elasticPoolName, sqlElasticPool.Name);
-            Assert.Equal(SQL_SERVER_NAME, sqlElasticPool.SqlServerName);
+            Assert.Equal(SqlServerName, sqlElasticPool.SqlServerName);
             Assert.Equal(ElasticPoolEditions.Standard, sqlElasticPool.Edition);
             Assert.NotNull(sqlElasticPool.CreationDate);
             Assert.NotEqual(0, sqlElasticPool.DatabaseDtuMax);
@@ -830,13 +830,13 @@ namespace Azure.Tests.Sql
 
         private static void ValidateListSqlDatabase(IList<ISqlDatabase> sqlDatabases)
         {
-            Assert.True(sqlDatabases.Any(database => StringComparer.OrdinalIgnoreCase.Equals(database.Name, SQL_DATABASE_NAME)));
+            Assert.True(sqlDatabases.Any(database => StringComparer.OrdinalIgnoreCase.Equals(database.Name, SqlDatabaseName)));
         }
 
         private static void ValidateSqlServer(ISqlServer sqlServer)
         {
             Assert.NotNull(sqlServer);
-            Assert.Equal(RG_NAME, sqlServer.ResourceGroupName);
+            Assert.Equal(GroupName, sqlServer.ResourceGroupName);
             Assert.NotNull(sqlServer.FullyQualifiedDomainName);
             Assert.Equal(ServerVersion.OneTwoFullStopZero, sqlServer.Version);
             Assert.Equal("userName", sqlServer.AdministratorLogin);
@@ -846,15 +846,15 @@ namespace Azure.Tests.Sql
         {
             Assert.NotNull(sqlDatabase);
             Assert.Equal(sqlDatabase.Name, databaseName);
-            Assert.Equal(SQL_SERVER_NAME, sqlDatabase.SqlServerName);
-            Assert.Equal(sqlDatabase.Collation, COLLATION);
+            Assert.Equal(SqlServerName, sqlDatabase.SqlServerName);
+            Assert.Equal(sqlDatabase.Collation, Collation);
             Assert.Equal(sqlDatabase.Edition, DatabaseEditions.Standard);
         }
 
         private static void ValidateSqlDatabaseWithElasticPool(ISqlDatabase sqlDatabase, string databaseName)
         {
             ValidateSqlDatabase(sqlDatabase, databaseName);
-            Assert.Equal(SQL_ELASTIC_POOL_NAME, sqlDatabase.ElasticPoolName);
+            Assert.Equal(SqlElasticPoolName, sqlDatabase.ElasticPoolName);
         }
     }
 }

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/AppServicePlansTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/AppServicePlansTests.cs
@@ -11,8 +11,8 @@ namespace Azure.Tests.WebApp
 {
     public class AppServicePlansTests
     {
-        private static readonly string RG_NAME = ResourceNamer.RandomResourceName("javacsmrg", 20);
-        private static readonly string APP_SERVICE_PLAN_NAME = ResourceNamer.RandomResourceName("java-asp-", 20);
+        private static readonly string GroupName = ResourceNamer.RandomResourceName("javacsmrg", 20);
+        private static readonly string AppServicePlanName = ResourceNamer.RandomResourceName("java-asp-", 20);
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
         public void CanCRUDAppServicePlan()
@@ -21,9 +21,9 @@ namespace Azure.Tests.WebApp
 
             // CREATE
             var appServicePlan = appServiceManager.AppServicePlans
-                .Define(APP_SERVICE_PLAN_NAME)
+                .Define(AppServicePlanName)
                 .WithRegion(Region.US_WEST)
-                .WithNewResourceGroup(RG_NAME)
+                .WithNewResourceGroup(GroupName)
                 .WithPricingTier(AppServicePricingTier.Premium_P1)
                 .WithPerSiteScaling(false)
                 .WithCapacity(2)
@@ -35,13 +35,13 @@ namespace Azure.Tests.WebApp
             Assert.Equal(0, appServicePlan.NumberOfWebApps);
             Assert.Equal(20, appServicePlan.MaxInstances);
             // GET
-            Assert.NotNull(appServiceManager.AppServicePlans.GetByGroup(RG_NAME, APP_SERVICE_PLAN_NAME));
+            Assert.NotNull(appServiceManager.AppServicePlans.GetByGroup(GroupName, AppServicePlanName));
             // LIST
-            var appServicePlans = appServiceManager.AppServicePlans.ListByGroup(RG_NAME);
+            var appServicePlans = appServiceManager.AppServicePlans.ListByGroup(GroupName);
             var found = false;
             foreach (var asp in appServicePlans)
             {
-                if (APP_SERVICE_PLAN_NAME.Equals(asp.Name))
+                if (AppServicePlanName.Equals(asp.Name))
                 {
                     found = true;
                     break;

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/CertificateOrdersTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/CertificateOrdersTests.cs
@@ -9,8 +9,8 @@ namespace Azure.Tests.WebApp
 {
     public class CertificateOrdersTests
     {
-        private static string RG_NAME = "javacsmrg9b9912262";
-        private static string CERTIFICATE_NAME = "graphdmcert7720";
+        private static string GroupName = "javacsmrg9b9912262";
+        private static string CertificateName = "graphdmcert7720";
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
         public void CanCRUDCertificateOrder()
@@ -19,8 +19,8 @@ namespace Azure.Tests.WebApp
 
             // CREATE
             var certificateOrder = appServiceManager.AppServiceCertificateOrders
-                .Define(CERTIFICATE_NAME)
-                .WithExistingResourceGroup(RG_NAME)
+                .Define(CertificateName)
+                .WithExistingResourceGroup(GroupName)
                 .WithHostName("graph-dm7720.com")
                 .WithStandardSku()
                 .WithDomainVerification(appServiceManager.AppServiceDomains.GetByGroup("javacsmrg9b9912262", "graph-dm7720.com"))
@@ -29,13 +29,13 @@ namespace Azure.Tests.WebApp
                 .Create();
             Assert.NotNull(certificateOrder);
             // GET
-            Assert.NotNull(appServiceManager.AppServiceCertificateOrders.GetByGroup(RG_NAME, CERTIFICATE_NAME));
+            Assert.NotNull(appServiceManager.AppServiceCertificateOrders.GetByGroup(GroupName, CertificateName));
             // LIST
-            var certificateOrders = appServiceManager.AppServiceCertificateOrders.ListByGroup(RG_NAME);
+            var certificateOrders = appServiceManager.AppServiceCertificateOrders.ListByGroup(GroupName);
             var found = false;
             foreach (var co in certificateOrders)
             {
-                if (CERTIFICATE_NAME.Equals(co.Name))
+                if (CertificateName.Equals(co.Name))
                 {
                     found = true;
                     break;

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/CertificatesTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/CertificatesTests.cs
@@ -10,8 +10,8 @@ namespace Azure.Tests.WebApp
 {
     public class CertificatesTests
     {
-        private static readonly string RG_NAME = "javacsmrg319";
-        private static readonly string CERTIFICATE_NAME = "javagoodcert319";
+        private static readonly string GroupName = "javacsmrg319";
+        private static readonly string CertificateName = "javagoodcert319";
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
         public void CanCRDCertificate()
@@ -19,18 +19,18 @@ namespace Azure.Tests.WebApp
             var keyVaultManager = TestHelper.CreateKeyVaultManager();
             var appServiceManager = TestHelper.CreateAppServiceManager();
 
-            var vault = keyVaultManager.Vaults.GetByGroup(RG_NAME, "bananagraphwebapp319com");
+            var vault = keyVaultManager.Vaults.GetByGroup(GroupName, "bananagraphwebapp319com");
             var certificate = appServiceManager.AppServiceCertificates.Define("bananacert")
                 .WithRegion(Region.US_WEST)
-                .WithExistingResourceGroup(RG_NAME)
-                .WithExistingCertificateOrder(appServiceManager.AppServiceCertificateOrders.GetByGroup(RG_NAME, "graphwebapp319"))
+                .WithExistingResourceGroup(GroupName)
+                .WithExistingCertificateOrder(appServiceManager.AppServiceCertificateOrders.GetByGroup(GroupName, "graphwebapp319"))
                 .Create();
             Assert.NotNull(certificate);
 
             // CREATE
-            certificate = appServiceManager.AppServiceCertificates.Define(CERTIFICATE_NAME)
+            certificate = appServiceManager.AppServiceCertificates.Define(CertificateName)
                 .WithRegion(Region.US_EAST)
-                .WithExistingResourceGroup(RG_NAME)
+                .WithExistingResourceGroup(GroupName)
                 .WithPfxFile("/Users/jianghlu/Documents/code/certs/myserver.Pfx")
                 .WithPfxPassword("StrongPass!123")
                 .Create();

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/DeploymentSlotsTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/DeploymentSlotsTests.cs
@@ -12,12 +12,12 @@ namespace Azure.Tests.WebApp
 {
     public class DeploymentSlotsTests
     {
-        private static readonly string RG_NAME = ResourceNamer.RandomResourceName("javacsmrg", 20);
-        private static readonly string WEBAPP_NAME = ResourceNamer.RandomResourceName("java-webapp-", 20);
-        private static readonly string SLOT_NAME_1 = ResourceNamer.RandomResourceName("java-slot-", 20);
-        private static readonly string SLOT_NAME_2 = ResourceNamer.RandomResourceName("java-slot-", 20);
-        private static readonly string SLOT_NAME_3 = ResourceNamer.RandomResourceName("java-slot-", 20);
-        private static readonly string APP_SERVICE_PLAN_NAME = ResourceNamer.RandomResourceName("java-asp-", 20);
+        private static readonly string GroupName = ResourceNamer.RandomResourceName("javacsmrg", 20);
+        private static readonly string WebAppName = ResourceNamer.RandomResourceName("java-webapp-", 20);
+        private static readonly string SlotName1 = ResourceNamer.RandomResourceName("java-slot-", 20);
+        private static readonly string SlotName2 = ResourceNamer.RandomResourceName("java-slot-", 20);
+        private static readonly string SlotName3 = ResourceNamer.RandomResourceName("java-slot-", 20);
+        private static readonly string AppServicePlanName = ResourceNamer.RandomResourceName("java-asp-", 20);
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
         public void CanCRUDSwapSlots()
@@ -25,9 +25,9 @@ namespace Azure.Tests.WebApp
             var appServiceManager = TestHelper.CreateAppServiceManager();
 
             // Create web app
-            var webApp = appServiceManager.WebApps.Define(WEBAPP_NAME)
-                .WithNewResourceGroup(RG_NAME)
-                .WithNewAppServicePlan(APP_SERVICE_PLAN_NAME)
+            var webApp = appServiceManager.WebApps.Define(WebAppName)
+                .WithNewResourceGroup(GroupName)
+                .WithNewAppServicePlan(AppServicePlanName)
                 .WithRegion(Region.US_WEST)
                 .WithPricingTier(AppServicePricingTier.Standard_S2)
                 .WithAppSetting("appkey", "appvalue")
@@ -41,7 +41,7 @@ namespace Azure.Tests.WebApp
             Assert.Equal(Region.US_WEST, webApp.Region);
 
             // Create a deployment slot with empty config
-            var slot1 = webApp.DeploymentSlots.Define(SLOT_NAME_1)
+            var slot1 = webApp.DeploymentSlots.Define(SlotName1)
                 .WithBrandNewConfiguration()
                 .WithPythonVersion(PythonVersion.Python_27)
                 .Create();
@@ -56,7 +56,7 @@ namespace Azure.Tests.WebApp
             Assert.False(connectionStringMap.ContainsKey("stickyName"));
 
             // Create a deployment slot with web app's config
-            var slot2 = webApp.DeploymentSlots.Define(SLOT_NAME_2)
+            var slot2 = webApp.DeploymentSlots.Define(SlotName2)
                 .WithConfigurationFromParent()
                 .Create();
             Assert.NotNull(slot2);
@@ -86,7 +86,7 @@ namespace Azure.Tests.WebApp
             Assert.Equal("slot2value", appSettingMap["slot2key"].Value);
 
             // Create 3rd deployment slot with configuration from slot 2
-            var slot3 = webApp.DeploymentSlots.Define(SLOT_NAME_3)
+            var slot3 = webApp.DeploymentSlots.Define(SlotName3)
                     .WithConfigurationFromDeploymentSlot(slot2)
                     .Create();
             Assert.NotNull(slot3);
@@ -96,7 +96,7 @@ namespace Azure.Tests.WebApp
             Assert.Equal("slot2value", appSettingMap["slot2key"].Value);
 
             // Get
-            var deploymentSlot = webApp.DeploymentSlots.GetByName(SLOT_NAME_3);
+            var deploymentSlot = webApp.DeploymentSlots.GetByName(SlotName3);
             Assert.Equal(slot3.Id, deploymentSlot.Id);
 
             // List
@@ -105,7 +105,7 @@ namespace Azure.Tests.WebApp
 
             // Swap
             slot3.Swap(slot1.Name);
-            slot1 = webApp.DeploymentSlots.GetByName(SLOT_NAME_1);
+            slot1 = webApp.DeploymentSlots.GetByName(SlotName1);
             Assert.Equal(JavaVersion.Off, slot1.JavaVersion);
             Assert.Equal(PythonVersion.Python_34, slot1.PythonVersion);
             Assert.Equal(PythonVersion.Python_27, slot3.PythonVersion);

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/DomainsTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/DomainsTests.cs
@@ -9,8 +9,8 @@ namespace Azure.Tests.WebApp
 {
     public class DomainsTests
     {
-        private static readonly string RG_NAME = "javacsmrg9b9912262";
-        private static readonly string DOMAIN_NAME = "graph-dm7720.com";
+        private static readonly string GroupName = "javacsmrg9b9912262";
+        private static readonly string DomainName = "graph-dm7720.com";
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
         public void CanCRUDDomain()
@@ -18,8 +18,8 @@ namespace Azure.Tests.WebApp
             var appServiceManager = TestHelper.CreateAppServiceManager();
 
             // CREATE
-            var domain = appServiceManager.AppServiceDomains.Define(DOMAIN_NAME)
-                .WithExistingResourceGroup(RG_NAME)
+            var domain = appServiceManager.AppServiceDomains.Define(DomainName)
+                .WithExistingResourceGroup(GroupName)
                 .DefineRegistrantContact()
                     .WithFirstName("Jianghao")
                     .WithLastName("Lu")

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/HostnameSslTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/HostnameSslTests.cs
@@ -17,9 +17,9 @@ namespace Azure.Tests.WebApp
 {
     public class HostnameSslTests
     {
-        private static readonly string RG_NAME = ResourceNamer.RandomResourceName("javacsmrg", 20);
-        private static readonly string WEBAPP_NAME = ResourceNamer.RandomResourceName("java-webapp-", 20);
-        private static readonly string APP_SERVICE_PLAN_NAME = ResourceNamer.RandomResourceName("java-asp-", 20);
+        private static readonly string GroupName = ResourceNamer.RandomResourceName("javacsmrg", 20);
+        private static readonly string WebAppName = ResourceNamer.RandomResourceName("java-webapp-", 20);
+        private static readonly string AppServicePlanName = ResourceNamer.RandomResourceName("java-asp-", 20);
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
         public async Task CanBindHostnameAndSsl()
@@ -29,40 +29,40 @@ namespace Azure.Tests.WebApp
             var certificateOrder = appServiceManager.AppServiceCertificateOrders.GetByGroup("javacsmrg9b9912262", "graphdmcert7720");
 
             // hostname binding
-            appServiceManager.WebApps.Define(WEBAPP_NAME)
-                .WithNewResourceGroup(RG_NAME)
-                .WithNewAppServicePlan(APP_SERVICE_PLAN_NAME)
+            appServiceManager.WebApps.Define(WebAppName)
+                .WithNewResourceGroup(GroupName)
+                .WithNewAppServicePlan(AppServicePlanName)
                 .WithRegion(Region.US_WEST)
                 .WithPricingTier(AppServicePricingTier.Basic_B1)
                 .DefineHostnameBinding()
                     .WithAzureManagedDomain(domain)
-                    .WithSubDomain(WEBAPP_NAME)
+                    .WithSubDomain(WebAppName)
                     .WithDnsRecordType(CustomHostNameDnsRecordType.CName)
                     .Attach()
                 .Create();
 
-            var webApp = appServiceManager.WebApps.GetByGroup(RG_NAME, WEBAPP_NAME);
+            var webApp = appServiceManager.WebApps.GetByGroup(GroupName, WebAppName);
             Assert.NotNull(webApp);
 
-            var response = await CheckAddress("http://" + WEBAPP_NAME + "." + domain.Name);
+            var response = await CheckAddress("http://" + WebAppName + "." + domain.Name);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotNull(await response.Content.ReadAsStringAsync());
 
             // hostname binding shortcut
             webApp.Update()
-                    .WithManagedHostnameBindings(domain, WEBAPP_NAME + "-1", WEBAPP_NAME + "-2")
+                    .WithManagedHostnameBindings(domain, WebAppName + "-1", WebAppName + "-2")
                     .Apply();
-            response = await CheckAddress("http://" + WEBAPP_NAME + "-1." + domain.Name);
+            response = await CheckAddress("http://" + WebAppName + "-1." + domain.Name);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotNull(await response.Content.ReadAsStringAsync());
-            response = await CheckAddress("http://" + WEBAPP_NAME + "-2." + domain.Name);
+            response = await CheckAddress("http://" + WebAppName + "-2." + domain.Name);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotNull(await response.Content.ReadAsStringAsync());
 
             // SSL binding
             webApp.Update()
                     .DefineSslBinding()
-                        .ForHostname(WEBAPP_NAME + "." + domain.Name)
+                        .ForHostname(WebAppName + "." + domain.Name)
                         .WithExistingAppServiceCertificateOrder(certificateOrder)
                         .WithSniBasedSsl()
                         .Attach()
@@ -73,7 +73,7 @@ namespace Azure.Tests.WebApp
             {
                 try
                 {
-                    response = await CheckAddress("https://" + WEBAPP_NAME + "." + domain.Name);
+                    response = await CheckAddress("https://" + WebAppName + "." + domain.Name);
                 }
                 catch (Exception)
                 {

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/SourceControlTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/SourceControlTests.cs
@@ -15,9 +15,9 @@ namespace Azure.Tests.WebApp
 {
     public class SourceControlTests
     {
-        private static readonly string RG_NAME = ResourceNamer.RandomResourceName("javacsmrg", 20);
-        private static readonly string WEBAPP_NAME = ResourceNamer.RandomResourceName("java-webapp-", 20);
-        private static readonly string APP_SERVICE_PLAN_NAME = ResourceNamer.RandomResourceName("java-asp-", 20);
+        private static readonly string GroupName = ResourceNamer.RandomResourceName("javacsmrg", 20);
+        private static readonly string WebAppName = ResourceNamer.RandomResourceName("java-webapp-", 20);
+        private static readonly string AppServicePlanName = ResourceNamer.RandomResourceName("java-asp-", 20);
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
         public async Task CanDeploySourceControl()
@@ -25,9 +25,9 @@ namespace Azure.Tests.WebApp
             var appServiceManager = TestHelper.CreateAppServiceManager();
 
             // Create web app
-            var webApp = appServiceManager.WebApps.Define(WEBAPP_NAME)
-                .WithNewResourceGroup(RG_NAME)
-                .WithNewAppServicePlan(APP_SERVICE_PLAN_NAME)
+            var webApp = appServiceManager.WebApps.Define(WebAppName)
+                .WithNewResourceGroup(GroupName)
+                .WithNewAppServicePlan(AppServicePlanName)
                 .WithRegion(Region.US_WEST)
                 .WithPricingTier(AppServicePricingTier.Standard_S1)
                 .DefineSourceControl()
@@ -36,7 +36,7 @@ namespace Azure.Tests.WebApp
                     .Attach()
                 .Create();
             Assert.NotNull(webApp);
-            var response = await CheckAddress("http://" + WEBAPP_NAME + "." + "azurewebsites.Net");
+            var response = await CheckAddress("http://" + WebAppName + "." + "azurewebsites.Net");
             Assert.Equal(HttpStatusCode.OK.ToString(), response.StatusCode.ToString());
 
             var body = await response.Content.ReadAsStringAsync();

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/WebAppConfigTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/WebAppConfigTests.cs
@@ -12,9 +12,9 @@ namespace Azure.Tests.WebApp
 {
     public class WebAppConfigTests
     {
-        private static readonly string RG_NAME = ResourceNamer.RandomResourceName("javacsmrg", 20);
-        private static readonly string WEBAPP_NAME = ResourceNamer.RandomResourceName("java-webapp-", 20);
-        private static readonly string APP_SERVICE_PLAN_NAME = ResourceNamer.RandomResourceName("java-asp-", 20);
+        private static readonly string GroupName = ResourceNamer.RandomResourceName("javacsmrg", 20);
+        private static readonly string WebAppName = ResourceNamer.RandomResourceName("java-webapp-", 20);
+        private static readonly string AppServicePlanName = ResourceNamer.RandomResourceName("java-asp-", 20);
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
         public void CanCRUDWebAppConfig()
@@ -22,15 +22,15 @@ namespace Azure.Tests.WebApp
             var appServiceManager = TestHelper.CreateAppServiceManager();
 
             // Create with new app service plan
-            appServiceManager.WebApps.Define(WEBAPP_NAME)
-                .WithNewResourceGroup(RG_NAME)
-                .WithNewAppServicePlan(APP_SERVICE_PLAN_NAME)
+            appServiceManager.WebApps.Define(WebAppName)
+                .WithNewResourceGroup(GroupName)
+                .WithNewAppServicePlan(AppServicePlanName)
                 .WithRegion(Region.US_WEST)
                 .WithPricingTier(AppServicePricingTier.Basic_B1)
                 .WithNetFrameworkVersion(NetFrameworkVersion.V3_0)
                 .Create();
 
-            var webApp = appServiceManager.WebApps.GetByGroup(RG_NAME, WEBAPP_NAME);
+            var webApp = appServiceManager.WebApps.GetByGroup(GroupName, WebAppName);
             Assert.NotNull(webApp);
             Assert.Equal(Region.US_WEST, webApp.Region);
             Assert.Equal(NetFrameworkVersion.V3_0, webApp.NetFrameworkVersion);
@@ -40,14 +40,14 @@ namespace Azure.Tests.WebApp
                 .WithJavaVersion(JavaVersion.Java_1_7_0_51)
                 .WithWebContainer(WebContainer.Tomcat_7_0_50)
                 .Apply();
-            webApp = appServiceManager.WebApps.GetByGroup(RG_NAME, WEBAPP_NAME);
+            webApp = appServiceManager.WebApps.GetByGroup(GroupName, WebAppName);
             Assert.Equal(JavaVersion.Java_1_7_0_51, webApp.JavaVersion);
 
             // Python version
             webApp.Update()
                 .WithPythonVersion(PythonVersion.Python_34)
                 .Apply();
-            webApp = appServiceManager.WebApps.GetByGroup(RG_NAME, WEBAPP_NAME);
+            webApp = appServiceManager.WebApps.GetByGroup(GroupName, WebAppName);
             Assert.Equal(PythonVersion.Python_34, webApp.PythonVersion);
 
             // Default documents
@@ -55,7 +55,7 @@ namespace Azure.Tests.WebApp
             webApp.Update()
                     .WithDefaultDocument("somedocument.Html")
                     .Apply();
-            webApp = appServiceManager.WebApps.GetByGroup(RG_NAME, WEBAPP_NAME);
+            webApp = appServiceManager.WebApps.GetByGroup(GroupName, WebAppName);
             Assert.Equal(documentSize + 1, webApp.DefaultDocuments.Count);
             Assert.True(webApp.DefaultDocuments.Contains("somedocument.Html"));
 
@@ -64,7 +64,7 @@ namespace Azure.Tests.WebApp
                     .WithAppSetting("appkey", "appvalue")
                     .WithStickyAppSetting("stickykey", "stickyvalue")
                     .Apply();
-            webApp = appServiceManager.WebApps.GetByGroup(RG_NAME, WEBAPP_NAME);
+            webApp = appServiceManager.WebApps.GetByGroup(GroupName, WebAppName);
             var appSettingMap = webApp.AppSettings;
             Assert.Equal("appvalue", appSettingMap["appkey"].Value);
             Assert.Equal(false, appSettingMap["appkey"].Sticky);
@@ -76,7 +76,7 @@ namespace Azure.Tests.WebApp
                     .WithConnectionString("connectionName", "connectionValue", ConnectionStringType.Custom)
                     .WithStickyConnectionString("stickyName", "stickyValue", ConnectionStringType.Custom)
                     .Apply();
-            webApp = appServiceManager.WebApps.GetByGroup(RG_NAME, WEBAPP_NAME);
+            webApp = appServiceManager.WebApps.GetByGroup(GroupName, WebAppName);
             var connectionStringMap = webApp.ConnectionStrings;
             Assert.Equal("connectionValue", connectionStringMap["connectionName"].Value);
             Assert.Equal(false, connectionStringMap["connectionName"].Sticky);

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/WebAppsTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/WebAppsTests.cs
@@ -11,12 +11,12 @@ namespace Azure.Tests.WebApp
 {
     public class WebAppsTests
     {
-        private static readonly string RG_NAME_1 = ResourceNamer.RandomResourceName("javacsmrg", 20);
-        private static readonly string RG_NAME_2 = ResourceNamer.RandomResourceName("javacsmrg", 20);
-        private static readonly string WEBAPP_NAME_1 = ResourceNamer.RandomResourceName("java-webapp-", 20);
-        private static readonly string WEBAPP_NAME_2 = ResourceNamer.RandomResourceName("java-webapp-", 20);
-        private static readonly string APP_SERVICE_PLAN_NAME_1 = ResourceNamer.RandomResourceName("java-asp-", 20);
-        private static readonly string APP_SERVICE_PLAN_NAME_2 = ResourceNamer.RandomResourceName("java-asp-", 20);
+        private static readonly string GroupName1 = ResourceNamer.RandomResourceName("javacsmrg", 20);
+        private static readonly string GroupName2 = ResourceNamer.RandomResourceName("javacsmrg", 20);
+        private static readonly string WebAppName1 = ResourceNamer.RandomResourceName("java-webapp-", 20);
+        private static readonly string WebAppName2 = ResourceNamer.RandomResourceName("java-webapp-", 20);
+        private static readonly string AppServicePlanName1 = ResourceNamer.RandomResourceName("java-asp-", 20);
+        private static readonly string AppServicePlanName2 = ResourceNamer.RandomResourceName("java-asp-", 20);
 
         [Fact(Skip = "TODO: Convert to recorded tests")]
         public void CanCRUDWebApp()
@@ -24,46 +24,46 @@ namespace Azure.Tests.WebApp
             var appServiceManager = TestHelper.CreateAppServiceManager();
 
             // Create with new app service plan
-            var webApp1 = appServiceManager.WebApps.Define(WEBAPP_NAME_1)
-                .WithNewResourceGroup(RG_NAME_1)
-                .WithNewAppServicePlan(APP_SERVICE_PLAN_NAME_1)
+            var webApp1 = appServiceManager.WebApps.Define(WebAppName1)
+                .WithNewResourceGroup(GroupName1)
+                .WithNewAppServicePlan(AppServicePlanName1)
                 .WithRegion(Region.US_WEST)
                 .WithPricingTier(AppServicePricingTier.Basic_B1)
                 .WithRemoteDebuggingEnabled(RemoteVisualStudioVersion.VS2013)
                 .Create();
             Assert.NotNull(webApp1);
             Assert.Equal(Region.US_WEST, webApp1.Region);
-            var plan1 = appServiceManager.AppServicePlans.GetByGroup(RG_NAME_1, APP_SERVICE_PLAN_NAME_1);
+            var plan1 = appServiceManager.AppServicePlans.GetByGroup(GroupName1, AppServicePlanName1);
             Assert.NotNull(plan1);
             Assert.Equal(Region.US_WEST, plan1.Region);
             Assert.Equal(AppServicePricingTier.Basic_B1, plan1.PricingTier);
 
             // Create in a new group with existing app service plan
-            var webApp2 = appServiceManager.WebApps.Define(WEBAPP_NAME_2)
-                .WithNewResourceGroup(RG_NAME_2)
+            var webApp2 = appServiceManager.WebApps.Define(WebAppName2)
+                .WithNewResourceGroup(GroupName2)
                 .WithExistingAppServicePlan(plan1)
                 .Create();
             Assert.NotNull(webApp2);
             Assert.Equal(Region.US_WEST, webApp1.Region);
 
             // Get
-            var webApp = appServiceManager.WebApps.GetByGroup(RG_NAME_1, webApp1.Name);
+            var webApp = appServiceManager.WebApps.GetByGroup(GroupName1, webApp1.Name);
             Assert.Equal(webApp1.Id, webApp.Id);
             webApp = appServiceManager.WebApps.GetById(webApp2.Id);
             Assert.Equal(webApp2.Name, webApp.Name);
 
             // List
-            var webApps = appServiceManager.WebApps.ListByGroup(RG_NAME_1);
+            var webApps = appServiceManager.WebApps.ListByGroup(GroupName1);
             Assert.Equal(1, webApps.Count);
-            webApps = appServiceManager.WebApps.ListByGroup(RG_NAME_2);
+            webApps = appServiceManager.WebApps.ListByGroup(GroupName2);
             Assert.Equal(1, webApps.Count);
 
             // Update
             webApp1.Update()
-                .WithNewAppServicePlan(APP_SERVICE_PLAN_NAME_2)
+                .WithNewAppServicePlan(AppServicePlanName2)
                 .WithPricingTier(AppServicePricingTier.Standard_S2)
                 .Apply();
-            var plan2 = appServiceManager.AppServicePlans.GetByGroup(RG_NAME_1, APP_SERVICE_PLAN_NAME_2);
+            var plan2 = appServiceManager.AppServicePlans.GetByGroup(GroupName1, AppServicePlanName2);
             Assert.NotNull(plan2);
             Assert.Equal(Region.US_WEST, plan2.Region);
             Assert.Equal(AppServicePricingTier.Standard_S2, plan2.PricingTier);


### PR DESCRIPTION
cleaning up artifacts of the conversion from Java