### PR TITLE
Changed autorest reference in the gulp file.

### DIFF
--- a/src/ResourceManagement/gulpfile.js
+++ b/src/ResourceManagement/gulpfile.js
@@ -104,26 +104,23 @@ gulp.task('default', function() {
     Object.keys(mappings).forEach(function(i) {
         console.log('\t' + i.magenta);
     });
-    console.log("--autorest\n\tThe version of AutoRest. E.g. 0.15.0, or the location of AutoRest repo, E.g. E:\\repo\\autorest");
+    console.log("--autorest\n\tThe version of AutoRest. E.g. 1.0.1-20170222-2300-nightly, or the location of AutoRest repo, E.g. E:\\repo\\autorest");
+    console.log("--autorest-args\n\tPasses additional argument to AutoRest generator");
 });
 
 var specRoot = args['spec-root'] || "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master";
 var projects = args['projects'];
-var autoRestVersion = '1.0.0-Nightly20170111'; // default
+var autoRestVersion = 'latest'; // default
 if (args['autorest'] !== undefined) {
     autoRestVersion = args['autorest'];
 }
 var autoRestExe;
 
 gulp.task('codegen', function(cb) {
-    var nugetSource = 'https://www.myget.org/F/autorest/api/v2';
-    if (autoRestVersion.match(/[0-9]+\.[0-9]+\.[0-9]+.*/)) {
-        autoRestExe = 'packages\\autorest.' + autoRestVersion + '\\tools\\AutoRest.exe';
-        exec('tools\\nuget.exe install autorest -Source ' + nugetSource + ' -Version ' + autoRestVersion + ' -o packages', function(err, stdout, stderr) {
-            console.log(stdout);
-            console.error(stderr);
-            handleInput(projects, cb);
-        });
+    if (autoRestVersion.match(/[0-9]+\.[0-9]+\.[0-9]+.*/) ||
+        autoRestVersion == 'latest') {
+        autoRestExe = 'autorest ---version=' + autoRestVersion;
+        handleInput(projects, cb);
     } else {
         autoRestExe = autoRestVersion + "/" + GetAutoRestFolder() + "AutoRest.exe";
         if (process.platform !== 'win32') {
@@ -162,8 +159,13 @@ var codegen = function(project, cb) {
     if (mappings[project].composite !== null && mappings[project].composite === true) {
         modeler = 'CompositeSwagger';
     }
-    cmd = autoRestExe + ' -Modeler ' + modeler + ' -CodeGenerator ' + generator + ' -Namespace ' + mappings[project].package + ' -Input ' + specRoot + '/' + mappings[project].source + 
-            ' -outputDirectory ' + mappings[project].dir + '/Generated' + ' -Header MICROSOFT_MIT';
+    cmd = autoRestExe + ' -Modeler ' + modeler + 
+                        ' -CodeGenerator ' + generator + 
+			' -Namespace ' + mappings[project].package + 
+			' -Input ' + specRoot + '/' + mappings[project].source + 
+			' -outputDirectory ' + mappings[project].dir + '/Generated' + 
+			' -Header MICROSOFT_MIT' +
+                        ' -skipValidation true';
     if (mappings[project].args !== undefined) {
         cmd = cmd + ' ' + mappings[project].args;
     }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.