### PR TITLE
Fixing bug with get activity windows operation for named pipeline or …

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
@@ -1,4 +1,11 @@
-For additional details on features, see the full [Azure Data Factory Release Notes](https://azure.microsoft.com/en-us/documentation/articles/data-factory-release-notes). 
+﻿For additional details on features, see the full [Azure Data Factory Release Notes](https://azure.microsoft.com/en-us/documentation/articles/data-factory-release-notes). 
+
+## Version 4.11.1
+_Release date: 2017.02.03_ 
+
+### Feature Additions
+
+* Fixing bug with get activity windows operation for named pipeline or activity
 
 ## Version 4.11.0
 _Release date: 2016.09.13_ 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/ActivityTypeOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/ActivityTypeOperations.cs
@@ -231,11 +231,11 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                     {
                         result.Status = OperationStatus.Failed;
                     }
-                    if (statusCode == HttpStatusCode.OK)
+                    if (statusCode == HttpStatusCode.NoContent)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }
-                    if (statusCode == HttpStatusCode.NoContent)
+                    if (statusCode == HttpStatusCode.OK)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/ActivityWindowOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/ActivityWindowOperations.cs
@@ -927,7 +927,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(parameters.ResourceGroupName);
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(parameters.DataFactoryName);
-            url = url + "/pipelines/";
+            url = url + "/datapipelines/";
             url = url + Uri.EscapeDataString(parameters.PipelineName);
             url = url + "/activitywindows";
             List<string> queryParameters = new List<string>();
@@ -1338,7 +1338,7 @@ namespace Microsoft.Azure.Management.DataFactories.Core
             url = url + Uri.EscapeDataString(parameters.ResourceGroupName);
             url = url + "/providers/Microsoft.DataFactory/datafactories/";
             url = url + Uri.EscapeDataString(parameters.DataFactoryName);
-            url = url + "/pipelines/";
+            url = url + "/datapipelines/";
             url = url + Uri.EscapeDataString(parameters.PipelineName);
             url = url + "/activities/";
             url = url + Uri.EscapeDataString(parameters.ActivityName);

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/ComputeTypeOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/ComputeTypeOperations.cs
@@ -232,11 +232,11 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                     {
                         result.Status = OperationStatus.Failed;
                     }
-                    if (statusCode == HttpStatusCode.OK)
+                    if (statusCode == HttpStatusCode.NoContent)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }
-                    if (statusCode == HttpStatusCode.NoContent)
+                    if (statusCode == HttpStatusCode.OK)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/PipelineOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/PipelineOperations.cs
@@ -2233,11 +2233,11 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                     {
                         result.Status = OperationStatus.Failed;
                     }
-                    if (statusCode == HttpStatusCode.OK)
+                    if (statusCode == HttpStatusCode.NoContent)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }
-                    if (statusCode == HttpStatusCode.NoContent)
+                    if (statusCode == HttpStatusCode.OK)
                     {
                         result.Status = OperationStatus.Succeeded;
                     }

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataFactories
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataFactories">
-      <PackageVersion>4.11.0</PackageVersion>
+      <PackageVersion>4.11.1</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Factory management operations.")]
 
 [assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.11.0.0")]
+[assembly: AssemblyFileVersion("4.11.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
…activity

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/dev/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [x] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.