### PR TITLE
Downgrading Newtonsoft.Json version for compatibility in Hyak runtime

### DIFF
--- a/src/ClientRuntime/Hyak.Common/project.json
+++ b/src/ClientRuntime/Hyak.Common/project.json
@@ -39,7 +39,7 @@
         "System.Xml.Linq": ""
       },
       "dependencies": {
-          "Newtonsoft.Json": "[9.0.1, 10.0.0)",
+          "Newtonsoft.Json": "[6.0.8, 7.0.0)",
         }
       },
       "netstandard1.5": {

--- a/src/ClientRuntime/Hyak.Common/project.json
+++ b/src/ClientRuntime/Hyak.Common/project.json
@@ -16,7 +16,8 @@
     "buildOptions": {
         "delaySign": true,
         "publicSign": false,
-        "keyFile": "../../../tools/MSSharedLibKey.snk"
+        "keyFile": "../../../tools/MSSharedLibKey.snk",
+        "xmlDoc": true
     },
 
     "dependencies": {

--- a/src/ClientRuntime/Microsoft.Azure.Common/project.json
+++ b/src/ClientRuntime/Microsoft.Azure.Common/project.json
@@ -16,7 +16,8 @@
     "buildOptions": {
         "delaySign": true,
         "publicSign": false,
-        "keyFile": "../../../tools/MSSharedLibKey.snk"
+        "keyFile": "../../../tools/MSSharedLibKey.snk",
+        "xmlDoc": true
     },
 
   "dependencies": {

--- a/src/ClientRuntime/Microsoft.Azure.Common/project.json
+++ b/src/ClientRuntime/Microsoft.Azure.Common/project.json
@@ -41,7 +41,7 @@
         "System.Xml.Linq": ""
       },
       "dependencies": {
-        "Newtonsoft.Json": "[9.0.1, 10.0.0)"
+        "Newtonsoft.Json": "[6.0.8, 7)"
       }
     },
     "netstandard1.5": {


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.