### PR TITLE
Update comment about storage account of Analysis Services BackupConfiguration to use full resource id instead

### DIFF
--- a/src/ResourceManagement/AnalysisServices/Microsoft.Azure.Management.Analysis/Generated/Models/BackupConfiguration.cs
+++ b/src/ResourceManagement/AnalysisServices/Microsoft.Azure.Management.Analysis/Generated/Models/BackupConfiguration.cs
@@ -23,9 +23,8 @@ namespace Microsoft.Azure.Management.Analysis.Models
         /// <summary>
         /// Initializes a new instance of the BackupConfiguration class.
         /// </summary>
-        /// <param name="storageAccount">The name of storage account for
-        /// backup configuration. It is in the format of 'Resource Group
-        /// Name/Storage Account Name'</param>
+        /// <param name="storageAccount">Storage account full resource id for
+        /// backup configuration</param>
         /// <param name="blobContainer">The name of blob container for backup
         /// configuration</param>
         /// <param name="accessKey">The access key of storage account used for
@@ -38,8 +37,8 @@ namespace Microsoft.Azure.Management.Analysis.Models
         }
 
         /// <summary>
-        /// Gets or sets the name of storage account for backup configuration.
-        /// It is in the format of 'Resource Group Name/Storage Account Name'
+        /// Gets or sets storage account full resource id for backup
+        /// configuration
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "storageAccount")]
         public string StorageAccount { get; set; }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Update comment about storage account of Analysis Services
BackupConfiguration to use full resource id instead

Related to a comment to update storage account comment from Swagger changes pull request : https://github.com/Azure/azure-rest-api-specs/pull/946
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.