### PR TITLE
Publish Packages without scopes when package names are provided

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -65,7 +65,7 @@
 
 	<ItemGroup Condition="'$(PublishTestProjects)' == 'false' Or '$(PublishTestProjects)' == ''">
 		<LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\*.sln" Condition=" '$(Scope)' != 'all'  " />
-		<LibrariesToBuild Include="$(LibrarySourceFolder)\**\*.sln" Condition=" '$(Scope)' == 'all'  " />
+		<LibrariesToBuild Include="$(LibrarySourceFolder)\**\*.sln" Exclude="$(LibrarySourceFolder)\KeyVault\Microsoft.Azure.KeyVault.Samples\Microsoft.Azure.KeyVault.Samples.sln" Condition=" '$(Scope)' == 'all'  " />
 		<LibraryFxTargetList Include="$(FxTargetList)" />
 		<AutoRestLibraryFxTargetList Include="portable;net45" />
 		<ClientRuntimeProjects Include="$(LibrarySourceFolder)\ClientRuntime\**\*.xproj"/>

--- a/build.proj
+++ b/build.proj
@@ -407,7 +407,4 @@
 		<Copy SourceFiles="@(_PackageBinaries->'%(SignedFlatFileName)')" DestinationFiles="@(_PackageBinaries->'%(FullPath)')"></Copy>
 		<Exec Command="$(ZipExe) a -tzip -mx9 -r -y $(PackageOutputDir)\%(_NetCorePackages.Filename).nupkg" WorkingDirectory="$(PackageOutputDir)\%(_NetCorePackages.Filename)" />
 	</Target>
-	<Target Name="Debug">
-		<DebugTask/>
-	</Target>
 </Project>

--- a/build.proj
+++ b/build.proj
@@ -125,12 +125,12 @@
 		<FilterOutAutoRestLibraries SdkNugetPackageInput="@(SdkNuGetPackage)" AllLibraries="@(LibrariesToBuild)" AutoRestMark="AutoRestProjects" NugetPackagesToPublish="$(PackageName)">
 		  <Output TaskParameter="Non_NetCore_AutoRestLibraries" ItemName="Non_NetCore_AutoRestLibraries" />
 		  <Output TaskParameter="NetCore_AutoRestLibraries" ItemName="NetCore_AutoRestLibraries" />
-		  <Output TaskParameter="NonAutoRestLibraries" ItemName="NAutoRestLibraries" />
+		  <Output TaskParameter="NonAutoRestLibraries" ItemName="NonAutoRestLibraries" />
 		  <Output TaskParameter="SdkNuGetPackageOutput" ItemName="SdkNuGetPackageItem" />
 		</FilterOutAutoRestLibraries>
 		<Message Text="Non-NetCore based AutoRest Libraries: @(Non_NetCore_AutoRestLibraries)" />
 		<Message Text="NetCore AutoRest Libraries: @(NetCore_AutoRestLibraries)" />
-		<Message Text="NAutoRestLibraries Libraries: @(NAutoRestLibraries)" />		
+		<Message Text="NonAutoRestLibraries Libraries: @(NonAutoRestLibraries)" />		
 
 		<!--Do not build old libraries except Authentication, which Azure PowerShell still uses-->
 		<ItemGroup>

--- a/build.proj
+++ b/build.proj
@@ -121,19 +121,31 @@
 	<Import Condition=" $(OnPremiseBuild) " Project="$(CIToolsPath)\Microsoft.WindowsAzure.Build.OnPremise.msbuild" />
   
 	<Target Name="PrepareForAutoRestLibraries">
-		<FilterOutAutoRestLibraries AllLibraries="@(LibrariesToBuild)" AutoRestMark="AutoRestProjects" NugetPackagesToPublish="$(PackageName)">
+		<Message Text="SdkNugetPackages Before Filter: @(SdkNuGetPackage)" />
+		<FilterOutAutoRestLibraries SdkNugetPackageInput="@(SdkNuGetPackage)" AllLibraries="@(LibrariesToBuild)" AutoRestMark="AutoRestProjects" NugetPackagesToPublish="$(PackageName)">
 		  <Output TaskParameter="Non_NetCore_AutoRestLibraries" ItemName="Non_NetCore_AutoRestLibraries" />
 		  <Output TaskParameter="NetCore_AutoRestLibraries" ItemName="NetCore_AutoRestLibraries" />
+		  <Output TaskParameter="NonAutoRestLibraries" ItemName="NAutoRestLibraries" />
+		  <Output TaskParameter="SdkNuGetPackageOutput" ItemName="SdkNuGetPackageItem" />
 		</FilterOutAutoRestLibraries>
-		<Message Text="Non NetCore based AutoRest Libraries: @(Non_NetCore_AutoRestLibraries)" />
+		<Message Text="Non-NetCore based AutoRest Libraries: @(Non_NetCore_AutoRestLibraries)" />
 		<Message Text="NetCore AutoRest Libraries: @(NetCore_AutoRestLibraries)" />
+		<Message Text="NAutoRestLibraries Libraries: @(NAutoRestLibraries)" />		
 
 		<!--Do not build old libraries except Authentication, which Azure PowerShell still uses-->
 		<ItemGroup>
+		<!--
 			<NonAutoRestLibraries Include="$(LibrarySourceFolder)\Authentication\Authentication.sln"	  
 								Condition=" '$(Scope)' == 'all' or '$(Scope)' == 'Authentication' " />    	
+		-->
 		</ItemGroup>
-
+		
+		<!-- Fixing the ability to only publish non-NetCore nugets that are specified in Scope/Package Name -->
+		<ItemGroup>
+			<SdkNuGetPackage Remove="@(SdkNuGetPackage)" />
+			<SdkNuGetPackage Include="@(SdkNuGetPackageItem)" />
+		</ItemGroup>
+		<Message Text="SdkNugetPackages After Filter: @(SdkNuGetPackage)" />
 		<Message Text="Non-AutoRest Libraries: @(NonAutoRestLibraries)" />     
 		<Message Text="Ensure 7zip is available" />
 		<Exec
@@ -159,7 +171,7 @@
 
 		<!-- Restoring everyting from the root folder wipes out Storage nuget references and adds Storage project reference to all projects. -->
 		<!-- Restoring from root directory when publishing scope packages -->
-		<Exec Command="dotnet restore" WorkingDirectory="$(LibraryRoot)" />
+		<Exec Command="dotnet restore" WorkingDirectory="$(LibraryRoot)" Condition=" '$(Scope)' != 'all' "/>
 
 		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
 		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Test)" Condition=" @(NetCore_AutoRestLibraries) != '' and '%(NetCore_AutoRestLibraries.Test)' != '' and '$(Configuration)' != 'Release' "/>
@@ -394,5 +406,8 @@
 
 		<Copy SourceFiles="@(_PackageBinaries->'%(SignedFlatFileName)')" DestinationFiles="@(_PackageBinaries->'%(FullPath)')"></Copy>
 		<Exec Command="$(ZipExe) a -tzip -mx9 -r -y $(PackageOutputDir)\%(_NetCorePackages.Filename).nupkg" WorkingDirectory="$(PackageOutputDir)\%(_NetCorePackages.Filename)" />
+	</Target>
+	<Target Name="Debug">
+		<DebugTask/>
 	</Target>
 </Project>

--- a/build.proj
+++ b/build.proj
@@ -65,7 +65,7 @@
 
 	<ItemGroup Condition="'$(PublishTestProjects)' == 'false' Or '$(PublishTestProjects)' == ''">
 		<LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\*.sln" Condition=" '$(Scope)' != 'all'  " />
-		<LibrariesToBuild Include="$(LibrarySourceFolder)\**\*.sln" Condition=" '$(Scope)' == 'all'  " />
+		<LibrariesToBuild Include="$(LibrarySourceFolder)\**\*.sln" Exclude="$(LibrarySourceFolder)\KeyVault\Microsoft.Azure.KeyVault.Samples\Microsoft.Azure.KeyVault.Samples.sln" Condition=" '$(Scope)' == 'all'  " />
 		<LibraryFxTargetList Include="$(FxTargetList)" />
 		<AutoRestLibraryFxTargetList Include="portable;net45" />
 		<ClientRuntimeProjects Include="$(LibrarySourceFolder)\ClientRuntime\**\*.xproj"/>
@@ -121,19 +121,31 @@
 	<Import Condition=" $(OnPremiseBuild) " Project="$(CIToolsPath)\Microsoft.WindowsAzure.Build.OnPremise.msbuild" />
   
 	<Target Name="PrepareForAutoRestLibraries">
-		<FilterOutAutoRestLibraries AllLibraries="@(LibrariesToBuild)" AutoRestMark="AutoRestProjects" NugetPackagesToPublish="$(PackageName)">
+		<Message Text="SdkNugetPackages Before Filter: @(SdkNuGetPackage)" />
+		<FilterOutAutoRestLibraries SdkNugetPackageInput="@(SdkNuGetPackage)" AllLibraries="@(LibrariesToBuild)" AutoRestMark="AutoRestProjects" NugetPackagesToPublish="$(PackageName)">
 		  <Output TaskParameter="Non_NetCore_AutoRestLibraries" ItemName="Non_NetCore_AutoRestLibraries" />
 		  <Output TaskParameter="NetCore_AutoRestLibraries" ItemName="NetCore_AutoRestLibraries" />
+		  <Output TaskParameter="NonAutoRestLibraries" ItemName="NonAutoRestLibraries" />
+		  <Output TaskParameter="SdkNuGetPackageOutput" ItemName="SdkNuGetPackageItem" />
 		</FilterOutAutoRestLibraries>
-		<Message Text="Non NetCore based AutoRest Libraries: @(Non_NetCore_AutoRestLibraries)" />
+		<Message Text="Non-NetCore based AutoRest Libraries: @(Non_NetCore_AutoRestLibraries)" />
 		<Message Text="NetCore AutoRest Libraries: @(NetCore_AutoRestLibraries)" />
+		<Message Text="NonAutoRestLibraries Libraries: @(NonAutoRestLibraries)" />		
 
 		<!--Do not build old libraries except Authentication, which Azure PowerShell still uses-->
 		<ItemGroup>
+		<!--
 			<NonAutoRestLibraries Include="$(LibrarySourceFolder)\Authentication\Authentication.sln"	  
 								Condition=" '$(Scope)' == 'all' or '$(Scope)' == 'Authentication' " />    	
+		-->
 		</ItemGroup>
-
+		
+		<!-- Fixing the ability to only publish non-NetCore nugets that are specified in Scope/Package Name -->
+		<ItemGroup>
+			<SdkNuGetPackage Remove="@(SdkNuGetPackage)" />
+			<SdkNuGetPackage Include="@(SdkNuGetPackageItem)" />
+		</ItemGroup>
+		<Message Text="SdkNugetPackages After Filter: @(SdkNuGetPackage)" />
 		<Message Text="Non-AutoRest Libraries: @(NonAutoRestLibraries)" />     
 		<Message Text="Ensure 7zip is available" />
 		<Exec
@@ -159,7 +171,7 @@
 
 		<!-- Restoring everyting from the root folder wipes out Storage nuget references and adds Storage project reference to all projects. -->
 		<!-- Restoring from root directory when publishing scope packages -->
-		<Exec Command="dotnet restore" WorkingDirectory="$(LibraryRoot)" />
+		<Exec Command="dotnet restore" WorkingDirectory="$(LibraryRoot)" Condition=" '$(Scope)' != 'all' "/>
 
 		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
 		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Test)" Condition=" @(NetCore_AutoRestLibraries) != '' and '%(NetCore_AutoRestLibraries.Test)' != '' and '$(Configuration)' != 'Release' "/>

--- a/build.proj
+++ b/build.proj
@@ -172,7 +172,7 @@
 		<!-- Restoring everyting from the root folder wipes out Storage nuget references and adds Storage project reference to all projects. -->
 		<!-- Restoring from root directory when publishing scope packages -->
 		<Exec Command="dotnet restore" WorkingDirectory="$(LibraryRoot)" Condition=" '$(Scope)' != 'all' "/>
-
+		<Exec Command="dotnet restore %(NetCore_AutoRestLibraries.RootDir)\%(NetCore_AutoRestLibraries.Directory)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
 		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
 		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Test)" Condition=" @(NetCore_AutoRestLibraries) != '' and '%(NetCore_AutoRestLibraries.Test)' != '' and '$(Configuration)' != 'Release' "/>
 

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/Build.Tasks.Tests/PublishNugetPackageTests.proj
@@ -24,7 +24,26 @@
 		<AutoRestLibraryFxTargetList Include="portable;net45" />	
 	</ItemGroup>
 	
-	<Target Name="OnePackageInit">	
+	<Target Name="CommonInit" >
+		<Message Text="Executing 'CommonInit'" />
+		<Message Text="Trying to Create directory $(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
+		<MakeDir Directories="$(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
+		<Message Text="Test Publishing directory detected $(NuGetPublishingSource)" Condition="Exists($(NuGetPublishingSource))" />
+		<Error Text="Directory creation failed for '$(NuGetPublishingSource)'" Condition="!Exists($(NuGetPublishingSource))" />
+	</Target>	
+	<Target  Name="BuildTestPackages">
+		<Message Text="Non-NetCore Test Packages Libs to be built:  @(Non_NetCore_AutoRestLibraries)" />
+		<MSBuild Projects="@(Non_NetCore_AutoRestLibraries)"             
+				 Targets="Build" />
+
+		<Message Text="NetCore Test Packages Libs to be built:  @(Non_NetCore_AutoRestLibraries)" />
+		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
+		<Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" '%(NetCore_AutoRestLibraries.Library)'!= '' "/>
+
+		<Message Text="Building packages completed. Publishing not done" />
+  </Target>
+
+  	<Target Name="OnePackageInit">	
 		<Message Text="Executing 'OnePackageInit'" />
 		<PropertyGroup>
 		  <Scope>MultiProjectMultiSln</Scope>
@@ -56,26 +75,36 @@
 			<LibrariesToBuild Include="$(LibrarySourceFolder)\$(Scope)\**\*.sln" />
 		</ItemGroup>
 		<Error Text="No Project found to be built." Condition=" '@(LibrariesToBuild)' == '' " />
-	</Target>	
-	<Target Name="CommonInit" >
-		<Message Text="Executing 'CommonInit'" />
-		<Message Text="Trying to Create directory $(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
-		<MakeDir Directories="$(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
-		<Message Text="Test Publishing directory detected $(NuGetPublishingSource)" Condition="Exists($(NuGetPublishingSource))" />
-		<Error Text="Directory creation failed for '$(NuGetPublishingSource)'" Condition="!Exists($(NuGetPublishingSource))" />
-	</Target>	
-	<Target  Name="BuildTestPackages">
-		<Message Text="Non-NetCore Test Packages Libs to be built:  @(Non_NetCore_AutoRestLibraries)" />
-		<MSBuild Projects="@(Non_NetCore_AutoRestLibraries)"             
-				 Targets="Build" />
-
-		<Message Text="NetCore Test Packages Libs to be built:  @(Non_NetCore_AutoRestLibraries)" />
-		<Exec Command="dotnet restore" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" @(NetCore_AutoRestLibraries) != '' "/>
-		<Exec Command="dotnet build --configuration $(Configuration)" WorkingDirectory="%(NetCore_AutoRestLibraries.Library)" Condition=" '%(NetCore_AutoRestLibraries.Library)'!= '' "/>
-
-		<Message Text="Building packages completed. Publishing not done" />
-  </Target>
-  
+	</Target>
+	<Target Name="OnePackageNoScopeInit">	
+		<Message Text="Executing 'OnePackageNoScopeInit'" />
+		<PropertyGroup>
+		  <Scope/>
+		  <PackageName Condition=" '$(PackageName)' == '' ">RP1_MgmtPlane</PackageName>
+		</PropertyGroup>
+		<Message Text="Scope: '$(Scope)', PackageName: '$(PackageName)'"/>
+		<Error Text="No Project found to be built." Condition=" '@(LibrariesToBuild)' == '' " />
+		<DebugTask />
+	</Target>
+	<Target Name="RandomMultiPackageNoScopeInit">	
+		<Message Text="Executing 'RandomMultiPackageNoScopeInit'" />
+		<PropertyGroup>
+		  <Scope/>
+		  <PackageName Condition=" '$(PackageName)' == '' ">RP1_MgmtPlane NetCoreTestPublish</PackageName>
+		</PropertyGroup>
+		<Message Text="Scope: '$(Scope)', PackageName: '$(PackageName)'"/>
+		<Error Text="No Project found to be built." Condition=" '@(LibrariesToBuild)' == '' " />
+	</Target>
+	<Target Name="ScopePriorityOverPackageNameInit">	
+		<Message Text="Executing 'ScopePriorityOverPackageNameInit'" />
+		<PropertyGroup>
+		  <Scope Condition=" '$(Scope)' == '' ">MultiProjectSingleSln</Scope>
+		  <PackageName Condition=" '$(PackageName)' == '' ">RP1_MgmtPlane NetCoreTestPublish</PackageName>
+		</PropertyGroup>
+		<Message Text="Scope: '$(Scope)', PackageName: '$(PackageName)'"/>
+		<Error Text="No Project found to be built." Condition=" '@(LibrariesToBuild)' == '' " />
+	</Target>
+	
   <!-- TEST CASES -->
   
   <!-- Job commandline args
@@ -107,5 +136,32 @@
 		<Error Text="'Publish_OnePackage' failed" Condition="!Exists('$(NuGetPublishingSource)\CSProjTestPublish.0.0.1.nupkg')" />
 	</Target>
   
+	<!-- Use Case: You have to provide scope here, the way msbuild builds it's build graph for imports
+		and the way we have authored our DynamicNuSpec targets
+		msbuild build.proj /p:PublishTestProjects=true /t:Publish_OnePackageNoScope /p:PackageName=RP1_DataPlane
+	-->
+	<Target Name="Publish_OnePackageNoScope" DependsOnTargets="OnePackageNoScopeInit;$(TestInit)">
+		<Message Text="'Publish_OnePackageNoScope' succeeded" Condition="Exists('$(NuGetPublishingSource)\RP1_DataPlane.1.0.0.nupkg')" />
+		<Error Text="'Publish_OnePackageNoScope' failed" Condition="!Exists('$(NuGetPublishingSource)\RP1_DataPlane.1.0.0.nupkg')" />
+	</Target>
+	
+	<!-- Use Case: You have to provide scope here, the way msbuild builds it's build graph for imports
+		and the way we have authored our DynamicNuSpec targets
+		msbuild build.proj /p:PublishTestProjects=true /t:Publish_RandomMultiPackageNoScope
+	-->
+	<Target Name="Publish_RandomMultiPackageNoScope" DependsOnTargets="RandomMultiPackageNoScopeInit;$(TestInit)">
+		<Message Text="'Publish_RandomMultiPackageNoScope' succeeded" Condition="Exists('$(NuGetPublishingSource)\RP1_MgmtPlane.1.0.0.nupkg')" />
+		<Error Text="'Publish_RandomMultiPackageNoScope' failed" Condition="!Exists('$(NuGetPublishingSource)\RP1_MgmtPlane.1.0.0.nupkg')" />
+	</Target>
+	
+	<!-- Use Case: You have to provide scope here, the way msbuild builds it's build graph for imports
+		and the way we have authored our DynamicNuSpec targets
+		msbuild build.proj /p:PublishTestProjects=true /p:Scope=MultiProjectSingleSln /t:Publish_ScopePriorityOverPackageName /p:PackageName="RP1_MgmtPlane NetCoreTestPublish"
+	-->
+	<Target Name="Publish_ScopePriorityOverPackageName" DependsOnTargets="ScopePriorityOverPackageNameInit;$(TestInit)">
+		<Message Text="'Publish_ScopePriorityOverPackageName' succeeded" Condition="Exists('$(NuGetPublishingSource)\RP1_MgmtPlane.1.0.0.nupkg')" />
+		<Error Text="'Publish_ScopePriorityOverPackageName' failed" Condition="!Exists('$(NuGetPublishingSource)\RP1_MgmtPlane.1.0.0.nupkg')" />
+	</Target>
+	
   <!-- END OF TEST CASES -->
   </Project>

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/DebugTask.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/DebugTask.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Build.Tasks
         /// <summary>
         /// Default timeout
         /// </summary>
-        const int DEFAULT_TASK_TIMEOUT = 20000;
+        const int DEFAULT_TASK_TIMEOUT = 30000;
 
         /// <summary>
         /// Task Timeout

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
@@ -13,6 +13,9 @@ namespace Microsoft.WindowsAzure.Build.Tasks
     public class FilterOutAutoRestLibraries : Task
     {
         [Required]
+        public ITaskItem[] SdkNugetPackageInput { get; set; }
+
+        [Required]
         public ITaskItem[] AllLibraries { get; set; }
 
         [Required]
@@ -37,6 +40,9 @@ namespace Microsoft.WindowsAzure.Build.Tasks
         [Output]
         public ITaskItem[] NetCore_AutoRestLibraries { get; private set; }
 
+        [Output]
+        public ITaskItem[] SdkNuGetPackageOutput { get; private set; }
+
         public override bool Execute()
         {
             System.Text.StringBuilder sb = new System.Text.StringBuilder();
@@ -50,13 +56,30 @@ namespace Microsoft.WindowsAzure.Build.Tasks
             var nonNetCoreAutoRestLibraries = new List<ITaskItem>();
             var netCoreAutoRestLibraries = new List<ITaskItem>();
             var netCoreLibraryTestOnes = new List<ITaskItem>();
+            var SdkNuGetPackage = new List<ITaskItem>(); 
             var others =  new List<ITaskItem>();
             
             List<string> nPkgsList = null;
+            List<string> sdkItemSpec = (from item in SdkNugetPackageInput select item.ItemSpec).ToList<string>();
 
             if (!string.IsNullOrWhiteSpace(NugetPackagesToPublish))
             {
                 nPkgsList = NugetPackagesToPublish.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries).ToList<string>();
+            }
+
+            if(nPkgsList != null)
+            {
+                List<string> common = nPkgsList.Intersect<string>(sdkItemSpec).ToList<string>();
+                foreach(string projName in common)
+                {
+                    ITaskItem nProj = SdkNugetPackageInput.Where<ITaskItem>((item) => item.ItemSpec.Equals(projName, StringComparison.OrdinalIgnoreCase)).First<ITaskItem>();
+                    if (nProj != null)
+                        SdkNuGetPackage.Add(nProj);
+                }
+            }
+            else
+            {
+                SdkNuGetPackage = SdkNugetPackageInput.ToList<ITaskItem>();
             }
 
             foreach (ITaskItem solution in AllLibraries)
@@ -169,10 +192,12 @@ namespace Microsoft.WindowsAzure.Build.Tasks
 
             Log.LogMessage(MessageImportance.High, "We have found {0} non netcore autorest libraries.", nonNetCoreAutoRestLibraries.Count);
             Log.LogMessage(MessageImportance.High, "We have found {0} netcore autorest libraries.", netCoreAutoRestLibraries.Count);
-            Log.LogMessage(MessageImportance.High, "we have found {0} Non autorest libraries.", others.Count);
+            Log.LogMessage(MessageImportance.High, "We have found {0} Non autorest libraries.", others.Count);
+            Log.LogMessage(MessageImportance.High, "We have found {0} SdkNuget Packages.", SdkNuGetPackage.Count);
             Non_NetCore_AutoRestLibraries = nonNetCoreAutoRestLibraries.ToArray();
             NetCore_AutoRestLibraries = netCoreAutoRestLibraries.ToArray();
             NonAutoRestLibraries = others.ToArray();
+            SdkNuGetPackageOutput = SdkNuGetPackage.ToArray();
             return true;
         }
     }

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
@@ -77,6 +77,10 @@ namespace Microsoft.WindowsAzure.Build.Tasks
                         SdkNuGetPackage.Add(nProj);
                 }
             }
+            else
+            {
+                SdkNuGetPackage = SdkNugetPackageInput.ToList<ITaskItem>();
+            }
 
             foreach (ITaskItem solution in AllLibraries)
             {

--- a/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
+++ b/tools/Microsoft.WindowsAzure.Build.Tasks/FilterOutAutoRestLibraries.cs
@@ -13,6 +13,9 @@ namespace Microsoft.WindowsAzure.Build.Tasks
     public class FilterOutAutoRestLibraries : Task
     {
         [Required]
+        public ITaskItem[] SdkNugetPackageInput { get; set; }
+
+        [Required]
         public ITaskItem[] AllLibraries { get; set; }
 
         [Required]
@@ -37,6 +40,9 @@ namespace Microsoft.WindowsAzure.Build.Tasks
         [Output]
         public ITaskItem[] NetCore_AutoRestLibraries { get; private set; }
 
+        [Output]
+        public ITaskItem[] SdkNuGetPackageOutput { get; private set; }
+
         public override bool Execute()
         {
             System.Text.StringBuilder sb = new System.Text.StringBuilder();
@@ -50,13 +56,26 @@ namespace Microsoft.WindowsAzure.Build.Tasks
             var nonNetCoreAutoRestLibraries = new List<ITaskItem>();
             var netCoreAutoRestLibraries = new List<ITaskItem>();
             var netCoreLibraryTestOnes = new List<ITaskItem>();
+            var SdkNuGetPackage = new List<ITaskItem>(); 
             var others =  new List<ITaskItem>();
             
             List<string> nPkgsList = null;
+            List<string> sdkItemSpec = (from item in SdkNugetPackageInput select item.ItemSpec).ToList<string>();
 
             if (!string.IsNullOrWhiteSpace(NugetPackagesToPublish))
             {
                 nPkgsList = NugetPackagesToPublish.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries).ToList<string>();
+            }
+
+            if(nPkgsList != null)
+            {
+                List<string> common = nPkgsList.Intersect<string>(sdkItemSpec).ToList<string>();
+                foreach(string projName in common)
+                {
+                    ITaskItem nProj = SdkNugetPackageInput.Where<ITaskItem>((item) => item.ItemSpec.Equals(projName, StringComparison.OrdinalIgnoreCase)).First<ITaskItem>();
+                    if (nProj != null)
+                        SdkNuGetPackage.Add(nProj);
+                }
             }
 
             foreach (ITaskItem solution in AllLibraries)
@@ -169,10 +188,12 @@ namespace Microsoft.WindowsAzure.Build.Tasks
 
             Log.LogMessage(MessageImportance.High, "We have found {0} non netcore autorest libraries.", nonNetCoreAutoRestLibraries.Count);
             Log.LogMessage(MessageImportance.High, "We have found {0} netcore autorest libraries.", netCoreAutoRestLibraries.Count);
-            Log.LogMessage(MessageImportance.High, "we have found {0} Non autorest libraries.", others.Count);
+            Log.LogMessage(MessageImportance.High, "We have found {0} Non autorest libraries.", others.Count);
+            Log.LogMessage(MessageImportance.High, "We have found {0} SdkNuget Packages.", SdkNuGetPackage.Count);
             Non_NetCore_AutoRestLibraries = nonNetCoreAutoRestLibraries.ToArray();
             NetCore_AutoRestLibraries = netCoreAutoRestLibraries.ToArray();
             NonAutoRestLibraries = others.ToArray();
+            SdkNuGetPackageOutput = SdkNuGetPackage.ToArray();
             return true;
         }
     }

--- a/tools/nuget.targets
+++ b/tools/nuget.targets
@@ -75,6 +75,7 @@
 	</Target>
 
 	<Target Name="ListPackages">
+		<Message Text="Nuspec: %(SdkNuGetPackage.Folder)%(SdkNuGetPackage.Identity).nuspec" />		
 		<Message Text="%(SdkNuGetPackage.Identity) %(SdkNuGetPackage.PackageVersion) %(SdkNuGetPackage.Folder)" />
 	</Target>
 
@@ -82,7 +83,7 @@
 	Build NuGet packages
 	-->
 	<Target Name="Package" DependsOnTargets="PrepareForAutoRestLibraries">
-		<CallTarget Targets="BuildDynamicNuSpecs" Condition=" @(Non_NetCore_AutoRestLibraries) != '' or @(NonAutoRestLibraries) != ''" />
+		<CallTarget Targets="BuildDynamicNuSpecs" Condition=" @(Non_NetCore_AutoRestLibraries) != '' or @(SdkNuGetPackage) != ''" />
 
 		<Message Text="Generating NuGet library" Importance="high" />
 		<Exec Condition=" '%(SdkNuGetPackage.Identity)' != '' "
@@ -97,7 +98,7 @@
 	</Target>
 
 	<Target Name="Publish" DependsOnTargets="PrepareForAutoRestLibraries">
-		<Error Condition=" '$(Scope)' == 'all' OR '$(Scope)' == '' " Text="Publishing nuget package without specifying scope has now been disabled" />
+		<Error Condition=" ('$(PackageName)' == '') AND ('$(Scope)' == '' OR '$(Scope)' == 'all') " Text="Publishing nuget package without specifying scope or packageName has now been disabled" />
 		<Error Condition=" '$(NuGetKey)' == '' " Text="You must provide the NuGetKey parameter to the build: /p:NuGetKey=YOUR_PUBLISHING_KEY" />
 		<Message Text="Trying to Create directory $(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
 		<MakeDir Directories="$(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource)) AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$(NuGetPublishingSource)', '^(?i)http'))" />

--- a/tools/nuget.targets
+++ b/tools/nuget.targets
@@ -75,6 +75,7 @@
 	</Target>
 
 	<Target Name="ListPackages">
+		<Message Text="Nuspec: %(SdkNuGetPackage.Folder)%(SdkNuGetPackage.Identity).nuspec" />		
 		<Message Text="%(SdkNuGetPackage.Identity) %(SdkNuGetPackage.PackageVersion) %(SdkNuGetPackage.Folder)" />
 	</Target>
 
@@ -82,7 +83,7 @@
 	Build NuGet packages
 	-->
 	<Target Name="Package" DependsOnTargets="PrepareForAutoRestLibraries">
-		<CallTarget Targets="BuildDynamicNuSpecs" Condition=" @(Non_NetCore_AutoRestLibraries) != '' or @(NonAutoRestLibraries) != ''" />
+		<CallTarget Targets="BuildDynamicNuSpecs" Condition=" @(Non_NetCore_AutoRestLibraries) != '' or @(SdkNuGetPackage) != ''" />
 
 		<Message Text="Generating NuGet library" Importance="high" />
 		<Exec Condition=" '%(SdkNuGetPackage.Identity)' != '' "

--- a/tools/nuget.targets
+++ b/tools/nuget.targets
@@ -97,7 +97,7 @@
 	</Target>
 
 	<Target Name="Publish" DependsOnTargets="PrepareForAutoRestLibraries">
-		<Error Condition=" '$(Scope)' == 'all' OR '$(Scope)' == '' " Text="Publishing nuget package without specifying scope has now been disabled" />
+		<!-- Error Condition=" '$(Scope)' == 'all' OR '$(Scope)' == '' " Text="Publishing nuget package without specifying scope has now been disabled" / -->
 		<Error Condition=" '$(NuGetKey)' == '' " Text="You must provide the NuGetKey parameter to the build: /p:NuGetKey=YOUR_PUBLISHING_KEY" />
 		<Message Text="Trying to Create directory $(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
 		<MakeDir Directories="$(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource)) AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$(NuGetPublishingSource)', '^(?i)http'))" />

--- a/tools/nuget.targets
+++ b/tools/nuget.targets
@@ -97,7 +97,7 @@
 	</Target>
 
 	<Target Name="Publish" DependsOnTargets="PrepareForAutoRestLibraries">
-		<!-- Error Condition=" '$(Scope)' == 'all' OR '$(Scope)' == '' " Text="Publishing nuget package without specifying scope has now been disabled" / -->
+		<Error Condition=" ('$(PackageName)' == '') AND ('$(Scope)' == '' OR '$(Scope)' == 'all') " Text="Publishing nuget package without specifying scope or packageName has now been disabled" />
 		<Error Condition=" '$(NuGetKey)' == '' " Text="You must provide the NuGetKey parameter to the build: /p:NuGetKey=YOUR_PUBLISHING_KEY" />
 		<Message Text="Trying to Create directory $(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource))" />
 		<MakeDir Directories="$(NuGetPublishingSource)" Condition="!Exists($(NuGetPublishingSource)) AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$(NuGetPublishingSource)', '^(?i)http'))" />


### PR DESCRIPTION
Ability to publish netCore packages when package names are provided without scope.
Helps in publishing packages from multiple scopes.
Disabling publishing nuget packages for the entire repo if scope or package name is not specified.
Added tests for publishing packages.
