### PR TITLE
Fix deserialization of DataSliceRun.ActivityInputProperties

### DIFF
--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/DataFactoryManagementChangelog.md
@@ -1,5 +1,11 @@
 ﻿For additional details on features, see the full [Azure Data Factory Release Notes](https://azure.microsoft.com/en-us/documentation/articles/data-factory-release-notes). 
 
+## Version 4.12.1
+
+### Bug Fixes
+
+* Fixes deserialization of DataSliceRun.ActivityInputProperties
+
 ## Version 4.12.0
 _Release date: 2017.03.08_
 

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/DataSliceRunOperations.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Generated/Core/DataSliceRunOperations.cs
@@ -329,14 +329,14 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                                 dataSliceRunInstance.Type = typeInstance;
                             }
                             
-                            JToken activityinputpropertiesSequenceElement = ((JToken)responseDoc["activityinputproperties"]);
-                            if (activityinputpropertiesSequenceElement != null && activityinputpropertiesSequenceElement.Type != JTokenType.Null)
+                            JToken activityInputPropertiesSequenceElement = ((JToken)responseDoc["activityInputProperties"]);
+                            if (activityInputPropertiesSequenceElement != null && activityInputPropertiesSequenceElement.Type != JTokenType.Null)
                             {
-                                foreach (JProperty property in activityinputpropertiesSequenceElement)
+                                foreach (JProperty property in activityInputPropertiesSequenceElement)
                                 {
-                                    string activityinputpropertiesKey = ((string)property.Name);
-                                    string activityinputpropertiesValue = ((string)property.Value);
-                                    dataSliceRunInstance.ActivityInputProperties.Add(activityinputpropertiesKey, activityinputpropertiesValue);
+                                    string activityInputPropertiesKey = ((string)property.Name);
+                                    string activityInputPropertiesValue = ((string)property.Value);
+                                    dataSliceRunInstance.ActivityInputProperties.Add(activityInputPropertiesKey, activityInputPropertiesValue);
                                 }
                             }
                             
@@ -997,14 +997,14 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                                         dataSliceRunInstance.Type = typeInstance;
                                     }
                                     
-                                    JToken activityinputpropertiesSequenceElement = ((JToken)valueValue["activityinputproperties"]);
-                                    if (activityinputpropertiesSequenceElement != null && activityinputpropertiesSequenceElement.Type != JTokenType.Null)
+                                    JToken activityInputPropertiesSequenceElement = ((JToken)valueValue["activityInputProperties"]);
+                                    if (activityInputPropertiesSequenceElement != null && activityInputPropertiesSequenceElement.Type != JTokenType.Null)
                                     {
-                                        foreach (JProperty property in activityinputpropertiesSequenceElement)
+                                        foreach (JProperty property in activityInputPropertiesSequenceElement)
                                         {
-                                            string activityinputpropertiesKey = ((string)property.Name);
-                                            string activityinputpropertiesValue = ((string)property.Value);
-                                            dataSliceRunInstance.ActivityInputProperties.Add(activityinputpropertiesKey, activityinputpropertiesValue);
+                                            string activityInputPropertiesKey = ((string)property.Name);
+                                            string activityInputPropertiesValue = ((string)property.Value);
+                                            dataSliceRunInstance.ActivityInputProperties.Add(activityInputPropertiesKey, activityInputPropertiesValue);
                                         }
                                     }
                                     
@@ -1404,14 +1404,14 @@ namespace Microsoft.Azure.Management.DataFactories.Core
                                         dataSliceRunInstance.Type = typeInstance;
                                     }
                                     
-                                    JToken activityinputpropertiesSequenceElement = ((JToken)valueValue["activityinputproperties"]);
-                                    if (activityinputpropertiesSequenceElement != null && activityinputpropertiesSequenceElement.Type != JTokenType.Null)
+                                    JToken activityInputPropertiesSequenceElement = ((JToken)valueValue["activityInputProperties"]);
+                                    if (activityInputPropertiesSequenceElement != null && activityInputPropertiesSequenceElement.Type != JTokenType.Null)
                                     {
-                                        foreach (JProperty property in activityinputpropertiesSequenceElement)
+                                        foreach (JProperty property in activityInputPropertiesSequenceElement)
                                         {
-                                            string activityinputpropertiesKey = ((string)property.Name);
-                                            string activityinputpropertiesValue = ((string)property.Value);
-                                            dataSliceRunInstance.ActivityInputProperties.Add(activityinputpropertiesKey, activityinputpropertiesValue);
+                                            string activityInputPropertiesKey = ((string)property.Name);
+                                            string activityInputPropertiesValue = ((string)property.Value);
+                                            dataSliceRunInstance.ActivityInputProperties.Add(activityInputPropertiesKey, activityInputPropertiesValue);
                                         }
                                     }
                                     

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuget.proj
@@ -5,7 +5,7 @@
     Microsoft.Azure.Management.DataFactories
     -->
     <SdkNuGetPackage Include="Microsoft.Azure.Management.DataFactories">
-      <PackageVersion>4.12.0</PackageVersion>
+      <PackageVersion>4.12.1</PackageVersion>
       <Folder>$(MSBuildThisFileDirectory)</Folder>
     </SdkNuGetPackage>
   </ItemGroup>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Microsoft.Azure.Management.DataFactories.nuspec
@@ -3,7 +3,7 @@
   <metadata minClientVersion="2.5">
     <id>Microsoft.Azure.Management.DataFactories</id>
     <title>Microsoft Azure Data Factory Management Library</title>
-    <releaseNotes>https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log/#version-4120</releaseNotes>
+    <releaseNotes>https://azure.microsoft.com/en-us/documentation/articles/data-factory-api-change-log/#version-4121</releaseNotes>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>azure-sdk, Microsoft</owners>

--- a/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DataFactory/DataFactoryManagement/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Factory management operations.")]
 
 [assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.12.0.0")]
+[assembly: AssemblyFileVersion("4.12.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.