### PR TITLE
Add helpers API surface for JSON and CSV parsing indexer configuration

### DIFF
--- a/src/Search/Microsoft.Azure.Search/Customizations/Indexers/Models/IndexingParametersExtensions.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Indexers/Models/IndexingParametersExtensions.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Search.Models
     /// </summary>
     public static class IndexingParametersExtensions
     {
+        private const string ParsingModeKey = "parsingMode";
+
         /// <summary> 
         /// Specifies that the indexer will index only the storage metadata and completely skip the document extraction process. This is useful when 
         /// you don't need the document content, nor do you need any of the content type-specific metadata properties. 
@@ -108,6 +110,77 @@ namespace Microsoft.Azure.Search.Models
         public static IndexingParameters SetBlobExtractionMode(this IndexingParameters parameters, BlobExtractionMode extractionMode)
         {
             return Configure(parameters, "dataToExtract", (string)extractionMode);
+        }
+
+        /// <summary>
+        /// Tells the indexer to assume that all blobs contain JSON, which it will then parse such that each blob's JSON will map to a single
+        /// document in the Azure Search index.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-howto-index-json-blobs/" /> for details.
+        /// </summary>
+        /// <param name="parameters">IndexingParameters to configure.</param>
+        /// <remarks>
+        /// This option only applies to indexers that index Azure Blob Storage.
+        /// </remarks>
+        /// <returns>The IndexingParameters instance.</returns>
+        public static IndexingParameters ParseJson(this IndexingParameters parameters)
+        {
+            return Configure(parameters, ParsingModeKey, "json");
+        }
+
+        /// <summary>
+        /// Tells the indexer to assume that all blobs contain JSON arrays, which it will then parse such that each JSON object in each array will
+        /// map to a single document in the Azure Search index.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-howto-index-json-blobs" /> for details.
+        /// </summary>
+        /// <param name="parameters">IndexingParameters to configure.</param>
+        /// <param name="documentRoot">
+        /// An optional JSON Pointer that tells the indexer how to find the JSON array if it's not the top-level JSON property of each blob. If this
+        /// parameter is null or empty, the indexer will assume that the JSON array can be found in the top-level JSON property of each blob.
+        /// Default is null.
+        /// </param>
+        /// <remarks>
+        /// This option only applies to indexers that index Azure Blob Storage.
+        /// </remarks>
+        /// <returns>The IndexingParameters instance.</returns>
+        public static IndexingParameters ParseJsonArrays(this IndexingParameters parameters, string documentRoot = null)
+        {
+            Configure(parameters, ParsingModeKey, "jsonArray");
+
+            if (!string.IsNullOrEmpty(documentRoot))
+            {
+                Configure(parameters, "documentRoot", documentRoot);
+            }
+
+            return parameters;
+        }
+
+        /// <summary>
+        /// Tells the indexer to assume that all blobs are delimited text files. Currently only comma-separated value (CSV) text files are supported.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-howto-index-csv-blobs" /> for details.
+        /// </summary>
+        /// <param name="parameters">IndexingParameters to configure.</param>
+        /// <param name="headers">
+        /// Specifies column headers that the indexer will use to map values to specific fields in the Azure Search index. If you don't specify any
+        /// headers, the indexer assumes that the first non-blank line of each blob contains comma-separated headers.
+        /// </param>
+        /// <remarks>
+        /// This option only applies to indexers that index Azure Blob Storage.
+        /// </remarks>
+        /// <returns>The IndexingParameters instance.</returns>
+        public static IndexingParameters ParseDelimitedTextFiles(this IndexingParameters parameters, params string[] headers)
+        {
+            Configure(parameters, ParsingModeKey, "delimitedText");
+
+            if (headers?.Length > 0)
+            {
+                Configure(parameters, "delimitedTextHeaders", headers.ToCommaSeparatedString());
+            }
+            else
+            {
+                Configure(parameters, "firstLineContainsHeaders", true);
+            }
+
+            return parameters;
         }
 
         /// <summary>

--- a/src/Search/Search.Tests/Tests/IndexingParametersTests.cs
+++ b/src/Search/Search.Tests/Tests/IndexingParametersTests.cs
@@ -11,6 +11,15 @@ namespace Microsoft.Azure.Search.Tests
 
     public sealed class IndexingParametersTests
     {
+        private const string ExpectedParsingModeKey = "parsingMode";
+
+        [Fact]
+        public void ParseJsonSetCorrectly()
+        {
+            var parameters = new IndexingParameters().ParseJson();
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "json");
+        }
+
         [Fact]
         public void IndexFileNameExtensionsSetCorrectly()
         {
@@ -68,6 +77,50 @@ namespace Microsoft.Azure.Search.Tests
         {
             var parameters = new IndexingParameters().DoNotFailOnUnsupportedContentType();
             AssertHasConfigItem(parameters, "failOnUnsupportedContentType", false);
+        }
+
+        [Fact]
+        public void ParseJsonArraysWithNullDocumentRootSetCorrectly()
+        {
+            var parameters = new IndexingParameters().ParseJsonArrays();
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "jsonArray");
+        }
+
+        [Fact]
+        public void ParseJsonArraysWithEmptyDocumentRootSetCorrectly()
+        {
+            var parameters = new IndexingParameters().ParseJsonArrays(string.Empty);
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "jsonArray");
+        }
+
+        [Fact]
+        public void ParseJsonArraysWithDocumentRootSetCorrectly()
+        {
+            const int ExpectedCount = 2;
+
+            var parameters = new IndexingParameters().ParseJsonArrays("/my/path");
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "jsonArray", ExpectedCount);
+            AssertHasConfigItem(parameters, "documentRoot", "/my/path", ExpectedCount);
+        }
+
+        [Fact]
+        public void ParseDelimitedTextFilesWithInlineHeadersSetCorrectly()
+        {
+            const int ExpectedCount = 2;
+
+            var parameters = new IndexingParameters().ParseDelimitedTextFiles();
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "delimitedText", ExpectedCount);
+            AssertHasConfigItem(parameters, "firstLineContainsHeaders", true, ExpectedCount);
+        }
+
+        [Fact]
+        public void ParseDelimitedTextFilesWithGivenHeadersSetCorrectly()
+        {
+            const int ExpectedCount = 2;
+
+            var parameters = new IndexingParameters().ParseDelimitedTextFiles("id", "name", "address");
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "delimitedText", ExpectedCount);
+            AssertHasConfigItem(parameters, "delimitedTextHeaders", "id,name,address", ExpectedCount);
         }
 
         private static void AssertHasConfigItem(


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [X] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [X] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [X] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [X] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.