### PR TITLE
Beta markings, misc doc comment scrub, rename VM.GetExtensions() as .ListExtensions()

### DIFF
--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceManager.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceManager.cs
@@ -9,6 +9,12 @@ using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 
 namespace Microsoft.Azure.Management.AppService.Fluent
 {
+    /// <summary>
+    /// Entry point to Azure app service management.
+    /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public class AppServiceManager : Manager<IWebSiteManagementClient>, IAppServiceManager
     {
         private IKeyVaultManager keyVaultManager;

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificate.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificate.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// <summary>
     /// An immutable client-side representation of an Azure app service certificate.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAppServiceCertificate  :
         IGroupableResource<IAppServiceManager, CertificateInner>,
         IRefreshable<IAppServiceCertificate>

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificateKeyVaultBinding.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificateKeyVaultBinding.cs
@@ -6,8 +6,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     /// <summary>
-    /// An immutable client-side representation of an Azure App Service Certificate.
+    /// An immutable client-side representation of an Azure App Service Key Vault binding.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAppServiceCertificateKeyVaultBinding  :
         IIndependentChildResource<IAppServiceManager, AppServiceCertificateInner>
     {

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificateOrder.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificateOrder.cs
@@ -12,8 +12,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using System;
 
     /// <summary>
-    /// An immutable client-side representation of an Azure App Service Certificate Order.
+    /// An immutable client-side representation of an Azure App Service certificate order.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAppServiceCertificateOrder  :
         IGroupableResource<IAppServiceManager, AppServiceCertificateOrderInner>,
         IRefreshable<Microsoft.Azure.Management.AppService.Fluent.IAppServiceCertificateOrder>,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificateOrders.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificateOrders.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// <summary>
     /// Entry point for app service certificate order management API.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAppServiceCertificateOrders  :
         ISupportsCreating<IBlank>,
         ISupportsDeletingById,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificates.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificates.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// <summary>
     /// Entry point for certificate management API.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAppServiceCertificates  :
         ISupportsCreating<AppServiceCertificate.Definition.IBlank>,
         ISupportsDeletingById,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceDomain.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceDomain.cs
@@ -14,13 +14,12 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// <summary>
     /// An immutable client-side representation of a domain.
     /// Domains in Azure are purchased from 3rd party domain providers. By calling
-    /// Creatable.create()} or {.
+    /// Creatable.create() or Creatable.createAsync() you agree to
+    /// the agreements listed in AppServiceDomains#listAgreements(String).
     /// </summary>
-    /// <link>
-    /// Creatable.createAsync() you agree to
-    /// the agreements listed in Creatable.create()} or {.
-    /// </link>
-    /// <link>Creatable.createAsync().</link>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAppServiceDomain  :
         IGroupableResource<IAppServiceManager, DomainInner>,
         IHasName,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceDomains.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceDomains.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// <summary>
     /// Entry point for domain management API.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAppServiceDomains  :
         ISupportsCreating<AppServiceDomain.Definition.IBlank>,
         ISupportsListing<Microsoft.Azure.Management.AppService.Fluent.IAppServiceDomain>,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServicePlan.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServicePlan.cs
@@ -8,8 +8,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
 
     /// <summary>
-    /// An immutable client-side representation of an Azure App Service Plan.
+    /// An immutable client-side representation of an Azure App service plan.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAppServicePlan  :
         IGroupableResource<IAppServiceManager, AppServicePlanInner>,
         IHasName,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServicePlans.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServicePlans.cs
@@ -9,8 +9,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using ResourceManager.Fluent.Core;
 
     /// <summary>
-    /// Entry point for app service plan management API.
+    /// Entry point for App Service plan management API.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAppServicePlans  :
         ISupportsCreating<AppServicePlan.Definition.IBlank>,
         ISupportsDeletingById,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/ICertificateDetails.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/ICertificateDetails.cs
@@ -7,8 +7,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using System;
 
     /// <summary>
-    /// An immutable client-side representation of an Azure Web App.
+    /// An immutable client-side representation of an Azure Web App certificate.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ICertificateDetails  :
         IHasInner<Models.CertificateDetailsInner>
     {

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IConnectionString.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IConnectionString.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// <summary>
     /// An immutable client-side representation of a connection string on a web app.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IConnectionString 
     {
         /// <summary>

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IDeploymentSlot.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IDeploymentSlot.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// <summary>
     /// An immutable client-side representation of an Azure Web App deployment slot.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IDeploymentSlot  :
         IIndependentChildResource<IAppServiceManager, SiteInner>,
         IWebAppBase,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IDeploymentSlots.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IDeploymentSlots.cs
@@ -7,8 +7,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using ResourceManager.Fluent.Core;
 
     /// <summary>
-    /// Entry point for storage accounts management API.
+    /// Entry point for Azure web app deployment slot management API.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IDeploymentSlots  :
         ISupportsCreating<DeploymentSlot.Definition.IBlank>,
         ISupportsListing<Microsoft.Azure.Management.AppService.Fluent.IDeploymentSlot>,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IDomainContact.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IDomainContact.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// <summary>
     /// A domain contact definition.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IDomainContact  :
         IHasInner<Models.Contact>,
         IChildResource<Microsoft.Azure.Management.AppService.Fluent.IAppServiceDomain>

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IDomainLegalAgreement.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IDomainLegalAgreement.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// <summary>
     /// An immutable client-side representation of an Azure domain legal agreement.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IDomainLegalAgreement  :
         IHasInner<Models.TldLegalAgreement>
     {

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IHostNameBinding.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IHostNameBinding.cs
@@ -6,8 +6,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     /// <summary>
-    /// A host name binding object.
+    /// An immutable representation of a host name binding.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IHostNameBinding  :
         IHasInner<Models.HostNameBindingInner>,
         IExternalChildResource<Microsoft.Azure.Management.AppService.Fluent.IHostNameBinding,Microsoft.Azure.Management.AppService.Fluent.IWebAppBase>,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IHostNameSslBinding.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IHostNameSslBinding.cs
@@ -6,8 +6,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     /// <summary>
-    /// A Host name - SSL certificate binding definition.
+    /// An immutable representation of an host name SSL binding.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IHostNameSslBinding  :
         IHasInner<Models.HostNameSslState>,
         IChildResource<Microsoft.Azure.Management.AppService.Fluent.IWebAppBase>

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IWebAppSourceControl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IWebAppSourceControl.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     /// <summary>
-    /// A web app source control in a web app.
+    /// An immutable representation of a web app source control configuration in a web app.
     /// </summary>
     public interface IWebAppSourceControl  :
         IHasInner<Models.SiteSourceControlInner>,

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineExtensionTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineExtensionTests.cs
@@ -51,8 +51,8 @@ namespace Fluent.Tests.Compute
                     .Attach()
                     .Apply();
 
-                Assert.True(vm.GetExtensions().Count() > 0);
-                Assert.True(vm.GetExtensions().ContainsKey("VMAccessForLinux"));
+                Assert.True(vm.ListExtensions().Count() > 0);
+                Assert.True(vm.ListExtensions().ContainsKey("VMAccessForLinux"));
 
                 vm.Update()
                         .UpdateExtension("VMAccessForLinux")
@@ -104,10 +104,10 @@ namespace Fluent.Tests.Compute
                         .Attach()
                         .Create();
 
-                Assert.True(vm.GetExtensions().Count > 0);
-                Assert.True(vm.GetExtensions().ContainsKey("CustomScriptForLinux"));
+                Assert.True(vm.ListExtensions().Count > 0);
+                Assert.True(vm.ListExtensions().ContainsKey("CustomScriptForLinux"));
                 IVirtualMachineExtension customScriptExtension;
-                Assert.True(vm.GetExtensions().TryGetValue("CustomScriptForLinux", out customScriptExtension));
+                Assert.True(vm.ListExtensions().TryGetValue("CustomScriptForLinux", out customScriptExtension));
                 Assert.Equal(customScriptExtension.PublisherName, "Microsoft.OSTCExtensions");
                 Assert.Equal(customScriptExtension.TypeName, "CustomScriptForLinux");
                 Assert.Equal(customScriptExtension.AutoUpgradeMinorVersionEnabled, true);
@@ -118,7 +118,7 @@ namespace Fluent.Tests.Compute
                         .WithoutExtension("CustomScriptForLinux")
                         .Apply();
 
-                Assert.True(vm.GetExtensions().Count() == 0);
+                Assert.True(vm.ListExtensions().Count() == 0);
             }
         }
 
@@ -156,7 +156,7 @@ namespace Fluent.Tests.Compute
                     .Attach()
                     .Create();
 
-                Assert.True(vm.GetExtensions().Count() > 0);
+                Assert.True(vm.ListExtensions().Count() > 0);
 
                 // Get the created virtual machine via VM List not by VM GET
                 var virtualMachines = azure.VirtualMachines
@@ -194,7 +194,7 @@ namespace Fluent.Tests.Compute
                 Assert.NotNull(vmWithExtensionReference);
 
                 IVirtualMachineExtension accessExtension = null;
-                foreach (var extension in vmWithExtensionReference.GetExtensions().Values)
+                foreach (var extension in vmWithExtensionReference.ListExtensions().Values)
                 {
                     if (extension.Name.Equals("VMAccessForLinux", StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/Domain/IApplicationPackage.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/Domain/IApplicationPackage.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
 
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     /// <summary>
-    /// An immutable client-side representation of an Azure batch account application.
+    /// An immutable client-side representation of an Azure batch account application package.
     /// </summary>
     public interface IApplicationPackage  :
         IExternalChildResource<Microsoft.Azure.Management.Batch.Fluent.IApplicationPackage,Microsoft.Azure.Management.Batch.Fluent.IApplication>,

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/Domain/IBatchAccount.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/Domain/IBatchAccount.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     /// <summary>
-    /// An immutable client-side representation of an Azure batch account.
+    /// An immutable client-side representation of an Azure Batch account.
     /// </summary>
     public interface IBatchAccount  :
         IGroupableResource<IBatchManager, BatchAccountInner>,

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/Domain/IBatchAccounts.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/Domain/IBatchAccounts.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
     using Microsoft.Azure.Management.Batch.Fluent.BatchAccount.Definition;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     /// <summary>
-    /// Entry point to batch account management API.
+    /// Entry point to Azure Batch account management API.
     /// </summary>
     public interface IBatchAccounts  :
         ISupportsCreating<Microsoft.Azure.Management.Batch.Fluent.BatchAccount.Definition.IBlank>,

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IDiskVolumeEncryptionMonitor.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IDiskVolumeEncryptionMonitor.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// <summary>
     /// Type that can be used to monitor encryption enable and disable status of a virtual machine.
     /// User get access to implementation of this interface from following methods:
-    /// 1. VirtualMachineEncryption.[enable|disable]{1}[Async]{0-1}
-    /// 2. VirtualMachineEncryption.getMonitor[Async]{0-1}
+    /// 1. VirtualMachineEncryption.[Enable|Disable]{1}[Async]{0-1}
+    /// 2. VirtualMachineEncryption.GetMonitor[Async]{0-1}
     /// It is possible that user first get monitor instance via 2 then starts encrypting the virtual
     /// machine, in this case he can still use the same monitor instance to monitor the encryption
     /// progress.

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IVirtualMachine.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IVirtualMachine.cs
@@ -186,10 +186,10 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         Models.StorageAccountTypes? OsDiskStorageAccountType { get; }
 
         /// <return>An observable that emits extensions attached to the virtual machine.</return>
-        Task<IReadOnlyList<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtension>> GetExtensionsAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtension>> ListExtensionsAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <return>The extensions attached to the Virtual Machine.</return>
-        System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtension> GetExtensions();
+        System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtension> ListExtensions();
 
         /// <summary>
         /// Gets the public IP address associated with this virtual machine's primary network interface.

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IVirtualMachineCustomImages.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IVirtualMachineCustomImages.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using ResourceManager.Fluent.Core;
 
     /// <summary>
-    /// Entry point for image management API.
+    /// Entry point to custom virtual machine image management..
     /// </summary>
     public interface IVirtualMachineCustomImages  :
         ISupportsListing<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineCustomImage>,

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IVirtualMachineExtensionImages.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/IVirtualMachineExtensionImages.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
 
     /// <summary>
-    /// Entry point to virtual machine extension image management API.
+    /// Entry point to virtual machine extension image management.
     /// </summary>
     public interface IVirtualMachineExtensionImages  :
         ISupportsListingByRegion<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtensionImage>

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
@@ -1296,13 +1296,13 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         /// <return>An observable that emits extensions attached to the virtual machine.</return>
-        async Task<IReadOnlyList<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtension>> Microsoft.Azure.Management.Compute.Fluent.IVirtualMachine.GetExtensionsAsync(CancellationToken cancellationToken)
+        async Task<IReadOnlyList<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtension>> Microsoft.Azure.Management.Compute.Fluent.IVirtualMachine.ListExtensionsAsync(CancellationToken cancellationToken)
         {
             return await this.GetExtensionsAsync(cancellationToken);
         }
 
         /// <return>The extensions attached to the Virtual Machine.</return>
-        System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtension> Microsoft.Azure.Management.Compute.Fluent.IVirtualMachine.GetExtensions()
+        System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtension> Microsoft.Azure.Management.Compute.Fluent.IVirtualMachine.ListExtensions()
         {
             return this.GetExtensions() as System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtension>;
         }

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineEncryptionHelper.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineEncryptionHelper.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:9E0CF934F182F50D2FE7A72E02617F94:324B026FB14C16BEDA7B060212E59DE0
         private async Task<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtension> GetEncryptionExtensionInstalledInVMAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            var extensions = await virtualMachine.GetExtensionsAsync(cancellationToken);
+            var extensions = await virtualMachine.ListExtensionsAsync(cancellationToken);
             IVirtualMachineExtension encryptionExtension = extensions
                 .FirstOrDefault(e => e.PublisherName.Equals(encryptionExtensionPublisher, StringComparison.OrdinalIgnoreCase)
                                         && e.TypeName.Equals(EncryptionExtensionType(), StringComparison.OrdinalIgnoreCase));

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IActiveDirectoryGroup.cs
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IActiveDirectoryGroup.cs
@@ -4,10 +4,13 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 {
 
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Graph.RBAC.Fluent.Models ;
+    using Microsoft.Azure.Management.Graph.RBAC.Fluent.Models;
     /// <summary>
     /// An immutable client-side representation of an Azure AD group.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IActiveDirectoryGroup  :
         IHasInner<Microsoft.Azure.Management.Graph.RBAC.Fluent.Models .ADGroupInner>
     {

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IGroups.cs
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IGroups.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// <summary>
     /// Entry point to AD group management API.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IGroups  :
         ISupportsCreating<Microsoft.Azure.Management.Graph.RBAC.Fluent.ActiveDirectoryGroup.Definition.IBlank>,
         ISupportsListing<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryGroup>,

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IServicePrincipal.cs
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IServicePrincipal.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// <summary>
     /// An immutable client-side representation of an Azure AD service principal.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IServicePrincipal  :
         IHasInner<Microsoft.Azure.Management.Graph.RBAC.Fluent.Models .ServicePrincipalInner>
     {

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IServicePrincipals.cs
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IServicePrincipals.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// <summary>
     /// Entry point to service principal management API.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IServicePrincipals  :
         // ISupportsCreating<Microsoft.Azure.Management.Graph.RBAC.Fluent.ServicePrincipal.Definition.IBlank>,
         ISupportsListing<Microsoft.Azure.Management.Graph.RBAC.Fluent.IServicePrincipal>,

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IUser.cs
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IUser.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// <summary>
     /// An immutable client-side representation of an Azure AD user.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IUser  :
         IHasInner<Microsoft.Azure.Management.Graph.RBAC.Fluent.Models .UserInner>
     {

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IUsers.cs
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/Domain/RBAC/IUsers.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// <summary>
     /// Entry point to AD user management API.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IUsers  :
         // ISupportsCreating<Microsoft.Azure.Management.Graph.RBAC.Fluent.User.Definition.IBlank>,
         ISupportsListing<Microsoft.Azure.Management.Graph.RBAC.Fluent.IUser>,

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/GraphRBACManager.cs
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/GraphRBACManager.cs
@@ -8,6 +8,12 @@ using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 
 namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 {
+    /// <summary>
+    /// Entry point to Azure Graoh RBAC management.
+    /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public class GraphRbacManager : Manager<IGraphRbacManagementClient>, IGraphRbacManager
     {
         #region Fluent private collections

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGateway.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGateway.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// Entry point for application gateway management API in Azure.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IApplicationGateway  :
         IGroupableResource<INetworkManager, ApplicationGatewayInner>,
         IRefreshable<Microsoft.Azure.Management.Network.Fluent.IApplicationGateway>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayBackend.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayBackend.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of an application gateway backend.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IApplicationGatewayBackend  :
         IHasInner<Models.ApplicationGatewayBackendAddressPoolInner>,
         IChildResource<Microsoft.Azure.Management.Network.Fluent.IApplicationGateway>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayBackendHttpConfiguration.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayBackendHttpConfiguration.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of an application gateway's backend HTTP configuration.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IApplicationGatewayBackendHttpConfiguration  :
         IHasInner<Models.ApplicationGatewayBackendHttpSettingsInner>,
         IChildResource<Microsoft.Azure.Management.Network.Fluent.IApplicationGateway>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayFrontend.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayFrontend.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of an application gateway frontend.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IApplicationGatewayFrontend  :
         IHasInner<Models.ApplicationGatewayFrontendIPConfigurationInner>,
         IChildResource<Microsoft.Azure.Management.Network.Fluent.IApplicationGateway>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayIpConfiguration.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayIpConfiguration.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of an application gateway IP configuration.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IApplicationGatewayIPConfiguration  :
         IHasInner<Models.ApplicationGatewayIPConfigurationInner>,
         IChildResource<Microsoft.Azure.Management.Network.Fluent.IApplicationGateway>

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayListener.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayListener.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of an application gateway's HTTP listener.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IApplicationGatewayListener  :
         IHasInner<Models.ApplicationGatewayHttpListenerInner>,
         IChildResource<Microsoft.Azure.Management.Network.Fluent.IApplicationGateway>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayRequestRoutingRule.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewayRequestRoutingRule.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of an application gateway request routing rule.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IApplicationGatewayRequestRoutingRule  :
         IHasInner<Models.ApplicationGatewayRequestRoutingRuleInner>,
         IChildResource<Microsoft.Azure.Management.Network.Fluent.IApplicationGateway>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewaySslCertificate.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGatewaySslCertificate.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of an application gateway SSL certificate.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IApplicationGatewaySslCertificate  :
         IHasInner<Models.ApplicationGatewaySslCertificateInner>,
         IChildResource<Microsoft.Azure.Management.Network.Fluent.IApplicationGateway>

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGateways.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/IApplicationGateways.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// Entry point to application gateway management API in Azure.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IApplicationGateways  :
         ISupportsCreating<ApplicationGateway.Definition.IBlank>,
         ISupportsListing<Microsoft.Azure.Management.Network.Fluent.IApplicationGateway>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerBackend.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerBackend.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of a load balancer backend address pool.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ILoadBalancerBackend  :
         IHasInner<Models.BackendAddressPoolInner>,
         IChildResource<Microsoft.Azure.Management.Network.Fluent.ILoadBalancer>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerFrontend.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerFrontend.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of a load balancer frontend.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ILoadBalancerFrontend  :
         IHasInner<Models.FrontendIPConfigurationInner>,
         IChildResource<Microsoft.Azure.Management.Network.Fluent.ILoadBalancer>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerHttpProbe.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerHttpProbe.cs
@@ -5,6 +5,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of an HTTP load balancing probe.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ILoadBalancerHttpProbe  :
         ILoadBalancerProbe
     {

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerInboundNatPool.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerInboundNatPool.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of an inbound NAT rule.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ILoadBalancerInboundNatPool  :
         IHasFrontend,
         IHasBackendPort,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerInboundNatRule.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerInboundNatRule.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of an inbound NAT rule.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ILoadBalancerInboundNatRule  :
         IHasFrontend,
         IHasBackendPort,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerPrivateFrontend.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerPrivateFrontend.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of a private frontend of an internal load balancer.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ILoadBalancerPrivateFrontend  :
         ILoadBalancerFrontend,
         IHasPrivateIPAddress,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerProbe.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerProbe.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of a load balancing probe.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ILoadBalancerProbe  :
         IHasInner<Models.ProbeInner>,
         IChildResource<Microsoft.Azure.Management.Network.Fluent.ILoadBalancer>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerPublicFrontend.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerPublicFrontend.cs
@@ -5,6 +5,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of a public frontend of an Internet-facing load balancer.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ILoadBalancerPublicFrontend  :
         ILoadBalancerFrontend,
         IHasPublicIPAddress

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerTcpProbe.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancerTcpProbe.cs
@@ -5,6 +5,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of a TCP load balancing probe.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ILoadBalancerTcpProbe  :
         ILoadBalancerProbe
     {

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancers.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancers.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// Entry point to load balancer management API in Azure.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ILoadBalancers  :
         ISupportsCreating<LoadBalancer.Definition.IBlank>,
         ISupportsListing<Microsoft.Azure.Management.Network.Fluent.ILoadBalancer>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancingRule.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/Domain/ILoadBalancingRule.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// <summary>
     /// An immutable client-side representation of an HTTP load balancing rule.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ILoadBalancingRule  :
         IHasInner<Models.LoadBalancingRuleInner>,
         IChildResource<Microsoft.Azure.Management.Network.Fluent.ILoadBalancer>,

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkManager.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkManager.cs
@@ -7,7 +7,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     using System;
     using System.Linq;
     using ResourceManager.Fluent.Authentication;
-
+    /// <summary>
+    /// Entry point to Azure networking management.
+    /// </summary>
     public class NetworkManager : Manager<INetworkManagementClient>, INetworkManager
     {
         private PublicIPAddressesImpl publicIPAddresses;
@@ -154,6 +156,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         /// <summary>
         /// Entry point to application gateway management.
         /// </summary>
+        /// <remarks>
+        /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+        /// </remarks>
         public IApplicationGateways ApplicationGateways
         {
             get
@@ -170,6 +175,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         /// <summary>
         /// returns entry point to load balancer management
         /// </summary>
+        /// <remarks>
+        /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+        /// </remarks>
         public ILoadBalancers LoadBalancers
         {
             get

--- a/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent/Domain/IRedisAccessKeys.cs
+++ b/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent/Domain/IRedisAccessKeys.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.Azure.Management.Redis.Fluent
 {
     /// <summary>
-    /// The RedisCache.keys action result.
+    /// The RedisCache.Keys action result.
     /// </summary>
     public interface IRedisAccessKeys 
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationKeys.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationKeys.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Authorization key and connection string of authorization rule associated with Service Bus entities.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAuthorizationKeys  :
         IHasInner<Management.Fluent.ServiceBus.Models.ResourceListKeysInner>
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationRule.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationRule.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// Type representing authorization rule.
     /// </summary>
     /// <typeparam name="Rule">The specific rule type.</typeparam>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAuthorizationRule<RuleT>  :
         IIndependentChildResource<ServiceBus.Fluent.IServiceBusManager, Management.Fluent.ServiceBus.Models.SharedAccessAuthorizationRuleInner>,
         IRefreshable<RuleT>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationRules.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationRules.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// Entry point to authorization rules management API.
     /// </summary>
     /// <typeparam name="Rule">The specific rule type.</typeparam>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IAuthorizationRules<RuleT>  :
         ISupportsGettingByName<RuleT>,
         ISupportsListing<RuleT>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ICheckNameAvailabilityResult.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ICheckNameAvailabilityResult.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// The result of checking for Service Bus namespace name availability.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ICheckNameAvailabilityResult  :
         IHasInner<CheckNameAvailabilityResultInner>
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/INamespaceAuthorizationRule.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/INamespaceAuthorizationRule.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Type representing authorization rule defined for namespace.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface INamespaceAuthorizationRule  :
         IAuthorizationRule<Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRule>,
         IUpdatable<NamespaceAuthorizationRule.Update.IUpdate>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/INamespaceAuthorizationRules.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/INamespaceAuthorizationRules.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Entry point to namespace authorization rules management API.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface INamespaceAuthorizationRules  :
         IAuthorizationRules<Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRule>,
         ISupportsCreating<NamespaceAuthorizationRule.Definition.IBlank>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueue.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueue.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Type representing Service Bus queue.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IQueue  :
         IIndependentChildResource<ServiceBus.Fluent.IServiceBusManager, Management.Fluent.ServiceBus.Models.QueueInner>,
         IRefreshable<Microsoft.Azure.Management.Servicebus.Fluent.IQueue>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueueAuthorizationRule.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueueAuthorizationRule.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Type representing authorization rule defined for queue.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IQueueAuthorizationRule  :
         IAuthorizationRule<Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule>,
         IUpdatable<QueueAuthorizationRule.Update.IUpdate>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueueAuthorizationRules.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueueAuthorizationRules.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Entry point to queue authorization rules management API.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IQueueAuthorizationRules  :
         IAuthorizationRules<Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule>,
         ISupportsCreating<QueueAuthorizationRule.Definition.IBlank>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueues.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueues.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Entry point to service bus queue management API in Azure.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IQueues  :
         ISupportsCreating<Queue.Definition.IBlank>,
         ISupportsGettingByName<Microsoft.Azure.Management.Servicebus.Fluent.IQueue>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespace.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespace.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// An immutable client-side representation of an Azure Service Bus namespace.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IServiceBusNamespace  :
         IGroupableResource<ServiceBus.Fluent.IServiceBusManager, Management.Fluent.ServiceBus.Models.NamespaceModelInner>,
         IRefreshable<Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespaces.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespaces.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Entry point to Service Bus namespace API in Azure.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface IServiceBusNamespaces  :
         ISupportsCreating<ServiceBusNamespace.Definition.IBlank>,
         ISupportsBatchCreation<Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscription.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscription.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Type representing service bus topic subscription.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ISubscription  :
         IIndependentChildResource<ServiceBus.Fluent.IServiceBusManager, Management.Fluent.ServiceBus.Models.SubscriptionInner>,
         IRefreshable<Microsoft.Azure.Management.Servicebus.Fluent.ISubscription>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscriptions.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscriptions.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Entry point to service bus queue management API in Azure.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ISubscriptions  :
         ISupportsCreating<Subscription.Definition.IBlank>,
         ISupportsGettingByName<Microsoft.Azure.Management.Servicebus.Fluent.ISubscription>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopic.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopic.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Type representing Service Bus topic.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ITopic  :
         IIndependentChildResource<IServiceBusManager, Management.Fluent.ServiceBus.Models.TopicInner>,
         IRefreshable<Microsoft.Azure.Management.Servicebus.Fluent.ITopic>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopicAuthorizationRule.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopicAuthorizationRule.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Type representing authorization rule defined for topic.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ITopicAuthorizationRule  :
         IAuthorizationRule<Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule>,
         IUpdatable<TopicAuthorizationRule.Update.IUpdate>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopicAuthorizationRules.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopicAuthorizationRules.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Entry point to topic authorization rules management API.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ITopicAuthorizationRules  :
         IAuthorizationRules<Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule>,
         ISupportsCreating<TopicAuthorizationRule.Definition.IBlank>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopics.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopics.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// <summary>
     /// Entry point to Service Bus topic management API in Azure.
     /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public interface ITopics  :
         ISupportsCreating<Topic.Definition.IBlank>,
         ISupportsGettingByName<Microsoft.Azure.Management.Servicebus.Fluent.ITopic>,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusManager.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusManager.cs
@@ -6,12 +6,16 @@ using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Servicebus.Fluent;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
+    /// <summary>
+    /// Entry point to Azure Service Bus management.
+    /// </summary>
+    /// <remarks>
+    /// (Beta: This functionality is in preview and as such is subject to change in non-backwards compatible ways in future releases, including removal, regardless of any compatibility expectations set by the containing library version number.)
+    /// </remarks>
     public class ServiceBusManager : Manager<IServiceBusManagementClient>, IServiceBusManager
     {
         #region Fluent private collections


### PR DESCRIPTION
includes port of Java SDK https://github.com/Azure/azure-sdk-for-java/commit/40fd9ff7085af0b6a809b5797f38b202330a51b7, which is the compat break from Beta5.
(`IVirtualMachine.GetExtensions()` as `IVirtualMachine.ListExtensions()`)
