### PR TITLE
Search SDK: Adding missing descriptions to preview SDK

### DIFF
--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/AsciiFoldingTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/AsciiFoldingTokenFilter.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the AsciiFoldingTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="preserveOriginal">A value indicating whether the
         /// original token will be kept. Default is false.</param>
         public AsciiFoldingTokenFilter(string name, bool? preserveOriginal = default(bool?))

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/CharFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/CharFilter.cs
@@ -28,12 +28,19 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the CharFilter class.
         /// </summary>
+        /// <param name="name">The name of the char filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         public CharFilter(string name)
         {
             Name = name;
         }
 
         /// <summary>
+        /// Gets or sets the name of the char filter. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128 characters.
         /// </summary>
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/CjkBigramTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/CjkBigramTokenFilter.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the CjkBigramTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="ignoreScripts">The scripts to ignore.</param>
         /// <param name="outputUnigrams">A value indicating whether to output
         /// both unigrams and bigrams (if true), or just bigrams (if false).

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ClassicTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ClassicTokenizer.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the ClassicTokenizer class.
         /// </summary>
+        /// <param name="name">The name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="maxTokenLength">The maximum token length. Default is
         /// 255. Tokens longer than the maximum length are split. The maximum
         /// token length that can be used is 300 characters.</param>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/CommonGramTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/CommonGramTokenFilter.cs
@@ -33,6 +33,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the CommonGramTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="commonWords">The set of common words.</param>
         /// <param name="ignoreCase">A value indicating whether common words
         /// matching will be case insensitive. Default is false.</param>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DictionaryDecompounderTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/DictionaryDecompounderTokenFilter.cs
@@ -34,6 +34,10 @@ namespace Microsoft.Azure.Search.Models
         /// Initializes a new instance of the DictionaryDecompounderTokenFilter
         /// class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="wordList">The list of words to match against.</param>
         /// <param name="minWordSize">The minimum word size. Only words longer
         /// than this get processed. Default is 5. Maximum is 300.</param>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/EdgeNGramTokenFilterV2.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/EdgeNGramTokenFilterV2.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the EdgeNGramTokenFilterV2 class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="minGram">The minimum n-gram length. Default is 1.
         /// Maximum is 300. Must be less than the value of maxGram.</param>
         /// <param name="maxGram">The maximum n-gram length. Default is 2.

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/EdgeNGramTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/EdgeNGramTokenizer.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the EdgeNGramTokenizer class.
         /// </summary>
+        /// <param name="name">The name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="minGram">The minimum n-gram length. Default is 1.
         /// Maximum is 300. Must be less than the value of maxGram.</param>
         /// <param name="maxGram">The maximum n-gram length. Default is 2.

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ElisionTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ElisionTokenFilter.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the ElisionTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="articles">The set of articles to remove.</param>
         public ElisionTokenFilter(string name, IList<string> articles = default(IList<string>))
             : base(name)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/KeepTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/KeepTokenFilter.cs
@@ -33,6 +33,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the KeepTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="keepWords">The list of words to keep.</param>
         /// <param name="lowerCaseKeepWords">A value indicating whether to
         /// lower case all words first. Default is false.</param>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/KeywordMarkerTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/KeywordMarkerTokenFilter.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the KeywordMarkerTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="keywords">A list of words to mark as keywords.</param>
         /// <param name="ignoreCase">A value indicating whether to ignore case.
         /// If true, all words are converted to lower case first. Default is

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/KeywordTokenizerV2.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/KeywordTokenizerV2.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the KeywordTokenizerV2 class.
         /// </summary>
+        /// <param name="name">The name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="maxTokenLength">The maximum token length. Default is
         /// 256. Tokens longer than the maximum length are split. The maximum
         /// token length that can be used is 300 characters.</param>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/LengthTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/LengthTokenFilter.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the LengthTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="min">The minimum length in characters. Default is 0.
         /// Maximum is 300. Must be less than the value of max.</param>
         /// <param name="max">The maximum length in characters. Default and

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/LimitTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/LimitTokenFilter.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the LimitTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="maxTokenCount">The maximum number of tokens to
         /// produce. Default is 1.</param>
         /// <param name="consumeAllTokens">A value indicating whether all

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MappingCharFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MappingCharFilter.cs
@@ -34,6 +34,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the MappingCharFilter class.
         /// </summary>
+        /// <param name="name">The name of the char filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="mappings">A list of mappings of the following format:
         /// "a=&gt;b" (all occurrences of the character "a" will be replaced
         /// with character "b").</param>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MicrosoftLanguageStemmingTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MicrosoftLanguageStemmingTokenizer.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Azure.Search.Models
         /// Initializes a new instance of the
         /// MicrosoftLanguageStemmingTokenizer class.
         /// </summary>
+        /// <param name="name">The name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="maxTokenLength">The maximum token length. Tokens
         /// longer than the maximum length are split. Maximum token length that
         /// can be used is 300 characters. Tokens longer than 300 characters

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MicrosoftLanguageTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/MicrosoftLanguageTokenizer.cs
@@ -28,6 +28,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the MicrosoftLanguageTokenizer class.
         /// </summary>
+        /// <param name="name">The name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="maxTokenLength">The maximum token length. Tokens
         /// longer than the maximum length are split. Maximum token length that
         /// can be used is 300 characters. Tokens longer than 300 characters

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/NGramTokenFilterV2.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/NGramTokenFilterV2.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the NGramTokenFilterV2 class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="minGram">The minimum n-gram length. Default is 1.
         /// Maximum is 300. Must be less than the value of maxGram.</param>
         /// <param name="maxGram">The maximum n-gram length. Default is 2.

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/NGramTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/NGramTokenizer.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the NGramTokenizer class.
         /// </summary>
+        /// <param name="name">The name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="minGram">The minimum n-gram length. Default is 1.
         /// Maximum is 300. Must be less than the value of maxGram.</param>
         /// <param name="maxGram">The maximum n-gram length. Default is 2.

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PathHierarchyTokenizerV2.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PathHierarchyTokenizerV2.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the PathHierarchyTokenizerV2 class.
         /// </summary>
+        /// <param name="name">The name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="delimiter">The delimiter character to use. Default is
         /// "/".</param>
         /// <param name="replacement">A value that, if set, replaces the

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PatternCaptureTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PatternCaptureTokenFilter.cs
@@ -33,6 +33,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the PatternCaptureTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="patterns">A list of patterns to match against each
         /// token.</param>
         /// <param name="preserveOriginal">A value indicating whether to return

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PatternReplaceCharFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PatternReplaceCharFilter.cs
@@ -34,6 +34,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the PatternReplaceCharFilter class.
         /// </summary>
+        /// <param name="name">The name of the char filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="pattern">A regular expression pattern.</param>
         /// <param name="replacement">The replacement text.</param>
         public PatternReplaceCharFilter(string name, string pattern, string replacement)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PatternReplaceTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PatternReplaceTokenFilter.cs
@@ -34,6 +34,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the PatternReplaceTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="pattern">A regular expression pattern.</param>
         /// <param name="replacement">The replacement text.</param>
         public PatternReplaceTokenFilter(string name, string pattern, string replacement)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PatternTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PatternTokenizer.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the PatternTokenizer class.
         /// </summary>
+        /// <param name="name">The name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="pattern">A regular expression pattern to match token
         /// separators. Default is an expression that matches one or more
         /// whitespace characters.</param>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PhoneticTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/PhoneticTokenFilter.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the PhoneticTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="encoder">The phonetic encoder to use. Default is
         /// "metaphone". Possible values include: 'metaphone',
         /// 'doubleMetaphone', 'soundex', 'refinedSoundex', 'caverphone1',

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ShingleTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/ShingleTokenFilter.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the ShingleTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="maxShingleSize">The maximum shingle size. Default and
         /// minimum value is 2.</param>
         /// <param name="minShingleSize">The minimum shingle size. Default and

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/SnowballTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/SnowballTokenFilter.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the SnowballTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="language">The language to use. Possible values
         /// include: 'armenian', 'basque', 'catalan', 'danish', 'dutch',
         /// 'english', 'finnish', 'french', 'german', 'german2', 'hungarian',

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StandardTokenizerV2.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StandardTokenizerV2.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the StandardTokenizerV2 class.
         /// </summary>
+        /// <param name="name">The name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="maxTokenLength">The maximum token length. Default is
         /// 255. Tokens longer than the maximum length are split. The maximum
         /// token length that can be used is 300 characters.</param>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StemmerOverrideTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StemmerOverrideTokenFilter.cs
@@ -35,6 +35,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the StemmerOverrideTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="rules">A list of stemming rules in the following
         /// format: "word =&gt; stem", for example: "ran =&gt; run".</param>
         public StemmerOverrideTokenFilter(string name, IList<string> rules)

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StemmerTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StemmerTokenFilter.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the StemmerTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="language">The language to use. Possible values
         /// include: 'arabic', 'armenian', 'basque', 'brazilian', 'bulgarian',
         /// 'catalan', 'czech', 'danish', 'dutch', 'dutchKp', 'english',

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StopwordsTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/StopwordsTokenFilter.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the StopwordsTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="stopwords">The list of stopwords. This property and
         /// the stopwords list property cannot both be set.</param>
         /// <param name="stopwordsList">A predefined list of stopwords to use.

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/SynonymTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/SynonymTokenFilter.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the SynonymTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="synonyms">A list of synonyms in following one of two
         /// formats: 1. incredible, unbelievable, fabulous =&gt; amazing - all
         /// terms on the left side of =&gt; symbol will be replaced with all

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/TokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/TokenFilter.cs
@@ -28,12 +28,19 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the TokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         public TokenFilter(string name)
         {
             Name = name;
         }
 
         /// <summary>
+        /// Gets or sets the name of the token filter. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128 characters.
         /// </summary>
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/Tokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/Tokenizer.cs
@@ -28,12 +28,19 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the Tokenizer class.
         /// </summary>
+        /// <param name="name">The name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         public Tokenizer(string name)
         {
             Name = name;
         }
 
         /// <summary>
+        /// Gets or sets the name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128 characters.
         /// </summary>
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/TruncateTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/TruncateTokenFilter.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the TruncateTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="length">The length at which terms will be truncated.
         /// Default and maximum is 300.</param>
         public TruncateTokenFilter(string name, int? length = default(int?))

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/UaxUrlEmailTokenizer.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/UaxUrlEmailTokenizer.cs
@@ -30,6 +30,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the UaxUrlEmailTokenizer class.
         /// </summary>
+        /// <param name="name">The name of the tokenizer. It must only contain
+        /// letters, digits, spaces, dashes or underscores, can only start and
+        /// end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="maxTokenLength">The maximum token length. Default is
         /// 255. Tokens longer than the maximum length are split. The maximum
         /// token length that can be used is 300 characters.</param>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/UniqueTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/UniqueTokenFilter.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the UniqueTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="onlyOnSamePosition">A value indicating whether to
         /// remove duplicates only at the same position. Default is
         /// false.</param>

--- a/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/WordDelimiterTokenFilter.cs
+++ b/src/Search/Microsoft.Azure.Search/GeneratedSearchService/Models/WordDelimiterTokenFilter.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Azure.Search.Models
         /// <summary>
         /// Initializes a new instance of the WordDelimiterTokenFilter class.
         /// </summary>
+        /// <param name="name">The name of the token filter. It must only
+        /// contain letters, digits, spaces, dashes or underscores, can only
+        /// start and end with alphanumeric characters, and is limited to 128
+        /// characters.</param>
         /// <param name="generateWordParts">A value indicating whether to
         /// generate part words. If set, causes parts of words to be generated;
         /// for example "AzureSearch" becomes "Azure" "Search". Default is


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Adding comments to generated code that were missing from the Swagger spec. See related PR https://github.com/Azure/azure-rest-api-specs-pr/pull/54

FYI @Yahnoosh @mhko

<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [X] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [X] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [X] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [X] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.