### PR TITLE
ClientRuntime: Don't serialize protected members.

### DIFF
--- a/src/ClientRuntime/Microsoft.Rest.ClientRuntime.Tests/JsonSerializationTests.cs
+++ b/src/ClientRuntime/Microsoft.Rest.ClientRuntime.Tests/JsonSerializationTests.cs
@@ -100,8 +100,11 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             serializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
             serializeSettings.ContractResolver = new ReadOnlyJsonContractResolver();
 
-            var firstAlienJson = JsonConvert.SerializeObject(new Alien("green") { Name = "autorest", Planet = "Mars", Body = JObject.Parse(@"{ ""custom"" : ""json"" }") },
+            var firstAlienJson = JsonConvert.SerializeObject(new Alien("green", "quite decent") { Name = "autorest", Planet = "Mars", Body = JObject.Parse(@"{ ""custom"" : ""json"" }") },
                 Formatting.Indented, serializeSettings);
+
+            Assert.DoesNotContain(@"""color""", firstAlienJson);
+            Assert.DoesNotContain(@"""smell""", firstAlienJson);
 
             var firstAlien = JsonConvert.DeserializeObject<Alien>(firstAlienJson, serializeSettings);
 
@@ -131,7 +134,7 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             serializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
             serializeSettings.ContractResolver = new ReadOnlyJsonContractResolver();
 
-            var firstAlienJson = JsonConvert.SerializeObject(new Alien("green") { Name = "autorest", Planet = "Mars" },
+            var firstAlienJson = JsonConvert.SerializeObject(new Alien("green", "quite decent") { Name = "autorest", Planet = "Mars" },
                 Formatting.Indented, serializeSettings);
 
             var firstAlien = JsonConvert.DeserializeObject<Alien>(firstAlienJson, serializeSettings);

--- a/src/ClientRuntime/Microsoft.Rest.ClientRuntime.Tests/Resources/Animal.cs
+++ b/src/ClientRuntime/Microsoft.Rest.ClientRuntime.Tests/Resources/Animal.cs
@@ -52,9 +52,10 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Resources
             
         }
 
-        public Alien(string color)
+        public Alien(string color, string smell)
         {
             Color = color;
+            Smell = smell;
         }
 
         private string _planet;
@@ -64,6 +65,9 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Resources
 
         [JsonProperty("color")]
         public string Color { get; private set; }
+
+        [JsonProperty("smell")]
+        public string Smell { get; protected set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/src/ClientRuntime/Microsoft.Rest.ClientRuntime/Serialization/ReadOnlyJsonContractResolver.cs
+++ b/src/ClientRuntime/Microsoft.Rest.ClientRuntime/Serialization/ReadOnlyJsonContractResolver.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Rest.Serialization
             if (propertyInfo != null)
             {
                 jsonProperty.ShouldSerialize = t => 
-                    (propertyInfo.SetMethod != null && !propertyInfo.SetMethod.IsPrivate) || 
+                    (propertyInfo.SetMethod != null && !propertyInfo.SetMethod.IsPrivate /* && !propertyInfo.SetMethod.IsFamily */) || 
                     (propertyInfo.GetMethod != null && propertyInfo.GetMethod.IsStatic);
             }
 

--- a/src/ClientRuntime/Microsoft.Rest.ClientRuntime/Serialization/ReadOnlyJsonContractResolver.cs
+++ b/src/ClientRuntime/Microsoft.Rest.ClientRuntime/Serialization/ReadOnlyJsonContractResolver.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Rest.Serialization
             if (propertyInfo != null)
             {
                 jsonProperty.ShouldSerialize = t => 
-                    (propertyInfo.SetMethod != null && !propertyInfo.SetMethod.IsPrivate /* && !propertyInfo.SetMethod.IsFamily */) || 
+                    (propertyInfo.SetMethod != null && !propertyInfo.SetMethod.IsPrivate && !propertyInfo.SetMethod.IsFamily) || 
                     (propertyInfo.GetMethod != null && propertyInfo.GetMethod.IsStatic);
             }
 

--- a/src/ClientRuntime/Microsoft.Rest.ClientRuntime/project.json
+++ b/src/ClientRuntime/Microsoft.Rest.ClientRuntime/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.6",
+  "version": "2.3.5",
   "copyright": "Copyright (c) Microsoft Corporation",
   "title": "Client Runtime Library for Microsoft AutoRest Generated Clients",
   "description": "Infrastructure for error handling, tracing, and HttpClient pipeline configuration. Required by client libraries generated using AutoRest. \nSupported Platforms:\n  -   Portable Class Libraries\n  -   .NET Framework 4.5\n  -   Windows 8\n  -   Windows Phone 8.1\n  -   DotNet Core",

--- a/src/ClientRuntime/Microsoft.Rest.ClientRuntime/project.json
+++ b/src/ClientRuntime/Microsoft.Rest.ClientRuntime/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.5",
+  "version": "2.3.6",
   "copyright": "Copyright (c) Microsoft Corporation",
   "title": "Client Runtime Library for Microsoft AutoRest Generated Clients",
   "description": "Infrastructure for error handling, tracing, and HttpClient pipeline configuration. Required by client libraries generated using AutoRest. \nSupported Platforms:\n  -   Portable Class Libraries\n  -   .NET Framework 4.5\n  -   Windows 8\n  -   Windows Phone 8.1\n  -   DotNet Core",


### PR DESCRIPTION


(abusing CI since my machine is no longer capable of opening that project in VS, msbuild also can't find some targets... guess the move to VS2017 messed that up)