### PR TITLE
[Search] Update analyze api tests

### DIFF
--- a/src/Search/Search.Tests/SessionRecords/Microsoft.Azure.Search.Tests.CustomAnalyzerTests/CanAnalyzeWithAllPossibleNames.json
+++ b/src/Search/Search.Tests/SessionRecords/Microsoft.Azure.Search.Tests.CustomAnalyzerTests/CanAnalyzeWithAllPossibleNames.json
@@ -7,17 +7,17 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "eba6195a-9840-41da-a659-c95df17013fa"
+          "d80ddd46-fcde-4599-9e31-383a04897019"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
+          "FxVersion/4.6.24410.01",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.1.1-preview"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/providers/Microsoft.Search\",\r\n  \"namespace\": \"Microsoft.Search\",\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"searchServices\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesCit\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesNxt\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesInt\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesPpe\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityCit\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityNxt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityInt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityPpe\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityCit\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityNxt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityInt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityPpe\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/providers/Microsoft.Search\",\r\n  \"namespace\": \"Microsoft.Search\",\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"searchServices\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesCit\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesNxt\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesInt\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"searchServicesPpe\",\r\n      \"locations\": [\r\n        \"West US\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityCit\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityNxt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityInt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkServiceNameAvailabilityPpe\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-02-28\",\r\n        \"2014-07-31-Preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityCit\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityNxt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityInt\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailabilityPpe\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"resourceHealthMetadata\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2015-08-19\",\r\n        \"2015-02-28\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -29,25 +29,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:11 GMT"
+          "Tue, 07 Mar 2017 19:42:05 GMT"
         ],
         "Pragma": [
           "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
         ],
         "Vary": [
           "Accept-Encoding"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1127"
+          "1199"
         ],
         "x-ms-request-id": [
-          "2bd4d2fb-8995-43f4-b616-e921ecd80d01"
+          "48d209e8-b0c4-4934-bc22-8f98c7d64312"
         ],
         "x-ms-correlation-request-id": [
-          "2bd4d2fb-8995-43f4-b616-e921ecd80d01"
+          "48d209e8-b0c4-4934-bc22-8f98c7d64312"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20161123T185311Z:2bd4d2fb-8995-43f4-b616-e921ecd80d01"
+          "CENTRALUS:20170307T194206Z:48d209e8-b0c4-4934-bc22-8f98c7d64312"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -56,8 +59,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourcegroups/azsmnet9502?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlZ3JvdXBzL2F6c21uZXQ5NTAyP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourcegroups/azsmnet6410?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlZ3JvdXBzL2F6c21uZXQ2NDEwP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"location\": \"West US\"\r\n}",
       "RequestHeaders": {
@@ -68,17 +71,17 @@
           "29"
         ],
         "x-ms-client-request-id": [
-          "408cd311-17f9-45ac-8830-69cf11dcf7f2"
+          "2ea5c36d-12aa-4b12-90ee-eda3859e60cb"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
+          "FxVersion/4.6.24410.01",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.1.1-preview"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet9502\",\r\n  \"name\": \"azsmnet9502\",\r\n  \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410\",\r\n  \"name\": \"azsmnet6410\",\r\n  \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "175"
@@ -93,22 +96,22 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:11 GMT"
+          "Tue, 07 Mar 2017 19:42:06 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1126"
+          "1198"
         ],
         "x-ms-request-id": [
-          "67762dcd-1070-4d32-82c1-ac42f9095691"
+          "75bd0f45-ee0b-4c70-a514-e93f6ca4260f"
         ],
         "x-ms-correlation-request-id": [
-          "67762dcd-1070-4d32-82c1-ac42f9095691"
+          "75bd0f45-ee0b-4c70-a514-e93f6ca4260f"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20161123T185312Z:67762dcd-1070-4d32-82c1-ac42f9095691"
+          "CENTRALUS:20170307T194206Z:75bd0f45-ee0b-4c70-a514-e93f6ca4260f"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -117,8 +120,8 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet9502/providers/Microsoft.Search/searchServices/azs-9455?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ5NTAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy05NDU1P2FwaS12ZXJzaW9uPTIwMTUtMDgtMTk=",
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410/providers/Microsoft.Search/searchServices/azs-280?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ2NDEwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0yODA/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"free\"\r\n  },\r\n  \"location\": \"West US\"\r\n}",
       "RequestHeaders": {
@@ -129,20 +132,20 @@
           "67"
         ],
         "x-ms-client-request-id": [
-          "f655a41a-d520-4241-baf6-1459e1b0041d"
+          "c653020f-0ed9-4b3a-b149-d36910cbe2c7"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.1"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet9502/providers/Microsoft.Search/searchServices/azs-9455\",\r\n  \"name\": \"azs-9455\",\r\n  \"type\": \"Microsoft.Search/searchServices\",\r\n  \"location\": \"West US\",\r\n  \"properties\": {\r\n    \"replicaCount\": 1,\r\n    \"partitionCount\": 1,\r\n    \"status\": \"running\",\r\n    \"statusDetails\": null,\r\n    \"provisioningState\": \"succeeded\",\r\n    \"hostingMode\": \"Default\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"free\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410/providers/Microsoft.Search/searchServices/azs-280\",\r\n  \"name\": \"azs-280\",\r\n  \"type\": \"Microsoft.Search/searchServices\",\r\n  \"location\": \"West US\",\r\n  \"properties\": {\r\n    \"replicaCount\": 1,\r\n    \"partitionCount\": 1,\r\n    \"status\": \"running\",\r\n    \"statusDetails\": \"\",\r\n    \"provisioningState\": \"succeeded\",\r\n    \"hostingMode\": \"Default\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"free\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "387"
+          "383"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -154,22 +157,22 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:19 GMT"
+          "Tue, 07 Mar 2017 19:42:09 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "ETag": [
-          "W/\"datetime'2016-11-23T18%3A53%3A20.0139955Z'\""
+          "W/\"datetime'2017-03-07T19%3A42%3A10.5668754Z'\""
         ],
         "x-ms-request-id": [
-          "f655a41a-d520-4241-baf6-1459e1b0041d"
+          "c653020f-0ed9-4b3a-b149-d36910cbe2c7"
         ],
         "request-id": [
-          "f655a41a-d520-4241-baf6-1459e1b0041d"
+          "c653020f-0ed9-4b3a-b149-d36910cbe2c7"
         ],
         "elapsed-time": [
-          "6336"
+          "2153"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -178,35 +181,35 @@
           "4.0.30319"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1190"
+          "1199"
         ],
         "x-ms-correlation-request-id": [
-          "61965062-e23b-4513-99d5-aa0253ba47c7"
+          "db3b022b-87ef-4412-95df-844b185259b8"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20161123T185320Z:61965062-e23b-4513-99d5-aa0253ba47c7"
+          "CENTRALUS:20170307T194210Z:db3b022b-87ef-4412-95df-844b185259b8"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet9502/providers/Microsoft.Search/searchServices/azs-9455/listAdminKeys?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ5NTAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy05NDU1L2xpc3RBZG1pbktleXM/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410/providers/Microsoft.Search/searchServices/azs-280/listAdminKeys?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ2NDEwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0yODAvbGlzdEFkbWluS2V5cz9hcGktdmVyc2lvbj0yMDE1LTA4LTE5",
       "RequestMethod": "POST",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "f99eb175-3399-4a0d-9b94-9c56d13c64d3"
+          "8c302060-329b-4d16-a3b5-17828ff87518"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.1"
         ]
       },
-      "ResponseBody": "{\r\n  \"primaryKey\": \"C0112890AC467F0D05E9B6F23EC86404\",\r\n  \"secondaryKey\": \"5CE3F37AA0DEFB079E71F13623024CB0\"\r\n}",
+      "ResponseBody": "{\r\n  \"primaryKey\": \"762FB1557922A9278184C38F1B96DCFF\",\r\n  \"secondaryKey\": \"C3A7850C25287F83AE60EBE3B5159C80\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -218,7 +221,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:21 GMT"
+          "Tue, 07 Mar 2017 19:42:16 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -231,13 +234,13 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "f99eb175-3399-4a0d-9b94-9c56d13c64d3"
+          "8c302060-329b-4d16-a3b5-17828ff87518"
         ],
         "request-id": [
-          "f99eb175-3399-4a0d-9b94-9c56d13c64d3"
+          "8c302060-329b-4d16-a3b5-17828ff87518"
         ],
         "elapsed-time": [
-          "365"
+          "160"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -246,35 +249,35 @@
           "4.0.30319"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1189"
+          "1198"
         ],
         "x-ms-correlation-request-id": [
-          "8ea9c967-880f-4e18-8ffa-c57c7864637d"
+          "a44b04ce-59c2-4f61-8e1d-6d02e5f29a67"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20161123T185322Z:8ea9c967-880f-4e18-8ffa-c57c7864637d"
+          "CENTRALUS:20170307T194216Z:a44b04ce-59c2-4f61-8e1d-6d02e5f29a67"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet9502/providers/Microsoft.Search/searchServices/azs-9455/listQueryKeys?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ5NTAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy05NDU1L2xpc3RRdWVyeUtleXM/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410/providers/Microsoft.Search/searchServices/azs-280/listQueryKeys?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ2NDEwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0yODAvbGlzdFF1ZXJ5S2V5cz9hcGktdmVyc2lvbj0yMDE1LTA4LTE5",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "4251c8f9-72b4-41e9-989e-7e59ff25383a"
+          "c4ff89cb-fb4b-4b68-83c8-ba84be844da9"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.1"
         ]
       },
-      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": null,\r\n      \"key\": \"CC9324DA5A70175342AF3662C5CBC1C8\"\r\n    }\r\n  ],\r\n  \"nextLink\": null\r\n}",
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": null,\r\n      \"key\": \"A61BC61C22F686DC9411E7BBB1A0ECE9\"\r\n    }\r\n  ],\r\n  \"nextLink\": null\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -286,7 +289,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:21 GMT"
+          "Tue, 07 Mar 2017 19:42:16 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -299,13 +302,13 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "4251c8f9-72b4-41e9-989e-7e59ff25383a"
+          "c4ff89cb-fb4b-4b68-83c8-ba84be844da9"
         ],
         "request-id": [
-          "4251c8f9-72b4-41e9-989e-7e59ff25383a"
+          "c4ff89cb-fb4b-4b68-83c8-ba84be844da9"
         ],
         "elapsed-time": [
-          "251"
+          "149"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -314,13 +317,13 @@
           "4.0.30319"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14997"
+          "14999"
         ],
         "x-ms-correlation-request-id": [
-          "40041cec-a549-4d93-aa7c-10b52355236d"
+          "a2ae23be-487c-4e14-a774-7045903c4439"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20161123T185322Z:40041cec-a549-4d93-aa7c-10b52355236d"
+          "CENTRALUS:20170307T194217Z:a2ae23be-487c-4e14-a774-7045903c4439"
         ]
       },
       "StatusCode": 200
@@ -329,7 +332,7 @@
       "RequestUri": "/indexes?api-version=2016-09-01",
       "EncodedRequestUri": "L2luZGV4ZXM/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"name\": \"azsmnet1192\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": true,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"descriptionFr\",\r\n      \"type\": \"Edm.String\",\r\n      \"analyzer\": \"fr.lucene\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"nearest\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"distance\",\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"myloc\",\r\n            \"boostingDistance\": 100.0\r\n          },\r\n          \"fieldName\": \"location\",\r\n          \"boost\": 2.0\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"sum\"\r\n    }\r\n  ],\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"sg\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"description\",\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ]\r\n}",
+      "RequestBody": "{\r\n  \"name\": \"azsmnet2698\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": true,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"descriptionFr\",\r\n      \"type\": \"Edm.String\",\r\n      \"analyzer\": \"fr.lucene\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"nearest\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"distance\",\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"myloc\",\r\n            \"boostingDistance\": 100.0\r\n          },\r\n          \"fieldName\": \"location\",\r\n          \"boost\": 2.0\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"sum\"\r\n    }\r\n  ],\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"sg\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"description\",\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ]\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -338,26 +341,26 @@
           "3401"
         ],
         "client-request-id": [
-          "999467b7-a19d-469d-9505-56f338da57d2"
+          "b21affd8-01df-41bd-a835-0762e4de983e"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
+          "762FB1557922A9278184C38F1B96DCFF"
         ],
         "Prefer": [
           "return=representation"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://azs-9455.search-dogfood.windows-int.net/$metadata#indexes/$entity\",\r\n  \"@odata.etag\": \"\\\"0x8D413D2012546CE\\\"\",\r\n  \"name\": \"azsmnet1192\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": true,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"descriptionFr\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": \"fr.lucene\"\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"nearest\",\r\n      \"text\": null,\r\n      \"functions\": [\r\n        {\r\n          \"fieldName\": \"location\",\r\n          \"freshness\": null,\r\n          \"interpolation\": \"linear\",\r\n          \"magnitude\": null,\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"myloc\",\r\n            \"boostingDistance\": 100.0\r\n          },\r\n          \"tag\": null,\r\n          \"type\": \"distance\",\r\n          \"boost\": 2.0\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"sum\"\r\n    }\r\n  ],\r\n  \"defaultScoringProfile\": null,\r\n  \"corsOptions\": null,\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"sg\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"description\",\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ],\r\n  \"analyzers\": [],\r\n  \"tokenizers\": [],\r\n  \"tokenFilters\": [],\r\n  \"charFilters\": []\r\n}",
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://azs-280.search-dogfood.windows-int.net/$metadata#indexes/$entity\",\r\n  \"@odata.etag\": \"\\\"0x8D46592129E780C\\\"\",\r\n  \"name\": \"azsmnet2698\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": true,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"descriptionFr\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": \"fr.lucene\"\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"nearest\",\r\n      \"text\": null,\r\n      \"functions\": [\r\n        {\r\n          \"fieldName\": \"location\",\r\n          \"freshness\": null,\r\n          \"interpolation\": \"linear\",\r\n          \"magnitude\": null,\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"myloc\",\r\n            \"boostingDistance\": 100.0\r\n          },\r\n          \"tag\": null,\r\n          \"type\": \"distance\",\r\n          \"boost\": 2.0\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"sum\"\r\n    }\r\n  ],\r\n  \"defaultScoringProfile\": null,\r\n  \"corsOptions\": null,\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"sg\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"description\",\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ],\r\n  \"analyzers\": [],\r\n  \"tokenizers\": [],\r\n  \"tokenFilters\": [],\r\n  \"charFilters\": []\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "3141"
+          "3140"
         ],
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -369,22 +372,22 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:23 GMT"
+          "Tue, 07 Mar 2017 19:42:22 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "ETag": [
-          "W/\"0x8D413D2012546CE\""
+          "W/\"0x8D46592129E780C\""
         ],
         "Location": [
-          "https://azs-9455.search-dogfood.windows-int.net/indexes('azsmnet1192')?api-version=2016-09-01"
+          "https://azs-280.search-dogfood.windows-int.net/indexes('azsmnet2698')?api-version=2016-09-01"
         ],
         "request-id": [
-          "999467b7-a19d-469d-9505-56f338da57d2"
+          "b21affd8-01df-41bd-a835-0762e4de983e"
         ],
         "elapsed-time": [
-          "674"
+          "2799"
         ],
         "OData-Version": [
           "4.0"
@@ -402,7 +405,7 @@
       "RequestUri": "/indexes?api-version=2016-09-01",
       "EncodedRequestUri": "L2luZGV4ZXM/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"name\": \"azsmnet9050\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": true,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description_fr\",\r\n      \"type\": \"Edm.String\",\r\n      \"analyzer\": \"fr.lucene\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description_custom\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchAnalyzer\": \"stop\",\r\n      \"indexAnalyzer\": \"stop\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"totalGuests\",\r\n      \"type\": \"Edm.Int64\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": false\r\n    },\r\n    {\r\n      \"name\": \"profitMargin\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"MyProfile\",\r\n      \"text\": {\r\n        \"weights\": {\r\n          \"description\": 1.5,\r\n          \"category\": 2.0\r\n        }\r\n      },\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 1.0,\r\n            \"boostingRangeEnd\": 4.0,\r\n            \"constantBoostBeyondRange\": true\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 2.0,\r\n          \"interpolation\": \"constant\"\r\n        },\r\n        {\r\n          \"type\": \"distance\",\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"loc\",\r\n            \"boostingDistance\": 5.0\r\n          },\r\n          \"fieldName\": \"location\",\r\n          \"boost\": 1.5,\r\n          \"interpolation\": \"linear\"\r\n        },\r\n        {\r\n          \"type\": \"freshness\",\r\n          \"freshness\": {\r\n            \"boostingDuration\": \"P365D\"\r\n          },\r\n          \"fieldName\": \"lastRenovationDate\",\r\n          \"boost\": 1.1,\r\n          \"interpolation\": \"logarithmic\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"average\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileTwo\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"tag\",\r\n          \"tag\": {\r\n            \"tagsParameter\": \"mytags\"\r\n          },\r\n          \"fieldName\": \"tags\",\r\n          \"boost\": 1.5,\r\n          \"interpolation\": \"linear\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"maximum\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileThree\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 0.0,\r\n            \"boostingRangeEnd\": 10.0,\r\n            \"constantBoostBeyondRange\": false\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 3.0,\r\n          \"interpolation\": \"quadratic\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"minimum\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileFour\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 1.0,\r\n            \"boostingRangeEnd\": 5.0,\r\n            \"constantBoostBeyondRange\": false\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 3.14,\r\n          \"interpolation\": \"constant\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"firstMatching\"\r\n    }\r\n  ],\r\n  \"defaultScoringProfile\": \"MyProfile\",\r\n  \"corsOptions\": {\r\n    \"allowedOrigins\": [\r\n      \"http://tempuri.org\",\r\n      \"http://localhost:80\"\r\n    ],\r\n    \"maxAgeInSeconds\": 60\r\n  },\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"FancySuggester\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ]\r\n}",
+      "RequestBody": "{\r\n  \"name\": \"azsmnet7517\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": true,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description_fr\",\r\n      \"type\": \"Edm.String\",\r\n      \"analyzer\": \"fr.lucene\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description_custom\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchAnalyzer\": \"stop\",\r\n      \"indexAnalyzer\": \"stop\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"totalGuests\",\r\n      \"type\": \"Edm.Int64\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": false\r\n    },\r\n    {\r\n      \"name\": \"profitMargin\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"MyProfile\",\r\n      \"text\": {\r\n        \"weights\": {\r\n          \"description\": 1.5,\r\n          \"category\": 2.0\r\n        }\r\n      },\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 1.0,\r\n            \"boostingRangeEnd\": 4.0,\r\n            \"constantBoostBeyondRange\": true\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 2.0,\r\n          \"interpolation\": \"constant\"\r\n        },\r\n        {\r\n          \"type\": \"distance\",\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"loc\",\r\n            \"boostingDistance\": 5.0\r\n          },\r\n          \"fieldName\": \"location\",\r\n          \"boost\": 1.5,\r\n          \"interpolation\": \"linear\"\r\n        },\r\n        {\r\n          \"type\": \"freshness\",\r\n          \"freshness\": {\r\n            \"boostingDuration\": \"P365D\"\r\n          },\r\n          \"fieldName\": \"lastRenovationDate\",\r\n          \"boost\": 1.1,\r\n          \"interpolation\": \"logarithmic\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"average\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileTwo\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"tag\",\r\n          \"tag\": {\r\n            \"tagsParameter\": \"mytags\"\r\n          },\r\n          \"fieldName\": \"tags\",\r\n          \"boost\": 1.5,\r\n          \"interpolation\": \"linear\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"maximum\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileThree\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 0.0,\r\n            \"boostingRangeEnd\": 10.0,\r\n            \"constantBoostBeyondRange\": false\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 3.0,\r\n          \"interpolation\": \"quadratic\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"minimum\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileFour\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 1.0,\r\n            \"boostingRangeEnd\": 5.0,\r\n            \"constantBoostBeyondRange\": false\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 3.14,\r\n          \"interpolation\": \"constant\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"firstMatching\"\r\n    }\r\n  ],\r\n  \"defaultScoringProfile\": \"MyProfile\",\r\n  \"corsOptions\": {\r\n    \"allowedOrigins\": [\r\n      \"http://tempuri.org\",\r\n      \"http://localhost:80\"\r\n    ],\r\n    \"maxAgeInSeconds\": 60\r\n  },\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"FancySuggester\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ]\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -411,26 +414,26 @@
           "6270"
         ],
         "client-request-id": [
-          "f8922aa7-7fb4-4029-9435-df91dd45b1ce"
+          "e9cf7222-3319-4067-82e0-db2105e0f873"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
+          "762FB1557922A9278184C38F1B96DCFF"
         ],
         "Prefer": [
           "return=representation"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#indexes/$entity\",\"@odata.etag\":\"\\\"0x8D413D20EECD284\\\"\",\"name\":\"azsmnet9050\",\"fields\":[{\"name\":\"hotelId\",\"type\":\"Edm.String\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":true,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"baseRate\",\"type\":\"Edm.Double\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"description\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"description_fr\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":\"fr.lucene\"},{\"name\":\"description_custom\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":\"stop\",\"searchAnalyzer\":\"stop\",\"analyzer\":null},{\"name\":\"hotelName\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"category\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"tags\",\"type\":\"Collection(Edm.String)\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":false,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"parkingIncluded\",\"type\":\"Edm.Boolean\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"smokingAllowed\",\"type\":\"Edm.Boolean\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"lastRenovationDate\",\"type\":\"Edm.DateTimeOffset\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"rating\",\"type\":\"Edm.Int32\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"location\",\"type\":\"Edm.GeographyPoint\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"totalGuests\",\"type\":\"Edm.Int64\",\"searchable\":false,\"filterable\":true,\"retrievable\":false,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"profitMargin\",\"type\":\"Edm.Double\",\"searchable\":false,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null}],\"scoringProfiles\":[{\"name\":\"MyProfile\",\"text\":{\"weights\":{\"description\":1.5,\"category\":2.0}},\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"constant\",\"magnitude\":{\"boostingRangeStart\":1.0,\"boostingRangeEnd\":4.0,\"constantBoostBeyondRange\":true},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":2.0},{\"fieldName\":\"location\",\"freshness\":null,\"interpolation\":\"linear\",\"magnitude\":null,\"distance\":{\"referencePointParameter\":\"loc\",\"boostingDistance\":5.0},\"tag\":null,\"type\":\"distance\",\"boost\":1.5},{\"fieldName\":\"lastRenovationDate\",\"freshness\":{\"boostingDuration\":\"P365D\"},\"interpolation\":\"logarithmic\",\"magnitude\":null,\"distance\":null,\"tag\":null,\"type\":\"freshness\",\"boost\":1.1}],\"functionAggregation\":\"average\"},{\"name\":\"ProfileTwo\",\"text\":null,\"functions\":[{\"fieldName\":\"tags\",\"freshness\":null,\"interpolation\":\"linear\",\"magnitude\":null,\"distance\":null,\"tag\":{\"tagsParameter\":\"mytags\"},\"type\":\"tag\",\"boost\":1.5}],\"functionAggregation\":\"maximum\"},{\"name\":\"ProfileThree\",\"text\":null,\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"quadratic\",\"magnitude\":{\"boostingRangeStart\":0.0,\"boostingRangeEnd\":10.0,\"constantBoostBeyondRange\":false},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":3.0}],\"functionAggregation\":\"minimum\"},{\"name\":\"ProfileFour\",\"text\":null,\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"constant\",\"magnitude\":{\"boostingRangeStart\":1.0,\"boostingRangeEnd\":5.0,\"constantBoostBeyondRange\":false},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":3.14}],\"functionAggregation\":\"firstMatching\"}],\"defaultScoringProfile\":\"MyProfile\",\"corsOptions\":{\"allowedOrigins\":[\"http://tempuri.org\",\"http://localhost:80\"],\"maxAgeInSeconds\":60},\"suggesters\":[{\"name\":\"FancySuggester\",\"searchMode\":\"analyzingInfixMatching\",\"sourceFields\":[\"hotelName\"]}],\"analyzers\":[],\"tokenizers\":[],\"tokenFilters\":[],\"charFilters\":[]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#indexes/$entity\",\"@odata.etag\":\"\\\"0x8D465921F706C39\\\"\",\"name\":\"azsmnet7517\",\"fields\":[{\"name\":\"hotelId\",\"type\":\"Edm.String\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":true,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"baseRate\",\"type\":\"Edm.Double\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"description\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"description_fr\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":\"fr.lucene\"},{\"name\":\"description_custom\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":\"stop\",\"searchAnalyzer\":\"stop\",\"analyzer\":null},{\"name\":\"hotelName\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"category\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"tags\",\"type\":\"Collection(Edm.String)\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":false,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"parkingIncluded\",\"type\":\"Edm.Boolean\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"smokingAllowed\",\"type\":\"Edm.Boolean\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"lastRenovationDate\",\"type\":\"Edm.DateTimeOffset\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"rating\",\"type\":\"Edm.Int32\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"location\",\"type\":\"Edm.GeographyPoint\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"totalGuests\",\"type\":\"Edm.Int64\",\"searchable\":false,\"filterable\":true,\"retrievable\":false,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"profitMargin\",\"type\":\"Edm.Double\",\"searchable\":false,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null}],\"scoringProfiles\":[{\"name\":\"MyProfile\",\"text\":{\"weights\":{\"description\":1.5,\"category\":2.0}},\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"constant\",\"magnitude\":{\"boostingRangeStart\":1.0,\"boostingRangeEnd\":4.0,\"constantBoostBeyondRange\":true},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":2.0},{\"fieldName\":\"location\",\"freshness\":null,\"interpolation\":\"linear\",\"magnitude\":null,\"distance\":{\"referencePointParameter\":\"loc\",\"boostingDistance\":5.0},\"tag\":null,\"type\":\"distance\",\"boost\":1.5},{\"fieldName\":\"lastRenovationDate\",\"freshness\":{\"boostingDuration\":\"P365D\"},\"interpolation\":\"logarithmic\",\"magnitude\":null,\"distance\":null,\"tag\":null,\"type\":\"freshness\",\"boost\":1.1}],\"functionAggregation\":\"average\"},{\"name\":\"ProfileTwo\",\"text\":null,\"functions\":[{\"fieldName\":\"tags\",\"freshness\":null,\"interpolation\":\"linear\",\"magnitude\":null,\"distance\":null,\"tag\":{\"tagsParameter\":\"mytags\"},\"type\":\"tag\",\"boost\":1.5}],\"functionAggregation\":\"maximum\"},{\"name\":\"ProfileThree\",\"text\":null,\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"quadratic\",\"magnitude\":{\"boostingRangeStart\":0.0,\"boostingRangeEnd\":10.0,\"constantBoostBeyondRange\":false},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":3.0}],\"functionAggregation\":\"minimum\"},{\"name\":\"ProfileFour\",\"text\":null,\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"constant\",\"magnitude\":{\"boostingRangeStart\":1.0,\"boostingRangeEnd\":5.0,\"constantBoostBeyondRange\":false},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":3.14}],\"functionAggregation\":\"firstMatching\"}],\"defaultScoringProfile\":\"MyProfile\",\"corsOptions\":{\"allowedOrigins\":[\"http://tempuri.org\",\"http://localhost:80\"],\"maxAgeInSeconds\":60},\"suggesters\":[{\"name\":\"FancySuggester\",\"searchMode\":\"analyzingInfixMatching\",\"sourceFields\":[\"hotelName\"]}],\"analyzers\":[],\"tokenizers\":[],\"tokenFilters\":[],\"charFilters\":[]}",
       "ResponseHeaders": {
         "Content-Length": [
-          "5143"
+          "5142"
         ],
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -442,22 +445,22 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
+          "Tue, 07 Mar 2017 19:42:43 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "ETag": [
-          "W/\"0x8D413D20EECD284\""
+          "W/\"0x8D465921F706C39\""
         ],
         "Location": [
-          "https://azs-9455.search-dogfood.windows-int.net/indexes('azsmnet9050')?api-version=2016-09-01"
+          "https://azs-280.search-dogfood.windows-int.net/indexes('azsmnet7517')?api-version=2016-09-01"
         ],
         "request-id": [
-          "f8922aa7-7fb4-4029-9435-df91dd45b1ce"
+          "e9cf7222-3319-4067-82e0-db2105e0f873"
         ],
         "elapsed-time": [
-          "1614"
+          "805"
         ],
         "OData-Version": [
           "4.0"
@@ -472,8 +475,8 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
       "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ar.microsoft\"\r\n}",
       "RequestHeaders": {
@@ -484,23 +487,23 @@
           "56"
         ],
         "client-request-id": [
-          "4250a1c9-88f2-4c0b-818f-35f9d88e8864"
+          "6be1e2e0-f377-4161-8bc0-8d3e46b040de"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
+          "762FB1557922A9278184C38F1B96DCFF"
         ],
         "Prefer": [
           "return=representation"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -512,7 +515,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
+          "Tue, 07 Mar 2017 19:42:43 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -521,10 +524,10 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "4250a1c9-88f2-4c0b-818f-35f9d88e8864"
+          "6be1e2e0-f377-4161-8bc0-8d3e46b040de"
         ],
         "elapsed-time": [
-          "27"
+          "728"
         ],
         "OData-Version": [
           "4.0"
@@ -539,8 +542,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
       "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ar.lucene\"\r\n}",
       "RequestHeaders": {
@@ -551,23 +554,23 @@
           "53"
         ],
         "client-request-id": [
-          "dc208dee-c8db-416b-b204-3cb7bee3c6c4"
+          "f14f77bf-3081-4429-a880-71978b05f4e8"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
+          "762FB1557922A9278184C38F1B96DCFF"
         ],
         "Prefer": [
           "return=representation"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -579,7 +582,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
+          "Tue, 07 Mar 2017 19:42:43 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -588,2687 +591,7 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "dc208dee-c8db-416b-b204-3cb7bee3c6c4"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hy.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "9d303190-1bc9-457c-a283-12721a00eb82"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "9d303190-1bc9-457c-a283-12721a00eb82"
-        ],
-        "elapsed-time": [
-          "15"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"bn.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "303c594d-e22a-489b-bd6d-f74aa931fe14"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "303c594d-e22a-489b-bd6d-f74aa931fe14"
-        ],
-        "elapsed-time": [
-          "22"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"eu.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "c1dde450-840b-4679-ba2b-c40583e26cc3"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "c1dde450-840b-4679-ba2b-c40583e26cc3"
-        ],
-        "elapsed-time": [
-          "14"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"bg.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "31d17726-c7bc-4544-8514-891376a0151a"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "31d17726-c7bc-4544-8514-891376a0151a"
-        ],
-        "elapsed-time": [
-          "25"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"bg.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "314fe650-362b-462b-887c-f129fc62caa3"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "314fe650-362b-462b-887c-f129fc62caa3"
-        ],
-        "elapsed-time": [
-          "16"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ca.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "2c61a6f8-281f-41fc-aee5-d52e551e285f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "2c61a6f8-281f-41fc-aee5-d52e551e285f"
-        ],
-        "elapsed-time": [
-          "19"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ca.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "986d695b-3ccd-4f54-a0fb-fd48b7985d02"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "986d695b-3ccd-4f54-a0fb-fd48b7985d02"
-        ],
-        "elapsed-time": [
-          "16"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hans.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "61"
-        ],
-        "client-request-id": [
-          "a10a0b8b-958c-49d8-841a-32cbb8d6234f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "a10a0b8b-958c-49d8-841a-32cbb8d6234f"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hans.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "58"
-        ],
-        "client-request-id": [
-          "fd86b04a-7ec5-407f-8914-5f94ca7c6e94"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "fd86b04a-7ec5-407f-8914-5f94ca7c6e94"
-        ],
-        "elapsed-time": [
-          "15"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hant.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "61"
-        ],
-        "client-request-id": [
-          "aec35dfe-410b-4cba-b078-ade1563c83ff"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "aec35dfe-410b-4cba-b078-ade1563c83ff"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hant.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "58"
-        ],
-        "client-request-id": [
-          "53c337b2-06a6-437b-816b-aa288d8038be"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "53c337b2-06a6-437b-816b-aa288d8038be"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hr.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "b5754234-eb0d-48b7-b32a-d3a3b26ebba7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"onaj\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b5754234-eb0d-48b7-b32a-d3a3b26ebba7"
-        ],
-        "elapsed-time": [
-          "19"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"cs.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "d67c5000-c4b6-44a3-971c-0ccc9450dee6"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"twa\",\"startOffset\":4,\"endOffset\":7,\"position\":1},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "d67c5000-c4b6-44a3-971c-0ccc9450dee6"
-        ],
-        "elapsed-time": [
-          "19"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"cs.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "0c5c28d0-d57d-40e8-95e7-93abbba1cba7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "0c5c28d0-d57d-40e8-95e7-93abbba1cba7"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"da.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "5b1b2b2e-7e9f-4edf-97cd-8901c8076fb2"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "5b1b2b2e-7e9f-4edf-97cd-8901c8076fb2"
-        ],
-        "elapsed-time": [
-          "31"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"da.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "ada51a3a-3de3-4932-af02-b8e922240f42"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "ada51a3a-3de3-4932-af02-b8e922240f42"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nl.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "9ec65ed0-ca49-4b5b-b25c-f45e79dc42a7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "9ec65ed0-ca49-4b5b-b25c-f45e79dc42a7"
-        ],
-        "elapsed-time": [
-          "25"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nl.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "70ca598f-6e8b-43e5-8b72-07073c636573"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "70ca598f-6e8b-43e5-8b72-07073c636573"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"en.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "e353f607-88db-4ebf-9046-538ac4ed3969"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "e353f607-88db-4ebf-9046-538ac4ed3969"
-        ],
-        "elapsed-time": [
-          "21"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"en.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "cdf7d20f-284b-4155-abf0-6ec82c9c7ade"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "cdf7d20f-284b-4155-abf0-6ec82c9c7ade"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"et.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "e510e26f-0aaf-426c-ba6a-932b1c06d778"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "e510e26f-0aaf-426c-ba6a-932b1c06d778"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fi.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "991cf0ba-f55f-4244-b3df-4e3f06d62e40"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "991cf0ba-f55f-4244-b3df-4e3f06d62e40"
-        ],
-        "elapsed-time": [
-          "17"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fi.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "702a5adc-4685-4d4e-b80b-23daf760978f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "702a5adc-4685-4d4e-b80b-23daf760978f"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fr.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "2bd48da3-08f8-4e53-97b0-a3859b3dc902"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "2bd48da3-08f8-4e53-97b0-a3859b3dc902"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fr.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "58fbe29b-4071-477e-80cb-10fde1bf3856"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "58fbe29b-4071-477e-80cb-10fde1bf3856"
-        ],
-        "elapsed-time": [
-          "14"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"gl.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "3655e3ff-8026-4dd7-ad36-a78f68219c33"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "3655e3ff-8026-4dd7-ad36-a78f68219c33"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"de.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "7f63f754-868e-4c35-9004-cb2f4e3c7aab"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "7f63f754-868e-4c35-9004-cb2f4e3c7aab"
-        ],
-        "elapsed-time": [
-          "29"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"de.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "04739bb9-1c72-48fe-b599-98523acbae73"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "04739bb9-1c72-48fe-b599-98523acbae73"
-        ],
-        "elapsed-time": [
-          "16"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"el.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "611ce1a6-30bd-4253-98a7-77109b39e1d7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "611ce1a6-30bd-4253-98a7-77109b39e1d7"
-        ],
-        "elapsed-time": [
-          "29"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"el.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "fa84f3bb-7430-42ff-99cd-2678fc354b30"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "fa84f3bb-7430-42ff-99cd-2678fc354b30"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"gu.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "b4c350ba-c8e6-4e8c-83ea-104a36e7db0f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b4c350ba-c8e6-4e8c-83ea-104a36e7db0f"
-        ],
-        "elapsed-time": [
-          "21"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"he.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "d64bf0cd-e142-4c61-a600-4e6055a6447b"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "d64bf0cd-e142-4c61-a600-4e6055a6447b"
-        ],
-        "elapsed-time": [
-          "171"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hi.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "2517d70f-f566-4788-bc92-4e31e8c6cd3d"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "2517d70f-f566-4788-bc92-4e31e8c6cd3d"
-        ],
-        "elapsed-time": [
-          "21"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hi.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "4ee3d634-9bf3-46d6-a975-9eff7f630597"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "4ee3d634-9bf3-46d6-a975-9eff7f630597"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hu.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "83bc4f81-44da-4e46-b943-088b518e77dc"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "83bc4f81-44da-4e46-b943-088b518e77dc"
-        ],
-        "elapsed-time": [
-          "16"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hu.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "283a6523-9dbf-4818-944f-19a749846bd4"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "283a6523-9dbf-4818-944f-19a749846bd4"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"is.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "7b71b65a-2b2f-4a2a-890f-c7051d94d3b3"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "7b71b65a-2b2f-4a2a-890f-c7051d94d3b3"
-        ],
-        "elapsed-time": [
-          "23"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"id.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "53b02717-87f7-4443-a3cf-cf50977b62ec"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "53b02717-87f7-4443-a3cf-cf50977b62ec"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"id.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "8b00fe1a-558f-4467-bb1e-33bb651df59d"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "8b00fe1a-558f-4467-bb1e-33bb651df59d"
-        ],
-        "elapsed-time": [
-          "15"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ga.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "3b4bc726-2731-4842-bd2a-02a9c2177183"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "3b4bc726-2731-4842-bd2a-02a9c2177183"
+          "f14f77bf-3081-4429-a880-71978b05f4e8"
         ],
         "elapsed-time": [
           "11"
@@ -3286,77 +609,10 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"it.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "3cd278c0-9937-4ec4-8f8f-57097f3b1db1"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "3cd278c0-9937-4ec4-8f8f-57097f3b1db1"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"it.lucene\"\r\n}",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hy.lucene\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -3365,23 +621,23 @@
           "53"
         ],
         "client-request-id": [
-          "4b79ba47-9a7c-4c0b-8669-05d1ee880976"
+          "555828e8-9bc5-4823-ac1b-14642b7fc46e"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
+          "762FB1557922A9278184C38F1B96DCFF"
         ],
         "Prefer": [
           "return=representation"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -3393,7 +649,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
+          "Tue, 07 Mar 2017 19:42:44 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -3402,3826 +658,7 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "4b79ba47-9a7c-4c0b-8669-05d1ee880976"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ja.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "37c76f53-5303-452a-a290-703658215ef7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "37c76f53-5303-452a-a290-703658215ef7"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ja.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "f53b40da-1eba-4c9a-9a77-987e3ed0d653"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "f53b40da-1eba-4c9a-9a77-987e3ed0d653"
-        ],
-        "elapsed-time": [
-          "14"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"kn.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "17764607-a66b-41fb-8c20-a10ecb80900e"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "17764607-a66b-41fb-8c20-a10ecb80900e"
-        ],
-        "elapsed-time": [
-          "25"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ko.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "772800c7-7e01-4963-a3d7-583b7947e482"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "772800c7-7e01-4963-a3d7-583b7947e482"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ko.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "1c82ae84-1fdf-45c0-b902-47d291820d0d"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "1c82ae84-1fdf-45c0-b902-47d291820d0d"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lv.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "5e13af6f-f5f2-4853-990d-da931a915183"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "5e13af6f-f5f2-4853-990d-da931a915183"
-        ],
-        "elapsed-time": [
-          "17"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lv.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "19e4af82-8e37-4946-b91f-ff62ff06e25c"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "19e4af82-8e37-4946-b91f-ff62ff06e25c"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lt.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "9c227e14-6e0c-4f45-bcab-c01298eb0c22"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "9c227e14-6e0c-4f45-bcab-c01298eb0c22"
-        ],
-        "elapsed-time": [
-          "15"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ml.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "aee50e5d-1153-4382-bc6a-1c158c112a25"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "aee50e5d-1153-4382-bc6a-1c158c112a25"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ms.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "a158981b-b958-4268-9941-6fba209cc19d"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "a158981b-b958-4268-9941-6fba209cc19d"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"mr.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "e9f6d48f-e813-4d7f-ad19-5a02de38b6a8"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "e9f6d48f-e813-4d7f-ad19-5a02de38b6a8"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nb.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "0fa22c57-d540-4c15-a18f-e9347ac273ec"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "0fa22c57-d540-4c15-a18f-e9347ac273ec"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"no.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "8fec06fe-aaeb-465c-913e-620fb50b1f6d"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "8fec06fe-aaeb-465c-913e-620fb50b1f6d"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fa.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "879b298a-d217-45ea-8118-3d477bbcaecc"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "879b298a-d217-45ea-8118-3d477bbcaecc"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pl.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "73eee113-968f-45f4-a16d-fac320016174"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "73eee113-968f-45f4-a16d-fac320016174"
-        ],
-        "elapsed-time": [
-          "26"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pl.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "1ff57c20-dbff-4934-8e20-799218b26668"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "1ff57c20-dbff-4934-8e20-799218b26668"
-        ],
-        "elapsed-time": [
-          "18"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-BR.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "59"
-        ],
-        "client-request-id": [
-          "bdf2477b-6e7c-4c44-a053-c7c7243ba867"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "bdf2477b-6e7c-4c44-a053-c7c7243ba867"
-        ],
-        "elapsed-time": [
-          "22"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-BR.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "6c23d2b9-aa4c-4a91-9716-7631789189e2"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "6c23d2b9-aa4c-4a91-9716-7631789189e2"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-PT.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "59"
-        ],
-        "client-request-id": [
-          "b808ab15-2f22-4646-acf2-733b1455bd55"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b808ab15-2f22-4646-acf2-733b1455bd55"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-PT.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "7b6e5664-4c6c-4744-a5a1-340a8ae30890"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "7b6e5664-4c6c-4744-a5a1-340a8ae30890"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pa.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "72f71148-e8d6-4cd2-a0de-c71d704a0658"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:51 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "72f71148-e8d6-4cd2-a0de-c71d704a0658"
-        ],
-        "elapsed-time": [
-          "21"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ro.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "ea86dddb-da9f-4145-ab6e-d18b39c3aec7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "ea86dddb-da9f-4145-ab6e-d18b39c3aec7"
-        ],
-        "elapsed-time": [
-          "21"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ro.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "1b9d7a02-e71f-441c-b28f-ccd41cf68d1e"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "1b9d7a02-e71f-441c-b28f-ccd41cf68d1e"
-        ],
-        "elapsed-time": [
-          "14"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ru.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "3aefe46f-fe23-4fb3-85e1-a37da98c8f68"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "3aefe46f-fe23-4fb3-85e1-a37da98c8f68"
-        ],
-        "elapsed-time": [
-          "19"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ru.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "c8604f10-8f9b-40f8-9d2a-030a0543db84"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "c8604f10-8f9b-40f8-9d2a-030a0543db84"
-        ],
-        "elapsed-time": [
-          "14"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sr-cyrillic.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "65"
-        ],
-        "client-request-id": [
-          "33daa3bf-ae45-4f09-94eb-3b858ec0a640"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "33daa3bf-ae45-4f09-94eb-3b858ec0a640"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sr-latin.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "62"
-        ],
-        "client-request-id": [
-          "c9342782-47c6-4596-b485-8dcb097815ab"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"ona\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"onaj\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "c9342782-47c6-4596-b485-8dcb097815ab"
-        ],
-        "elapsed-time": [
-          "23"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sk.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "cb262c78-8e44-4816-aee3-33c2e6469c23"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "cb262c78-8e44-4816-aee3-33c2e6469c23"
-        ],
-        "elapsed-time": [
-          "16"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sl.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "377c9bf7-a744-4d9f-9247-430e06915ae2"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"oni\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"twa\",\"startOffset\":4,\"endOffset\":7,\"position\":1},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "377c9bf7-a744-4d9f-9247-430e06915ae2"
-        ],
-        "elapsed-time": [
-          "19"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"es.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "a046c995-f6b8-4bd1-9475-c46c25a785f2"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "a046c995-f6b8-4bd1-9475-c46c25a785f2"
-        ],
-        "elapsed-time": [
-          "27"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"es.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "9364a3b4-fecd-4d2f-a8d7-aa6429de3612"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "9364a3b4-fecd-4d2f-a8d7-aa6429de3612"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sv.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "b7f54e8a-4c1b-44ec-be5b-581a594f2ae7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b7f54e8a-4c1b-44ec-be5b-581a594f2ae7"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sv.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "dae2c29c-a584-4c64-8ced-9748afbb6411"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "dae2c29c-a584-4c64-8ced-9748afbb6411"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ta.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "07350193-8d40-4c97-ba42-b9e537b7a797"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "07350193-8d40-4c97-ba42-b9e537b7a797"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"te.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "77d155cb-f03b-46e0-b24a-8c278f0c94a7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "77d155cb-f03b-46e0-b24a-8c278f0c94a7"
-        ],
-        "elapsed-time": [
-          "20"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"th.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "ef928dd5-fb5d-493e-be5c-ddbf19fd6084"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "ef928dd5-fb5d-493e-be5c-ddbf19fd6084"
-        ],
-        "elapsed-time": [
-          "15"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"th.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "7987198e-276c-444b-8b0e-ec29d9f723f4"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "7987198e-276c-444b-8b0e-ec29d9f723f4"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"tr.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "157b2d2f-637a-4cd7-b1a1-b73881bf5723"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "157b2d2f-637a-4cd7-b1a1-b73881bf5723"
-        ],
-        "elapsed-time": [
-          "19"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"tr.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "09800993-f2c0-42cb-9520-f48e049dc1ef"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "09800993-f2c0-42cb-9520-f48e049dc1ef"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"uk.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "e808a2eb-b7b1-44b8-bcda-83a43145d0fc"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "e808a2eb-b7b1-44b8-bcda-83a43145d0fc"
-        ],
-        "elapsed-time": [
-          "38"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ur.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "58f20735-5c19-4809-952a-57ef813ad68f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "58f20735-5c19-4809-952a-57ef813ad68f"
-        ],
-        "elapsed-time": [
-          "22"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"vi.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "af582ed6-5b64-4cbd-a9b3-10f3b2d9725f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "af582ed6-5b64-4cbd-a9b3-10f3b2d9725f"
-        ],
-        "elapsed-time": [
-          "16"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"standardasciifolding.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "71"
-        ],
-        "client-request-id": [
-          "0cd8241a-93f4-4aa6-aece-72f0be0aed57"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "0cd8241a-93f4-4aa6-aece-72f0be0aed57"
-        ],
-        "elapsed-time": [
-          "15"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"keyword\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "51"
-        ],
-        "client-request-id": [
-          "bfd6d0dd-93a2-4989-ac80-b4020bc28492"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One two\",\"startOffset\":0,\"endOffset\":7,\"position\":0}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "bfd6d0dd-93a2-4989-ac80-b4020bc28492"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pattern\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "51"
-        ],
-        "client-request-id": [
-          "f56e8bc7-1f74-4f37-9f3a-ec73b06c8d6d"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:52 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "f56e8bc7-1f74-4f37-9f3a-ec73b06c8d6d"
-        ],
-        "elapsed-time": [
-          "14"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"simple\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "50"
-        ],
-        "client-request-id": [
-          "4d405d57-b686-40fc-845c-2cceb1d88d24"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "4d405d57-b686-40fc-845c-2cceb1d88d24"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"stop\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "48"
-        ],
-        "client-request-id": [
-          "530b539b-d79e-4049-bba2-05292e555e60"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "530b539b-d79e-4049-bba2-05292e555e60"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"whitespace\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "54"
-        ],
-        "client-request-id": [
-          "8db3d5cd-ad35-44fe-8f5c-b0b5d0efe1f3"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "8db3d5cd-ad35-44fe-8f5c-b0b5d0efe1f3"
-        ],
-        "elapsed-time": [
-          "14"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"classic\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "52"
-        ],
-        "client-request-id": [
-          "6f1e3667-c1ed-4c63-beb4-9f8693c2ff8f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "6f1e3667-c1ed-4c63-beb4-9f8693c2ff8f"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"edgeNGram\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "54"
-        ],
-        "client-request-id": [
-          "8b553eb8-fa70-45da-9b4f-782b5ea6fbd4"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":1,\"position\":0}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "8b553eb8-fa70-45da-9b4f-782b5ea6fbd4"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"keyword_v2\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "55"
-        ],
-        "client-request-id": [
-          "b9e0f508-01bc-424d-b764-3c0251416b92"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One two\",\"startOffset\":0,\"endOffset\":7,\"position\":0}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b9e0f508-01bc-424d-b764-3c0251416b92"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"letter\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "51"
-        ],
-        "client-request-id": [
-          "3f6d81ac-660e-4168-8586-b35a703aeee1"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "3f6d81ac-660e-4168-8586-b35a703aeee1"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"lowercase\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "54"
-        ],
-        "client-request-id": [
-          "f55c886c-39f2-4def-834a-a6442868458d"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "f55c886c-39f2-4def-834a-a6442868458d"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"nGram\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "50"
-        ],
-        "client-request-id": [
-          "5d0c1f32-d485-42b8-872f-73aed81ad2d4"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":1,\"position\":0},{\"token\":\"On\",\"startOffset\":0,\"endOffset\":2,\"position\":1},{\"token\":\"ne\",\"startOffset\":1,\"endOffset\":3,\"position\":2},{\"token\":\"n\",\"startOffset\":1,\"endOffset\":2,\"position\":3},{\"token\":\"e\",\"startOffset\":2,\"endOffset\":3,\"position\":4},{\"token\":\"e \",\"startOffset\":2,\"endOffset\":4,\"position\":5},{\"token\":\" t\",\"startOffset\":3,\"endOffset\":5,\"position\":6},{\"token\":\" \",\"startOffset\":3,\"endOffset\":4,\"position\":7},{\"token\":\"tw\",\"startOffset\":4,\"endOffset\":6,\"position\":8},{\"token\":\"t\",\"startOffset\":4,\"endOffset\":5,\"position\":9},{\"token\":\"wo\",\"startOffset\":5,\"endOffset\":7,\"position\":10},{\"token\":\"w\",\"startOffset\":5,\"endOffset\":6,\"position\":11},{\"token\":\"o\",\"startOffset\":6,\"endOffset\":7,\"position\":12}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "5d0c1f32-d485-42b8-872f-73aed81ad2d4"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"path_hierarchy_v2\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "62"
-        ],
-        "client-request-id": [
-          "6a584f0a-32d5-44ce-bd69-a218f97c80cb"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "6a584f0a-32d5-44ce-bd69-a218f97c80cb"
-        ],
-        "elapsed-time": [
-          "14"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"pattern\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "52"
-        ],
-        "client-request-id": [
-          "52405860-41c3-4cbc-8aab-d3b98a6dd706"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "52405860-41c3-4cbc-8aab-d3b98a6dd706"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"standard_v2\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "7883c16b-e664-405d-8389-ec6efb59de02"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "7883c16b-e664-405d-8389-ec6efb59de02"
+          "555828e8-9bc5-4823-ac1b-14642b7fc46e"
         ],
         "elapsed-time": [
           "10"
@@ -7239,35 +676,35 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"uax_url_email\"\r\n}",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"bn.microsoft\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "58"
+          "56"
         ],
         "client-request-id": [
-          "ca6da3f0-484d-4fc4-9d58-b88c11d3226d"
+          "05f51556-17b0-49b3-86c9-145c07a65ec8"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
+          "762FB1557922A9278184C38F1B96DCFF"
         ],
         "Prefer": [
           "return=representation"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -7279,7 +716,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
+          "Tue, 07 Mar 2017 19:42:44 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -7288,10 +725,10 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "ca6da3f0-484d-4fc4-9d58-b88c11d3226d"
+          "05f51556-17b0-49b3-86c9-145c07a65ec8"
         ],
         "elapsed-time": [
-          "39"
+          "720"
         ],
         "OData-Version": [
           "4.0"
@@ -7306,35 +743,35 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"whitespace\"\r\n}",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"eu.lucene\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "55"
+          "53"
         ],
         "client-request-id": [
-          "a9f5d497-6a79-463d-815f-47de56fa7cb7"
+          "d8c7cae5-b7cd-41ce-aebb-bfe155e6bc04"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
+          "762FB1557922A9278184C38F1B96DCFF"
         ],
         "Prefer": [
           "return=representation"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -7346,7 +783,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
+          "Tue, 07 Mar 2017 19:42:44 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -7355,7 +792,1682 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "a9f5d497-6a79-463d-815f-47de56fa7cb7"
+          "d8c7cae5-b7cd-41ce-aebb-bfe155e6bc04"
+        ],
+        "elapsed-time": [
+          "30"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"bg.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "6be94abb-da8b-4518-8eed-0294a8f5e843"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:45 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "6be94abb-da8b-4518-8eed-0294a8f5e843"
+        ],
+        "elapsed-time": [
+          "255"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"bg.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "ae6b2eae-d4bf-437a-95a3-4d13661dd31c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:45 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "ae6b2eae-d4bf-437a-95a3-4d13661dd31c"
+        ],
+        "elapsed-time": [
+          "12"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ca.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "37364c44-58fe-4fbe-aaef-a1b26b83ded3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:45 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "37364c44-58fe-4fbe-aaef-a1b26b83ded3"
+        ],
+        "elapsed-time": [
+          "23"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ca.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "2fa8b7cf-213b-4ffa-b913-5f3ec4565851"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:45 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "2fa8b7cf-213b-4ffa-b913-5f3ec4565851"
+        ],
+        "elapsed-time": [
+          "13"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hans.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "61"
+        ],
+        "client-request-id": [
+          "50cee1e9-df5a-402c-9786-c29ce3c5241f"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:45 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "50cee1e9-df5a-402c-9786-c29ce3c5241f"
+        ],
+        "elapsed-time": [
+          "68"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hans.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "58"
+        ],
+        "client-request-id": [
+          "2f12fe46-0346-44ab-9d4f-7fe1c8c2d8b4"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:45 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "2f12fe46-0346-44ab-9d4f-7fe1c8c2d8b4"
+        ],
+        "elapsed-time": [
+          "690"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hant.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "61"
+        ],
+        "client-request-id": [
+          "32448880-620a-41e1-85b7-ab0fa02c5e8c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "32448880-620a-41e1-85b7-ab0fa02c5e8c"
+        ],
+        "elapsed-time": [
+          "397"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hant.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "58"
+        ],
+        "client-request-id": [
+          "bd1f5d37-9d1d-4a74-a5de-43a342eedac8"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "bd1f5d37-9d1d-4a74-a5de-43a342eedac8"
+        ],
+        "elapsed-time": [
+          "165"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hr.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "a51a988c-2523-4965-9c91-8b1b77217c58"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"onaj\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "a51a988c-2523-4965-9c91-8b1b77217c58"
+        ],
+        "elapsed-time": [
+          "35"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"cs.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "b96d157d-8307-4d23-9a99-6be3848ccad8"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"twa\",\"startOffset\":4,\"endOffset\":7,\"position\":1},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b96d157d-8307-4d23-9a99-6be3848ccad8"
+        ],
+        "elapsed-time": [
+          "45"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"cs.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "54420fce-e0bd-41e4-9fb2-5e3a841466c3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "54420fce-e0bd-41e4-9fb2-5e3a841466c3"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"da.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "a0666bfb-8d40-4835-a5bb-b06707291deb"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "a0666bfb-8d40-4835-a5bb-b06707291deb"
+        ],
+        "elapsed-time": [
+          "71"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"da.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "fb82c927-0148-47c7-837b-401bee658d6c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "fb82c927-0148-47c7-837b-401bee658d6c"
+        ],
+        "elapsed-time": [
+          "12"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nl.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "b443e3fb-4ccb-496b-99fe-3a60b778a0d9"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b443e3fb-4ccb-496b-99fe-3a60b778a0d9"
+        ],
+        "elapsed-time": [
+          "40"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nl.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "1433019a-3a7f-4935-86d7-6863d2af619b"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1433019a-3a7f-4935-86d7-6863d2af619b"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"en.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "ca2d4ec3-737a-4923-b4a3-ba92987c2308"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "ca2d4ec3-737a-4923-b4a3-ba92987c2308"
+        ],
+        "elapsed-time": [
+          "217"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"en.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "ae333d46-7467-49a5-b6d7-6b8ece1dfb2b"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "ae333d46-7467-49a5-b6d7-6b8ece1dfb2b"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"et.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "1309c925-8944-402a-ac2f-7af6fc95fe0e"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1309c925-8944-402a-ac2f-7af6fc95fe0e"
+        ],
+        "elapsed-time": [
+          "18"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fi.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "22fc4ce3-609c-4f33-91a3-ec2d60bc543c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "22fc4ce3-609c-4f33-91a3-ec2d60bc543c"
+        ],
+        "elapsed-time": [
+          "42"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fi.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "6366cfdc-ebc8-4b58-8fe5-def666aef47e"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "6366cfdc-ebc8-4b58-8fe5-def666aef47e"
+        ],
+        "elapsed-time": [
+          "17"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fr.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "33a6db80-dc33-4b1f-97a2-164f36413fdb"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "33a6db80-dc33-4b1f-97a2-164f36413fdb"
+        ],
+        "elapsed-time": [
+          "41"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fr.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "5aacccbc-d777-4450-a17a-4672cd79540e"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "5aacccbc-d777-4450-a17a-4672cd79540e"
+        ],
+        "elapsed-time": [
+          "33"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"gl.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "1a45ccc4-885d-4ffc-b4ae-a428516be184"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1a45ccc4-885d-4ffc-b4ae-a428516be184"
+        ],
+        "elapsed-time": [
+          "21"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"de.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "f13a1b95-8e93-4bb3-a227-e11da40ff558"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "f13a1b95-8e93-4bb3-a227-e11da40ff558"
+        ],
+        "elapsed-time": [
+          "54"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"de.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "147a97d2-0d14-4860-935e-b370bb31d73f"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "147a97d2-0d14-4860-935e-b370bb31d73f"
         ],
         "elapsed-time": [
           "14"
@@ -7373,35 +2485,35 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet9050')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ5MDUwJykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"whitespace\",\r\n  \"tokenFilters\": [\r\n    \"arabic_normalization\",\r\n    \"apostrophe\",\r\n    \"asciifolding\",\r\n    \"cjk_bigram\",\r\n    \"cjk_width\",\r\n    \"classic\",\r\n    \"common_grams\",\r\n    \"edgeNGram_v2\",\r\n    \"elision\",\r\n    \"german_normalization\",\r\n    \"hindi_normalization\",\r\n    \"indic_normalization\",\r\n    \"keyword_repeat\",\r\n    \"kstem\",\r\n    \"length\",\r\n    \"limit\",\r\n    \"lowercase\",\r\n    \"nGram_v2\",\r\n    \"persian_normalization\",\r\n    \"phonetic\",\r\n    \"porter_stem\",\r\n    \"reverse\",\r\n    \"scandinavian_normalization\",\r\n    \"scandinavian_folding\",\r\n    \"shingle\",\r\n    \"snowball\",\r\n    \"sorani_normalization\",\r\n    \"stemmer\",\r\n    \"stopwords\",\r\n    \"trim\",\r\n    \"truncate\",\r\n    \"unique\",\r\n    \"uppercase\",\r\n    \"word_delimiter\"\r\n  ],\r\n  \"charFilters\": [\r\n    \"html_strip\"\r\n  ]\r\n}",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"el.microsoft\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "820"
+          "56"
         ],
         "client-request-id": [
-          "cbd8369c-a5e3-4393-9ba5-e9164db6c9bb"
+          "fd9e0d4d-07eb-4645-905e-4c9120e4f94b"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "C0112890AC467F0D05E9B6F23EC86404"
+          "762FB1557922A9278184C38F1B96DCFF"
         ],
         "Prefer": [
           "return=representation"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-9455.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":3,\"position\":0}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -7413,7 +2525,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:53 GMT"
+          "Tue, 07 Mar 2017 19:42:48 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -7422,10 +2534,10 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "cbd8369c-a5e3-4393-9ba5-e9164db6c9bb"
+          "fd9e0d4d-07eb-4645-905e-4c9120e4f94b"
         ],
         "elapsed-time": [
-          "149"
+          "47"
         ],
         "OData-Version": [
           "4.0"
@@ -7440,20 +2552,5045 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet9502/providers/Microsoft.Search/searchServices/azs-9455?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ5NTAyL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy05NDU1P2FwaS12ZXJzaW9uPTIwMTUtMDgtMTk=",
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"el.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "903bb40e-01ca-4d41-9d32-4f35b656a786"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "903bb40e-01ca-4d41-9d32-4f35b656a786"
+        ],
+        "elapsed-time": [
+          "50"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"gu.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "0d185fd9-e442-4e65-932f-a169a6237b12"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "0d185fd9-e442-4e65-932f-a169a6237b12"
+        ],
+        "elapsed-time": [
+          "17"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"he.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "6914f2f3-ea1e-42d3-9ab1-36a3a92a271a"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "6914f2f3-ea1e-42d3-9ab1-36a3a92a271a"
+        ],
+        "elapsed-time": [
+          "73"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hi.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "f722cd79-5951-48be-bcf5-1f634cc4edfa"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "f722cd79-5951-48be-bcf5-1f634cc4edfa"
+        ],
+        "elapsed-time": [
+          "38"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hi.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "54c55fe4-a951-4c35-9ff3-4b87a481de86"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "54c55fe4-a951-4c35-9ff3-4b87a481de86"
+        ],
+        "elapsed-time": [
+          "23"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hu.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "5553ddda-869b-416d-96b4-46c081679f63"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "5553ddda-869b-416d-96b4-46c081679f63"
+        ],
+        "elapsed-time": [
+          "206"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hu.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "dff164ad-8653-4905-9e58-41dc4ab08639"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "dff164ad-8653-4905-9e58-41dc4ab08639"
+        ],
+        "elapsed-time": [
+          "16"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"is.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "8961ccc6-4580-43fb-957a-4309e65ce67c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "8961ccc6-4580-43fb-957a-4309e65ce67c"
+        ],
+        "elapsed-time": [
+          "50"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"id.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "a6e24414-3b53-49d0-a0c0-0d05216a9455"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "a6e24414-3b53-49d0-a0c0-0d05216a9455"
+        ],
+        "elapsed-time": [
+          "59"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"id.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "09040892-ff9e-48cf-ad5b-37b242edfd25"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "09040892-ff9e-48cf-ad5b-37b242edfd25"
+        ],
+        "elapsed-time": [
+          "13"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ga.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "f5a095f5-e64a-4561-b5f1-ee519221c8f8"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "f5a095f5-e64a-4561-b5f1-ee519221c8f8"
+        ],
+        "elapsed-time": [
+          "40"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"it.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "78b85462-17c6-4e2c-932a-fa328ec2bc4f"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "78b85462-17c6-4e2c-932a-fa328ec2bc4f"
+        ],
+        "elapsed-time": [
+          "40"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"it.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "8b106534-ba31-46e6-8c7e-f1069f77cc38"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "8b106534-ba31-46e6-8c7e-f1069f77cc38"
+        ],
+        "elapsed-time": [
+          "28"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ja.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "1f92ef5a-4352-4364-9036-4d746bda08c4"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1f92ef5a-4352-4364-9036-4d746bda08c4"
+        ],
+        "elapsed-time": [
+          "438"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ja.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "a82f98a1-71a0-4470-9f7b-be5083e01016"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "a82f98a1-71a0-4470-9f7b-be5083e01016"
+        ],
+        "elapsed-time": [
+          "417"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"kn.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "8b753566-a54a-4d51-8f8e-577758b31ade"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "8b753566-a54a-4d51-8f8e-577758b31ade"
+        ],
+        "elapsed-time": [
+          "30"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ko.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "7731adcb-b5c3-4ade-8816-1dfce6891e5a"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "7731adcb-b5c3-4ade-8816-1dfce6891e5a"
+        ],
+        "elapsed-time": [
+          "571"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ko.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "3a63849d-35bf-4256-bcd5-0389b3f2536d"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "3a63849d-35bf-4256-bcd5-0389b3f2536d"
+        ],
+        "elapsed-time": [
+          "21"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lv.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "e6931087-a5f7-401f-afd8-9c9e94efd0ef"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "e6931087-a5f7-401f-afd8-9c9e94efd0ef"
+        ],
+        "elapsed-time": [
+          "16"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lv.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "0c73f4ee-c751-4c3c-b83a-1ff5b50a3e3b"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "0c73f4ee-c751-4c3c-b83a-1ff5b50a3e3b"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lt.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "8318854e-dfbe-4b38-b018-31ea4acdcc5d"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "8318854e-dfbe-4b38-b018-31ea4acdcc5d"
+        ],
+        "elapsed-time": [
+          "15"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ml.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "e67cc620-14ba-48c8-b445-934b7cb51bd7"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "e67cc620-14ba-48c8-b445-934b7cb51bd7"
+        ],
+        "elapsed-time": [
+          "67"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ms.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "1274e2e3-ea2b-4aa2-8de9-aad82a4869f4"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1274e2e3-ea2b-4aa2-8de9-aad82a4869f4"
+        ],
+        "elapsed-time": [
+          "1656"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"mr.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "f6c19043-46a9-43c9-82ba-b1b31a3a2f25"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "f6c19043-46a9-43c9-82ba-b1b31a3a2f25"
+        ],
+        "elapsed-time": [
+          "236"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nb.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "b9f1f711-8cbd-4534-af3a-83f6a83f7a4b"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b9f1f711-8cbd-4534-af3a-83f6a83f7a4b"
+        ],
+        "elapsed-time": [
+          "31"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"no.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "98f82f60-157b-472e-a81e-ce759a5923ad"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "98f82f60-157b-472e-a81e-ce759a5923ad"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fa.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "ef40bd03-6b5f-4747-8c53-582a908988a2"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "ef40bd03-6b5f-4747-8c53-582a908988a2"
+        ],
+        "elapsed-time": [
+          "11"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pl.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "d3e7dbf2-5148-4b52-bed9-1922529970bd"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "d3e7dbf2-5148-4b52-bed9-1922529970bd"
+        ],
+        "elapsed-time": [
+          "21"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pl.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "0ae9fd5d-a5ab-4786-963c-d8a3bbb50b29"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "0ae9fd5d-a5ab-4786-963c-d8a3bbb50b29"
+        ],
+        "elapsed-time": [
+          "14"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-BR.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "59"
+        ],
+        "client-request-id": [
+          "c9a5944f-2d1f-4a67-81b6-0ca03dcfe96f"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "c9a5944f-2d1f-4a67-81b6-0ca03dcfe96f"
+        ],
+        "elapsed-time": [
+          "25"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-BR.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "f9bf991f-ca67-472a-8991-d56c8d5816bc"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "f9bf991f-ca67-472a-8991-d56c8d5816bc"
+        ],
+        "elapsed-time": [
+          "25"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-PT.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "59"
+        ],
+        "client-request-id": [
+          "8c3fd446-a0a2-463d-915d-3c38a1fe9ce3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "8c3fd446-a0a2-463d-915d-3c38a1fe9ce3"
+        ],
+        "elapsed-time": [
+          "31"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-PT.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "e4dc3791-648d-4422-a2ed-449af8d8fb53"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "e4dc3791-648d-4422-a2ed-449af8d8fb53"
+        ],
+        "elapsed-time": [
+          "18"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pa.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "db4d8259-f916-4dff-85ec-887b5fc3e41d"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "db4d8259-f916-4dff-85ec-887b5fc3e41d"
+        ],
+        "elapsed-time": [
+          "47"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ro.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "18fcc0f7-c5b0-4639-9fff-bce41b4be421"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "18fcc0f7-c5b0-4639-9fff-bce41b4be421"
+        ],
+        "elapsed-time": [
+          "24"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ro.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "d1445d56-cfa3-4b59-b6cd-79b7321fd4fd"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "d1445d56-cfa3-4b59-b6cd-79b7321fd4fd"
+        ],
+        "elapsed-time": [
+          "13"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ru.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "46e1225c-6bc3-4b1e-81f5-82df4ea14511"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "46e1225c-6bc3-4b1e-81f5-82df4ea14511"
+        ],
+        "elapsed-time": [
+          "35"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ru.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "44549211-c7a0-4e8c-8b4d-f9c75e4ea34a"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "44549211-c7a0-4e8c-8b4d-f9c75e4ea34a"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sr-cyrillic.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "65"
+        ],
+        "client-request-id": [
+          "6461798e-eb5e-4263-a6ca-e589e57a4655"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "6461798e-eb5e-4263-a6ca-e589e57a4655"
+        ],
+        "elapsed-time": [
+          "241"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sr-latin.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "62"
+        ],
+        "client-request-id": [
+          "dbff30b2-c8bc-4ae3-8dcd-d69f1f64fff8"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"ona\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"onaj\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "dbff30b2-c8bc-4ae3-8dcd-d69f1f64fff8"
+        ],
+        "elapsed-time": [
+          "23"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sk.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "d1fd35b6-9397-497c-b72a-8acfe34b24d9"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "d1fd35b6-9397-497c-b72a-8acfe34b24d9"
+        ],
+        "elapsed-time": [
+          "17"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sl.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "5516ad03-74ec-432d-aaa0-62880f543ece"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"oni\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"twa\",\"startOffset\":4,\"endOffset\":7,\"position\":1},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "5516ad03-74ec-432d-aaa0-62880f543ece"
+        ],
+        "elapsed-time": [
+          "17"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"es.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "b05a7aaf-7616-4213-9249-d3cf076c4863"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b05a7aaf-7616-4213-9249-d3cf076c4863"
+        ],
+        "elapsed-time": [
+          "26"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"es.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "2c1fd595-a0d6-49e1-b968-ca0171a8a340"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "2c1fd595-a0d6-49e1-b968-ca0171a8a340"
+        ],
+        "elapsed-time": [
+          "15"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sv.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "1f627c9e-71b7-43b6-b0d2-947a04956fe4"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1f627c9e-71b7-43b6-b0d2-947a04956fe4"
+        ],
+        "elapsed-time": [
+          "52"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sv.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "aeeb9e71-b989-49e7-8d88-9b403949d1b2"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "aeeb9e71-b989-49e7-8d88-9b403949d1b2"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ta.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "2eda58a7-be40-4dd2-b7d6-796083420e0f"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "2eda58a7-be40-4dd2-b7d6-796083420e0f"
+        ],
+        "elapsed-time": [
+          "35"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"te.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "b79ec631-8b6d-4592-a21a-40ff1b94a0a2"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b79ec631-8b6d-4592-a21a-40ff1b94a0a2"
+        ],
+        "elapsed-time": [
+          "18"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"th.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "96d9fe2c-3c2d-4029-9be6-df44416bedeb"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "96d9fe2c-3c2d-4029-9be6-df44416bedeb"
+        ],
+        "elapsed-time": [
+          "241"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"th.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "b032e349-a8df-48e9-ba72-eb979631cea1"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b032e349-a8df-48e9-ba72-eb979631cea1"
+        ],
+        "elapsed-time": [
+          "38"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"tr.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "063f61f2-0d1f-48f6-b3d8-f2f67e75ffa3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "063f61f2-0d1f-48f6-b3d8-f2f67e75ffa3"
+        ],
+        "elapsed-time": [
+          "46"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"tr.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "31600e93-8e5f-4ee4-94ed-e566384d72b5"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "31600e93-8e5f-4ee4-94ed-e566384d72b5"
+        ],
+        "elapsed-time": [
+          "12"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"uk.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "cc9b5436-3f50-4f9b-9667-a9db46daf90d"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "cc9b5436-3f50-4f9b-9667-a9db46daf90d"
+        ],
+        "elapsed-time": [
+          "17"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ur.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "2c8f6550-8ad6-4447-92b1-aebd018f6287"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "2c8f6550-8ad6-4447-92b1-aebd018f6287"
+        ],
+        "elapsed-time": [
+          "41"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"vi.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "976dca29-db16-4be4-b910-89154c1ef52c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "976dca29-db16-4be4-b910-89154c1ef52c"
+        ],
+        "elapsed-time": [
+          "18"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"standardasciifolding.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "71"
+        ],
+        "client-request-id": [
+          "f94a42a4-990e-43e5-88a5-eef8effbd8b7"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "f94a42a4-990e-43e5-88a5-eef8effbd8b7"
+        ],
+        "elapsed-time": [
+          "12"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"keyword\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "51"
+        ],
+        "client-request-id": [
+          "362ee99a-3255-4126-a655-54cd9b536a9c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One two\",\"startOffset\":0,\"endOffset\":7,\"position\":0}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "362ee99a-3255-4126-a655-54cd9b536a9c"
+        ],
+        "elapsed-time": [
+          "12"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pattern\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "51"
+        ],
+        "client-request-id": [
+          "790499e5-7461-4f3d-9f52-72355016c021"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "790499e5-7461-4f3d-9f52-72355016c021"
+        ],
+        "elapsed-time": [
+          "8"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"simple\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "50"
+        ],
+        "client-request-id": [
+          "27e1a94d-5eb1-4e03-9d32-1343dcada595"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "27e1a94d-5eb1-4e03-9d32-1343dcada595"
+        ],
+        "elapsed-time": [
+          "18"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"stop\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "48"
+        ],
+        "client-request-id": [
+          "841d2b18-d889-4609-9839-eeb7982fe10a"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "841d2b18-d889-4609-9839-eeb7982fe10a"
+        ],
+        "elapsed-time": [
+          "8"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"whitespace\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "54"
+        ],
+        "client-request-id": [
+          "fe094211-d862-450c-b522-c2bcec2542b8"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "fe094211-d862-450c-b522-c2bcec2542b8"
+        ],
+        "elapsed-time": [
+          "8"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"classic\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "52"
+        ],
+        "client-request-id": [
+          "0bb9ecec-e240-437d-bf0b-d5de3a3e4165"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "0bb9ecec-e240-437d-bf0b-d5de3a3e4165"
+        ],
+        "elapsed-time": [
+          "16"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"edgeNGram\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "54"
+        ],
+        "client-request-id": [
+          "1000b825-2e1a-4416-ad3d-084eee10359c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":1,\"position\":0}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1000b825-2e1a-4416-ad3d-084eee10359c"
+        ],
+        "elapsed-time": [
+          "11"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"keyword_v2\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "55"
+        ],
+        "client-request-id": [
+          "34d48e80-ecea-47c0-84e4-b94f7a0e9437"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One two\",\"startOffset\":0,\"endOffset\":7,\"position\":0}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "34d48e80-ecea-47c0-84e4-b94f7a0e9437"
+        ],
+        "elapsed-time": [
+          "21"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"letter\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "51"
+        ],
+        "client-request-id": [
+          "aa907f3d-c175-4659-8904-6c38e733996f"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "aa907f3d-c175-4659-8904-6c38e733996f"
+        ],
+        "elapsed-time": [
+          "16"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"lowercase\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "54"
+        ],
+        "client-request-id": [
+          "c1ba1bc6-5494-4a08-a1d8-5817e313bed8"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "c1ba1bc6-5494-4a08-a1d8-5817e313bed8"
+        ],
+        "elapsed-time": [
+          "11"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"microsoft_language_tokenizer\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "73"
+        ],
+        "client-request-id": [
+          "15d222ee-6152-41d0-9cff-11959f6999cb"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "15d222ee-6152-41d0-9cff-11959f6999cb"
+        ],
+        "elapsed-time": [
+          "17"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"microsoft_language_stemming_tokenizer\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "82"
+        ],
+        "client-request-id": [
+          "483d72a3-07f4-4d21-bd7e-7d2c0aa91aeb"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "483d72a3-07f4-4d21-bd7e-7d2c0aa91aeb"
+        ],
+        "elapsed-time": [
+          "12"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"nGram\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "50"
+        ],
+        "client-request-id": [
+          "b712d4ee-e3da-4c73-ad18-e73117a83fd0"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":1,\"position\":0},{\"token\":\"On\",\"startOffset\":0,\"endOffset\":2,\"position\":1},{\"token\":\"ne\",\"startOffset\":1,\"endOffset\":3,\"position\":2},{\"token\":\"n\",\"startOffset\":1,\"endOffset\":2,\"position\":3},{\"token\":\"e\",\"startOffset\":2,\"endOffset\":3,\"position\":4},{\"token\":\"e \",\"startOffset\":2,\"endOffset\":4,\"position\":5},{\"token\":\" t\",\"startOffset\":3,\"endOffset\":5,\"position\":6},{\"token\":\" \",\"startOffset\":3,\"endOffset\":4,\"position\":7},{\"token\":\"tw\",\"startOffset\":4,\"endOffset\":6,\"position\":8},{\"token\":\"t\",\"startOffset\":4,\"endOffset\":5,\"position\":9},{\"token\":\"wo\",\"startOffset\":5,\"endOffset\":7,\"position\":10},{\"token\":\"w\",\"startOffset\":5,\"endOffset\":6,\"position\":11},{\"token\":\"o\",\"startOffset\":6,\"endOffset\":7,\"position\":12}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b712d4ee-e3da-4c73-ad18-e73117a83fd0"
+        ],
+        "elapsed-time": [
+          "20"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"path_hierarchy_v2\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "62"
+        ],
+        "client-request-id": [
+          "1ec62a22-d09d-4572-ac65-fcc02ed40e7b"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1ec62a22-d09d-4572-ac65-fcc02ed40e7b"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"pattern\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "52"
+        ],
+        "client-request-id": [
+          "7c959f20-b455-4e40-9141-f1e19f3b42c3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "7c959f20-b455-4e40-9141-f1e19f3b42c3"
+        ],
+        "elapsed-time": [
+          "12"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"standard_v2\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "eddd5473-d6fb-407a-b7d6-33d707808e5f"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "eddd5473-d6fb-407a-b7d6-33d707808e5f"
+        ],
+        "elapsed-time": [
+          "11"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"uax_url_email\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "58"
+        ],
+        "client-request-id": [
+          "49dc581a-3529-4b7c-b869-1d66618cb154"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "49dc581a-3529-4b7c-b869-1d66618cb154"
+        ],
+        "elapsed-time": [
+          "33"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"whitespace\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "55"
+        ],
+        "client-request-id": [
+          "9f9e2f7c-9083-4261-aab3-500b27079b69"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "9f9e2f7c-9083-4261-aab3-500b27079b69"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"whitespace\",\r\n  \"tokenFilters\": [\r\n    \"arabic_normalization\",\r\n    \"apostrophe\",\r\n    \"asciifolding\",\r\n    \"cjk_bigram\",\r\n    \"cjk_width\",\r\n    \"classic\",\r\n    \"common_grams\",\r\n    \"edgeNGram_v2\",\r\n    \"elision\",\r\n    \"german_normalization\",\r\n    \"hindi_normalization\",\r\n    \"indic_normalization\",\r\n    \"keyword_repeat\",\r\n    \"kstem\",\r\n    \"length\",\r\n    \"limit\",\r\n    \"lowercase\",\r\n    \"nGram_v2\",\r\n    \"persian_normalization\",\r\n    \"phonetic\",\r\n    \"porter_stem\",\r\n    \"reverse\",\r\n    \"scandinavian_normalization\",\r\n    \"scandinavian_folding\",\r\n    \"shingle\",\r\n    \"snowball\",\r\n    \"sorani_normalization\",\r\n    \"stemmer\",\r\n    \"stopwords\",\r\n    \"trim\",\r\n    \"truncate\",\r\n    \"unique\",\r\n    \"uppercase\",\r\n    \"word_delimiter\"\r\n  ],\r\n  \"charFilters\": [\r\n    \"html_strip\"\r\n  ]\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "820"
+        ],
+        "client-request-id": [
+          "b3d31159-79b8-4098-a42e-9701f6f7d37e"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "762FB1557922A9278184C38F1B96DCFF"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":3,\"position\":0}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:42:56 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b3d31159-79b8-4098-a42e-9701f6f7d37e"
+        ],
+        "elapsed-time": [
+          "235"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410/providers/Microsoft.Search/searchServices/azs-280?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ2NDEwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0yODA/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "173f45a8-d000-425d-adc2-4ee83367f665"
+          "4af4f5b0-2470-43de-8d1c-fdc5d6ec21f0"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.24214.01",
-          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.0-rc"
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.1"
         ]
       },
       "ResponseBody": "",
@@ -7468,19 +7605,19 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 23 Nov 2016 18:53:54 GMT"
+          "Tue, 07 Mar 2017 19:42:56 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "x-ms-request-id": [
-          "173f45a8-d000-425d-adc2-4ee83367f665"
+          "4af4f5b0-2470-43de-8d1c-fdc5d6ec21f0"
         ],
         "request-id": [
-          "173f45a8-d000-425d-adc2-4ee83367f665"
+          "4af4f5b0-2470-43de-8d1c-fdc5d6ec21f0"
         ],
         "elapsed-time": [
-          "540"
+          "701"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -7489,13 +7626,13 @@
           "4.0.30319"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1133"
+          "1197"
         ],
         "x-ms-correlation-request-id": [
-          "81386625-9d87-460b-8d3e-bf87be864d91"
+          "df22c314-f974-431e-9d8e-416eca7ae750"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20161123T185355Z:81386625-9d87-460b-8d3e-bf87be864d91"
+          "CENTRALUS:20170307T194257Z:df22c314-f974-431e-9d8e-416eca7ae750"
         ]
       },
       "StatusCode": 200
@@ -7503,12 +7640,12 @@
   ],
   "Names": {
     "GenerateName": [
-      "azsmnet9502",
-      "azsmnet1192",
-      "azsmnet9050"
+      "azsmnet6410",
+      "azsmnet2698",
+      "azsmnet7517"
     ],
     "GenerateServiceName": [
-      "azs-9455"
+      "azs-280"
     ]
   },
   "Variables": {

--- a/src/Search/Search.Tests/SessionRecords/Microsoft.Azure.Search.Tests.CustomAnalyzerTests/CanAnalyzeWithAllPossibleNames.json
+++ b/src/Search/Search.Tests/SessionRecords/Microsoft.Azure.Search.Tests.CustomAnalyzerTests/CanAnalyzeWithAllPossibleNames.json
@@ -7,7 +7,7 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "d80ddd46-fcde-4599-9e31-383a04897019"
+          "3faa02aa-befc-4c9e-923b-50a2cd128bf8"
         ],
         "accept-language": [
           "en-US"
@@ -29,7 +29,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:05 GMT"
+          "Tue, 07 Mar 2017 19:55:53 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -41,16 +41,16 @@
           "Accept-Encoding"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1199"
+          "1184"
         ],
         "x-ms-request-id": [
-          "48d209e8-b0c4-4934-bc22-8f98c7d64312"
+          "3f392837-73ed-4c6c-954e-9c7826111ffd"
         ],
         "x-ms-correlation-request-id": [
-          "48d209e8-b0c4-4934-bc22-8f98c7d64312"
+          "3f392837-73ed-4c6c-954e-9c7826111ffd"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20170307T194206Z:48d209e8-b0c4-4934-bc22-8f98c7d64312"
+          "CENTRALUS:20170307T195553Z:3f392837-73ed-4c6c-954e-9c7826111ffd"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -59,8 +59,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourcegroups/azsmnet6410?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlZ3JvdXBzL2F6c21uZXQ2NDEwP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourcegroups/azsmnet8601?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlZ3JvdXBzL2F6c21uZXQ4NjAxP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"location\": \"West US\"\r\n}",
       "RequestHeaders": {
@@ -71,7 +71,7 @@
           "29"
         ],
         "x-ms-client-request-id": [
-          "2ea5c36d-12aa-4b12-90ee-eda3859e60cb"
+          "07c3785b-0e2d-4fd8-a78e-fafca2b38773"
         ],
         "accept-language": [
           "en-US"
@@ -81,7 +81,7 @@
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.1.1-preview"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410\",\r\n  \"name\": \"azsmnet6410\",\r\n  \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet8601\",\r\n  \"name\": \"azsmnet8601\",\r\n  \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "175"
@@ -96,22 +96,22 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:06 GMT"
+          "Tue, 07 Mar 2017 19:55:54 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1198"
+          "1183"
         ],
         "x-ms-request-id": [
-          "75bd0f45-ee0b-4c70-a514-e93f6ca4260f"
+          "bafc1be5-ae1f-405d-8d4e-4fd789c1e650"
         ],
         "x-ms-correlation-request-id": [
-          "75bd0f45-ee0b-4c70-a514-e93f6ca4260f"
+          "bafc1be5-ae1f-405d-8d4e-4fd789c1e650"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20170307T194206Z:75bd0f45-ee0b-4c70-a514-e93f6ca4260f"
+          "CENTRALUS:20170307T195554Z:bafc1be5-ae1f-405d-8d4e-4fd789c1e650"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -120,8 +120,8 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410/providers/Microsoft.Search/searchServices/azs-280?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ2NDEwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0yODA/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet8601/providers/Microsoft.Search/searchServices/azs-1141?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ4NjAxL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0xMTQxP2FwaS12ZXJzaW9uPTIwMTUtMDgtMTk=",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"free\"\r\n  },\r\n  \"location\": \"West US\"\r\n}",
       "RequestHeaders": {
@@ -132,7 +132,7 @@
           "67"
         ],
         "x-ms-client-request-id": [
-          "c653020f-0ed9-4b3a-b149-d36910cbe2c7"
+          "6a57ae25-359b-4669-8ee1-4c0bc9194d6c"
         ],
         "accept-language": [
           "en-US"
@@ -142,10 +142,10 @@
           "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.1"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410/providers/Microsoft.Search/searchServices/azs-280\",\r\n  \"name\": \"azs-280\",\r\n  \"type\": \"Microsoft.Search/searchServices\",\r\n  \"location\": \"West US\",\r\n  \"properties\": {\r\n    \"replicaCount\": 1,\r\n    \"partitionCount\": 1,\r\n    \"status\": \"running\",\r\n    \"statusDetails\": \"\",\r\n    \"provisioningState\": \"succeeded\",\r\n    \"hostingMode\": \"Default\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"free\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet8601/providers/Microsoft.Search/searchServices/azs-1141\",\r\n  \"name\": \"azs-1141\",\r\n  \"type\": \"Microsoft.Search/searchServices\",\r\n  \"location\": \"West US\",\r\n  \"properties\": {\r\n    \"replicaCount\": 1,\r\n    \"partitionCount\": 1,\r\n    \"status\": \"running\",\r\n    \"statusDetails\": \"\",\r\n    \"provisioningState\": \"succeeded\",\r\n    \"hostingMode\": \"Default\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"free\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "383"
+          "385"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -157,22 +157,22 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:09 GMT"
+          "Tue, 07 Mar 2017 19:55:55 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "ETag": [
-          "W/\"datetime'2017-03-07T19%3A42%3A10.5668754Z'\""
+          "W/\"datetime'2017-03-07T19%3A55%3A56.1132702Z'\""
         ],
         "x-ms-request-id": [
-          "c653020f-0ed9-4b3a-b149-d36910cbe2c7"
+          "6a57ae25-359b-4669-8ee1-4c0bc9194d6c"
         ],
         "request-id": [
-          "c653020f-0ed9-4b3a-b149-d36910cbe2c7"
+          "6a57ae25-359b-4669-8ee1-4c0bc9194d6c"
         ],
         "elapsed-time": [
-          "2153"
+          "524"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -181,25 +181,25 @@
           "4.0.30319"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1199"
+          "1180"
         ],
         "x-ms-correlation-request-id": [
-          "db3b022b-87ef-4412-95df-844b185259b8"
+          "d00711d4-438d-4f66-b6df-3a8c4fb2eca9"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20170307T194210Z:db3b022b-87ef-4412-95df-844b185259b8"
+          "CENTRALUS:20170307T195555Z:d00711d4-438d-4f66-b6df-3a8c4fb2eca9"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410/providers/Microsoft.Search/searchServices/azs-280/listAdminKeys?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ2NDEwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0yODAvbGlzdEFkbWluS2V5cz9hcGktdmVyc2lvbj0yMDE1LTA4LTE5",
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet8601/providers/Microsoft.Search/searchServices/azs-1141/listAdminKeys?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ4NjAxL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0xMTQxL2xpc3RBZG1pbktleXM/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
       "RequestMethod": "POST",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "8c302060-329b-4d16-a3b5-17828ff87518"
+          "5a5fc066-b2db-4e0d-b1ab-f24d6af4cf69"
         ],
         "accept-language": [
           "en-US"
@@ -209,7 +209,7 @@
           "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.1"
         ]
       },
-      "ResponseBody": "{\r\n  \"primaryKey\": \"762FB1557922A9278184C38F1B96DCFF\",\r\n  \"secondaryKey\": \"C3A7850C25287F83AE60EBE3B5159C80\"\r\n}",
+      "ResponseBody": "{\r\n  \"primaryKey\": \"9C747DAC975294606708FB47FFC266E4\",\r\n  \"secondaryKey\": \"E35686D854C1BD0E28FF33AE7FE4311C\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -221,7 +221,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:16 GMT"
+          "Tue, 07 Mar 2017 19:55:57 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -234,13 +234,13 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "8c302060-329b-4d16-a3b5-17828ff87518"
+          "5a5fc066-b2db-4e0d-b1ab-f24d6af4cf69"
         ],
         "request-id": [
-          "8c302060-329b-4d16-a3b5-17828ff87518"
+          "5a5fc066-b2db-4e0d-b1ab-f24d6af4cf69"
         ],
         "elapsed-time": [
-          "160"
+          "150"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -249,25 +249,25 @@
           "4.0.30319"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1198"
+          "1179"
         ],
         "x-ms-correlation-request-id": [
-          "a44b04ce-59c2-4f61-8e1d-6d02e5f29a67"
+          "a61a5ae1-6e30-478a-8322-30aab4f684b5"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20170307T194216Z:a44b04ce-59c2-4f61-8e1d-6d02e5f29a67"
+          "CENTRALUS:20170307T195557Z:a61a5ae1-6e30-478a-8322-30aab4f684b5"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410/providers/Microsoft.Search/searchServices/azs-280/listQueryKeys?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ2NDEwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0yODAvbGlzdFF1ZXJ5S2V5cz9hcGktdmVyc2lvbj0yMDE1LTA4LTE5",
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet8601/providers/Microsoft.Search/searchServices/azs-1141/listQueryKeys?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ4NjAxL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0xMTQxL2xpc3RRdWVyeUtleXM/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "c4ff89cb-fb4b-4b68-83c8-ba84be844da9"
+          "86e5472e-1391-484c-acf8-1579948cea1b"
         ],
         "accept-language": [
           "en-US"
@@ -277,7 +277,7 @@
           "Microsoft.Azure.Management.Search.SearchManagementClient/1.0.1"
         ]
       },
-      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": null,\r\n      \"key\": \"A61BC61C22F686DC9411E7BBB1A0ECE9\"\r\n    }\r\n  ],\r\n  \"nextLink\": null\r\n}",
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": null,\r\n      \"key\": \"3C7129AF75DB022866B563BDB8116EDE\"\r\n    }\r\n  ],\r\n  \"nextLink\": null\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -289,7 +289,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:16 GMT"
+          "Tue, 07 Mar 2017 19:55:57 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -302,13 +302,13 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "c4ff89cb-fb4b-4b68-83c8-ba84be844da9"
+          "86e5472e-1391-484c-acf8-1579948cea1b"
         ],
         "request-id": [
-          "c4ff89cb-fb4b-4b68-83c8-ba84be844da9"
+          "86e5472e-1391-484c-acf8-1579948cea1b"
         ],
         "elapsed-time": [
-          "149"
+          "136"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -317,13 +317,13 @@
           "4.0.30319"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14999"
+          "14997"
         ],
         "x-ms-correlation-request-id": [
-          "a2ae23be-487c-4e14-a774-7045903c4439"
+          "35f77c45-420d-494d-a809-ca346db8b9d0"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20170307T194217Z:a2ae23be-487c-4e14-a774-7045903c4439"
+          "CENTRALUS:20170307T195558Z:35f77c45-420d-494d-a809-ca346db8b9d0"
         ]
       },
       "StatusCode": 200
@@ -332,22 +332,22 @@
       "RequestUri": "/indexes?api-version=2016-09-01",
       "EncodedRequestUri": "L2luZGV4ZXM/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"name\": \"azsmnet2698\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": true,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"descriptionFr\",\r\n      \"type\": \"Edm.String\",\r\n      \"analyzer\": \"fr.lucene\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"nearest\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"distance\",\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"myloc\",\r\n            \"boostingDistance\": 100.0\r\n          },\r\n          \"fieldName\": \"location\",\r\n          \"boost\": 2.0\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"sum\"\r\n    }\r\n  ],\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"sg\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"description\",\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ]\r\n}",
+      "RequestBody": "{\r\n  \"name\": \"azsmnet520\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": true,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"descriptionFr\",\r\n      \"type\": \"Edm.String\",\r\n      \"analyzer\": \"fr.lucene\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"nearest\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"distance\",\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"myloc\",\r\n            \"boostingDistance\": 100.0\r\n          },\r\n          \"fieldName\": \"location\",\r\n          \"boost\": 2.0\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"sum\"\r\n    }\r\n  ],\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"sg\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"description\",\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ]\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "3401"
+          "3400"
         ],
         "client-request-id": [
-          "b21affd8-01df-41bd-a835-0762e4de983e"
+          "31ae38a3-fc74-42ba-8e04-246309854b04"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -357,7 +357,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://azs-280.search-dogfood.windows-int.net/$metadata#indexes/$entity\",\r\n  \"@odata.etag\": \"\\\"0x8D46592129E780C\\\"\",\r\n  \"name\": \"azsmnet2698\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": true,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"descriptionFr\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": \"fr.lucene\"\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"nearest\",\r\n      \"text\": null,\r\n      \"functions\": [\r\n        {\r\n          \"fieldName\": \"location\",\r\n          \"freshness\": null,\r\n          \"interpolation\": \"linear\",\r\n          \"magnitude\": null,\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"myloc\",\r\n            \"boostingDistance\": 100.0\r\n          },\r\n          \"tag\": null,\r\n          \"type\": \"distance\",\r\n          \"boost\": 2.0\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"sum\"\r\n    }\r\n  ],\r\n  \"defaultScoringProfile\": null,\r\n  \"corsOptions\": null,\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"sg\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"description\",\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ],\r\n  \"analyzers\": [],\r\n  \"tokenizers\": [],\r\n  \"tokenFilters\": [],\r\n  \"charFilters\": []\r\n}",
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://azs-1141.search-dogfood.windows-int.net/$metadata#indexes/$entity\",\r\n  \"@odata.etag\": \"\\\"0x8D46593FB2345F3\\\"\",\r\n  \"name\": \"azsmnet520\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": true,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"descriptionFr\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": \"fr.lucene\"\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"retrievable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"key\": false,\r\n      \"indexAnalyzer\": null,\r\n      \"searchAnalyzer\": null,\r\n      \"analyzer\": null\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"nearest\",\r\n      \"text\": null,\r\n      \"functions\": [\r\n        {\r\n          \"fieldName\": \"location\",\r\n          \"freshness\": null,\r\n          \"interpolation\": \"linear\",\r\n          \"magnitude\": null,\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"myloc\",\r\n            \"boostingDistance\": 100.0\r\n          },\r\n          \"tag\": null,\r\n          \"type\": \"distance\",\r\n          \"boost\": 2.0\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"sum\"\r\n    }\r\n  ],\r\n  \"defaultScoringProfile\": null,\r\n  \"corsOptions\": null,\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"sg\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"description\",\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ],\r\n  \"analyzers\": [],\r\n  \"tokenizers\": [],\r\n  \"tokenFilters\": [],\r\n  \"charFilters\": []\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "3140"
@@ -372,22 +372,22 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:22 GMT"
+          "Tue, 07 Mar 2017 19:56:00 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "ETag": [
-          "W/\"0x8D46592129E780C\""
+          "W/\"0x8D46593FB2345F3\""
         ],
         "Location": [
-          "https://azs-280.search-dogfood.windows-int.net/indexes('azsmnet2698')?api-version=2016-09-01"
+          "https://azs-1141.search-dogfood.windows-int.net/indexes('azsmnet520')?api-version=2016-09-01"
         ],
         "request-id": [
-          "b21affd8-01df-41bd-a835-0762e4de983e"
+          "31ae38a3-fc74-42ba-8e04-246309854b04"
         ],
         "elapsed-time": [
-          "2799"
+          "2663"
         ],
         "OData-Version": [
           "4.0"
@@ -405,7 +405,7 @@
       "RequestUri": "/indexes?api-version=2016-09-01",
       "EncodedRequestUri": "L2luZGV4ZXM/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"name\": \"azsmnet7517\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": true,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description_fr\",\r\n      \"type\": \"Edm.String\",\r\n      \"analyzer\": \"fr.lucene\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description_custom\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchAnalyzer\": \"stop\",\r\n      \"indexAnalyzer\": \"stop\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"totalGuests\",\r\n      \"type\": \"Edm.Int64\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": false\r\n    },\r\n    {\r\n      \"name\": \"profitMargin\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"MyProfile\",\r\n      \"text\": {\r\n        \"weights\": {\r\n          \"description\": 1.5,\r\n          \"category\": 2.0\r\n        }\r\n      },\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 1.0,\r\n            \"boostingRangeEnd\": 4.0,\r\n            \"constantBoostBeyondRange\": true\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 2.0,\r\n          \"interpolation\": \"constant\"\r\n        },\r\n        {\r\n          \"type\": \"distance\",\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"loc\",\r\n            \"boostingDistance\": 5.0\r\n          },\r\n          \"fieldName\": \"location\",\r\n          \"boost\": 1.5,\r\n          \"interpolation\": \"linear\"\r\n        },\r\n        {\r\n          \"type\": \"freshness\",\r\n          \"freshness\": {\r\n            \"boostingDuration\": \"P365D\"\r\n          },\r\n          \"fieldName\": \"lastRenovationDate\",\r\n          \"boost\": 1.1,\r\n          \"interpolation\": \"logarithmic\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"average\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileTwo\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"tag\",\r\n          \"tag\": {\r\n            \"tagsParameter\": \"mytags\"\r\n          },\r\n          \"fieldName\": \"tags\",\r\n          \"boost\": 1.5,\r\n          \"interpolation\": \"linear\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"maximum\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileThree\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 0.0,\r\n            \"boostingRangeEnd\": 10.0,\r\n            \"constantBoostBeyondRange\": false\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 3.0,\r\n          \"interpolation\": \"quadratic\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"minimum\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileFour\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 1.0,\r\n            \"boostingRangeEnd\": 5.0,\r\n            \"constantBoostBeyondRange\": false\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 3.14,\r\n          \"interpolation\": \"constant\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"firstMatching\"\r\n    }\r\n  ],\r\n  \"defaultScoringProfile\": \"MyProfile\",\r\n  \"corsOptions\": {\r\n    \"allowedOrigins\": [\r\n      \"http://tempuri.org\",\r\n      \"http://localhost:80\"\r\n    ],\r\n    \"maxAgeInSeconds\": 60\r\n  },\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"FancySuggester\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ]\r\n}",
+      "RequestBody": "{\r\n  \"name\": \"azsmnet6388\",\r\n  \"fields\": [\r\n    {\r\n      \"name\": \"hotelId\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": true,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"baseRate\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description_fr\",\r\n      \"type\": \"Edm.String\",\r\n      \"analyzer\": \"fr.lucene\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"description_custom\",\r\n      \"type\": \"Edm.String\",\r\n      \"searchAnalyzer\": \"stop\",\r\n      \"indexAnalyzer\": \"stop\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"hotelName\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"category\",\r\n      \"type\": \"Edm.String\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"tags\",\r\n      \"type\": \"Collection(Edm.String)\",\r\n      \"key\": false,\r\n      \"searchable\": true,\r\n      \"filterable\": true,\r\n      \"sortable\": false,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"parkingIncluded\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"smokingAllowed\",\r\n      \"type\": \"Edm.Boolean\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"lastRenovationDate\",\r\n      \"type\": \"Edm.DateTimeOffset\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"rating\",\r\n      \"type\": \"Edm.Int32\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"location\",\r\n      \"type\": \"Edm.GeographyPoint\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    },\r\n    {\r\n      \"name\": \"totalGuests\",\r\n      \"type\": \"Edm.Int64\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": true,\r\n      \"sortable\": true,\r\n      \"facetable\": true,\r\n      \"retrievable\": false\r\n    },\r\n    {\r\n      \"name\": \"profitMargin\",\r\n      \"type\": \"Edm.Double\",\r\n      \"key\": false,\r\n      \"searchable\": false,\r\n      \"filterable\": false,\r\n      \"sortable\": false,\r\n      \"facetable\": false,\r\n      \"retrievable\": true\r\n    }\r\n  ],\r\n  \"scoringProfiles\": [\r\n    {\r\n      \"name\": \"MyProfile\",\r\n      \"text\": {\r\n        \"weights\": {\r\n          \"description\": 1.5,\r\n          \"category\": 2.0\r\n        }\r\n      },\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 1.0,\r\n            \"boostingRangeEnd\": 4.0,\r\n            \"constantBoostBeyondRange\": true\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 2.0,\r\n          \"interpolation\": \"constant\"\r\n        },\r\n        {\r\n          \"type\": \"distance\",\r\n          \"distance\": {\r\n            \"referencePointParameter\": \"loc\",\r\n            \"boostingDistance\": 5.0\r\n          },\r\n          \"fieldName\": \"location\",\r\n          \"boost\": 1.5,\r\n          \"interpolation\": \"linear\"\r\n        },\r\n        {\r\n          \"type\": \"freshness\",\r\n          \"freshness\": {\r\n            \"boostingDuration\": \"P365D\"\r\n          },\r\n          \"fieldName\": \"lastRenovationDate\",\r\n          \"boost\": 1.1,\r\n          \"interpolation\": \"logarithmic\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"average\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileTwo\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"tag\",\r\n          \"tag\": {\r\n            \"tagsParameter\": \"mytags\"\r\n          },\r\n          \"fieldName\": \"tags\",\r\n          \"boost\": 1.5,\r\n          \"interpolation\": \"linear\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"maximum\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileThree\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 0.0,\r\n            \"boostingRangeEnd\": 10.0,\r\n            \"constantBoostBeyondRange\": false\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 3.0,\r\n          \"interpolation\": \"quadratic\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"minimum\"\r\n    },\r\n    {\r\n      \"name\": \"ProfileFour\",\r\n      \"functions\": [\r\n        {\r\n          \"type\": \"magnitude\",\r\n          \"magnitude\": {\r\n            \"boostingRangeStart\": 1.0,\r\n            \"boostingRangeEnd\": 5.0,\r\n            \"constantBoostBeyondRange\": false\r\n          },\r\n          \"fieldName\": \"rating\",\r\n          \"boost\": 3.14,\r\n          \"interpolation\": \"constant\"\r\n        }\r\n      ],\r\n      \"functionAggregation\": \"firstMatching\"\r\n    }\r\n  ],\r\n  \"defaultScoringProfile\": \"MyProfile\",\r\n  \"corsOptions\": {\r\n    \"allowedOrigins\": [\r\n      \"http://tempuri.org\",\r\n      \"http://localhost:80\"\r\n    ],\r\n    \"maxAgeInSeconds\": 60\r\n  },\r\n  \"suggesters\": [\r\n    {\r\n      \"name\": \"FancySuggester\",\r\n      \"searchMode\": \"analyzingInfixMatching\",\r\n      \"sourceFields\": [\r\n        \"hotelName\"\r\n      ]\r\n    }\r\n  ]\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -414,13 +414,13 @@
           "6270"
         ],
         "client-request-id": [
-          "e9cf7222-3319-4067-82e0-db2105e0f873"
+          "f4e00602-38b3-4614-bc24-39226b0ba61b"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -430,10 +430,10 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#indexes/$entity\",\"@odata.etag\":\"\\\"0x8D465921F706C39\\\"\",\"name\":\"azsmnet7517\",\"fields\":[{\"name\":\"hotelId\",\"type\":\"Edm.String\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":true,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"baseRate\",\"type\":\"Edm.Double\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"description\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"description_fr\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":\"fr.lucene\"},{\"name\":\"description_custom\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":\"stop\",\"searchAnalyzer\":\"stop\",\"analyzer\":null},{\"name\":\"hotelName\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"category\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"tags\",\"type\":\"Collection(Edm.String)\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":false,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"parkingIncluded\",\"type\":\"Edm.Boolean\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"smokingAllowed\",\"type\":\"Edm.Boolean\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"lastRenovationDate\",\"type\":\"Edm.DateTimeOffset\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"rating\",\"type\":\"Edm.Int32\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"location\",\"type\":\"Edm.GeographyPoint\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"totalGuests\",\"type\":\"Edm.Int64\",\"searchable\":false,\"filterable\":true,\"retrievable\":false,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"profitMargin\",\"type\":\"Edm.Double\",\"searchable\":false,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null}],\"scoringProfiles\":[{\"name\":\"MyProfile\",\"text\":{\"weights\":{\"description\":1.5,\"category\":2.0}},\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"constant\",\"magnitude\":{\"boostingRangeStart\":1.0,\"boostingRangeEnd\":4.0,\"constantBoostBeyondRange\":true},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":2.0},{\"fieldName\":\"location\",\"freshness\":null,\"interpolation\":\"linear\",\"magnitude\":null,\"distance\":{\"referencePointParameter\":\"loc\",\"boostingDistance\":5.0},\"tag\":null,\"type\":\"distance\",\"boost\":1.5},{\"fieldName\":\"lastRenovationDate\",\"freshness\":{\"boostingDuration\":\"P365D\"},\"interpolation\":\"logarithmic\",\"magnitude\":null,\"distance\":null,\"tag\":null,\"type\":\"freshness\",\"boost\":1.1}],\"functionAggregation\":\"average\"},{\"name\":\"ProfileTwo\",\"text\":null,\"functions\":[{\"fieldName\":\"tags\",\"freshness\":null,\"interpolation\":\"linear\",\"magnitude\":null,\"distance\":null,\"tag\":{\"tagsParameter\":\"mytags\"},\"type\":\"tag\",\"boost\":1.5}],\"functionAggregation\":\"maximum\"},{\"name\":\"ProfileThree\",\"text\":null,\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"quadratic\",\"magnitude\":{\"boostingRangeStart\":0.0,\"boostingRangeEnd\":10.0,\"constantBoostBeyondRange\":false},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":3.0}],\"functionAggregation\":\"minimum\"},{\"name\":\"ProfileFour\",\"text\":null,\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"constant\",\"magnitude\":{\"boostingRangeStart\":1.0,\"boostingRangeEnd\":5.0,\"constantBoostBeyondRange\":false},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":3.14}],\"functionAggregation\":\"firstMatching\"}],\"defaultScoringProfile\":\"MyProfile\",\"corsOptions\":{\"allowedOrigins\":[\"http://tempuri.org\",\"http://localhost:80\"],\"maxAgeInSeconds\":60},\"suggesters\":[{\"name\":\"FancySuggester\",\"searchMode\":\"analyzingInfixMatching\",\"sourceFields\":[\"hotelName\"]}],\"analyzers\":[],\"tokenizers\":[],\"tokenFilters\":[],\"charFilters\":[]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#indexes/$entity\",\"@odata.etag\":\"\\\"0x8D4659409042D88\\\"\",\"name\":\"azsmnet6388\",\"fields\":[{\"name\":\"hotelId\",\"type\":\"Edm.String\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":true,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"baseRate\",\"type\":\"Edm.Double\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"description\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"description_fr\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":\"fr.lucene\"},{\"name\":\"description_custom\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":\"stop\",\"searchAnalyzer\":\"stop\",\"analyzer\":null},{\"name\":\"hotelName\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"category\",\"type\":\"Edm.String\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"tags\",\"type\":\"Collection(Edm.String)\",\"searchable\":true,\"filterable\":true,\"retrievable\":true,\"sortable\":false,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"parkingIncluded\",\"type\":\"Edm.Boolean\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"smokingAllowed\",\"type\":\"Edm.Boolean\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"lastRenovationDate\",\"type\":\"Edm.DateTimeOffset\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"rating\",\"type\":\"Edm.Int32\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"location\",\"type\":\"Edm.GeographyPoint\",\"searchable\":false,\"filterable\":true,\"retrievable\":true,\"sortable\":true,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"totalGuests\",\"type\":\"Edm.Int64\",\"searchable\":false,\"filterable\":true,\"retrievable\":false,\"sortable\":true,\"facetable\":true,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null},{\"name\":\"profitMargin\",\"type\":\"Edm.Double\",\"searchable\":false,\"filterable\":false,\"retrievable\":true,\"sortable\":false,\"facetable\":false,\"key\":false,\"indexAnalyzer\":null,\"searchAnalyzer\":null,\"analyzer\":null}],\"scoringProfiles\":[{\"name\":\"MyProfile\",\"text\":{\"weights\":{\"description\":1.5,\"category\":2.0}},\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"constant\",\"magnitude\":{\"boostingRangeStart\":1.0,\"boostingRangeEnd\":4.0,\"constantBoostBeyondRange\":true},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":2.0},{\"fieldName\":\"location\",\"freshness\":null,\"interpolation\":\"linear\",\"magnitude\":null,\"distance\":{\"referencePointParameter\":\"loc\",\"boostingDistance\":5.0},\"tag\":null,\"type\":\"distance\",\"boost\":1.5},{\"fieldName\":\"lastRenovationDate\",\"freshness\":{\"boostingDuration\":\"P365D\"},\"interpolation\":\"logarithmic\",\"magnitude\":null,\"distance\":null,\"tag\":null,\"type\":\"freshness\",\"boost\":1.1}],\"functionAggregation\":\"average\"},{\"name\":\"ProfileTwo\",\"text\":null,\"functions\":[{\"fieldName\":\"tags\",\"freshness\":null,\"interpolation\":\"linear\",\"magnitude\":null,\"distance\":null,\"tag\":{\"tagsParameter\":\"mytags\"},\"type\":\"tag\",\"boost\":1.5}],\"functionAggregation\":\"maximum\"},{\"name\":\"ProfileThree\",\"text\":null,\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"quadratic\",\"magnitude\":{\"boostingRangeStart\":0.0,\"boostingRangeEnd\":10.0,\"constantBoostBeyondRange\":false},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":3.0}],\"functionAggregation\":\"minimum\"},{\"name\":\"ProfileFour\",\"text\":null,\"functions\":[{\"fieldName\":\"rating\",\"freshness\":null,\"interpolation\":\"constant\",\"magnitude\":{\"boostingRangeStart\":1.0,\"boostingRangeEnd\":5.0,\"constantBoostBeyondRange\":false},\"distance\":null,\"tag\":null,\"type\":\"magnitude\",\"boost\":3.14}],\"functionAggregation\":\"firstMatching\"}],\"defaultScoringProfile\":\"MyProfile\",\"corsOptions\":{\"allowedOrigins\":[\"http://tempuri.org\",\"http://localhost:80\"],\"maxAgeInSeconds\":60},\"suggesters\":[{\"name\":\"FancySuggester\",\"searchMode\":\"analyzingInfixMatching\",\"sourceFields\":[\"hotelName\"]}],\"analyzers\":[],\"tokenizers\":[],\"tokenFilters\":[],\"charFilters\":[]}",
       "ResponseHeaders": {
         "Content-Length": [
-          "5142"
+          "5143"
         ],
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -445,22 +445,22 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:43 GMT"
+          "Tue, 07 Mar 2017 19:56:24 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "ETag": [
-          "W/\"0x8D465921F706C39\""
+          "W/\"0x8D4659409042D88\""
         ],
         "Location": [
-          "https://azs-280.search-dogfood.windows-int.net/indexes('azsmnet7517')?api-version=2016-09-01"
+          "https://azs-1141.search-dogfood.windows-int.net/indexes('azsmnet6388')?api-version=2016-09-01"
         ],
         "request-id": [
-          "e9cf7222-3319-4067-82e0-db2105e0f873"
+          "f4e00602-38b3-4614-bc24-39226b0ba61b"
         ],
         "elapsed-time": [
-          "805"
+          "2709"
         ],
         "OData-Version": [
           "4.0"
@@ -475,8 +475,8 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
       "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ar.microsoft\"\r\n}",
       "RequestHeaders": {
@@ -487,13 +487,13 @@
           "56"
         ],
         "client-request-id": [
-          "6be1e2e0-f377-4161-8bc0-8d3e46b040de"
+          "fa3a6862-a87e-41d2-a350-b3846c98b9fe"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -503,7 +503,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -515,7 +515,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:43 GMT"
+          "Tue, 07 Mar 2017 19:56:24 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -524,10 +524,10 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "6be1e2e0-f377-4161-8bc0-8d3e46b040de"
+          "fa3a6862-a87e-41d2-a350-b3846c98b9fe"
         ],
         "elapsed-time": [
-          "728"
+          "114"
         ],
         "OData-Version": [
           "4.0"
@@ -542,8 +542,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
       "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ar.lucene\"\r\n}",
       "RequestHeaders": {
@@ -554,13 +554,13 @@
           "53"
         ],
         "client-request-id": [
-          "f14f77bf-3081-4429-a880-71978b05f4e8"
+          "dd5dfe6a-3f46-4f55-9ad8-a4676b8ff4b2"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -570,7 +570,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -582,7 +582,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:43 GMT"
+          "Tue, 07 Mar 2017 19:56:24 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -591,7 +591,7 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "f14f77bf-3081-4429-a880-71978b05f4e8"
+          "dd5dfe6a-3f46-4f55-9ad8-a4676b8ff4b2"
         ],
         "elapsed-time": [
           "11"
@@ -609,8 +609,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
       "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hy.lucene\"\r\n}",
       "RequestHeaders": {
@@ -621,13 +621,13 @@
           "53"
         ],
         "client-request-id": [
-          "555828e8-9bc5-4823-ac1b-14642b7fc46e"
+          "4f6272b1-56ea-4bc5-895b-9c3fc12a5900"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -637,7 +637,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -649,7 +649,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:44 GMT"
+          "Tue, 07 Mar 2017 19:56:24 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -658,7 +658,7 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "555828e8-9bc5-4823-ac1b-14642b7fc46e"
+          "4f6272b1-56ea-4bc5-895b-9c3fc12a5900"
         ],
         "elapsed-time": [
           "10"
@@ -676,8 +676,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
       "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"bn.microsoft\"\r\n}",
       "RequestHeaders": {
@@ -688,13 +688,13 @@
           "56"
         ],
         "client-request-id": [
-          "05f51556-17b0-49b3-86c9-145c07a65ec8"
+          "091d131c-96ad-4b51-9e42-8400de2b8f26"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -704,7 +704,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -716,7 +716,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:44 GMT"
+          "Tue, 07 Mar 2017 19:56:25 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -725,10 +725,10 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "05f51556-17b0-49b3-86c9-145c07a65ec8"
+          "091d131c-96ad-4b51-9e42-8400de2b8f26"
         ],
         "elapsed-time": [
-          "720"
+          "341"
         ],
         "OData-Version": [
           "4.0"
@@ -743,8 +743,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
       "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"eu.lucene\"\r\n}",
       "RequestHeaders": {
@@ -755,13 +755,13 @@
           "53"
         ],
         "client-request-id": [
-          "d8c7cae5-b7cd-41ce-aebb-bfe155e6bc04"
+          "4ce0c576-ca6f-48de-a40e-c26a6e6682b7"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -771,7 +771,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -783,7 +783,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:44 GMT"
+          "Tue, 07 Mar 2017 19:56:25 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -792,10 +792,10 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "d8c7cae5-b7cd-41ce-aebb-bfe155e6bc04"
+          "4ce0c576-ca6f-48de-a40e-c26a6e6682b7"
         ],
         "elapsed-time": [
-          "30"
+          "11"
         ],
         "OData-Version": [
           "4.0"
@@ -810,8 +810,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
       "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"bg.microsoft\"\r\n}",
       "RequestHeaders": {
@@ -822,13 +822,13 @@
           "56"
         ],
         "client-request-id": [
-          "6be94abb-da8b-4518-8eed-0294a8f5e843"
+          "becccfd3-a4c4-446c-9eb0-9c897ecccb1b"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -838,7 +838,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -850,7 +850,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:45 GMT"
+          "Tue, 07 Mar 2017 19:56:25 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -859,10 +859,10 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "6be94abb-da8b-4518-8eed-0294a8f5e843"
+          "becccfd3-a4c4-446c-9eb0-9c897ecccb1b"
         ],
         "elapsed-time": [
-          "255"
+          "23"
         ],
         "OData-Version": [
           "4.0"
@@ -877,8 +877,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
       "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"bg.lucene\"\r\n}",
       "RequestHeaders": {
@@ -889,13 +889,13 @@
           "53"
         ],
         "client-request-id": [
-          "ae6b2eae-d4bf-437a-95a3-4d13661dd31c"
+          "57d30089-71f7-4386-af3f-0e96f0537b7a"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -905,7 +905,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -917,7 +917,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:45 GMT"
+          "Tue, 07 Mar 2017 19:56:25 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -926,10 +926,10 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "ae6b2eae-d4bf-437a-95a3-4d13661dd31c"
+          "57d30089-71f7-4386-af3f-0e96f0537b7a"
         ],
         "elapsed-time": [
-          "12"
+          "8"
         ],
         "OData-Version": [
           "4.0"
@@ -944,8 +944,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
       "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ca.microsoft\"\r\n}",
       "RequestHeaders": {
@@ -956,13 +956,13 @@
           "56"
         ],
         "client-request-id": [
-          "37364c44-58fe-4fbe-aaef-a1b26b83ded3"
+          "86b2418a-951b-4735-898b-b71e2eb902e5"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -972,7 +972,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -984,7 +984,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:45 GMT"
+          "Tue, 07 Mar 2017 19:56:25 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -993,6171 +993,7 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "37364c44-58fe-4fbe-aaef-a1b26b83ded3"
-        ],
-        "elapsed-time": [
-          "23"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ca.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "2fa8b7cf-213b-4ffa-b913-5f3ec4565851"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:45 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "2fa8b7cf-213b-4ffa-b913-5f3ec4565851"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hans.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "61"
-        ],
-        "client-request-id": [
-          "50cee1e9-df5a-402c-9786-c29ce3c5241f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:45 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "50cee1e9-df5a-402c-9786-c29ce3c5241f"
-        ],
-        "elapsed-time": [
-          "68"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hans.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "58"
-        ],
-        "client-request-id": [
-          "2f12fe46-0346-44ab-9d4f-7fe1c8c2d8b4"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:45 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "2f12fe46-0346-44ab-9d4f-7fe1c8c2d8b4"
-        ],
-        "elapsed-time": [
-          "690"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hant.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "61"
-        ],
-        "client-request-id": [
-          "32448880-620a-41e1-85b7-ab0fa02c5e8c"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "32448880-620a-41e1-85b7-ab0fa02c5e8c"
-        ],
-        "elapsed-time": [
-          "397"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hant.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "58"
-        ],
-        "client-request-id": [
-          "bd1f5d37-9d1d-4a74-a5de-43a342eedac8"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "bd1f5d37-9d1d-4a74-a5de-43a342eedac8"
-        ],
-        "elapsed-time": [
-          "165"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hr.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "a51a988c-2523-4965-9c91-8b1b77217c58"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"onaj\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "a51a988c-2523-4965-9c91-8b1b77217c58"
-        ],
-        "elapsed-time": [
-          "35"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"cs.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "b96d157d-8307-4d23-9a99-6be3848ccad8"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"twa\",\"startOffset\":4,\"endOffset\":7,\"position\":1},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b96d157d-8307-4d23-9a99-6be3848ccad8"
-        ],
-        "elapsed-time": [
-          "45"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"cs.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "54420fce-e0bd-41e4-9fb2-5e3a841466c3"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "54420fce-e0bd-41e4-9fb2-5e3a841466c3"
-        ],
-        "elapsed-time": [
-          "10"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"da.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "a0666bfb-8d40-4835-a5bb-b06707291deb"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "a0666bfb-8d40-4835-a5bb-b06707291deb"
-        ],
-        "elapsed-time": [
-          "71"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"da.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "fb82c927-0148-47c7-837b-401bee658d6c"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "fb82c927-0148-47c7-837b-401bee658d6c"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nl.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "b443e3fb-4ccb-496b-99fe-3a60b778a0d9"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b443e3fb-4ccb-496b-99fe-3a60b778a0d9"
-        ],
-        "elapsed-time": [
-          "40"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nl.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "1433019a-3a7f-4935-86d7-6863d2af619b"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "1433019a-3a7f-4935-86d7-6863d2af619b"
-        ],
-        "elapsed-time": [
-          "10"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"en.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "ca2d4ec3-737a-4923-b4a3-ba92987c2308"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "ca2d4ec3-737a-4923-b4a3-ba92987c2308"
-        ],
-        "elapsed-time": [
-          "217"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"en.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "ae333d46-7467-49a5-b6d7-6b8ece1dfb2b"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "ae333d46-7467-49a5-b6d7-6b8ece1dfb2b"
-        ],
-        "elapsed-time": [
-          "10"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"et.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "1309c925-8944-402a-ac2f-7af6fc95fe0e"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "1309c925-8944-402a-ac2f-7af6fc95fe0e"
-        ],
-        "elapsed-time": [
-          "18"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fi.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "22fc4ce3-609c-4f33-91a3-ec2d60bc543c"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "22fc4ce3-609c-4f33-91a3-ec2d60bc543c"
-        ],
-        "elapsed-time": [
-          "42"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fi.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "6366cfdc-ebc8-4b58-8fe5-def666aef47e"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "6366cfdc-ebc8-4b58-8fe5-def666aef47e"
-        ],
-        "elapsed-time": [
-          "17"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fr.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "33a6db80-dc33-4b1f-97a2-164f36413fdb"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "33a6db80-dc33-4b1f-97a2-164f36413fdb"
-        ],
-        "elapsed-time": [
-          "41"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fr.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "5aacccbc-d777-4450-a17a-4672cd79540e"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "5aacccbc-d777-4450-a17a-4672cd79540e"
-        ],
-        "elapsed-time": [
-          "33"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"gl.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "1a45ccc4-885d-4ffc-b4ae-a428516be184"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "1a45ccc4-885d-4ffc-b4ae-a428516be184"
-        ],
-        "elapsed-time": [
-          "21"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"de.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "f13a1b95-8e93-4bb3-a227-e11da40ff558"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "f13a1b95-8e93-4bb3-a227-e11da40ff558"
-        ],
-        "elapsed-time": [
-          "54"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"de.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "147a97d2-0d14-4860-935e-b370bb31d73f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "147a97d2-0d14-4860-935e-b370bb31d73f"
-        ],
-        "elapsed-time": [
-          "14"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"el.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "fd9e0d4d-07eb-4645-905e-4c9120e4f94b"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "fd9e0d4d-07eb-4645-905e-4c9120e4f94b"
-        ],
-        "elapsed-time": [
-          "47"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"el.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "903bb40e-01ca-4d41-9d32-4f35b656a786"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "903bb40e-01ca-4d41-9d32-4f35b656a786"
-        ],
-        "elapsed-time": [
-          "50"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"gu.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "0d185fd9-e442-4e65-932f-a169a6237b12"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "0d185fd9-e442-4e65-932f-a169a6237b12"
-        ],
-        "elapsed-time": [
-          "17"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"he.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "6914f2f3-ea1e-42d3-9ab1-36a3a92a271a"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "6914f2f3-ea1e-42d3-9ab1-36a3a92a271a"
-        ],
-        "elapsed-time": [
-          "73"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hi.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "f722cd79-5951-48be-bcf5-1f634cc4edfa"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "f722cd79-5951-48be-bcf5-1f634cc4edfa"
-        ],
-        "elapsed-time": [
-          "38"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hi.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "54c55fe4-a951-4c35-9ff3-4b87a481de86"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:48 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "54c55fe4-a951-4c35-9ff3-4b87a481de86"
-        ],
-        "elapsed-time": [
-          "23"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hu.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "5553ddda-869b-416d-96b4-46c081679f63"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "5553ddda-869b-416d-96b4-46c081679f63"
-        ],
-        "elapsed-time": [
-          "206"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hu.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "dff164ad-8653-4905-9e58-41dc4ab08639"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "dff164ad-8653-4905-9e58-41dc4ab08639"
-        ],
-        "elapsed-time": [
-          "16"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"is.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "8961ccc6-4580-43fb-957a-4309e65ce67c"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "8961ccc6-4580-43fb-957a-4309e65ce67c"
-        ],
-        "elapsed-time": [
-          "50"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"id.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "a6e24414-3b53-49d0-a0c0-0d05216a9455"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "a6e24414-3b53-49d0-a0c0-0d05216a9455"
-        ],
-        "elapsed-time": [
-          "59"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"id.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "09040892-ff9e-48cf-ad5b-37b242edfd25"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "09040892-ff9e-48cf-ad5b-37b242edfd25"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ga.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "f5a095f5-e64a-4561-b5f1-ee519221c8f8"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "f5a095f5-e64a-4561-b5f1-ee519221c8f8"
-        ],
-        "elapsed-time": [
-          "40"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"it.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "78b85462-17c6-4e2c-932a-fa328ec2bc4f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "78b85462-17c6-4e2c-932a-fa328ec2bc4f"
-        ],
-        "elapsed-time": [
-          "40"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"it.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "8b106534-ba31-46e6-8c7e-f1069f77cc38"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "8b106534-ba31-46e6-8c7e-f1069f77cc38"
-        ],
-        "elapsed-time": [
-          "28"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ja.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "1f92ef5a-4352-4364-9036-4d746bda08c4"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:49 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "1f92ef5a-4352-4364-9036-4d746bda08c4"
-        ],
-        "elapsed-time": [
-          "438"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ja.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "a82f98a1-71a0-4470-9f7b-be5083e01016"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "a82f98a1-71a0-4470-9f7b-be5083e01016"
-        ],
-        "elapsed-time": [
-          "417"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"kn.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "8b753566-a54a-4d51-8f8e-577758b31ade"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "8b753566-a54a-4d51-8f8e-577758b31ade"
-        ],
-        "elapsed-time": [
-          "30"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ko.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "7731adcb-b5c3-4ade-8816-1dfce6891e5a"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "7731adcb-b5c3-4ade-8816-1dfce6891e5a"
-        ],
-        "elapsed-time": [
-          "571"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ko.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "3a63849d-35bf-4256-bcd5-0389b3f2536d"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "3a63849d-35bf-4256-bcd5-0389b3f2536d"
-        ],
-        "elapsed-time": [
-          "21"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lv.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "e6931087-a5f7-401f-afd8-9c9e94efd0ef"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "e6931087-a5f7-401f-afd8-9c9e94efd0ef"
-        ],
-        "elapsed-time": [
-          "16"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lv.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "0c73f4ee-c751-4c3c-b83a-1ff5b50a3e3b"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "0c73f4ee-c751-4c3c-b83a-1ff5b50a3e3b"
-        ],
-        "elapsed-time": [
-          "10"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lt.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "8318854e-dfbe-4b38-b018-31ea4acdcc5d"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "8318854e-dfbe-4b38-b018-31ea4acdcc5d"
-        ],
-        "elapsed-time": [
-          "15"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ml.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "e67cc620-14ba-48c8-b445-934b7cb51bd7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "e67cc620-14ba-48c8-b445-934b7cb51bd7"
-        ],
-        "elapsed-time": [
-          "67"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ms.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "1274e2e3-ea2b-4aa2-8de9-aad82a4869f4"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "1274e2e3-ea2b-4aa2-8de9-aad82a4869f4"
-        ],
-        "elapsed-time": [
-          "1656"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"mr.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "f6c19043-46a9-43c9-82ba-b1b31a3a2f25"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "f6c19043-46a9-43c9-82ba-b1b31a3a2f25"
-        ],
-        "elapsed-time": [
-          "236"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nb.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "b9f1f711-8cbd-4534-af3a-83f6a83f7a4b"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b9f1f711-8cbd-4534-af3a-83f6a83f7a4b"
-        ],
-        "elapsed-time": [
-          "31"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"no.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "98f82f60-157b-472e-a81e-ce759a5923ad"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "98f82f60-157b-472e-a81e-ce759a5923ad"
-        ],
-        "elapsed-time": [
-          "9"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fa.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "ef40bd03-6b5f-4747-8c53-582a908988a2"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "ef40bd03-6b5f-4747-8c53-582a908988a2"
-        ],
-        "elapsed-time": [
-          "11"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pl.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "d3e7dbf2-5148-4b52-bed9-1922529970bd"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "d3e7dbf2-5148-4b52-bed9-1922529970bd"
-        ],
-        "elapsed-time": [
-          "21"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pl.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "0ae9fd5d-a5ab-4786-963c-d8a3bbb50b29"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "0ae9fd5d-a5ab-4786-963c-d8a3bbb50b29"
-        ],
-        "elapsed-time": [
-          "14"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-BR.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "59"
-        ],
-        "client-request-id": [
-          "c9a5944f-2d1f-4a67-81b6-0ca03dcfe96f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "c9a5944f-2d1f-4a67-81b6-0ca03dcfe96f"
-        ],
-        "elapsed-time": [
-          "25"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-BR.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "f9bf991f-ca67-472a-8991-d56c8d5816bc"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "f9bf991f-ca67-472a-8991-d56c8d5816bc"
-        ],
-        "elapsed-time": [
-          "25"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-PT.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "59"
-        ],
-        "client-request-id": [
-          "8c3fd446-a0a2-463d-915d-3c38a1fe9ce3"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "8c3fd446-a0a2-463d-915d-3c38a1fe9ce3"
-        ],
-        "elapsed-time": [
-          "31"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-PT.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "e4dc3791-648d-4422-a2ed-449af8d8fb53"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "e4dc3791-648d-4422-a2ed-449af8d8fb53"
-        ],
-        "elapsed-time": [
-          "18"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pa.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "db4d8259-f916-4dff-85ec-887b5fc3e41d"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "db4d8259-f916-4dff-85ec-887b5fc3e41d"
-        ],
-        "elapsed-time": [
-          "47"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ro.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "18fcc0f7-c5b0-4639-9fff-bce41b4be421"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "18fcc0f7-c5b0-4639-9fff-bce41b4be421"
-        ],
-        "elapsed-time": [
-          "24"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ro.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "d1445d56-cfa3-4b59-b6cd-79b7321fd4fd"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "d1445d56-cfa3-4b59-b6cd-79b7321fd4fd"
-        ],
-        "elapsed-time": [
-          "13"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ru.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "46e1225c-6bc3-4b1e-81f5-82df4ea14511"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "46e1225c-6bc3-4b1e-81f5-82df4ea14511"
-        ],
-        "elapsed-time": [
-          "35"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ru.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "44549211-c7a0-4e8c-8b4d-f9c75e4ea34a"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:53 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "44549211-c7a0-4e8c-8b4d-f9c75e4ea34a"
-        ],
-        "elapsed-time": [
-          "10"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sr-cyrillic.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "65"
-        ],
-        "client-request-id": [
-          "6461798e-eb5e-4263-a6ca-e589e57a4655"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "6461798e-eb5e-4263-a6ca-e589e57a4655"
-        ],
-        "elapsed-time": [
-          "241"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sr-latin.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "62"
-        ],
-        "client-request-id": [
-          "dbff30b2-c8bc-4ae3-8dcd-d69f1f64fff8"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"ona\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"onaj\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "dbff30b2-c8bc-4ae3-8dcd-d69f1f64fff8"
-        ],
-        "elapsed-time": [
-          "23"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sk.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "d1fd35b6-9397-497c-b72a-8acfe34b24d9"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "d1fd35b6-9397-497c-b72a-8acfe34b24d9"
-        ],
-        "elapsed-time": [
-          "17"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sl.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "5516ad03-74ec-432d-aaa0-62880f543ece"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"oni\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"twa\",\"startOffset\":4,\"endOffset\":7,\"position\":1},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "5516ad03-74ec-432d-aaa0-62880f543ece"
-        ],
-        "elapsed-time": [
-          "17"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"es.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "b05a7aaf-7616-4213-9249-d3cf076c4863"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b05a7aaf-7616-4213-9249-d3cf076c4863"
-        ],
-        "elapsed-time": [
-          "26"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"es.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "2c1fd595-a0d6-49e1-b968-ca0171a8a340"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "2c1fd595-a0d6-49e1-b968-ca0171a8a340"
-        ],
-        "elapsed-time": [
-          "15"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sv.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "1f627c9e-71b7-43b6-b0d2-947a04956fe4"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "1f627c9e-71b7-43b6-b0d2-947a04956fe4"
-        ],
-        "elapsed-time": [
-          "52"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sv.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "aeeb9e71-b989-49e7-8d88-9b403949d1b2"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "aeeb9e71-b989-49e7-8d88-9b403949d1b2"
-        ],
-        "elapsed-time": [
-          "10"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ta.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "2eda58a7-be40-4dd2-b7d6-796083420e0f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "2eda58a7-be40-4dd2-b7d6-796083420e0f"
-        ],
-        "elapsed-time": [
-          "35"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"te.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "b79ec631-8b6d-4592-a21a-40ff1b94a0a2"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b79ec631-8b6d-4592-a21a-40ff1b94a0a2"
-        ],
-        "elapsed-time": [
-          "18"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"th.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "96d9fe2c-3c2d-4029-9be6-df44416bedeb"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "96d9fe2c-3c2d-4029-9be6-df44416bedeb"
-        ],
-        "elapsed-time": [
-          "241"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"th.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "b032e349-a8df-48e9-ba72-eb979631cea1"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b032e349-a8df-48e9-ba72-eb979631cea1"
-        ],
-        "elapsed-time": [
-          "38"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"tr.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "063f61f2-0d1f-48f6-b3d8-f2f67e75ffa3"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "063f61f2-0d1f-48f6-b3d8-f2f67e75ffa3"
-        ],
-        "elapsed-time": [
-          "46"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"tr.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "53"
-        ],
-        "client-request-id": [
-          "31600e93-8e5f-4ee4-94ed-e566384d72b5"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "31600e93-8e5f-4ee4-94ed-e566384d72b5"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"uk.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "cc9b5436-3f50-4f9b-9667-a9db46daf90d"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "cc9b5436-3f50-4f9b-9667-a9db46daf90d"
-        ],
-        "elapsed-time": [
-          "17"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ur.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "2c8f6550-8ad6-4447-92b1-aebd018f6287"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "2c8f6550-8ad6-4447-92b1-aebd018f6287"
-        ],
-        "elapsed-time": [
-          "41"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"vi.microsoft\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "976dca29-db16-4be4-b910-89154c1ef52c"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "976dca29-db16-4be4-b910-89154c1ef52c"
-        ],
-        "elapsed-time": [
-          "18"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"standardasciifolding.lucene\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "71"
-        ],
-        "client-request-id": [
-          "f94a42a4-990e-43e5-88a5-eef8effbd8b7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "f94a42a4-990e-43e5-88a5-eef8effbd8b7"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"keyword\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "51"
-        ],
-        "client-request-id": [
-          "362ee99a-3255-4126-a655-54cd9b536a9c"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One two\",\"startOffset\":0,\"endOffset\":7,\"position\":0}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "362ee99a-3255-4126-a655-54cd9b536a9c"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pattern\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "51"
-        ],
-        "client-request-id": [
-          "790499e5-7461-4f3d-9f52-72355016c021"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "790499e5-7461-4f3d-9f52-72355016c021"
-        ],
-        "elapsed-time": [
-          "8"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"simple\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "50"
-        ],
-        "client-request-id": [
-          "27e1a94d-5eb1-4e03-9d32-1343dcada595"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "27e1a94d-5eb1-4e03-9d32-1343dcada595"
-        ],
-        "elapsed-time": [
-          "18"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"stop\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "48"
-        ],
-        "client-request-id": [
-          "841d2b18-d889-4609-9839-eeb7982fe10a"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "841d2b18-d889-4609-9839-eeb7982fe10a"
-        ],
-        "elapsed-time": [
-          "8"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"whitespace\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "54"
-        ],
-        "client-request-id": [
-          "fe094211-d862-450c-b522-c2bcec2542b8"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "fe094211-d862-450c-b522-c2bcec2542b8"
-        ],
-        "elapsed-time": [
-          "8"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"classic\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "52"
-        ],
-        "client-request-id": [
-          "0bb9ecec-e240-437d-bf0b-d5de3a3e4165"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "0bb9ecec-e240-437d-bf0b-d5de3a3e4165"
-        ],
-        "elapsed-time": [
-          "16"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"edgeNGram\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "54"
-        ],
-        "client-request-id": [
-          "1000b825-2e1a-4416-ad3d-084eee10359c"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":1,\"position\":0}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "1000b825-2e1a-4416-ad3d-084eee10359c"
-        ],
-        "elapsed-time": [
-          "11"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"keyword_v2\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "55"
-        ],
-        "client-request-id": [
-          "34d48e80-ecea-47c0-84e4-b94f7a0e9437"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One two\",\"startOffset\":0,\"endOffset\":7,\"position\":0}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "34d48e80-ecea-47c0-84e4-b94f7a0e9437"
-        ],
-        "elapsed-time": [
-          "21"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"letter\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "51"
-        ],
-        "client-request-id": [
-          "aa907f3d-c175-4659-8904-6c38e733996f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "aa907f3d-c175-4659-8904-6c38e733996f"
-        ],
-        "elapsed-time": [
-          "16"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"lowercase\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "54"
-        ],
-        "client-request-id": [
-          "c1ba1bc6-5494-4a08-a1d8-5817e313bed8"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "c1ba1bc6-5494-4a08-a1d8-5817e313bed8"
-        ],
-        "elapsed-time": [
-          "11"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"microsoft_language_tokenizer\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "73"
-        ],
-        "client-request-id": [
-          "15d222ee-6152-41d0-9cff-11959f6999cb"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "15d222ee-6152-41d0-9cff-11959f6999cb"
-        ],
-        "elapsed-time": [
-          "17"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"microsoft_language_stemming_tokenizer\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "82"
-        ],
-        "client-request-id": [
-          "483d72a3-07f4-4d21-bd7e-7d2c0aa91aeb"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "483d72a3-07f4-4d21-bd7e-7d2c0aa91aeb"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"nGram\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "50"
-        ],
-        "client-request-id": [
-          "b712d4ee-e3da-4c73-ad18-e73117a83fd0"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":1,\"position\":0},{\"token\":\"On\",\"startOffset\":0,\"endOffset\":2,\"position\":1},{\"token\":\"ne\",\"startOffset\":1,\"endOffset\":3,\"position\":2},{\"token\":\"n\",\"startOffset\":1,\"endOffset\":2,\"position\":3},{\"token\":\"e\",\"startOffset\":2,\"endOffset\":3,\"position\":4},{\"token\":\"e \",\"startOffset\":2,\"endOffset\":4,\"position\":5},{\"token\":\" t\",\"startOffset\":3,\"endOffset\":5,\"position\":6},{\"token\":\" \",\"startOffset\":3,\"endOffset\":4,\"position\":7},{\"token\":\"tw\",\"startOffset\":4,\"endOffset\":6,\"position\":8},{\"token\":\"t\",\"startOffset\":4,\"endOffset\":5,\"position\":9},{\"token\":\"wo\",\"startOffset\":5,\"endOffset\":7,\"position\":10},{\"token\":\"w\",\"startOffset\":5,\"endOffset\":6,\"position\":11},{\"token\":\"o\",\"startOffset\":6,\"endOffset\":7,\"position\":12}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "b712d4ee-e3da-4c73-ad18-e73117a83fd0"
+          "86b2418a-951b-4735-898b-b71e2eb902e5"
         ],
         "elapsed-time": [
           "20"
@@ -7175,25 +1011,25 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"path_hierarchy_v2\"\r\n}",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ca.lucene\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "62"
+          "53"
         ],
         "client-request-id": [
-          "1ec62a22-d09d-4572-ac65-fcc02ed40e7b"
+          "6fdb324a-dbfa-4223-8bd3-19f6c1f07ea9"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -7203,7 +1039,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -7215,7 +1051,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
+          "Tue, 07 Mar 2017 19:56:25 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -7224,141 +1060,7 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "1ec62a22-d09d-4572-ac65-fcc02ed40e7b"
-        ],
-        "elapsed-time": [
-          "9"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"pattern\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "52"
-        ],
-        "client-request-id": [
-          "7c959f20-b455-4e40-9141-f1e19f3b42c3"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "7c959f20-b455-4e40-9141-f1e19f3b42c3"
-        ],
-        "elapsed-time": [
-          "12"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "Preference-Applied": [
-          "odata.include-annotations=\"*\""
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"standard_v2\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "56"
-        ],
-        "client-request-id": [
-          "eddd5473-d6fb-407a-b7d6-33d707808e5f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
-        ],
-        "Prefer": [
-          "return=representation"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
-        ]
-      },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "request-id": [
-          "eddd5473-d6fb-407a-b7d6-33d707808e5f"
+          "6fdb324a-dbfa-4223-8bd3-19f6c1f07ea9"
         ],
         "elapsed-time": [
           "11"
@@ -7376,25 +1078,25 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"uax_url_email\"\r\n}",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hans.microsoft\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "58"
+          "61"
         ],
         "client-request-id": [
-          "49dc581a-3529-4b7c-b869-1d66618cb154"
+          "1584ae7c-489c-47f7-bbc4-b58b389bac7e"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -7404,7 +1106,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -7416,7 +1118,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
+          "Tue, 07 Mar 2017 19:56:25 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -7425,10 +1127,10 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "49dc581a-3529-4b7c-b869-1d66618cb154"
+          "1584ae7c-489c-47f7-bbc4-b58b389bac7e"
         ],
         "elapsed-time": [
-          "33"
+          "255"
         ],
         "OData-Version": [
           "4.0"
@@ -7443,25 +1145,25 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"whitespace\"\r\n}",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hans.lucene\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "55"
+          "58"
         ],
         "client-request-id": [
-          "9f9e2f7c-9083-4261-aab3-500b27079b69"
+          "7b470224-2765-4a0c-90c5-7aba183e47c1"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -7471,7 +1173,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -7483,7 +1185,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:55 GMT"
+          "Tue, 07 Mar 2017 19:56:26 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -7492,7 +1194,342 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "9f9e2f7c-9083-4261-aab3-500b27079b69"
+          "7b470224-2765-4a0c-90c5-7aba183e47c1"
+        ],
+        "elapsed-time": [
+          "455"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hant.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "61"
+        ],
+        "client-request-id": [
+          "88bf9213-7121-4348-be1c-3a5bc6f09de3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "88bf9213-7121-4348-be1c-3a5bc6f09de3"
+        ],
+        "elapsed-time": [
+          "51"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"zh-Hant.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "58"
+        ],
+        "client-request-id": [
+          "84bb7e7c-6e96-4925-9b7d-57d370679d2e"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "84bb7e7c-6e96-4925-9b7d-57d370679d2e"
+        ],
+        "elapsed-time": [
+          "8"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hr.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "adf5be21-a887-4936-943c-4eed88437016"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"onaj\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "adf5be21-a887-4936-943c-4eed88437016"
+        ],
+        "elapsed-time": [
+          "224"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"cs.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "de595d34-6561-463e-9f96-3e3cfa1ba55c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"twa\",\"startOffset\":4,\"endOffset\":7,\"position\":1},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "de595d34-6561-463e-9f96-3e3cfa1ba55c"
+        ],
+        "elapsed-time": [
+          "24"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"cs.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "b155c818-c5bc-4c31-8a94-846f166f961b"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b155c818-c5bc-4c31-8a94-846f166f961b"
         ],
         "elapsed-time": [
           "10"
@@ -7510,25 +1547,25 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/indexes('azsmnet7517')/search.analyze?api-version=2016-09-01",
-      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ3NTE3Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"whitespace\",\r\n  \"tokenFilters\": [\r\n    \"arabic_normalization\",\r\n    \"apostrophe\",\r\n    \"asciifolding\",\r\n    \"cjk_bigram\",\r\n    \"cjk_width\",\r\n    \"classic\",\r\n    \"common_grams\",\r\n    \"edgeNGram_v2\",\r\n    \"elision\",\r\n    \"german_normalization\",\r\n    \"hindi_normalization\",\r\n    \"indic_normalization\",\r\n    \"keyword_repeat\",\r\n    \"kstem\",\r\n    \"length\",\r\n    \"limit\",\r\n    \"lowercase\",\r\n    \"nGram_v2\",\r\n    \"persian_normalization\",\r\n    \"phonetic\",\r\n    \"porter_stem\",\r\n    \"reverse\",\r\n    \"scandinavian_normalization\",\r\n    \"scandinavian_folding\",\r\n    \"shingle\",\r\n    \"snowball\",\r\n    \"sorani_normalization\",\r\n    \"stemmer\",\r\n    \"stopwords\",\r\n    \"trim\",\r\n    \"truncate\",\r\n    \"unique\",\r\n    \"uppercase\",\r\n    \"word_delimiter\"\r\n  ],\r\n  \"charFilters\": [\r\n    \"html_strip\"\r\n  ]\r\n}",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"da.microsoft\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "820"
+          "56"
         ],
         "client-request-id": [
-          "b3d31159-79b8-4098-a42e-9701f6f7d37e"
+          "4d68aa77-a8ee-44e1-acad-a8f1cc2eeed5"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "762FB1557922A9278184C38F1B96DCFF"
+          "9C747DAC975294606708FB47FFC266E4"
         ],
         "Prefer": [
           "return=representation"
@@ -7538,7 +1575,7 @@
           "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
         ]
       },
-      "ResponseBody": "{\"@odata.context\":\"https://azs-280.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":3,\"position\":0}]}",
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal"
@@ -7550,7 +1587,7 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:56 GMT"
+          "Tue, 07 Mar 2017 19:56:26 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -7559,10 +1596,10 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "b3d31159-79b8-4098-a42e-9701f6f7d37e"
+          "4d68aa77-a8ee-44e1-acad-a8f1cc2eeed5"
         ],
         "elapsed-time": [
-          "235"
+          "31"
         ],
         "OData-Version": [
           "4.0"
@@ -7577,13 +1614,6043 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet6410/providers/Microsoft.Search/searchServices/azs-280?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ2NDEwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0yODA/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"da.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "36f48e7a-b3ff-4693-b98b-b731d1d97898"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "36f48e7a-b3ff-4693-b98b-b731d1d97898"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nl.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "7af65e76-d1fa-4da2-9b5a-29bec41e3f63"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "7af65e76-d1fa-4da2-9b5a-29bec41e3f63"
+        ],
+        "elapsed-time": [
+          "22"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nl.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "3dc4c9b5-38aa-41ce-81a9-a243368f5f28"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "3dc4c9b5-38aa-41ce-81a9-a243368f5f28"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"en.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "61b68df2-464b-47f1-b16b-64487ef14293"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "61b68df2-464b-47f1-b16b-64487ef14293"
+        ],
+        "elapsed-time": [
+          "21"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"en.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "7f8ab70c-6ac0-4a65-9eb8-0e0bfd30386d"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "7f8ab70c-6ac0-4a65-9eb8-0e0bfd30386d"
+        ],
+        "elapsed-time": [
+          "8"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"et.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "959decca-9762-4ff1-8e6d-8d3cc920054b"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "959decca-9762-4ff1-8e6d-8d3cc920054b"
+        ],
+        "elapsed-time": [
+          "16"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fi.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "3fa88f28-ffa6-459d-963b-18a056920658"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "3fa88f28-ffa6-459d-963b-18a056920658"
+        ],
+        "elapsed-time": [
+          "16"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fi.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "a12f3c06-a6ad-44e2-9e67-d63eb6ea87b7"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "a12f3c06-a6ad-44e2-9e67-d63eb6ea87b7"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fr.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "b6a1174d-946c-4e89-8e50-97e543c6fe21"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b6a1174d-946c-4e89-8e50-97e543c6fe21"
+        ],
+        "elapsed-time": [
+          "223"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fr.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "d62d692b-69a6-4141-99bb-8146aaafc7f5"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "d62d692b-69a6-4141-99bb-8146aaafc7f5"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"gl.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "56a25f62-0bb3-4cdd-8382-a3e5e34091e8"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "56a25f62-0bb3-4cdd-8382-a3e5e34091e8"
+        ],
+        "elapsed-time": [
+          "31"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"de.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "95521863-d84e-41eb-9644-d94c11c7c7dd"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "95521863-d84e-41eb-9644-d94c11c7c7dd"
+        ],
+        "elapsed-time": [
+          "27"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"de.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "8e921180-96da-49c1-af44-f4516ecdc234"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "8e921180-96da-49c1-af44-f4516ecdc234"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"el.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "dbf8a8a2-aafe-4597-a4f7-57bfca78b2c6"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "dbf8a8a2-aafe-4597-a4f7-57bfca78b2c6"
+        ],
+        "elapsed-time": [
+          "17"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"el.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "f5457d42-c42b-4288-a00d-494600d20d00"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "f5457d42-c42b-4288-a00d-494600d20d00"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"gu.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "0ed0826f-fd69-4bce-92c4-59998fa913a5"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "0ed0826f-fd69-4bce-92c4-59998fa913a5"
+        ],
+        "elapsed-time": [
+          "16"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"he.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "0b75c940-ff4c-466a-a9b3-c22662c63b57"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "0b75c940-ff4c-466a-a9b3-c22662c63b57"
+        ],
+        "elapsed-time": [
+          "16"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hi.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "697b2db4-2123-4218-b420-7a3fdf943474"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "697b2db4-2123-4218-b420-7a3fdf943474"
+        ],
+        "elapsed-time": [
+          "30"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hi.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "2e697c33-5f09-4e88-ad15-235b61de6ece"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "2e697c33-5f09-4e88-ad15-235b61de6ece"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hu.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "708d9060-e824-40df-97de-95c33d2fd3ea"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "708d9060-e824-40df-97de-95c33d2fd3ea"
+        ],
+        "elapsed-time": [
+          "17"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"hu.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "934d8552-9c76-4695-9e03-37eedcaf9dbc"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"on\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "934d8552-9c76-4695-9e03-37eedcaf9dbc"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"is.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "a8c18832-3e76-4d44-86e7-25fc4d440e92"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "a8c18832-3e76-4d44-86e7-25fc4d440e92"
+        ],
+        "elapsed-time": [
+          "18"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"id.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "7766559c-bf62-4ddd-a82c-224f49d8fb97"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:28 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "7766559c-bf62-4ddd-a82c-224f49d8fb97"
+        ],
+        "elapsed-time": [
+          "213"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"id.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "1d1ad4c8-b2dd-4426-a938-6116ad2fd02f"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:28 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1d1ad4c8-b2dd-4426-a938-6116ad2fd02f"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ga.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "a25a5cfd-b806-453a-8098-43229ab9c700"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:28 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "a25a5cfd-b806-453a-8098-43229ab9c700"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"it.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "de4f59b9-9286-4ed5-9174-1aa09ba41553"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:28 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "de4f59b9-9286-4ed5-9174-1aa09ba41553"
+        ],
+        "elapsed-time": [
+          "21"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"it.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "de0f96b9-095a-48eb-b68b-0778845f7314"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:28 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "de0f96b9-095a-48eb-b68b-0778845f7314"
+        ],
+        "elapsed-time": [
+          "7"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ja.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "07b93697-d11d-44a5-9dca-8ee0afc9ba43"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:28 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "07b93697-d11d-44a5-9dca-8ee0afc9ba43"
+        ],
+        "elapsed-time": [
+          "118"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ja.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "4105fd5f-8675-4dac-8d7f-f22d848f255e"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:28 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "4105fd5f-8675-4dac-8d7f-f22d848f255e"
+        ],
+        "elapsed-time": [
+          "438"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"kn.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "9a45ad9a-de61-4bcb-a1a3-82c4ef81edee"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:28 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "9a45ad9a-de61-4bcb-a1a3-82c4ef81edee"
+        ],
+        "elapsed-time": [
+          "222"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ko.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "0da907ba-4ed8-4e90-ad2b-23561784c655"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "0da907ba-4ed8-4e90-ad2b-23561784c655"
+        ],
+        "elapsed-time": [
+          "254"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ko.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "2fdc000b-8c23-4fd2-95e4-f7181a490518"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "2fdc000b-8c23-4fd2-95e4-f7181a490518"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lv.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "7fbcd093-b425-408b-9afe-15ad3141517d"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "7fbcd093-b425-408b-9afe-15ad3141517d"
+        ],
+        "elapsed-time": [
+          "17"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lv.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "340d3258-9145-45ab-adf4-2f31eea291c1"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "340d3258-9145-45ab-adf4-2f31eea291c1"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"lt.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "f11299dc-edbb-454d-94b4-8de47862e003"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "f11299dc-edbb-454d-94b4-8de47862e003"
+        ],
+        "elapsed-time": [
+          "15"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ml.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "c95cdd7b-80fa-4d37-aec9-56716f573fb8"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "c95cdd7b-80fa-4d37-aec9-56716f573fb8"
+        ],
+        "elapsed-time": [
+          "34"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ms.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "6c3d185b-bd4d-4efa-a39d-027832056083"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "6c3d185b-bd4d-4efa-a39d-027832056083"
+        ],
+        "elapsed-time": [
+          "40"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"mr.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "4f52065d-e2ca-4f06-b69c-fcb57a78de55"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "4f52065d-e2ca-4f06-b69c-fcb57a78de55"
+        ],
+        "elapsed-time": [
+          "174"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"nb.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "b31fcfed-ab8d-4b42-8bef-02ac91841137"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b31fcfed-ab8d-4b42-8bef-02ac91841137"
+        ],
+        "elapsed-time": [
+          "18"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"no.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "c4b5a267-5dac-42f3-8056-f43a459aa1ff"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "c4b5a267-5dac-42f3-8056-f43a459aa1ff"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"fa.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "10925855-1feb-4a87-9cbd-baf161b5ab2c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "10925855-1feb-4a87-9cbd-baf161b5ab2c"
+        ],
+        "elapsed-time": [
+          "8"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pl.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "274cdd66-e40b-472d-941f-af1bbe408989"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "274cdd66-e40b-472d-941f-af1bbe408989"
+        ],
+        "elapsed-time": [
+          "25"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pl.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "1e7921c8-707b-4ad2-8f60-c2fc505e0578"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1e7921c8-707b-4ad2-8f60-c2fc505e0578"
+        ],
+        "elapsed-time": [
+          "7"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-BR.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "59"
+        ],
+        "client-request-id": [
+          "e8302d0c-0bb1-46df-94cf-6df3d34df6e3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "e8302d0c-0bb1-46df-94cf-6df3d34df6e3"
+        ],
+        "elapsed-time": [
+          "218"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-BR.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "4d57864b-4f72-4c95-82bd-6f94b3eb93c5"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "4d57864b-4f72-4c95-82bd-6f94b3eb93c5"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-PT.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "59"
+        ],
+        "client-request-id": [
+          "ed9d3d66-ce76-4514-a2e7-7ff2b81600ae"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "ed9d3d66-ce76-4514-a2e7-7ff2b81600ae"
+        ],
+        "elapsed-time": [
+          "22"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pt-PT.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "b2de3379-e831-4ef9-8e47-398d6803862b"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b2de3379-e831-4ef9-8e47-398d6803862b"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pa.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "1ad55a88-0109-4a25-9341-f440f95eb214"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1ad55a88-0109-4a25-9341-f440f95eb214"
+        ],
+        "elapsed-time": [
+          "23"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ro.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "453d79f5-7f04-479e-b25d-4b3c472a9d60"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "453d79f5-7f04-479e-b25d-4b3c472a9d60"
+        ],
+        "elapsed-time": [
+          "18"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ro.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "1ef8f8ef-91cb-4ea2-8b62-61ff1a1097b8"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1ef8f8ef-91cb-4ea2-8b62-61ff1a1097b8"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ru.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "50ea29e3-351d-4861-870f-1d23e5467fac"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "50ea29e3-351d-4861-870f-1d23e5467fac"
+        ],
+        "elapsed-time": [
+          "19"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ru.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "7f7a9c1f-ce18-4fbc-bcb4-4ba0d39434d2"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "7f7a9c1f-ce18-4fbc-bcb4-4ba0d39434d2"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sr-cyrillic.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "65"
+        ],
+        "client-request-id": [
+          "e278594a-babe-46d5-bcd6-61b48a7faaa1"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "e278594a-babe-46d5-bcd6-61b48a7faaa1"
+        ],
+        "elapsed-time": [
+          "18"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sr-latin.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "62"
+        ],
+        "client-request-id": [
+          "c31aa8c9-407b-47cc-92cb-e67df5b050a3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"ona\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"onaj\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "c31aa8c9-407b-47cc-92cb-e67df5b050a3"
+        ],
+        "elapsed-time": [
+          "19"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sk.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "a63891f2-9f1a-46ae-8eab-785d6f1c437d"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "a63891f2-9f1a-46ae-8eab-785d6f1c437d"
+        ],
+        "elapsed-time": [
+          "16"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sl.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "388986be-9b42-41a1-a146-4a9bb7c0f5da"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"oni\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"twa\",\"startOffset\":4,\"endOffset\":7,\"position\":1},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "388986be-9b42-41a1-a146-4a9bb7c0f5da"
+        ],
+        "elapsed-time": [
+          "226"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"es.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "e82bcaa3-229b-4691-80f1-b518f0e07790"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "e82bcaa3-229b-4691-80f1-b518f0e07790"
+        ],
+        "elapsed-time": [
+          "20"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"es.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "94189dca-2607-433a-b497-05194ee33d40"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "94189dca-2607-433a-b497-05194ee33d40"
+        ],
+        "elapsed-time": [
+          "8"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sv.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "a8d0e112-dc70-49d1-bab4-a15dea198ebc"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "a8d0e112-dc70-49d1-bab4-a15dea198ebc"
+        ],
+        "elapsed-time": [
+          "21"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"sv.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "0f4a96e7-7b09-41c4-a714-be9749261777"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "0f4a96e7-7b09-41c4-a714-be9749261777"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ta.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "2c878fba-1929-495a-85ce-0a720b988cde"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "2c878fba-1929-495a-85ce-0a720b988cde"
+        ],
+        "elapsed-time": [
+          "26"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"te.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "dc9b6937-dc7d-4c10-9255-f3e804daf8d9"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:30 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "dc9b6937-dc7d-4c10-9255-f3e804daf8d9"
+        ],
+        "elapsed-time": [
+          "25"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"th.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "10e469ab-11cb-4230-b3ab-e545e1ce201a"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "10e469ab-11cb-4230-b3ab-e545e1ce201a"
+        ],
+        "elapsed-time": [
+          "243"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"th.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "d1f1b08a-b0df-417f-ad1f-d5ff82c0a630"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "d1f1b08a-b0df-417f-ad1f-d5ff82c0a630"
+        ],
+        "elapsed-time": [
+          "27"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"tr.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "a2d7885b-66e5-445a-a841-deb01f2f5cc9"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "a2d7885b-66e5-445a-a841-deb01f2f5cc9"
+        ],
+        "elapsed-time": [
+          "16"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"tr.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ],
+        "client-request-id": [
+          "fcf73138-fd30-491c-b7f0-24d9023c8215"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "fcf73138-fd30-491c-b7f0-24d9023c8215"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"uk.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "e953b17e-c624-4613-a149-c9673576fc24"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "e953b17e-c624-4613-a149-c9673576fc24"
+        ],
+        "elapsed-time": [
+          "19"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"ur.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "b77e2a50-4e37-459a-9c38-0a06ec9869cc"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b77e2a50-4e37-459a-9c38-0a06ec9869cc"
+        ],
+        "elapsed-time": [
+          "37"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"vi.microsoft\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "831a9bcc-c96c-4a42-8792-fe857c38463e"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "831a9bcc-c96c-4a42-8792-fe857c38463e"
+        ],
+        "elapsed-time": [
+          "13"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"standard.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "59"
+        ],
+        "client-request-id": [
+          "5d465480-2b2d-45d6-950a-c44a1c53ea99"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "5d465480-2b2d-45d6-950a-c44a1c53ea99"
+        ],
+        "elapsed-time": [
+          "8"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"standardasciifolding.lucene\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "71"
+        ],
+        "client-request-id": [
+          "654c63f2-4e9e-4237-9263-377d381a4fb9"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "654c63f2-4e9e-4237-9263-377d381a4fb9"
+        ],
+        "elapsed-time": [
+          "11"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"keyword\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "51"
+        ],
+        "client-request-id": [
+          "1fdd56f7-7903-4f63-b53b-33082557fc84"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One two\",\"startOffset\":0,\"endOffset\":7,\"position\":0}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "1fdd56f7-7903-4f63-b53b-33082557fc84"
+        ],
+        "elapsed-time": [
+          "14"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"pattern\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "51"
+        ],
+        "client-request-id": [
+          "c430972e-2afd-4f77-a545-6dc810c277b5"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "c430972e-2afd-4f77-a545-6dc810c277b5"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"simple\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "50"
+        ],
+        "client-request-id": [
+          "731c2914-d451-4b4f-9e85-9e00adc29387"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "731c2914-d451-4b4f-9e85-9e00adc29387"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"stop\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "48"
+        ],
+        "client-request-id": [
+          "737a3701-3f82-4546-9213-ed02132162ba"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "737a3701-3f82-4546-9213-ed02132162ba"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"analyzer\": \"whitespace\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "54"
+        ],
+        "client-request-id": [
+          "cb683928-b87c-4446-8d09-31c4a6cc2d13"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "cb683928-b87c-4446-8d09-31c4a6cc2d13"
+        ],
+        "elapsed-time": [
+          "8"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"classic\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "52"
+        ],
+        "client-request-id": [
+          "16932cad-84ac-4b19-b9f4-e5720e142e81"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "16932cad-84ac-4b19-b9f4-e5720e142e81"
+        ],
+        "elapsed-time": [
+          "27"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"edgeNGram\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "54"
+        ],
+        "client-request-id": [
+          "51924124-eb18-4b8d-b113-362459ae2721"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":1,\"position\":0}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "51924124-eb18-4b8d-b113-362459ae2721"
+        ],
+        "elapsed-time": [
+          "16"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"keyword_v2\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "55"
+        ],
+        "client-request-id": [
+          "66bd6296-1c96-4666-8121-81752354e86b"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One two\",\"startOffset\":0,\"endOffset\":7,\"position\":0}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "66bd6296-1c96-4666-8121-81752354e86b"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"letter\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "51"
+        ],
+        "client-request-id": [
+          "7469b6c7-23f1-4448-a9cf-c8307f52bec6"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "7469b6c7-23f1-4448-a9cf-c8307f52bec6"
+        ],
+        "elapsed-time": [
+          "10"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"lowercase\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "54"
+        ],
+        "client-request-id": [
+          "8a48878f-e076-4381-af7f-a7a1cc6d97a0"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"one\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "8a48878f-e076-4381-af7f-a7a1cc6d97a0"
+        ],
+        "elapsed-time": [
+          "8"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"microsoft_language_tokenizer\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "73"
+        ],
+        "client-request-id": [
+          "66b1181b-f2eb-43aa-9138-c27418ccc861"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "66b1181b-f2eb-43aa-9138-c27418ccc861"
+        ],
+        "elapsed-time": [
+          "12"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"microsoft_language_stemming_tokenizer\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "82"
+        ],
+        "client-request-id": [
+          "3569d6c3-35b1-4b9e-8d5e-de799520c2e1"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "3569d6c3-35b1-4b9e-8d5e-de799520c2e1"
+        ],
+        "elapsed-time": [
+          "18"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"nGram\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "50"
+        ],
+        "client-request-id": [
+          "48aed166-95a4-4d76-a883-a7d384759c02"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":1,\"position\":0},{\"token\":\"On\",\"startOffset\":0,\"endOffset\":2,\"position\":1},{\"token\":\"ne\",\"startOffset\":1,\"endOffset\":3,\"position\":2},{\"token\":\"n\",\"startOffset\":1,\"endOffset\":2,\"position\":3},{\"token\":\"e\",\"startOffset\":2,\"endOffset\":3,\"position\":4},{\"token\":\"e \",\"startOffset\":2,\"endOffset\":4,\"position\":5},{\"token\":\" t\",\"startOffset\":3,\"endOffset\":5,\"position\":6},{\"token\":\" \",\"startOffset\":3,\"endOffset\":4,\"position\":7},{\"token\":\"tw\",\"startOffset\":4,\"endOffset\":6,\"position\":8},{\"token\":\"t\",\"startOffset\":4,\"endOffset\":5,\"position\":9},{\"token\":\"wo\",\"startOffset\":5,\"endOffset\":7,\"position\":10},{\"token\":\"w\",\"startOffset\":5,\"endOffset\":6,\"position\":11},{\"token\":\"o\",\"startOffset\":6,\"endOffset\":7,\"position\":12}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:32 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "48aed166-95a4-4d76-a883-a7d384759c02"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"path_hierarchy_v2\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "62"
+        ],
+        "client-request-id": [
+          "ce158f5c-ca2d-4fba-987a-98531ad15e7f"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:32 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "ce158f5c-ca2d-4fba-987a-98531ad15e7f"
+        ],
+        "elapsed-time": [
+          "8"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"pattern\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "52"
+        ],
+        "client-request-id": [
+          "3ec29df5-49ef-4d60-b4ad-66daa0b8bc61"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:32 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "3ec29df5-49ef-4d60-b4ad-66daa0b8bc61"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"standard_v2\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "56"
+        ],
+        "client-request-id": [
+          "ea278637-fc3d-4c12-b9e1-b1009f7dca90"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:32 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "ea278637-fc3d-4c12-b9e1-b1009f7dca90"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"uax_url_email\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "58"
+        ],
+        "client-request-id": [
+          "b9e125ff-09e8-4870-ab76-cdf3aa286b2d"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:32 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "b9e125ff-09e8-4870-ab76-cdf3aa286b2d"
+        ],
+        "elapsed-time": [
+          "37"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"whitespace\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "55"
+        ],
+        "client-request-id": [
+          "71389754-5f14-41b4-a098-6475b29280e5"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"One\",\"startOffset\":0,\"endOffset\":3,\"position\":0},{\"token\":\"two\",\"startOffset\":4,\"endOffset\":7,\"position\":1}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:32 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "71389754-5f14-41b4-a098-6475b29280e5"
+        ],
+        "elapsed-time": [
+          "9"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/indexes('azsmnet6388')/search.analyze?api-version=2016-09-01",
+      "EncodedRequestUri": "L2luZGV4ZXMoJ2F6c21uZXQ2Mzg4Jykvc2VhcmNoLmFuYWx5emU/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"text\": \"One two\",\r\n  \"tokenizer\": \"whitespace\",\r\n  \"tokenFilters\": [\r\n    \"arabic_normalization\",\r\n    \"apostrophe\",\r\n    \"asciifolding\",\r\n    \"cjk_bigram\",\r\n    \"cjk_width\",\r\n    \"classic\",\r\n    \"common_grams\",\r\n    \"edgeNGram_v2\",\r\n    \"elision\",\r\n    \"german_normalization\",\r\n    \"hindi_normalization\",\r\n    \"indic_normalization\",\r\n    \"keyword_repeat\",\r\n    \"kstem\",\r\n    \"length\",\r\n    \"limit\",\r\n    \"lowercase\",\r\n    \"nGram_v2\",\r\n    \"persian_normalization\",\r\n    \"phonetic\",\r\n    \"porter_stem\",\r\n    \"reverse\",\r\n    \"scandinavian_normalization\",\r\n    \"scandinavian_folding\",\r\n    \"shingle\",\r\n    \"snowball\",\r\n    \"sorani_normalization\",\r\n    \"stemmer\",\r\n    \"stopwords\",\r\n    \"trim\",\r\n    \"truncate\",\r\n    \"unique\",\r\n    \"uppercase\",\r\n    \"word_delimiter\"\r\n  ],\r\n  \"charFilters\": [\r\n    \"html_strip\"\r\n  ]\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "820"
+        ],
+        "client-request-id": [
+          "dee040af-d234-49f9-a608-f93ccd75ee70"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "api-key": [
+          "9C747DAC975294606708FB47FFC266E4"
+        ],
+        "Prefer": [
+          "return=representation"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Search.SearchServiceClient/3.0.2"
+        ]
+      },
+      "ResponseBody": "{\"@odata.context\":\"https://azs-1141.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01.AnalyzeResult\",\"tokens\":[{\"token\":\"O\",\"startOffset\":0,\"endOffset\":3,\"position\":0}]}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata.metadata=minimal"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 07 Mar 2017 19:56:32 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "request-id": [
+          "dee040af-d234-49f9-a608-f93ccd75ee70"
+        ],
+        "elapsed-time": [
+          "239"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "Preference-Applied": [
+          "odata.include-annotations=\"*\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/b80cf239-2c72-47ab-b309-b26aec4656b1/resourceGroups/azsmnet8601/providers/Microsoft.Search/searchServices/azs-1141?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYjgwY2YyMzktMmM3Mi00N2FiLWIzMDktYjI2YWVjNDY1NmIxL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ4NjAxL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy0xMTQxP2FwaS12ZXJzaW9uPTIwMTUtMDgtMTk=",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "4af4f5b0-2470-43de-8d1c-fdc5d6ec21f0"
+          "4f27ecab-b4f9-42e0-9eee-e4c3ffeb154f"
         ],
         "accept-language": [
           "en-US"
@@ -7605,19 +7672,19 @@
           "no-cache"
         ],
         "Date": [
-          "Tue, 07 Mar 2017 19:42:56 GMT"
+          "Tue, 07 Mar 2017 19:56:34 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "x-ms-request-id": [
-          "4af4f5b0-2470-43de-8d1c-fdc5d6ec21f0"
+          "4f27ecab-b4f9-42e0-9eee-e4c3ffeb154f"
         ],
         "request-id": [
-          "4af4f5b0-2470-43de-8d1c-fdc5d6ec21f0"
+          "4f27ecab-b4f9-42e0-9eee-e4c3ffeb154f"
         ],
         "elapsed-time": [
-          "701"
+          "872"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -7626,13 +7693,13 @@
           "4.0.30319"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1197"
+          "1182"
         ],
         "x-ms-correlation-request-id": [
-          "df22c314-f974-431e-9d8e-416eca7ae750"
+          "64e9a9a5-2ce7-44c3-b694-ce80e49009d1"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20170307T194257Z:df22c314-f974-431e-9d8e-416eca7ae750"
+          "CENTRALUS:20170307T195634Z:64e9a9a5-2ce7-44c3-b694-ce80e49009d1"
         ]
       },
       "StatusCode": 200
@@ -7640,12 +7707,12 @@
   ],
   "Names": {
     "GenerateName": [
-      "azsmnet6410",
-      "azsmnet2698",
-      "azsmnet7517"
+      "azsmnet8601",
+      "azsmnet520",
+      "azsmnet6388"
     ],
     "GenerateServiceName": [
-      "azs-280"
+      "azs-1141"
     ]
   },
   "Variables": {

--- a/src/Search/Search.Tests/Tests/CustomAnalyzerTests.cs
+++ b/src/Search/Search.Tests/Tests/CustomAnalyzerTests.cs
@@ -162,9 +162,7 @@ namespace Microsoft.Azure.Search.Tests
                 client.Indexes.Create(index);
 
                 AnalyzerName[] allAnalyzerNames = GetAllExtensibleEnumValues<AnalyzerName>();
-    
-                allAnalyzerNames = allAnalyzerNames.Except(new[] { AnalyzerName.StandardLucene }).ToArray();
-
+                    
                 var requests = allAnalyzerNames.Select(an => new AnalyzeRequest() { Text = "One two", Analyzer = an });
 
                 foreach (var req in requests)

--- a/src/Search/Search.Tests/Tests/CustomAnalyzerTests.cs
+++ b/src/Search/Search.Tests/Tests/CustomAnalyzerTests.cs
@@ -162,8 +162,7 @@ namespace Microsoft.Azure.Search.Tests
                 client.Indexes.Create(index);
 
                 AnalyzerName[] allAnalyzerNames = GetAllExtensibleEnumValues<AnalyzerName>();
-
-                //TODO,brjohnst: Remove this logic after Analyze API validation has been fixed
+    
                 allAnalyzerNames = allAnalyzerNames.Except(new[] { AnalyzerName.StandardLucene }).ToArray();
 
                 var requests = allAnalyzerNames.Select(an => new AnalyzeRequest() { Text = "One two", Analyzer = an });
@@ -174,13 +173,6 @@ namespace Microsoft.Azure.Search.Tests
                 }
 
                 TokenizerName[] allTokenizerNames = GetAllExtensibleEnumValues<TokenizerName>();
-
-                //TODO,brjohnst: Remove this logic after Analyze API validation has been fixed
-                allTokenizerNames =
-                    allTokenizerNames
-                        .Except(new[] { TokenizerName.MicrosoftLanguageTokenizer, TokenizerName.MicrosoftLanguageStemmingTokenizer })
-                        .ToArray();
-
                 requests = allTokenizerNames.Select(tn => new AnalyzeRequest() { Text = "One two", Tokenizer = tn });
 
                 foreach (var req in requests)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ x] Title of the pull request is clear and informative.
- [ x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [x ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.