### PR TITLE
Hydra SDK - Adding InGlobalLocation boolean property in ResourceType

### DIFF
--- a/src/ResourceManagement/AzureStackAdmin/AzureStackAdmin.Tests/ResourceProviderManifest.cs
+++ b/src/ResourceManagement/AzureStackAdmin/AzureStackAdmin.Tests/ResourceProviderManifest.cs
@@ -59,6 +59,7 @@ namespace AzureStackAdmin.Tests
                                 'name': 'hostingservers',
                                 'routingType': 'Default',
                                 'resourceDeletionPolicy': 'NotSpecified',
+                                'inGlobalLocation': true,
                                 'endpoints': [
                                     {
                                         'apiVersions': [
@@ -100,9 +101,10 @@ namespace AzureStackAdmin.Tests
             Assert.Equal(new TimeSpan(0, 0, 0), result.ProviderRegistration.Properties.ResourceTypes[0].Endpoints[0].Timeout);
             Assert.Equal(true, result.ProviderRegistration.Properties.ResourceTypes[0].Endpoints[0].Enabled);
             Assert.Equal(RoutingType.Default, result.ProviderRegistration.Properties.ResourceTypes[0].RoutingType);
+            Assert.Equal(true, result.ProviderRegistration.Properties.ResourceTypes[0].InGlobalLocation);
             Assert.Equal(ResourceDeletionPolicy.NotSpecified, result.ProviderRegistration.Properties.ResourceTypes[0].ResourceDeletionPolicy);
             Assert.Equal(MarketplaceType.NotSpecified, result.ProviderRegistration.Properties.ResourceTypes[0].MarketplaceType);
-            // Assert.Equal(ProvisioningState.Succeeded, result.ProviderRegistration.Properties.ProvisioningState);
+            Assert.Equal("Succeeded", result.ProviderRegistration.Properties.ProvisioningState);
         }
 
         [Fact]
@@ -132,6 +134,7 @@ namespace AzureStackAdmin.Tests
                                 'name': 'hostingservers',
                                 'routingType': 'Default',
                                 'resourceDeletionPolicy': 'NotSpecified',
+                                'inGlobalLocation': true,
                                 'endpoints': [
                                     {
                                         'apiVersions': [
@@ -177,6 +180,7 @@ namespace AzureStackAdmin.Tests
                                                              {
                                                                  Name = "hostingservers",
                                                                  RoutingType = RoutingType.Default,
+                                                                 InGlobalLocation = true,
                                                                  Endpoints = new ResourceProviderEndpoint[]
                                                                              {
                                                                                  new ResourceProviderEndpoint()
@@ -211,6 +215,7 @@ namespace AzureStackAdmin.Tests
             Assert.Equal(new TimeSpan(0, 0, 0), result.ProviderRegistration.Properties.ResourceTypes[0].Endpoints[0].Timeout);
             Assert.Equal(true, result.ProviderRegistration.Properties.ResourceTypes[0].Endpoints[0].Enabled);
             Assert.Equal(RoutingType.Default, result.ProviderRegistration.Properties.ResourceTypes[0].RoutingType);
+            Assert.Equal(true, result.ProviderRegistration.Properties.ResourceTypes[0].InGlobalLocation);
             Assert.Equal(ResourceDeletionPolicy.NotSpecified, result.ProviderRegistration.Properties.ResourceTypes[0].ResourceDeletionPolicy);
             Assert.Equal(MarketplaceType.NotSpecified, result.ProviderRegistration.Properties.ResourceTypes[0].MarketplaceType);
         }

--- a/src/ResourceManagement/AzureStackAdmin/AzureStackManagement/Generated/Models/ResourceType.cs
+++ b/src/ResourceManagement/AzureStackAdmin/AzureStackManagement/Generated/Models/ResourceType.cs
@@ -54,6 +54,18 @@ namespace Microsoft.AzureStack.Management.Models
             set { this._endpoints = value; }
         }
         
+        private bool _inGlobalLocation;
+        
+        /// <summary>
+        /// Optional. Gets or sets a value indicating whether the resource type
+        /// is in global location.
+        /// </summary>
+        public bool InGlobalLocation
+        {
+            get { return this._inGlobalLocation; }
+            set { this._inGlobalLocation = value; }
+        }
+        
         private MarketplaceType _marketplaceType;
         
         /// <summary>

--- a/src/ResourceManagement/AzureStackAdmin/AzureStackManagement/Generated/ProviderRegistrationOperations.cs
+++ b/src/ResourceManagement/AzureStackAdmin/AzureStackManagement/Generated/ProviderRegistrationOperations.cs
@@ -314,6 +314,8 @@ namespace Microsoft.AzureStack.Management
                                 
                                 resourceTypeValue["routingType"] = resourceTypesItem.RoutingType.ToString();
                                 
+                                resourceTypeValue["inGlobalLocation"] = resourceTypesItem.InGlobalLocation;
+                                
                                 resourceTypeValue["resourceDeletionPolicy"] = resourceTypesItem.ResourceDeletionPolicy.ToString();
                                 
                                 if (resourceTypesItem.AllowedUnauthorizedActions != null)
@@ -667,6 +669,13 @@ namespace Microsoft.AzureStack.Management
                                         {
                                             RoutingType routingTypeInstance = ((RoutingType)Enum.Parse(typeof(RoutingType), ((string)routingTypeValue), true));
                                             resourceTypeInstance.RoutingType = routingTypeInstance;
+                                        }
+                                        
+                                        JToken inGlobalLocationValue = resourceTypesValue["inGlobalLocation"];
+                                        if (inGlobalLocationValue != null && inGlobalLocationValue.Type != JTokenType.Null)
+                                        {
+                                            bool inGlobalLocationInstance = ((bool)inGlobalLocationValue);
+                                            resourceTypeInstance.InGlobalLocation = inGlobalLocationInstance;
                                         }
                                         
                                         JToken resourceDeletionPolicyValue = resourceTypesValue["resourceDeletionPolicy"];
@@ -1302,6 +1311,13 @@ namespace Microsoft.AzureStack.Management
                                             resourceTypeInstance.RoutingType = routingTypeInstance;
                                         }
                                         
+                                        JToken inGlobalLocationValue = resourceTypesValue["inGlobalLocation"];
+                                        if (inGlobalLocationValue != null && inGlobalLocationValue.Type != JTokenType.Null)
+                                        {
+                                            bool inGlobalLocationInstance = ((bool)inGlobalLocationValue);
+                                            resourceTypeInstance.InGlobalLocation = inGlobalLocationInstance;
+                                        }
+                                        
                                         JToken resourceDeletionPolicyValue = resourceTypesValue["resourceDeletionPolicy"];
                                         if (resourceDeletionPolicyValue != null && resourceDeletionPolicyValue.Type != JTokenType.Null)
                                         {
@@ -1781,6 +1797,13 @@ namespace Microsoft.AzureStack.Management
                                                 {
                                                     RoutingType routingTypeInstance = ((RoutingType)Enum.Parse(typeof(RoutingType), ((string)routingTypeValue), true));
                                                     resourceTypeInstance.RoutingType = routingTypeInstance;
+                                                }
+                                                
+                                                JToken inGlobalLocationValue = resourceTypesValue["inGlobalLocation"];
+                                                if (inGlobalLocationValue != null && inGlobalLocationValue.Type != JTokenType.Null)
+                                                {
+                                                    bool inGlobalLocationInstance = ((bool)inGlobalLocationValue);
+                                                    resourceTypeInstance.InGlobalLocation = inGlobalLocationInstance;
                                                 }
                                                 
                                                 JToken resourceDeletionPolicyValue = resourceTypesValue["resourceDeletionPolicy"];

--- a/src/ResourceManagement/AzureStackAdmin/AzureStackManagement/Microsoft.AzureStack.Management.nuget.proj
+++ b/src/ResourceManagement/AzureStackAdmin/AzureStackManagement/Microsoft.AzureStack.Management.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.AzureStack.Management
     -->
     <SdkNuGetPackage Include="Microsoft.AzureStack.Management">
-      <PackageVersion>0.10.5-preview</PackageVersion>
+      <PackageVersion>0.10.6-preview</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/AzureStackAdmin/AzureStackManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/AzureStackAdmin/AzureStackManagement/Properties/AssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Resources;
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
 [assembly: AssemblyVersion("0.10.0.0")]
-[assembly: AssemblyFileVersion("0.10.5.0")]
+[assembly: AssemblyFileVersion("0.10.6.0")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Adding InGlobalLocation boolean property in ResourceType and test changes
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.
