### PR TITLE
Search SDK: Enable JSON blob indexer and bump version

### DIFF
--- a/src/Search/Microsoft.Azure.Search/Customizations/Indexers/Models/IndexingParametersExtensions.cs
+++ b/src/Search/Microsoft.Azure.Search/Customizations/Indexers/Models/IndexingParametersExtensions.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Search.Models
     /// </summary>
     public static class IndexingParametersExtensions
     {
+        private const string ParsingModeKey = "parsingMode";
+
         /// <summary> 
         /// Specifies that the indexer will index only the storage metadata and completely skip the document extraction process. This is useful when 
         /// you don't need the document content, nor do you need any of the content type-specific metadata properties. 
@@ -108,6 +110,21 @@ namespace Microsoft.Azure.Search.Models
         public static IndexingParameters SetBlobExtractionMode(this IndexingParameters parameters, BlobExtractionMode extractionMode)
         {
             return Configure(parameters, "dataToExtract", (string)extractionMode);
+        }
+
+        /// <summary>
+        /// Tells the indexer to assume that all blobs contain JSON, which it will then parse such that each blob's JSON will map to a single
+        /// document in the Azure Search index.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-howto-index-json-blobs/" /> for details.
+        /// </summary>
+        /// <param name="parameters">IndexingParameters to configure.</param>
+        /// <remarks>
+        /// This option only applies to indexers that index Azure Blob Storage.
+        /// </remarks>
+        /// <returns>The IndexingParameters instance.</returns>
+        public static IndexingParameters ParseJson(this IndexingParameters parameters)
+        {
+            return Configure(parameters, ParsingModeKey, "json");
         }
 
         /// <summary>

--- a/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
+++ b/src/Search/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Makes it easy to develop a .NET application that uses Azure Search.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.2.0")]
+[assembly: AssemblyFileVersion("3.0.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/Search/Microsoft.Azure.Search/project.json
+++ b/src/Search/Microsoft.Azure.Search/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.2",
+  "version": "3.0.3",
   "title": "Microsoft Azure Search Library",
   "description": "Makes it easy to develop a .NET application that uses Azure Search.",
   "authors": [ "Microsoft" ],
@@ -11,7 +11,7 @@
     "iconUrl": "http://go.microsoft.com/fwlink/?LinkID=288890",
     "tags": [ "Microsoft Azure Search", "REST HTTP client", "search", "azureofficial", "windowsazureofficial" ],
     "requireLicenseAcceptance": true,
-    "releaseNotes": "This is the newest major version of the Azure Search .NET SDK, based on version 2016-09-01 of the Azure Search REST API. New in this version is support for indexing Azure Blob and Table storage, indexer field mappings, custom analyzers, and ETags. Also included is support for reflection-based field definitions via the FieldBuilder class, thanks to a contribution from Ian Griffiths (https://github.com/idg10). See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade."
+    "releaseNotes": "This is the newest major version of the Azure Search .NET SDK, based on version 2016-09-01 of the Azure Search REST API. New in this version is support for indexing Azure Blob storage (including parsing of JSON blobs), indexing Azure Table storage, indexer field mappings, custom analyzers, and ETags. Also included is support for reflection-based field definitions via the FieldBuilder class, thanks to a contribution from Ian Griffiths (https://github.com/idg10). See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade."
   },
 
   "buildOptions": {

--- a/src/Search/Search.Management.Tests/project.json
+++ b/src/Search/Search.Management.Tests/project.json
@@ -33,7 +33,7 @@
     "Microsoft.Rest.ClientRuntime.Azure": "[3.3.4,4.0)",
     "Microsoft.Azure.Management.ResourceManager": "1.1.1-preview",
     "Microsoft.Azure.Management.Search": "1.0.1",
-    "Microsoft.Azure.Search": "3.0.2",
+    "Microsoft.Azure.Search": "3.0.3",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   }

--- a/src/Search/Search.Tests/Tests/IndexingParametersTests.cs
+++ b/src/Search/Search.Tests/Tests/IndexingParametersTests.cs
@@ -11,6 +11,15 @@ namespace Microsoft.Azure.Search.Tests
 
     public sealed class IndexingParametersTests
     {
+        private const string ExpectedParsingModeKey = "parsingMode";
+
+        [Fact]
+        public void ParseJsonSetCorrectly()
+        {
+            var parameters = new IndexingParameters().ParseJson();
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "json");
+        }
+
         [Fact]
         public void IndexFileNameExtensionsSetCorrectly()
         {

--- a/src/Search/Search.Tests/project.json
+++ b/src/Search/Search.Tests/project.json
@@ -29,7 +29,7 @@
       "version": "1.0.0" 
     }, 
     "Search.Management.Tests": "1.0.0",
-    "Microsoft.Azure.Search": "3.0.2",
+    "Microsoft.Azure.Search": "3.0.3",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0"
   }
 }


### PR DESCRIPTION
There is still a bit more work to be done before we can ship 3.0.3; Just bumping the version in case we forget.

There are no Swagger spec changes for this PR.

FYI @Yahnoosh @mhko

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [X] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [X] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [X] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [X] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.