### PR TITLE
Add Async methods in common interfaces.

### DIFF
--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ChildResource.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ChildResource.cs
@@ -27,13 +27,13 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
         /// Gets the reference to the parent implementation, this is used by
         /// the child resource impls to invoke methods in the parent such as
         /// method to add the child resource impl to collection of child resources
-        /// maintined by the parent.
+        /// maintained by the parent.
         /// </summary>
         public ParentImplT Parent { get; private set; }
 
         public abstract string Name();
 
-        string Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasName.Name
+        string IHasName.Name
         {
             get
             {

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/CreatableUpdatableResourcesRoot.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/CreatableUpdatableResourcesRoot.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
             this.keys = new List<string>();
         }
 
-        internal void AddCreatableDependencies(params ICreatable<IFluentResourceT>[] creatables)
+        internal void AddCreatableDependencies(IEnumerable<ICreatable<IFluentResourceT>> creatables)
         {
             foreach (ICreatable<IFluentResourceT> item in creatables)
             {

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/Extensions.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/Extensions.cs
@@ -5,6 +5,8 @@ using Microsoft.Rest.Azure;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 {

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/PagedCollection.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/PagedCollection.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Rest.Azure;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
+{
+    public class PagedCollection<T> : IEnumerable<T>
+    {
+        private IList<T> innerCollection;
+        private Func<string, CancellationToken, Task<IPage<T>>> nextPageDelegate;
+
+        public PagedCollection()
+        {
+            innerCollection = new List<T>();
+        }
+
+        public async static Task<PagedCollection<T>> Load(
+            Func<Task<IPage<T>>> firstPageAsyncDelegate, 
+            Func<string, CancellationToken, Task<IPage<T>>> nextPageAsyncDelegate,
+            CancellationToken cancellationToken)
+        {
+            var pagedCollection = new PagedCollection<T>();
+
+            var currentPage = await firstPageAsyncDelegate();
+
+            do
+            {
+                if (currentPage == null ||
+                    !currentPage.Any())
+                {
+                    break;
+                }
+
+                ((List<T>)pagedCollection.innerCollection).AddRange(currentPage);
+
+            } while (currentPage.NextPageLink != null &&
+                     !cancellationToken.IsCancellationRequested &&
+                     (currentPage = await nextPageAsyncDelegate(currentPage.NextPageLink, cancellationToken)) != null);
+
+            return pagedCollection;
+        }
+
+        private async Task<IPage<T>> LoadNextPageAsync(string nextPageLink, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await nextPageDelegate(nextPageLink, cancellationToken);
+        }
+        
+        public IEnumerator<T> GetEnumerator()
+        {
+            return innerCollection.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return innerCollection.GetEnumerator();
+        }
+    }
+}

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsBatchCreation.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsBatchCreation.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions
@@ -18,6 +20,12 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActio
         /// </summary>
         /// <param name="creatables">the creatables in the batch</param>
         /// <returns></returns>
+        ICreatedResources<IFluentResourceT> Create(IEnumerable<ICreatable<IFluentResourceT>> creatables);
+
+        /// <summary>
+        /// Creates a set (batch) of resources.
+        /// </summary>
+        /// <param name="creatables">the creatables in the batch</param>
         ICreatedResources<IFluentResourceT> Create(params ICreatable<IFluentResourceT>[] creatables);
 
         /// <summary>
@@ -25,6 +33,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActio
         /// </summary>
         /// <param name="creatables">the creatables in the batch</param>
         /// <returns></returns>
-        Task<ICreatedResources<IFluentResourceT>> CreateAsync(params ICreatable<IFluentResourceT>[] creatables);
+        Task<ICreatedResources<IFluentResourceT>> CreateAsync(
+            IEnumerable<ICreatable<IFluentResourceT>> creatables,
+            CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceGroup/ResourceGroupsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceGroup/ResourceGroupsImpl.cs
@@ -70,9 +70,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
             var resourceGroupInner = await Inner.GetAsync(name, cancellationToken);
             return WrapModel(resourceGroupInner);
         }
-
-        #region Implementation of CreatableWrappers abstract methods
-
+        
         protected override ResourceGroupImpl WrapModel(string name)
         {
             return new ResourceGroupImpl(new ResourceGroupInner
@@ -85,7 +83,5 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         {
             return new ResourceGroupImpl(inner, Inner);
         }
-
-        #endregion
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueImpl.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:1D23568874BE06880E14E0FB7622F67C:C668F81A8DA344C037D3349C4B8E22EA
         private async Task SubmitChildrenOperationsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            await this.AuthorizationRules().CreateAsync(this.rulesToCreate.ToArray());
+            await this.AuthorizationRules().CreateAsync(this.rulesToCreate, cancellationToken);
             await this.AuthorizationRules().DeleteByNameAsync(this.rulesToDelete, cancellationToken);
         }
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespaceImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespaceImpl.cs
@@ -174,11 +174,11 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:1D23568874BE06880E14E0FB7622F67C:348B5EED59A4609BB5965E7355718218
         private async Task SubmitChildrenOperationsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            await this.Queues().CreateAsync(this.queuesToCreate.ToArray());
+            await this.Queues().CreateAsync(this.queuesToCreate, cancellationToken);
             await this.Queues().DeleteByNameAsync(this.queuesToDelete, cancellationToken);
-            await this.Topics().CreateAsync(this.topicsToCreate.ToArray());
+            await this.Topics().CreateAsync(this.topicsToCreate, cancellationToken);
             await this.Topics().DeleteByNameAsync(this.topicsToDelete, cancellationToken);
-            await this.AuthorizationRules().CreateAsync(this.rulesToCreate.ToArray());
+            await this.AuthorizationRules().CreateAsync(this.rulesToCreate, cancellationToken);
             await this.AuthorizationRules().DeleteByNameAsync(this.rulesToDelete, cancellationToken);
         }
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicImpl.cs
@@ -222,9 +222,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:1D23568874BE06880E14E0FB7622F67C:BEFB1540B9E220B3B11C29E80D17FD1C
         private async Task SubmitChildrenOperationsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            await this.Subscriptions().CreateAsync(this.subscriptionsToCreate.ToArray());
+            await this.Subscriptions().CreateAsync(this.subscriptionsToCreate, cancellationToken);
             await this.Subscriptions().DeleteByNameAsync(this.subscriptionsToDelete, cancellationToken);
-            await this.AuthorizationRules().CreateAsync(this.rulesToCreate.ToArray());
+            await this.AuthorizationRules().CreateAsync(this.rulesToCreate, cancellationToken);
             await this.AuthorizationRules().DeleteByNameAsync(this.rulesToDelete, cancellationToken);
         }
 


### PR DESCRIPTION

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.