### PR TITLE
Search SDK: Fixing Timeout and removing unneeded projects from the so…

### DIFF
--- a/src/Search/Microsoft.Azure.Search/Customizations/Indexers/Models/IndexingParametersExtensions.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Indexers/Models/IndexingParametersExtensions.cs
@@ -93,8 +93,8 @@ namespace Microsoft.Azure.Search.Models
         public static IndexingParameters SkipContent(this IndexingParameters parameters)
         { 
             return parameters.SetBlobExtractionMode(BlobExtractionMode.AllMetadata); 
-        } 
- 
+        }
+
         /// <summary>
         /// Specifies which parts of a blob will be indexed by the blob storage indexer. 
         /// </summary>
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Search.Models
         /// <see href="https://docs.microsoft.com/azure/search/search-howto-indexing-azure-blob-storage" />
         /// </remarks>
         /// <param name="parameters">IndexingParameters to configure.</param>
-        /// <param name="extractionMode">A <c cref="BlobExtractionMode" /> value specifying what to index.</param>
+        /// <param name="extractionMode">A <c cref="BlobExtractionMode">BlobExtractionMode</c> value specifying what to index.</param>
         /// <returns>The IndexingParameters instance.</returns>
         public static IndexingParameters SetBlobExtractionMode(this IndexingParameters parameters, BlobExtractionMode extractionMode)
         {
@@ -111,8 +111,8 @@ namespace Microsoft.Azure.Search.Models
         }
 
         /// <summary>
-        /// Specifies that <c cref="BlobExtractionMode.StorageMetadata"/> blob extraction mode will be automatically used for blobs of unsupported content types.  
-        /// The default is false. 
+        /// Specifies that <c cref="BlobExtractionMode.StorageMetadata">BlobExtractionMode.StorageMetadata</c> blob extraction mode will be
+        /// automatically used for blobs of unsupported content types. The default is false.
         /// </summary>
         /// <remarks>
         /// This option only applies to indexers that index Azure Blob Storage.

--- a/src/Search/Microsoft.Azure.Search/Customizations/Indexes/IndexesOperations.Customization.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Indexes/IndexesOperations.Customization.cs
@@ -36,7 +36,9 @@ namespace Microsoft.Azure.Search
             // Argument checking is done by the SearchIndexClient constructor. Note that HttpClient can't be shared in
             // case it has already been used (SearchIndexClient will attempt to set the Timeout property on it).
             Uri indexBaseUri = new Uri(Client.BaseUri, String.Format("indexes('{0}')", indexName));
-            return new SearchIndexClient(indexBaseUri, Client.Credentials);
+            var indexClient = new SearchIndexClient(indexBaseUri, Client.Credentials);
+            indexClient.HttpClient.Timeout = this.Client.HttpClient.Timeout;
+            return indexClient;
         }
     }
 }

--- a/src/Search/Microsoft.Azure.Search/Customizations/Models/ExtensibleEnum.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Models/ExtensibleEnum.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Azure.Search.Models
         {
             Throw.IfArgumentNull(name, "name");
 
-            T analyzerName;
-            return _nameMap.Value.TryGetValue(name, out analyzerName) ? analyzerName : null;
+            T enumValue;
+            return _nameMap.Value.TryGetValue(name, out enumValue) ? enumValue : null;
         }
 
         /// <summary>

--- a/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
+++ b/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Makes it easy to develop a .NET application that uses Azure Search.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.1.0")]
+[assembly: AssemblyFileVersion("3.0.2.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/Search/Microsoft.Azure.Search/project.json
+++ b/src/Search/Microsoft.Azure.Search/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.1",
+  "version": "3.0.2",
   "title": "Microsoft Azure Search Library",
   "description": "Makes it easy to develop a .NET application that uses Azure Search.",
   "authors": [ "Microsoft" ],
@@ -11,7 +11,7 @@
     "iconUrl": "http://go.microsoft.com/fwlink/?LinkID=288890",
     "tags": [ "Microsoft Azure Search", "REST HTTP client", "search", "azureofficial", "windowsazureofficial" ],
     "requireLicenseAcceptance": true,
-    "releaseNotes": "This is the next major version of the Azure Search .NET SDK, based on version 2016-09-01 of the Azure Search REST API. New in this version is support for indexing Azure Blob and Table storage, indexer field mappings, custom analyzers, and ETags. Also included is support for reflection-based field definitions via the FieldBuilder class, thanks to a contribution from Ian Griffiths (https://github.com/idg10). See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade."
+    "releaseNotes": "This is the newest major version of the Azure Search .NET SDK, based on version 2016-09-01 of the Azure Search REST API. New in this version is support for indexing Azure Blob and Table storage, indexer field mappings, custom analyzers, and ETags. Also included is support for reflection-based field definitions via the FieldBuilder class, thanks to a contribution from Ian Griffiths (https://github.com/idg10). See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade."
   },
 
   "buildOptions": {

--- a/src/Search/Search.Management.Tests/project.json
+++ b/src/Search/Search.Management.Tests/project.json
@@ -29,11 +29,11 @@
       "version": "1.0.0"
     },
     "Microsoft.Azure.Test.HttpRecorder": "[1.6.7-preview,2.0.0)",
-    "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "[1.5.0-preview,2.0.0)",
+    "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "[1.5.1-preview,2.0.0)",
     "Microsoft.Rest.ClientRuntime.Azure": "[3.3.*,4.0)",
     "Microsoft.Azure.Management.ResourceManager": "1.1.1-preview",
     "Microsoft.Azure.Management.Search": "1.0.1",
-    "Microsoft.Azure.Search": "3.0.1",
+    "Microsoft.Azure.Search": "3.0.2",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   }

--- a/src/Search/Search.Tests/SessionRecords/Microsoft.Azure.Search.Tests.SearchServiceClientTests/IndexClientHasSameTimeoutAsSearchClient.json
+++ b/src/Search/Search.Tests/SessionRecords/Microsoft.Azure.Search.Tests.SearchServiceClientTests/IndexClientHasSameTimeoutAsSearchClient.json
@@ -1,0 +1,404 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/providers/Microsoft.Search/register?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3JlZ2lzdGVyP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "1f5ef22e-004b-42cd-ae55-34370ab94aa4"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24214.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.1.1-preview"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/providers/Microsoft.Search\",\r\n  \"namespace\": \"Microsoft.Search\",\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"searchServices\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesCit\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesNxt\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesInt\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesPpe\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityCit\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityNxt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityInt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityPpe\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityCit\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityNxt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityInt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityPpe\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 11 Jan 2017 01:44:42 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1194"
+        ],
+        "x-ms-request-id": [
+          "ee652046-247f-417c-b368-f2f93146e7ff"
+        ],
+        "x-ms-correlation-request-id": [
+          "ee652046-247f-417c-b368-f2f93146e7ff"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20170111T014442Z:ee652046-247f-417c-b368-f2f93146e7ff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourcegroups/azsmnet5114?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlZ3JvdXBzL2F6c21uZXQ1MTE0P2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"West US\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "29"
+        ],
+        "x-ms-client-request-id": [
+          "8ff74971-5887-4e6f-8779-54e4e6e5acea"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24214.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.1.1-preview"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet5114\",\r\n  \"name\": \"azsmnet5114\",\r\n  \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "175"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 11 Jan 2017 01:44:42 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1193"
+        ],
+        "x-ms-request-id": [
+          "700159e9-65e1-4dfa-b455-b1d4ca78c9e3"
+        ],
+        "x-ms-correlation-request-id": [
+          "700159e9-65e1-4dfa-b455-b1d4ca78c9e3"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20170111T014442Z:700159e9-65e1-4dfa-b455-b1d4ca78c9e3"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet5114/providers/Microsoft.Search/searchServices/azs-5680?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ1MTE0L3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy01NjgwP2FwaS12ZXJzaW9uPTIwMTUtMDgtMTk=",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"free\"\r\n  },\r\n  \"location\": \"West US\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "67"
+        ],
+        "x-ms-client-request-id": [
+          "8c21972c-a886-48b9-8443-b6b34e505e10"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24214.01",
+          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet5114/providers/Microsoft.Search/searchServices/azs-5680\",\r\n  \"name\": \"azs-5680\",\r\n  \"type\": \"Microsoft.Search/searchServices\",\r\n  \"location\": \"West US\",\r\n  \"properties\": {\r\n    \"replicaCount\": 1,\r\n    \"partitionCount\": 1,\r\n    \"status\": \"running\",\r\n    \"statusDetails\": null,\r\n    \"provisioningState\": \"succeeded\",\r\n    \"hostingMode\": \"Default\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"free\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "387"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 11 Jan 2017 01:44:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "ETag": [
+          "W/\"datetime'2017-01-11T01%3A44%3A51.0037433Z'\""
+        ],
+        "x-ms-request-id": [
+          "8c21972c-a886-48b9-8443-b6b34e505e10"
+        ],
+        "request-id": [
+          "8c21972c-a886-48b9-8443-b6b34e505e10"
+        ],
+        "elapsed-time": [
+          "5873"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1193"
+        ],
+        "x-ms-correlation-request-id": [
+          "c4e310d3-e872-474e-8254-8ec5482448ae"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20170111T014449Z:c4e310d3-e872-474e-8254-8ec5482448ae"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet5114/providers/Microsoft.Search/searchServices/azs-5680/listAdminKeys?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ1MTE0L3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy01NjgwL2xpc3RBZG1pbktleXM/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "bf6bd379-bae0-481e-a672-0f358b878907"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24214.01",
+          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"primaryKey\": \"323635C986C4DBA3004C6688C32C3880\",\r\n  \"secondaryKey\": \"11CB1F1B4555DA1C4A5AE3F83D05E3C2\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 11 Jan 2017 01:44:52 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding",
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "bf6bd379-bae0-481e-a672-0f358b878907"
+        ],
+        "request-id": [
+          "bf6bd379-bae0-481e-a672-0f358b878907"
+        ],
+        "elapsed-time": [
+          "395"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1192"
+        ],
+        "x-ms-correlation-request-id": [
+          "0dba3df2-d74d-4080-91c5-5c750f496c7a"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20170111T014452Z:0dba3df2-d74d-4080-91c5-5c750f496c7a"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet5114/providers/Microsoft.Search/searchServices/azs-5680/listQueryKeys?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ1MTE0L3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy01NjgwL2xpc3RRdWVyeUtleXM/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "3f15c9fd-e3cc-4741-9624-60564222accd"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24214.01",
+          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": null,\r\n      \"key\": \"698CD4BADD4CD69918C775EBA9E5F171\"\r\n    }\r\n  ],\r\n  \"nextLink\": null\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 11 Jan 2017 01:44:52 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding",
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "3f15c9fd-e3cc-4741-9624-60564222accd"
+        ],
+        "request-id": [
+          "3f15c9fd-e3cc-4741-9624-60564222accd"
+        ],
+        "elapsed-time": [
+          "281"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14992"
+        ],
+        "x-ms-correlation-request-id": [
+          "16abb290-ec41-431b-86a3-19b70d7e56c0"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20170111T014452Z:16abb290-ec41-431b-86a3-19b70d7e56c0"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet5114/providers/Microsoft.Search/searchServices/azs-5680?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ1MTE0L3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy01NjgwP2FwaS12ZXJzaW9uPTIwMTUtMDgtMTk=",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "b2ef444f-ed9b-4ebe-9262-3773e02b63c3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24214.01",
+          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.1"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 11 Jan 2017 01:44:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "b2ef444f-ed9b-4ebe-9262-3773e02b63c3"
+        ],
+        "request-id": [
+          "b2ef444f-ed9b-4ebe-9262-3773e02b63c3"
+        ],
+        "elapsed-time": [
+          "602"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1190"
+        ],
+        "x-ms-correlation-request-id": [
+          "bd325526-81cf-4b7b-a5b9-2bfe9ddd36b3"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20170111T014454Z:bd325526-81cf-4b7b-a5b9-2bfe9ddd36b3"
+        ]
+      },
+      "StatusCode": 200
+    }
+  ],
+  "Names": {
+    "GenerateName": [
+      "azsmnet5114"
+    ],
+    "GenerateServiceName": [
+      "azs-5680"
+    ]
+  },
+  "Variables": {
+    "SubscriptionId": "b80cf239-2c72-47ab-b309-b26aec4656b1"
+  }
+}

--- a/src/Search/Search.Tests/Tests/SearchServiceClientTests.cs
+++ b/src/Search/Search.Tests/Tests/SearchServiceClientTests.cs
@@ -46,6 +46,20 @@ namespace Microsoft.Azure.Search.Tests
         }
 
         [Fact]
+        public void IndexClientHasSameTimeoutAsSearchClient()
+        {
+            Run(() =>
+            {
+                SearchServiceClient serviceClient = Data.GetSearchServiceClient();
+                serviceClient.HttpClient.Timeout = TimeSpan.FromMinutes(30);
+
+                SearchIndexClient indexClient = (SearchIndexClient)serviceClient.Indexes.GetClient("test");
+
+                Assert.Equal(serviceClient.HttpClient.Timeout, indexClient.HttpClient.Timeout);
+            });
+        }
+
+        [Fact]
         public void CanGetAnIndexClientAfterUsingServiceClient()
         {
             Run(() =>

--- a/src/Search/Search.Tests/project.json
+++ b/src/Search/Search.Tests/project.json
@@ -29,7 +29,7 @@
       "version": "1.0.0" 
     }, 
     "Search.Management.Tests": "1.0.0",
-    "Microsoft.Azure.Search": "3.0.1",
+    "Microsoft.Azure.Search": "3.0.2",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0"
   }
 }

--- a/src/Search/Search.sln
+++ b/src/Search/Search.sln
@@ -11,12 +11,6 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Search.Tests", "Search.Test
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.Search", "Microsoft.Azure.Management.Search\Microsoft.Azure.Management.Search.xproj", "{4E616081-9A63-4778-B1D3-4CF35C5A5763}"
 EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Rest.ClientRuntime", "..\ClientRuntime\Microsoft.Rest.ClientRuntime\Microsoft.Rest.ClientRuntime.xproj", "{EDDB6367-5C7B-428C-B54C-96BCD90F6E6C}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Rest.ClientRuntime.Azure", "..\ClientRuntime\Microsoft.Rest.ClientRuntime.Azure\Microsoft.Rest.ClientRuntime.Azure.xproj", "{D5296EAB-C13E-4A88-9532-BD0677D18EC9}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Rest.ClientRuntime.Azure.Authentication", "..\ClientRuntime\Microsoft.Rest.ClientRuntime.Azure.Authentication\Microsoft.Rest.ClientRuntime.Azure.Authentication.xproj", "{6319205D-BBFC-4150-BEAE-31B1C9B911DD}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,18 +33,6 @@ Global
 		{4E616081-9A63-4778-B1D3-4CF35C5A5763}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4E616081-9A63-4778-B1D3-4CF35C5A5763}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4E616081-9A63-4778-B1D3-4CF35C5A5763}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EDDB6367-5C7B-428C-B54C-96BCD90F6E6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EDDB6367-5C7B-428C-B54C-96BCD90F6E6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EDDB6367-5C7B-428C-B54C-96BCD90F6E6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EDDB6367-5C7B-428C-B54C-96BCD90F6E6C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D5296EAB-C13E-4A88-9532-BD0677D18EC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D5296EAB-C13E-4A88-9532-BD0677D18EC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D5296EAB-C13E-4A88-9532-BD0677D18EC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D5296EAB-C13E-4A88-9532-BD0677D18EC9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6319205D-BBFC-4150-BEAE-31B1C9B911DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6319205D-BBFC-4150-BEAE-31B1C9B911DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6319205D-BBFC-4150-BEAE-31B1C9B911DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6319205D-BBFC-4150-BEAE-31B1C9B911DD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Search/global.json
+++ b/src/Search/global.json
@@ -1,3 +1,3 @@
 {
-  "projects": [ "../ClientRuntime", "Microsoft.Azure.Search", "Microsoft.Azure.Management.Search", "Search.Management.Tests", "Search.Tests", "../TestFramework" ]
+  "projects": [ "Microsoft.Azure.Search", "Microsoft.Azure.Management.Search", "Search.Management.Tests", "Search.Tests" ]
 }


### PR DESCRIPTION
…lution

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Fixes #2604

Now when you call `searchClient.Indexex.GetClient()`, it will propagate the `Timeout` value set on the searchClient's `HttpClient`.

FYI @markcowl: We're removing project references to TestFramework, HttpRecorder, and the ClientRuntime libraries. We prefer NuGet references over project references for the Search SDK solution for a couple reasons:

- It speeds up build times.
- It avoids build errors when the dependent projects change in unpredictable ways.
- It avoids the dreaded "An item with the same key has already been added" build error (see https://github.com/dotnet/cli/issues/1860)

Finally, we're also bumping the version of the data plane SDK to 3.0.2 and fixing some typos.

There are no Swagger or generated code changes for this PR.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md).**
- [X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/dev/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#testing-guidelines)
- [X] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#sdk-generation-guidelines)
- [X] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [X] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [X] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.