### PR TITLE
Remove frameworkAssemblies section in project.json

### DIFF
--- a/src/ResourceManagement/CognitiveServices/Microsoft.Azure.Management.CognitiveServices/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/CognitiveServices/Microsoft.Azure.Management.CognitiveServices/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Provides Microsoft Azure Cognitive Services management functions for managing Microsoft Azure Cognitive Services accounts.")]
 
 [assembly: AssemblyVersion("0.2.0.0")]
-[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.1.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/CognitiveServices/Microsoft.Azure.Management.CognitiveServices/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/CognitiveServices/Microsoft.Azure.Management.CognitiveServices/Properties/AssemblyInfo.cs
@@ -19,8 +19,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Management Library")]
 [assembly: AssemblyDescription("Provides Microsoft Azure Cognitive Services management functions for managing Microsoft Azure Cognitive Services accounts.")]
 
-[assembly: AssemblyVersion("0.2.1.0")]
-[assembly: AssemblyFileVersion("0.2.1.0")]
+[assembly: AssemblyVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.2.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/CognitiveServices/Microsoft.Azure.Management.CognitiveServices/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/CognitiveServices/Microsoft.Azure.Management.CognitiveServices/Properties/AssemblyInfo.cs
@@ -19,8 +19,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Management Library")]
 [assembly: AssemblyDescription("Provides Microsoft Azure Cognitive Services management functions for managing Microsoft Azure Cognitive Services accounts.")]
 
-[assembly: AssemblyVersion("0.2.0.0")]
-[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyVersion("0.2.1.0")]
+[assembly: AssemblyFileVersion("0.2.1.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/CognitiveServices/Microsoft.Azure.Management.CognitiveServices/project.json
+++ b/src/ResourceManagement/CognitiveServices/Microsoft.Azure.Management.CognitiveServices/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0-preview",
+  "version": "0.2.1-preview",
   "description": "Microsoft Azure Management Cognitive Services Library",
   "authors": [ "Microsoft" ],
 
@@ -23,12 +23,6 @@
 
   "frameworks": {
     "net45": {
-      "frameworkAssemblies": {
-        "System.Collections": "",
-        "System.Linq.Expressions": "",
-        "System.Runtime.Serialization": "",
-        "System.Threading.Tasks": ""
-      },
       "dependencies": {
         "Microsoft.Rest.ClientRuntime": "[2.1.0,3.0.0)",
         "Microsoft.Rest.ClientRuntime.Azure": "[3.1.0,4.0.0)"


### PR DESCRIPTION
Completely remove frameworkAssemblies section in project.json: this
section causes NuGet package installation failure in VS
ToolsVersion="12.0".
Bump the version to 0.2.1.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/dev/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [x] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.