### PR TITLE
Stop building ClientRuntime before every build

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -79,11 +79,6 @@
 	<UsingTask TaskName="FilterOutAutoRestLibraries" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
 	<UsingTask TaskName="BuildProjectTemplatesTask" AssemblyFile="$(LibraryToolsFolder)\Microsoft.WindowsAzure.Build.Tasks.dll"  />
   
-	<!-- Building ClientRuntime projects -->
-	<Target Name="BuildClientRuntime" Condition="Exists($(ClientRuntimeRootDir))">
-	  <Exec Command="dotnet restore" WorkingDirectory="%(ClientRuntimeProjects.RootDir)\%(ClientRuntimeProjects.Directory)"/>
-	  <Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(ClientRuntimeProjects.RootDir)\%(ClientRuntimeProjects.Directory)"/>
-	</Target>
 
 	<Target Name="DisableSN" > 
 		<!-- Check for admin privs -->
@@ -141,7 +136,7 @@
 		  Condition="!Exists('$(ZipExe)')" />
 	</Target>
   
-	<Target Name="Build" DependsOnTargets="BuildClientRuntime;BuildMsBuildTask;PrepareForAutoRestLibraries;RestoreNugetPackages">
+	<Target Name="Build" DependsOnTargets="BuildMsBuildTask;PrepareForAutoRestLibraries;RestoreNugetPackages">
 		<PropertyGroup>
 		  <_ExtraPropertyList>CodeSign=$(CodeSign)</_ExtraPropertyList>
 		  <_TemporaryNetCoreFeeds>-s https://api.nuget.org/v3/index.json -s https://dotnet.myget.org/F/cli-deps/api/v3/index.json</_TemporaryNetCoreFeeds>


### PR DESCRIPTION
  - The client runtime doesn't need to be built before every build. In the scope == all case, it is already
    covered by the recursive *.sln include, and in the individual package case it should be included by the target .sln if it's really needed.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/dev/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.