### PR TITLE
Changed default BaseUri to SSL (http to https)

### DIFF
--- a/src/ResourceManagement/PowerBIEmbedded/Microsoft.Azure.Management.PowerBIEmbedded/Generated/PowerBIEmbeddedManagementClient.cs
+++ b/src/ResourceManagement/PowerBIEmbedded/Microsoft.Azure.Management.PowerBIEmbedded/Generated/PowerBIEmbeddedManagementClient.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Azure.Management.PowerBIEmbedded
         {
             this.WorkspaceCollections = new WorkspaceCollectionsOperations(this);
             this.Workspaces = new WorkspacesOperations(this);
-            this.BaseUri = new Uri("http://management.azure.com");
+            this.BaseUri = new Uri("https://management.azure.com");
             this.ApiVersion = "2016-01-29";
             this.AcceptLanguage = "en-US";
             this.LongRunningOperationRetryTimeout = 30;

--- a/src/ResourceManagement/PowerBIEmbedded/Microsoft.Azure.Management.PowerBIEmbedded/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/PowerBIEmbedded/Microsoft.Azure.Management.PowerBIEmbedded/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Provides Microsoft Azure Power BI Embedded management functions for managing the Microsoft Azure Power BI Embedded.")]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.6.0")]
+[assembly: AssemblyFileVersion("1.0.7.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/PowerBIEmbedded/Microsoft.Azure.Management.PowerBIEmbedded/project.json
+++ b/src/ResourceManagement/PowerBIEmbedded/Microsoft.Azure.Management.PowerBIEmbedded/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.6-preview",
+    "version": "1.0.7-preview",
     "description": "Microsoft Azure Management Power BI Embedded Library",
     "authors": [
         "Microsoft"


### PR DESCRIPTION
https://github.com/Azure/azure-rest-api-specs/pull/900

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/dev/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [x] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.