### PR TITLE
Updating generated files after fixing virtualNetworkGateway resource swagger to remove unnecessary required params.

### DIFF
--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/LocalNetworkGatewaysOperations.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/LocalNetworkGatewaysOperations.cs
@@ -525,10 +525,6 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "parameters");
             }
-            if (parameters != null)
-            {
-                parameters.Validate();
-            }
             if (Client.SubscriptionId == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/Models/LocalNetworkGateway.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/Models/LocalNetworkGateway.cs
@@ -32,13 +32,13 @@ namespace Microsoft.Azure.Management.Network.Models
         /// <summary>
         /// Initializes a new instance of the LocalNetworkGateway class.
         /// </summary>
-        /// <param name="localNetworkAddressSpace">Local network site address
-        /// space.</param>
         /// <param name="id">Resource ID.</param>
         /// <param name="name">Resource name.</param>
         /// <param name="type">Resource type.</param>
         /// <param name="location">Resource location.</param>
         /// <param name="tags">Resource tags.</param>
+        /// <param name="localNetworkAddressSpace">Local network site address
+        /// space.</param>
         /// <param name="gatewayIpAddress">IP address of local network
         /// gateway.</param>
         /// <param name="bgpSettings">Local network gateway's BGP speaker
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// 'Deleting', and 'Failed'.</param>
         /// <param name="etag">A unique read-only string that changes whenever
         /// the resource is updated.</param>
-        public LocalNetworkGateway(AddressSpace localNetworkAddressSpace, string id = default(string), string name = default(string), string type = default(string), string location = default(string), IDictionary<string, string> tags = default(IDictionary<string, string>), string gatewayIpAddress = default(string), BgpSettings bgpSettings = default(BgpSettings), string resourceGuid = default(string), string provisioningState = default(string), string etag = default(string))
+        public LocalNetworkGateway(string id = default(string), string name = default(string), string type = default(string), string location = default(string), IDictionary<string, string> tags = default(IDictionary<string, string>), AddressSpace localNetworkAddressSpace = default(AddressSpace), string gatewayIpAddress = default(string), BgpSettings bgpSettings = default(BgpSettings), string resourceGuid = default(string), string provisioningState = default(string), string etag = default(string))
             : base(id, name, type, location, tags)
         {
             LocalNetworkAddressSpace = localNetworkAddressSpace;
@@ -100,19 +100,6 @@ namespace Microsoft.Azure.Management.Network.Models
         [JsonProperty(PropertyName = "etag")]
         public string Etag { get; set; }
 
-        /// <summary>
-        /// Validate the object.
-        /// </summary>
-        /// <exception cref="ValidationException">
-        /// Thrown if validation fails
-        /// </exception>
-        public virtual void Validate()
-        {
-            if (LocalNetworkAddressSpace == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "LocalNetworkAddressSpace");
-            }
-        }
     }
 }
 

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/Models/VirtualNetworkGateway.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/Models/VirtualNetworkGateway.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Azure.Management.Network.Models
         /// <summary>
         /// Initializes a new instance of the VirtualNetworkGateway class.
         /// </summary>
+        /// <param name="id">Resource ID.</param>
+        /// <param name="name">Resource name.</param>
+        /// <param name="type">Resource type.</param>
+        /// <param name="location">Resource location.</param>
+        /// <param name="tags">Resource tags.</param>
         /// <param name="ipConfigurations">IP configurations for virtual
         /// network gateway.</param>
         /// <param name="gatewayType">The type of this virtual network gateway.
@@ -40,11 +45,6 @@ namespace Microsoft.Azure.Management.Network.Models
         /// <param name="vpnType">The type of this virtual network gateway.
         /// Possible values are: 'PolicyBased' and 'RouteBased'. Possible
         /// values include: 'PolicyBased', 'RouteBased'</param>
-        /// <param name="id">Resource ID.</param>
-        /// <param name="name">Resource name.</param>
-        /// <param name="type">Resource type.</param>
-        /// <param name="location">Resource location.</param>
-        /// <param name="tags">Resource tags.</param>
         /// <param name="enableBgp">Whether BGP is enabled for this virtual
         /// network gateway or not.</param>
         /// <param name="activeActive">ActiveActive flag</param>
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// 'Deleting', and 'Failed'.</param>
         /// <param name="etag">Gets a unique read-only string that changes
         /// whenever the resource is updated.</param>
-        public VirtualNetworkGateway(IList<VirtualNetworkGatewayIPConfiguration> ipConfigurations, string gatewayType, string vpnType, string id = default(string), string name = default(string), string type = default(string), string location = default(string), IDictionary<string, string> tags = default(IDictionary<string, string>), bool? enableBgp = default(bool?), bool? activeActive = default(bool?), SubResource gatewayDefaultSite = default(SubResource), VirtualNetworkGatewaySku sku = default(VirtualNetworkGatewaySku), VpnClientConfiguration vpnClientConfiguration = default(VpnClientConfiguration), BgpSettings bgpSettings = default(BgpSettings), string resourceGuid = default(string), string provisioningState = default(string), string etag = default(string))
+        public VirtualNetworkGateway(string id = default(string), string name = default(string), string type = default(string), string location = default(string), IDictionary<string, string> tags = default(IDictionary<string, string>), IList<VirtualNetworkGatewayIPConfiguration> ipConfigurations = default(IList<VirtualNetworkGatewayIPConfiguration>), string gatewayType = default(string), string vpnType = default(string), bool? enableBgp = default(bool?), bool? activeActive = default(bool?), SubResource gatewayDefaultSite = default(SubResource), VirtualNetworkGatewaySku sku = default(VirtualNetworkGatewaySku), VpnClientConfiguration vpnClientConfiguration = default(VpnClientConfiguration), BgpSettings bgpSettings = default(BgpSettings), string resourceGuid = default(string), string provisioningState = default(string), string etag = default(string))
             : base(id, name, type, location, tags)
         {
             IpConfigurations = ipConfigurations;
@@ -168,41 +168,6 @@ namespace Microsoft.Azure.Management.Network.Models
         [JsonProperty(PropertyName = "etag")]
         public string Etag { get; set; }
 
-        /// <summary>
-        /// Validate the object.
-        /// </summary>
-        /// <exception cref="ValidationException">
-        /// Thrown if validation fails
-        /// </exception>
-        public virtual void Validate()
-        {
-            if (IpConfigurations == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "IpConfigurations");
-            }
-            if (GatewayType == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "GatewayType");
-            }
-            if (VpnType == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "VpnType");
-            }
-            if (IpConfigurations != null)
-            {
-                foreach (var element in IpConfigurations)
-                {
-                    if (element != null)
-                    {
-                        element.Validate();
-                    }
-                }
-            }
-            if (Sku != null)
-            {
-                Sku.Validate();
-            }
-        }
     }
 }
 

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/Models/VirtualNetworkGatewayConnection.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/Models/VirtualNetworkGatewayConnection.cs
@@ -223,18 +223,6 @@ namespace Microsoft.Azure.Management.Network.Models
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "ConnectionType");
             }
-            if (VirtualNetworkGateway1 != null)
-            {
-                VirtualNetworkGateway1.Validate();
-            }
-            if (VirtualNetworkGateway2 != null)
-            {
-                VirtualNetworkGateway2.Validate();
-            }
-            if (LocalNetworkGateway2 != null)
-            {
-                LocalNetworkGateway2.Validate();
-            }
             if (IpsecPolicies != null)
             {
                 foreach (var element in IpsecPolicies)

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/Models/VirtualNetworkGatewayIpConfiguration.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/Models/VirtualNetworkGatewayIpConfiguration.cs
@@ -32,13 +32,13 @@ namespace Microsoft.Azure.Management.Network.Models
         /// Initializes a new instance of the
         /// VirtualNetworkGatewayIPConfiguration class.
         /// </summary>
-        /// <param name="subnet">The reference of the subnet resource.</param>
-        /// <param name="publicIPAddress">The reference of the public IP
-        /// resource.</param>
         /// <param name="id">Resource ID.</param>
         /// <param name="privateIPAllocationMethod">The private IP allocation
         /// method. Possible values are: 'Static' and 'Dynamic'. Possible
         /// values include: 'Static', 'Dynamic'</param>
+        /// <param name="subnet">The reference of the subnet resource.</param>
+        /// <param name="publicIPAddress">The reference of the public IP
+        /// resource.</param>
         /// <param name="provisioningState">The provisioning state of the
         /// public IP resource. Possible values are: 'Updating', 'Deleting',
         /// and 'Failed'.</param>
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// resource.</param>
         /// <param name="etag">A unique read-only string that changes whenever
         /// the resource is updated.</param>
-        public VirtualNetworkGatewayIPConfiguration(SubResource subnet, SubResource publicIPAddress, string id = default(string), string privateIPAllocationMethod = default(string), string provisioningState = default(string), string name = default(string), string etag = default(string))
+        public VirtualNetworkGatewayIPConfiguration(string id = default(string), string privateIPAllocationMethod = default(string), SubResource subnet = default(SubResource), SubResource publicIPAddress = default(SubResource), string provisioningState = default(string), string name = default(string), string etag = default(string))
             : base(id)
         {
             PrivateIPAllocationMethod = privateIPAllocationMethod;
@@ -99,23 +99,6 @@ namespace Microsoft.Azure.Management.Network.Models
         [JsonProperty(PropertyName = "etag")]
         public string Etag { get; set; }
 
-        /// <summary>
-        /// Validate the object.
-        /// </summary>
-        /// <exception cref="ValidationException">
-        /// Thrown if validation fails
-        /// </exception>
-        public virtual void Validate()
-        {
-            if (Subnet == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "Subnet");
-            }
-            if (PublicIPAddress == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "PublicIPAddress");
-            }
-        }
     }
 }
 

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/Models/VirtualNetworkGatewaySku.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/Models/VirtualNetworkGatewaySku.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.Management.Network.Models
     using Azure;
     using Management;
     using Network;
-    using Rest;
     using Newtonsoft.Json;
     using System.Linq;
 
@@ -37,7 +36,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// values include: 'Basic', 'HighPerformance', 'Standard',
         /// 'UltraPerformance'</param>
         /// <param name="capacity">The capacity.</param>
-        public VirtualNetworkGatewaySku(string name, string tier, int? capacity = default(int?))
+        public VirtualNetworkGatewaySku(string name = default(string), string tier = default(string), int? capacity = default(int?))
         {
             Name = name;
             Tier = tier;
@@ -68,23 +67,6 @@ namespace Microsoft.Azure.Management.Network.Models
         [JsonProperty(PropertyName = "capacity")]
         public int? Capacity { get; set; }
 
-        /// <summary>
-        /// Validate the object.
-        /// </summary>
-        /// <exception cref="ValidationException">
-        /// Thrown if validation fails
-        /// </exception>
-        public virtual void Validate()
-        {
-            if (Name == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "Name");
-            }
-            if (Tier == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "Tier");
-            }
-        }
     }
 }
 

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/VirtualNetworkGatewaysOperations.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network/Generated/VirtualNetworkGatewaysOperations.cs
@@ -840,10 +840,6 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "parameters");
             }
-            if (parameters != null)
-            {
-                parameters.Validate();
-            }
             if (Client.SubscriptionId == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->
=> Updating generated files after fixing virtualNetworkGateway resource swagger to remove unnecessary required params.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.
=> No new changes, only removed non required fields. Existing tests cover the regression testing.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
=> Swagger changes PR:-https://github.com/Azure/azure-rest-api-specs/pull/1063

- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
=> NA

- [x] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
=> As we are merging all the network related changes in one branch:- network_changes, version is updated only once, so not changing in this PR.
