### PR TITLE
Fixed TestFramework multi-threaded access to records queue.

### DIFF
--- a/src/TestFramework/HttpRecorder.Tests/project.json
+++ b/src/TestFramework/HttpRecorder.Tests/project.json
@@ -30,8 +30,8 @@
       "type": "platform",
       "version": "1.0.0"
     },
-    "Microsoft.Azure.Test.HttpRecorder": "[1.6.8,2.0.0)",
-    "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "[1.5.2,2.0.0)",
+    "Microsoft.Azure.Test.HttpRecorder": "[1.6.9,2.0.0)",
+    "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "[1.5.3,2.0.0)",
     "Microsoft.Rest.ClientRuntime.Azure": "[3.3.5,4.0.0)",
     "xunit": "2.2.0-beta4-build3444",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"

--- a/src/TestFramework/Microsoft.Azure.Test.HttpRecorder/Properties/AssemblyInfo.cs
+++ b/src/TestFramework/Microsoft.Azure.Test.HttpRecorder/Properties/AssemblyInfo.cs
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("c77934b2-fc7c-4f23-b2e1-12da90bfe716")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.6.8.0")]
+[assembly: AssemblyFileVersion("1.6.9.0")]

--- a/src/TestFramework/Microsoft.Azure.Test.HttpRecorder/project.json
+++ b/src/TestFramework/Microsoft.Azure.Test.HttpRecorder/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.6.8",
+  "version": "1.6.9",
   "copyright": "Copyright (c) Microsoft Corporation",
   "title": "HttpRecorder Library for recording Clinet/Server communication in Azure",
   "description": "Microsoft.Azure.Test.HttpRecorder",

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/Properties/AssemblyInfo.cs
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/Properties/AssemblyInfo.cs
@@ -16,5 +16,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6eb355e3-e1e1-4f46-bcfa-737812ccff87")]
-[assembly: AssemblyVersion("1.5.1.0")]
-[assembly: AssemblyFileVersion("1.5.2.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.3.0")]

--- a/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/project.json
+++ b/src/TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.5.2",
+  "version": "1.5.3",
   "copyright": "Copyright (c) Microsoft Corporation",
   "title": "Test framework for Microsoft AutoRest Generated Clients",
   "description": "Microsoft.Rest.ClientRuntime.Azure.TestFramework",
@@ -39,7 +39,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.Azure.Test.HttpRecorder": "[1.6.8,2.0.0)",
+    "Microsoft.Azure.Test.HttpRecorder": "[1.6.9,2.0.0)",
     "Microsoft.Rest.ClientRuntime": "[2.3.5,3.0.0)",
     "Microsoft.Rest.ClientRuntime.Azure.Authentication": "[2.2.10,3.0.0)"
   }

--- a/src/TestFramework/TestFramework.Tests/project.json
+++ b/src/TestFramework/TestFramework.Tests/project.json
@@ -30,8 +30,8 @@
       "type": "platform",
       "version": "1.0.0"
     },
-    "Microsoft.Azure.Test.HttpRecorder": "[1.6.8,2.0.0)",
-    "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "[1.5.2,2.0.0)",
+    "Microsoft.Azure.Test.HttpRecorder": "[1.6.9,2.0.0)",
+    "Microsoft.Rest.ClientRuntime.Azure.TestFramework": "[1.5.3,2.0.0)",
     "Microsoft.Rest.ClientRuntime": "[2.3.5,3.0)",
     "xunit": "2.2.0-beta4-build3444",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"

--- a/src/TestFramework/global.json
+++ b/src/TestFramework/global.json
@@ -1,3 +1,3 @@
 {
-  "projects": [ "../ClientRuntime", "Microsoft.Rest.ClientRuntime.Azure.TestFramework", "Microsoft.Azure.Test.HttpRecorder" ]
+  "projects": [ "Microsoft.Rest.ClientRuntime.Azure.TestFramework", "Microsoft.Azure.Test.HttpRecorder" ]
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/dev/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.