### PR TITLE
[HyakNETCore] Add missed changes from HDInsight PR

### DIFF
--- a/src/ResourceManagement/HDInsight/HDInsight.Tests/UnitTests/ClusterCreateTests.cs
+++ b/src/ResourceManagement/HDInsight/HDInsight.Tests/UnitTests/ClusterCreateTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Azure.Management.HDInsight;
 using System.Collections.Generic;
 using Xunit;
+using System.Linq;
 using Microsoft.Azure.Management.HDInsight.Models;
 using Newtonsoft.Json;
 using HDInsight.Tests.Helpers;
@@ -88,6 +89,53 @@ namespace HDInsight.Tests.UnitTests
             Assert.Equal(extendedParams.Properties.ComputeProfile.Roles[0].HardwareProfile.VmSize, "Standard_D13_V2");
             Assert.Equal(extendedParams.Properties.ComputeProfile.Roles[0].Name, "headnode");
             Assert.Equal(extendedParams.Properties.ComputeProfile.Roles[0].TargetInstanceCount, 1);            
+        }
+
+        [Fact]
+        public void TestCreateRserverDefaultNodeSizesValues()
+        {
+            var clusterCreateParams = GetClusterSpecHelpers.GetCustomCreateParametersIaas();
+            clusterCreateParams.ClusterType = "RServer";
+            clusterCreateParams.Version = "3.5";
+            clusterCreateParams.WorkerNodeSize = null;
+            clusterCreateParams.HeadNodeSize = null;
+
+            ClusterOperations op = new ClusterOperations(new HDInsightManagementClient());
+            var extendedParams = op.GetExtendedClusterCreateParameters("hdisdk-RServerClusterEdgeNodeDefaultTest", clusterCreateParams);
+
+            List<Role> roles = new List<Role>(extendedParams.Properties.ComputeProfile.Roles);
+            ValidateRole(roles, "headnode", "Standard_D12_v2");
+            ValidateRole(roles, "workernode", "Standard_D4_v2", clusterCreateParams.ClusterSizeInNodes);
+            ValidateRole(roles, "edgenode", "Standard_D4_v2", 1);
+            ValidateRole(roles, "zookeepernode", "Medium");
+        }
+
+        [Fact]
+        public void TestCreateRserverEdgeNodeSpecified()
+        {
+            const string edgeNodeSizeToTest = "Standard_D12_v2";
+
+            var clusterCreateParams = GetClusterSpecHelpers.GetCustomCreateParametersIaas();
+            clusterCreateParams.ClusterType = "RServer";
+            clusterCreateParams.EdgeNodeSize = edgeNodeSizeToTest;
+            clusterCreateParams.Version = "3.5";
+
+            ClusterOperations op = new ClusterOperations(new HDInsightManagementClient());
+            var extendedParams = op.GetExtendedClusterCreateParameters("hdisdk-RServerClusterEdgeNodeSpecifiedTest", clusterCreateParams);
+
+            List<Role> roles = new List<Role>(extendedParams.Properties.ComputeProfile.Roles);
+            ValidateRole(roles, "edgenode", edgeNodeSizeToTest, 1);
+        }
+
+        private void ValidateRole(List<Role> roles, string roleName, string roleVmSize, int roleInstanceCount = -1)
+        {
+            var roleToValidate = roles.FirstOrDefault(r => r.Name.Equals(roleName, System.StringComparison.OrdinalIgnoreCase));
+            Assert.True(roleToValidate != null);
+
+            Assert.True(roleToValidate.HardwareProfile.VmSize.Equals(roleVmSize, System.StringComparison.OrdinalIgnoreCase));
+
+            if (roleInstanceCount != -1)
+                Assert.True(roleToValidate.TargetInstanceCount == roleInstanceCount);
         }
     }
 }

--- a/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/CustomizationModels/ClusterCreateParameters.cs
+++ b/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/CustomizationModels/ClusterCreateParameters.cs
@@ -111,6 +111,14 @@ namespace Microsoft.Azure.Management.HDInsight.Models
         public string ZookeeperNodeSize { get; set; }
 
         /// <summary>
+        /// Gets or sets the size of the Edge Node.
+        /// </summary>
+        /// <value>
+        /// The size of the edge node.
+        /// </value>
+        public string EdgeNodeSize { get; set; }
+
+        /// <summary>
         /// Gets additional Azure Blob Storage Account that you want to enable access to.
         /// </summary>
         public Dictionary<string, string> AdditionalStorageAccounts { get; private set; }

--- a/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/CustomizationModels/ClusterNodeType.cs
+++ b/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/CustomizationModels/ClusterNodeType.cs
@@ -18,6 +18,11 @@
         /// <summary>
         /// The zookeper nodes of the cluster.
         /// </summary>
-        ZookeeperNode
+        ZookeeperNode,
+
+        /// <summary>
+        /// The edge nodes of the cluster.
+        /// </summary>
+        EdgeNode
     }
 }

--- a/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Customizations/ClusterOperations.Create.Customizations.cs
+++ b/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Customizations/ClusterOperations.Create.Customizations.cs
@@ -570,12 +570,29 @@ namespace Microsoft.Azure.Management.HDInsight
 
             roles.Add(zookeepernode);
 
+            if (clusterCreateParameters.ClusterType.Equals("RServer", StringComparison.OrdinalIgnoreCase))
+            {
+                var EdgeNodeSize = GetEdgeNodeSize(clusterCreateParameters);
+                var EdgeNode = new Role
+                {
+                    Name = "edgenode",
+                    TargetInstanceCount = 1,
+                    HardwareProfile = new HardwareProfile
+                    {
+                        VmSize = EdgeNodeSize
+                    },
+                    OsProfile = osProfile
+                };
+                roles.Add(EdgeNode);
+            }
+
             return roles;
         }
 
         private static readonly Dictionary<string, string> HeadNodeDefaultSizes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { 
                     {"hadoop", "Standard_D3" },
                     {"spark", "Standard_D12"},
+                    {"rserver", "Standard_D12_v2"},
                     {"InteractiveHive", "Standard_D13_v2"},
                 };
 
@@ -599,6 +616,7 @@ namespace Microsoft.Azure.Management.HDInsight
 
         private static readonly Dictionary<string, string> WorkerNodeDefaultSizes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { 
                     {"spark", "Standard_D12"},
+                    {"rserver", "Standard_D4_v2"},
                     {"InteractiveHive", "Standard_D13_v2"},
                 };
 
@@ -618,6 +636,20 @@ namespace Microsoft.Azure.Management.HDInsight
             }
 
             return workerNodeSize;
+        }
+
+        private static string GetEdgeNodeSize(ClusterCreateParameters clusterCreateParameters)
+        {
+            string edgeNodeSize;
+            if (!String.IsNullOrEmpty(clusterCreateParameters.EdgeNodeSize))
+            {
+                edgeNodeSize = clusterCreateParameters.EdgeNodeSize;
+            }
+            else
+            {
+                edgeNodeSize = "Standard_D4_v2";
+            }
+            return edgeNodeSize;
         }
     }
 }

--- a/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Generated/ClusterOperations.cs
+++ b/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Generated/ClusterOperations.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Management.HDInsight
     /// </summary>
     internal partial class ClusterOperations : IServiceOperations<HDInsightManagementClient>, IClusterOperations
     {
-        private const string _userAgentString = "ARM SDK v2.0.4";
+        private const string _userAgentString = "ARM SDK v2.0.5";
 
         /// <summary>
         /// Initializes a new instance of the ClusterOperations class.

--- a/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Generated/ClusterOperations.cs
+++ b/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Generated/ClusterOperations.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Management.HDInsight
     /// </summary>
     internal partial class ClusterOperations : IServiceOperations<HDInsightManagementClient>, IClusterOperations
     {
-        private const string _userAgentString = "ARM SDK v2.0.2";
+        private const string _userAgentString = "ARM SDK v2.0.4";
 
         /// <summary>
         /// Initializes a new instance of the ClusterOperations class.

--- a/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.4.0")]
+[assembly: AssemblyFileVersion("2.0.5.0")]
 
 [assembly:InternalsVisibleTo("HDInsight.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/project.json
+++ b/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.4",
+    "version": "2.0.5",
     "title": "Microsoft Azure HDInsight Management Library",
     "description": "The generally available HDInsight Management NuGet package. This NuGet package allows you to create and manage Azure HDInsight clusters using Azure Resource Manager (ARM).",
     "authors": [ "Microsoft" ],


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

Adding in changes made in PR https://github.com/Azure/azure-sdk-for-net/pull/2826 that were missed when converting Hyak libraries to NET Core.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [x] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.