### PR TITLE
Fixing misc acronym capitalization issues per .NET naming conventions

### DIFF
--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineCustomImageOperationsTest.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineCustomImageOperationsTest.cs
@@ -29,7 +29,7 @@ namespace Fluent.Tests.Compute
 
                 try
                 {
-                    var linuxVM = PrepareGeneralizedVmWith2EmptyDataDisks(rgName,
+                    var linuxVM = PrepareGeneralizedVMWith2EmptyDataDisks(rgName,
                             SdkContext.RandomResourceName("muldvm", 15),
                             Location,
                             computeManager);
@@ -128,7 +128,7 @@ namespace Fluent.Tests.Compute
                 var resourceManager = TestHelper.CreateRollupClient();
                 var computeManager = TestHelper.CreateComputeManager();
                 var rgName = TestUtilities.GenerateName("rgfluentchash-");
-                var vm = PrepareGeneralizedVmWith2EmptyDataDisks(rgName, vmName, Location, computeManager);
+                var vm = PrepareGeneralizedVMWith2EmptyDataDisks(rgName, vmName, Location, computeManager);
 
                 try
                 {
@@ -188,7 +188,7 @@ namespace Fluent.Tests.Compute
                 var rgName = TestUtilities.GenerateName("rgfluentchash-");
                 try
                 {
-                    var nativeVm = computeManager.VirtualMachines
+                    var nativeVM = computeManager.VirtualMachines
                             .Define(vmName)
                             .WithRegion(Location)
                             .WithNewResourceGroup(rgName)
@@ -209,13 +209,13 @@ namespace Fluent.Tests.Compute
                             .WithOSDiskCaching(CachingTypes.ReadWrite)
                             .Create();
 
-                    Assert.False(nativeVm.IsManagedDiskEnabled);
-                    var osVhdUri = nativeVm.OsUnmanagedDiskVhdUri;
+                    Assert.False(nativeVM.IsManagedDiskEnabled);
+                    var osVhdUri = nativeVM.OsUnmanagedDiskVhdUri;
                     Assert.NotNull(osVhdUri);
-                    var dataDisks = nativeVm.UnmanagedDataDisks;
+                    var dataDisks = nativeVM.UnmanagedDataDisks;
                     Assert.Equal(dataDisks.Count, 2);
 
-                    computeManager.VirtualMachines.DeleteById(nativeVm.Id);
+                    computeManager.VirtualMachines.DeleteById(nativeVM.Id);
 
                     var osDiskName = SdkContext.RandomResourceName("dsk", 15);
                     // Create managed disk with Os from vm's Os disk
@@ -309,7 +309,7 @@ namespace Fluent.Tests.Compute
             }
         }
 
-        private IVirtualMachine PrepareGeneralizedVmWith2EmptyDataDisks(string rgName,
+        private IVirtualMachine PrepareGeneralizedVMWith2EmptyDataDisks(string rgName,
                                                      string vmName,
                                                      Region Location,
                                                      IComputeManager computeManager)

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineManagedDiskOperationsTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineManagedDiskOperationsTests.cs
@@ -543,7 +543,7 @@ namespace Fluent.Tests.Compute
                 {
                     // Creates a native virtual machine
                     //
-                    var nativeVm = computeManager.VirtualMachines
+                    var nativeVM = computeManager.VirtualMachines
                             .Define(vmName)
                             .WithRegion(Location)
                             .WithNewResourceGroup(rgName)
@@ -559,11 +559,11 @@ namespace Fluent.Tests.Compute
                             .WithOSDiskCaching(CachingTypes.ReadWrite)
                             .Create();
 
-                    Assert.False(nativeVm.IsManagedDiskEnabled);
-                    var osVhdUri = nativeVm.OsUnmanagedDiskVhdUri;
+                    Assert.False(nativeVM.IsManagedDiskEnabled);
+                    var osVhdUri = nativeVM.OsUnmanagedDiskVhdUri;
                     Assert.NotNull(osVhdUri);
 
-                    computeManager.VirtualMachines.DeleteById(nativeVm.Id);
+                    computeManager.VirtualMachines.DeleteById(nativeVM.Id);
 
                     var diskName = SdkContext.RandomResourceName("dsk-", 15);
                     var osDisk = computeManager.Disks.Define(diskName)
@@ -574,7 +574,7 @@ namespace Fluent.Tests.Compute
 
                     // Creates a managed virtual machine
                     //
-                    var managedVm = computeManager.VirtualMachines
+                    var managedVM = computeManager.VirtualMachines
                             .Define(vmName)
                             .WithRegion(Location)
                             .WithExistingResourceGroup(rgName)
@@ -586,8 +586,8 @@ namespace Fluent.Tests.Compute
                             .WithOSDiskCaching(CachingTypes.ReadWrite)
                             .Create();
 
-                    Assert.True(managedVm.IsManagedDiskEnabled);
-                    Assert.True(managedVm.OsDiskId.Equals(osDisk.Id, StringComparison.OrdinalIgnoreCase));
+                    Assert.True(managedVM.IsManagedDiskEnabled);
+                    Assert.True(managedVM.OsDiskId.Equals(osDisk.Id, StringComparison.OrdinalIgnoreCase));
                 }
                 finally
                 {
@@ -613,7 +613,7 @@ namespace Fluent.Tests.Compute
                 var rgName = TestUtilities.GenerateName("rgfluentchash-");
                 try
                 {
-                    var managedVm = computeManager.VirtualMachines
+                    var managedVM = computeManager.VirtualMachines
                             .Define(vmName)
                             .WithRegion(Location)
                             .WithNewResourceGroup(rgName)
@@ -631,8 +631,8 @@ namespace Fluent.Tests.Compute
                             .WithOSDiskCaching(CachingTypes.ReadWrite)
                             .Create();
 
-                    Assert.NotNull(managedVm.AvailabilitySetId);
-                    var availabilitySet = computeManager.AvailabilitySets.GetById(managedVm.AvailabilitySetId);
+                    Assert.NotNull(managedVM.AvailabilitySetId);
+                    var availabilitySet = computeManager.AvailabilitySets.GetById(managedVM.AvailabilitySetId);
                     Assert.True(availabilitySet.VirtualMachineIds.Count > 0);
                     Assert.Equal(availabilitySet.Sku, AvailabilitySetSkuTypes.Managed);
                 }

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineScaleSetTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineScaleSetTests.cs
@@ -330,7 +330,7 @@ namespace Fluent.Tests.Compute
                 Assert.True(vm.IsOSBasedOnPlatformImage);
                 Assert.Null(vm.StoredImageUnmanagedVhdUri);
                 Assert.False(vm.IsWindowsAutoUpdateEnabled);
-                Assert.False(vm.IsWindowsVmAgentProvisioned);
+                Assert.False(vm.IsWindowsVMAgentProvisioned);
                 Assert.True(vm.AdministratorUserName.Equals("jvuser", StringComparison.OrdinalIgnoreCase));
                 var vmImage = vm.GetOSPlatformImage();
                 Assert.NotNull(vmImage);

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IVirtualMachine.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IVirtualMachine.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// <summary>
         /// Gets the virtual machine unique id.
         /// </summary>
-        string VmId { get; }
+        string VMId { get; }
 
         /// <summary>
         /// Power off (stop) the virtual machine.

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IVirtualMachineScaleSetVM.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IVirtualMachineScaleSetVM.cs
@@ -173,9 +173,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         string BootDiagnosticStorageAccountUri { get; }
 
         /// <summary>
-        /// Gets true if this is a Windows virtual machine and Vm agent is provisioned, false otherwise.
+        /// Gets true if this is a Windows virtual machine and VM agent is provisioned, false otherwise.
         /// </summary>
-        bool IsWindowsVmAgentProvisioned { get; }
+        bool IsWindowsVMAgentProvisioned { get; }
 
         /// <summary>
         /// Updates the version of the installed operating system in the virtual machine instance.

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
@@ -650,9 +650,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// </summary>
         /// <param name="listener">The WinRmListener.</param>
         /// <return>The stage representing creatable Windows VM definition.</return>
-        VirtualMachine.Definition.IWithWindowsCreateUnmanaged VirtualMachine.Definition.IWithWindowsCreateUnmanaged.WithWinRm(WinRMListener listener)
+        VirtualMachine.Definition.IWithWindowsCreateUnmanaged VirtualMachine.Definition.IWithWindowsCreateUnmanaged.WithWinRM(WinRMListener listener)
         {
-            return this.WithWinRm(listener) as VirtualMachine.Definition.IWithWindowsCreateUnmanaged;
+            return this.WithWinRM(listener) as VirtualMachine.Definition.IWithWindowsCreateUnmanaged;
         }
 
         /// <summary>
@@ -777,11 +777,11 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// Specifies the WINRM listener.
         /// Each call to this method adds the given listener to the list of VM's WinRM listeners.
         /// </summary>
-        /// <param name="listener">The WinRmListener.</param>
+        /// <param name="listener">The WinRMListener.</param>
         /// <return>The stage representing creatable Windows VM definition.</return>
-        VirtualMachine.Definition.IWithWindowsCreateManaged VirtualMachine.Definition.IWithWindowsCreateManaged.WithWinRm(WinRMListener listener)
+        VirtualMachine.Definition.IWithWindowsCreateManaged VirtualMachine.Definition.IWithWindowsCreateManaged.WithWinRM(WinRMListener listener)
         {
-            return this.WithWinRm(listener) as VirtualMachine.Definition.IWithWindowsCreateManaged;
+            return this.WithWinRM(listener) as VirtualMachine.Definition.IWithWindowsCreateManaged;
         }
 
         /// <summary>

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
@@ -639,9 +639,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// Specifies that VM Agent should not be provisioned.
         /// </summary>
         /// <return>The stage representing creatable Windows VM definition.</return>
-        VirtualMachine.Definition.IWithWindowsCreateUnmanaged VirtualMachine.Definition.IWithWindowsCreateUnmanaged.WithoutVmAgent()
+        VirtualMachine.Definition.IWithWindowsCreateUnmanaged VirtualMachine.Definition.IWithWindowsCreateUnmanaged.WithoutVMAgent()
         {
-            return this.WithoutVmAgent() as VirtualMachine.Definition.IWithWindowsCreateUnmanaged;
+            return this.WithoutVMAgent() as VirtualMachine.Definition.IWithWindowsCreateUnmanaged;
         }
 
         /// <summary>
@@ -768,9 +768,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// Specifies that VM Agent should not be provisioned.
         /// </summary>
         /// <return>The stage representing creatable Windows VM definition.</return>
-        VirtualMachine.Definition.IWithWindowsCreateManaged VirtualMachine.Definition.IWithWindowsCreateManaged.WithoutVmAgent()
+        VirtualMachine.Definition.IWithWindowsCreateManaged VirtualMachine.Definition.IWithWindowsCreateManaged.WithoutVMAgent()
         {
-            return this.WithoutVmAgent() as VirtualMachine.Definition.IWithWindowsCreateManaged;
+            return this.WithoutVMAgent() as VirtualMachine.Definition.IWithWindowsCreateManaged;
         }
 
         /// <summary>
@@ -1357,11 +1357,11 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// <summary>
         /// Gets the virtual machine unique id.
         /// </summary>
-        string Microsoft.Azure.Management.Compute.Fluent.IVirtualMachine.VmId
+        string Microsoft.Azure.Management.Compute.Fluent.IVirtualMachine.VMId
         {
             get
             {
-                return this.VmId();
+                return this.VMId();
             }
         }
 

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineScaleSetImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineScaleSetImpl.cs
@@ -463,9 +463,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// Disables the VM agent.
         /// </summary>
         /// <return>The next stage of the definition.</return>
-        VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged.WithoutVmAgent()
+        VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged.WithoutVMAgent()
         {
-            return this.WithoutVmAgent() as VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged;
+            return this.WithoutVMAgent() as VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged;
         }
 
         /// <summary>
@@ -502,9 +502,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// Enables the VM agent.
         /// </summary>
         /// <return>The next stage of the definition.</return>
-        VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged.WithVmAgent()
+        VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged.WithVMAgent()
         {
-            return this.WithVmAgent() as VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged;
+            return this.WithVMAgent() as VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged;
         }
 
         /// <summary>
@@ -540,9 +540,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// Disables the VM agent.
         /// </summary>
         /// <return>The next stage of the definition.</return>
-        VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged.WithoutVmAgent()
+        VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged.WithoutVMAgent()
         {
-            return this.WithoutVmAgent() as VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged;
+            return this.WithoutVMAgent() as VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged;
         }
 
         /// <summary>
@@ -579,9 +579,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// Enables the VM agent.
         /// </summary>
         /// <return>The next stage of the definition.</return>
-        VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged.WithVmAgent()
+        VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged.WithVMAgent()
         {
-            return this.WithVmAgent() as VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged;
+            return this.WithVMAgent() as VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged;
         }
 
         /// <summary>

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineScaleSetImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineScaleSetImpl.cs
@@ -472,11 +472,11 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// Specifies the WinRM listener.
         /// Each call to this method adds the given listener to the list of VM's WinRM listeners.
         /// </summary>
-        /// <param name="listener">A WinRm listener.</param>
+        /// <param name="listener">A WinRM listener.</param>
         /// <return>The next stage of the definition.</return>
-        VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged.WithWinRm(WinRMListener listener)
+        VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged.WithWinRM(WinRMListener listener)
         {
-            return this.WithWinRm(listener) as VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged;
+            return this.WithWinRM(listener) as VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged;
         }
 
         /// <summary>
@@ -549,11 +549,11 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// Specifies the WinRM listener.
         /// Each call to this method adds the given listener to the list of VM's WinRM listeners.
         /// </summary>
-        /// <param name="listener">A WinRm listener.</param>
+        /// <param name="listener">A WinRM listener.</param>
         /// <return>The next stage of the definition.</return>
-        VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged.WithWinRm(WinRMListener listener)
+        VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged.WithWinRM(WinRMListener listener)
         {
-            return this.WithWinRm(listener) as VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged;
+            return this.WithWinRM(listener) as VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged;
         }
 
         /// <summary>

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineScaleSetVMImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineScaleSetVMImpl.cs
@@ -98,13 +98,13 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         /// <summary>
-        /// Gets true if this is a Windows virtual machine and Vm agent is provisioned, false otherwise.
+        /// Gets true if this is a Windows virtual machine and VM agent is provisioned, false otherwise.
         /// </summary>
-        bool Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineScaleSetVM.IsWindowsVmAgentProvisioned
+        bool Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineScaleSetVM.IsWindowsVMAgentProvisioned
         {
             get
             {
-                return this.IsWindowsVmAgentProvisioned();
+                return this.IsWindowsVMAgentProvisioned();
             }
         }
 

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Definition/IDefinition.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Definition/IDefinition.cs
@@ -307,9 +307,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         /// Specifies the WINRM listener.
         /// Each call to this method adds the given listener to the list of VM's WinRM listeners.
         /// </summary>
-        /// <param name="listener">The WinRmListener.</param>
+        /// <param name="listener">The WinRMListener.</param>
         /// <return>The stage representing creatable Windows VM definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateManaged WithWinRm(WinRMListener listener);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateManaged WithWinRM(WinRMListener listener);
 
         /// <summary>
         /// Specifies that VM Agent should not be provisioned.
@@ -387,9 +387,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         /// Specifies the WINRM listener.
         /// Each call to this method adds the given listener to the list of VM's WinRM listeners.
         /// </summary>
-        /// <param name="listener">The WinRmListener.</param>
+        /// <param name="listener">The WinRMListener.</param>
         /// <return>The stage representing creatable Windows VM definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateUnmanaged WithWinRm(WinRMListener listener);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateUnmanaged WithWinRM(WinRMListener listener);
 
         /// <summary>
         /// Specifies that VM Agent should not be provisioned.

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Definition/IDefinition.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Definition/IDefinition.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         /// Specifies that VM Agent should not be provisioned.
         /// </summary>
         /// <return>The stage representing creatable Windows VM definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateManaged WithoutVmAgent();
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateManaged WithoutVMAgent();
 
         /// <summary>
         /// Specifies that automatic updates should be disabled.
@@ -395,7 +395,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         /// Specifies that VM Agent should not be provisioned.
         /// </summary>
         /// <return>The stage representing creatable Windows VM definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateUnmanaged WithoutVmAgent();
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateUnmanaged WithoutVMAgent();
 
         /// <summary>
         /// Specifies that automatic updates should be disabled.

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachineScaleSet/Definition/IDefinition.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachineScaleSet/Definition/IDefinition.cs
@@ -162,13 +162,13 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Defin
         /// Disables the VM agent.
         /// </summary>
         /// <return>The next stage of the definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged WithoutVmAgent();
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged WithoutVMAgent();
 
         /// <summary>
         /// Enables the VM agent.
         /// </summary>
         /// <return>The next stage of the definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged WithVmAgent();
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged WithVMAgent();
 
         /// <summary>
         /// Disables automatic updates.
@@ -798,13 +798,13 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Defin
         /// Disables the VM agent.
         /// </summary>
         /// <return>The next stage of the definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged WithoutVmAgent();
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged WithoutVMAgent();
 
         /// <summary>
         /// Enables the VM agent.
         /// </summary>
         /// <return>The next stage of the definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged WithVmAgent();
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged WithVMAgent();
 
         /// <summary>
         /// Disables automatic updates.

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachineScaleSet/Definition/IDefinition.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachineScaleSet/Definition/IDefinition.cs
@@ -148,9 +148,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Defin
         /// Specifies the WinRM listener.
         /// Each call to this method adds the given listener to the list of VM's WinRM listeners.
         /// </summary>
-        /// <param name="listener">A WinRm listener.</param>
+        /// <param name="listener">A WinRM listener.</param>
         /// <return>The next stage of the definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged WithWinRm(WinRMListener listener);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateManaged WithWinRM(WinRMListener listener);
 
         /// <summary>
         /// Enables automatic updates.
@@ -784,9 +784,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Defin
         /// Specifies the WinRM listener.
         /// Each call to this method adds the given listener to the list of VM's WinRM listeners.
         /// </summary>
-        /// <param name="listener">A WinRm listener.</param>
+        /// <param name="listener">A WinRM listener.</param>
         /// <return>The next stage of the definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged WithWinRm(WinRMListener listener);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithWindowsCreateUnmanaged WithWinRM(WinRMListener listener);
 
         /// <summary>
         /// Enables automatic updates.

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImpl.cs
@@ -447,7 +447,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:F16446581B25DFD00E74CB1193EBF605:7DBCBEBCFCFF036703E8C4680854445D
-        public VirtualMachineImpl WithoutVmAgent()
+        public VirtualMachineImpl WithoutVMAgent()
         {
             Inner.OsProfile.WindowsConfiguration.ProvisionVMAgent = false;
             return this;
@@ -1356,7 +1356,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:F91DF44F14D53833479DE592AB2B2890:A44F980B37B6696BA13F0A8DB633DCCA
-        public string VmId()
+        public string VMId()
         {
             return Inner.VmId;
         }

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImpl.cs
@@ -468,7 +468,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:F7E8AD723108078BE0FE19CD860DD3D3:7AB774480B8E9543A8CAEE7340C4B7B8
-        public VirtualMachineImpl WithWinRm(WinRMListener listener)
+        public VirtualMachineImpl WithWinRM(WinRMListener listener)
         {
             if (Inner.OsProfile.WindowsConfiguration.WinRM == null)
             {

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:F16446581B25DFD00E74CB1193EBF605:438AB79E7DABFF084F3F25050C0B0DCB
-        public VirtualMachineScaleSetImpl WithoutVmAgent()
+        public VirtualMachineScaleSetImpl WithoutVMAgent()
         {
             Inner
                 .VirtualMachineProfile
@@ -2016,7 +2016,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:3CAA43EAEEB81309EADF54AA78725296:E14EB64EB306A8F5A0DF21CD2E85782B
-        public VirtualMachineScaleSetImpl WithVmAgent()
+        public VirtualMachineScaleSetImpl WithVMAgent()
         {
             Inner
                     .VirtualMachineProfile

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
@@ -1820,7 +1820,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:F7E8AD723108078BE0FE19CD860DD3D3:78969D0BA29AFC39123F017955CEE8EE
-        public VirtualMachineScaleSetImpl WithWinRm(WinRMListener listener)
+        public VirtualMachineScaleSetImpl WithWinRM(WinRMListener listener)
         {
             if (Inner.VirtualMachineProfile.OsProfile.WindowsConfiguration.WinRM == null)
             {

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetVMImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetVMImpl.cs
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:9F6C057D1401DFDC309A6553A712FD5F:D2CFA0DA4C386F7509555F3479BBB036
-        public bool IsWindowsVmAgentProvisioned()
+        public bool IsWindowsVMAgentProvisioned()
         {
             if (Inner.OsProfile.WindowsConfiguration != null) {
                 return Inner.OsProfile.WindowsConfiguration.ProvisionVMAgent ?? false;

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/Domain/DnsRecordSet/Update/IUpdate.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/Domain/DnsRecordSet/Update/IUpdate.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent.DnsRecordSet.Update
     public interface IWithNSRecordNameServer 
     {
         /// <summary>
-        /// Rmoves a NS record with the provided name server from this record set.
+        /// Removes a NS record with the provided name server from this record set.
         /// </summary>
         /// <param name="nameServerHostName">The name server host name.</param>
         /// <return>The next stage of the record set update.</return>

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/Domain/InterfaceImpl/DnsRecordSetImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/Domain/InterfaceImpl/DnsRecordSetImpl.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     internal abstract partial class DnsRecordSetImpl 
     {
         /// <summary>
-        /// Rmoves a NS record with the provided name server from this record set.
+        /// Removes a NS record with the provided name server from this record set.
         /// </summary>
         /// <param name="nameServerHostName">The name server host name.</param>
         /// <return>The next stage of the record set update.</return>


### PR DESCRIPTION
Equivalent to Java SDK commit: https://github.com/Azure/azure-sdk-for-java/pull/1549/commits/39f7301514cc243a12c611c38f220655992f9d54

Source code compat breaks from beta5:
-VirtualMachine model:
  - `VmId` renamed as `VMId`
  - `WithoutVmAgent()` renamed as `WithoutVMAgent()`
  - `WithWinRm()` renamed as `WithWinRM()`
- VitualMachineScaleSetVM model:
  - `IsWindowsVmAgentProvisioned``renamed as `IsWindowsVMAgentProvisioned`
  - `WithoutVmAgent()` renamed as `WithoutVMAgent()`
  - `WithVmAgent()` renamed as `WithVMAgent()`
- VirtualMachineScaleSet model:
  - `WithoutVmAgent()` renamed as `WithoutVMAgent()`
  - `WithVmAgent()` renamed as `WithVMAgent()`
  - `WithWinRm()` renamed as `WithWinRM()`
