### PR TITLE
Update the version of ADL the uploader uses

### DIFF
--- a/src/ResourceManagement/DataLake.StoreUploader/src/Microsoft.Azure.Management.DataLake.StoreUploader.csproj
+++ b/src/ResourceManagement/DataLake.StoreUploader/src/Microsoft.Azure.Management.DataLake.StoreUploader.csproj
@@ -68,7 +68,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.Management.DataLake.Store, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.1.0.2-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
+      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.1.0.3\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/src/ResourceManagement/DataLake.StoreUploader/src/Microsoft.Azure.Management.DataLake.StoreUploader.nuspec
+++ b/src/ResourceManagement/DataLake.StoreUploader/src/Microsoft.Azure.Management.DataLake.StoreUploader.nuspec
@@ -22,7 +22,7 @@
       </group>
     </references>
     <dependencies>
-      <dependency id="Microsoft.Azure.Management.DataLake.Store" version="[1.0.2-preview,2.0.0-preview)" />
+      <dependency id="Microsoft.Azure.Management.DataLake.Store" version="[1.0.3,2.0.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/ResourceManagement/DataLake.StoreUploader/src/packages.config
+++ b/src/ResourceManagement/DataLake.StoreUploader/src/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Management.DataLake.Store" version="1.0.2-preview" targetFramework="net45" />
+  <package id="Microsoft.Azure.Management.DataLake.Store" version="1.0.3" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.2" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />

--- a/src/ResourceManagement/DataLake.StoreUploader/tests/DataLakeStoreUploader.Tests.csproj
+++ b/src/ResourceManagement/DataLake.StoreUploader/tests/DataLakeStoreUploader.Tests.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.Management.DataLake.Store, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.1.0.2-preview\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
+      <HintPath>$(LibraryNugetPackageFolder)\Microsoft.Azure.Management.DataLake.Store.1.0.3\lib\net45\Microsoft.Azure.Management.DataLake.Store.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/src/ResourceManagement/DataLake.StoreUploader/tests/packages.config
+++ b/src/ResourceManagement/DataLake.StoreUploader/tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Management.DataLake.Store" version="1.0.2-preview" targetFramework="net45" />
+  <package id="Microsoft.Azure.Management.DataLake.Store" version="1.0.3" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.2" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />


### PR DESCRIPTION
Before publishing the latest uploader, I want to have it properly rely
on the stable versions of the ADL package and restrict it to the current
version range of the ADLS package.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Before publishing the latest uploader package, it should properly rely on the stable version of the ADL package. This change also properly restricts its versioning to 1.0.3 - 2.0.0 (removing -preview) in the version range.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/dev/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [x] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.