### PR TITLE
Update .NET SDK for Changes to Credentials Contract.

### DIFF
--- a/src/ResourceManagement/ApiManagement/ApiManagementManagement/ApiManagementManagement.csproj
+++ b/src/ResourceManagement/ApiManagement/ApiManagementManagement/ApiManagementManagement.csproj
@@ -30,6 +30,7 @@
     <Compile Include="Customizations\SmapiModels\AuthorizationServerListResponse.cs" />
     <Compile Include="Customizations\SmapiModels\AuthorizationServerPaged.cs" />
     <Compile Include="Customizations\SmapiModels\BackendGetContract.cs" />
+    <Compile Include="Customizations\SmapiModels\BackendListResponse.cs" />
     <Compile Include="Customizations\SmapiModels\BackendPaged.cs" />
     <Compile Include="Customizations\SmapiModels\CertificateContract.cs" />
     <Compile Include="Customizations\SmapiModels\CertificateListResponse.cs" />

--- a/src/ResourceManagement/ApiManagement/ApiManagementManagement/Customizations/SmapiModels/BackendListResponse.cs
+++ b/src/ResourceManagement/ApiManagement/ApiManagementManagement/Customizations/SmapiModels/BackendListResponse.cs
@@ -1,0 +1,23 @@
+﻿//  
+// Copyright (c) Microsoft.  All rights reserved.
+// 
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+namespace Microsoft.Azure.Management.ApiManagement.SmapiModels
+{
+    public partial class BackendListResponse : IPagedListResponse<BackendGetContract>
+    {
+        IPaged<BackendGetContract> IPagedListResponse<BackendGetContract>.Result
+        {
+            get { return this.Result; }
+        }
+    }
+}

--- a/src/ResourceManagement/ApiManagement/ApiManagementManagement/Generated/BackendOperations.cs
+++ b/src/ResourceManagement/ApiManagement/ApiManagementManagement/Generated/BackendOperations.cs
@@ -105,17 +105,6 @@ namespace Microsoft.Azure.Management.ApiManagement
             {
                 throw new ArgumentNullException("parameters");
             }
-            if (parameters.Credentials != null)
-            {
-                if (parameters.Credentials.Header == null)
-                {
-                    throw new ArgumentNullException("parameters.Credentials.Header");
-                }
-                if (parameters.Credentials.Query == null)
-                {
-                    throw new ArgumentNullException("parameters.Credentials.Query");
-                }
-            }
             if (parameters.Protocol == null)
             {
                 throw new ArgumentNullException("parameters.Protocol");
@@ -1571,17 +1560,6 @@ namespace Microsoft.Azure.Management.ApiManagement
             {
                 throw new ArgumentNullException("parameters");
             }
-            if (parameters.Credentials != null)
-            {
-                if (parameters.Credentials.Header == null)
-                {
-                    throw new ArgumentNullException("parameters.Credentials.Header");
-                }
-                if (parameters.Credentials.Query == null)
-                {
-                    throw new ArgumentNullException("parameters.Credentials.Query");
-                }
-            }
             if (etag == null)
             {
                 throw new ArgumentNullException("etag");
@@ -1768,6 +1746,27 @@ namespace Microsoft.Azure.Management.ApiManagement
                         {
                             authorizationValue["parameter"] = parameters.Credentials.Authorization.Parameter;
                         }
+                    }
+                }
+                
+                if (parameters.Proxy != null)
+                {
+                    JObject proxyValue = new JObject();
+                    backendUpdateParametersValue["proxy"] = proxyValue;
+                    
+                    if (parameters.Proxy.Url != null)
+                    {
+                        proxyValue["url"] = parameters.Proxy.Url;
+                    }
+                    
+                    if (parameters.Proxy.Username != null)
+                    {
+                        proxyValue["username"] = parameters.Proxy.Username;
+                    }
+                    
+                    if (parameters.Proxy.Password != null)
+                    {
+                        proxyValue["password"] = parameters.Proxy.Password;
                     }
                 }
                 

--- a/src/ResourceManagement/ApiManagement/ApiManagementManagement/Generated/SmapiModels/BackendCredentialsContract.cs
+++ b/src/ResourceManagement/ApiManagement/ApiManagementManagement/Generated/SmapiModels/BackendCredentialsContract.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Management.ApiManagement.SmapiModels
         private IDictionary<string, List<string>> _header;
         
         /// <summary>
-        /// Required. Gets or sets Custom header authentication.
+        /// Optional. Gets or sets Custom header authentication.
         /// </summary>
         public IDictionary<string, List<string>> Header
         {
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Management.ApiManagement.SmapiModels
         private IDictionary<string, List<string>> _query;
         
         /// <summary>
-        /// Required. Gets or sets Custom query parameter authentication.
+        /// Optional. Gets or sets Custom query parameter authentication.
         /// </summary>
         public IDictionary<string, List<string>> Query
         {
@@ -84,25 +84,6 @@ namespace Microsoft.Azure.Management.ApiManagement.SmapiModels
             this.Certificate = new LazyList<string>();
             this.Header = new LazyDictionary<string, List<string>>();
             this.Query = new LazyDictionary<string, List<string>>();
-        }
-        
-        /// <summary>
-        /// Initializes a new instance of the BackendCredentialsContract class
-        /// with required arguments.
-        /// </summary>
-        public BackendCredentialsContract(IDictionary<string, List<string>> query, IDictionary<string, List<string>> header)
-            : this()
-        {
-            if (query == null)
-            {
-                throw new ArgumentNullException("query");
-            }
-            if (header == null)
-            {
-                throw new ArgumentNullException("header");
-            }
-            this.Query = query;
-            this.Header = header;
         }
     }
 }

--- a/src/ResourceManagement/ApiManagement/ApiManagementManagement/Generated/SmapiModels/BackendUpdateParameters.cs
+++ b/src/ResourceManagement/ApiManagement/ApiManagementManagement/Generated/SmapiModels/BackendUpdateParameters.cs
@@ -76,6 +76,17 @@ namespace Microsoft.Azure.Management.ApiManagement.SmapiModels
             set { this._protocol = value; }
         }
         
+        private BackendProxyContract _proxy;
+        
+        /// <summary>
+        /// Optional. Gets or sets proxy details.
+        /// </summary>
+        public BackendProxyContract Proxy
+        {
+            get { return this._proxy; }
+            set { this._proxy = value; }
+        }
+        
         private string _resourceId;
         
         /// <summary>

--- a/src/ResourceManagement/ApiManagement/ApiManagementManagement/Microsoft.Azure.Management.ApiManagement.nuget.proj
+++ b/src/ResourceManagement/ApiManagement/ApiManagementManagement/Microsoft.Azure.Management.ApiManagement.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.ApiManagement
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.ApiManagement">
-      <PackageVersion>3.3.0-preview</PackageVersion>
+      <PackageVersion>3.4.0-preview</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/ApiManagement/ApiManagementManagement/Microsoft.Azure.Management.ApiManagement.nuspec
+++ b/src/ResourceManagement/ApiManagement/ApiManagementManagement/Microsoft.Azure.Management.ApiManagement.nuspec
@@ -4,8 +4,9 @@
     <id>Microsoft.Azure.Management.ApiManagement</id>
     <title>Microsoft Azure ApiManagement Service Management Library</title>
     <releaseNotes><![CDATA[
-3.3.0
-  * Added support for Backend entity in ApiManagement  
+3.4.0
+  * Fixed the BackendCredentials Contract by making Query and Headers as Optional parameters.
+  * Added support for updating BackendProxy details
 ]]></releaseNotes>
     <version>$version$</version>
     <authors>Microsoft</authors>

--- a/src/ResourceManagement/ApiManagement/ApiManagementManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/ApiManagement/ApiManagementManagement/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Azure API Management Management Library")]
 [assembly: AssemblyDescription("Provides Microsoft Azure API Management management operations.")]
 
-[assembly: AssemblyVersion("3.3.0.0")]
-[assembly: AssemblyFileVersion("3.3.0.0")]
+[assembly: AssemblyVersion("3.4.0.0")]
+[assembly: AssemblyFileVersion("3.4.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
This is based on changes in Hydra Spec
https://github.com/Azure/hydra-specs-pr/pull/1377

Fixes in a new Contract which is not being consumed by anybody. The changes were merged on Friday 
https://github.com/Azure/azure-sdk-for-net/pull/2898, but found few bugs after writing powershell tests.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.