### PR TITLE
[Fluent] Added TopLevelModifiableResources in .NET

### DIFF
--- a/Samples/Common/project.json
+++ b/Samples/Common/project.json
@@ -11,9 +11,9 @@
   },
   
   "frameworks": {
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificateOrdersImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificateOrdersImpl.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.AppService.Fluent
 {
+    using Management.Fluent.Resource.Core;
     using Models;
     using ResourceManager.Fluent.Core;
+    using Rest.Azure;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -13,7 +15,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmFwcHNlcnZpY2UuaW1wbGVtZW50YXRpb24uQXBwU2VydmljZUNlcnRpZmljYXRlT3JkZXJzSW1wbA==
     internal partial class AppServiceCertificateOrdersImpl :
-        GroupableResources<
+        TopLevelModifiableResources<
             IAppServiceCertificateOrder,
             AppServiceCertificateOrderImpl,
             AppServiceCertificateOrderInner,
@@ -29,10 +31,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:D505D44BBE5A66C92A4176DBA1DD5891:68BABEE90E833AD1BFA7F46A8C19127A
-        public async override Task<Microsoft.Azure.Management.AppService.Fluent.IAppServiceCertificateOrder> GetByGroupAsync(string resourceGroupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<AppServiceCertificateOrderInner> GetInnerByGroupAsync(string resourceGroupName, string name, CancellationToken cancellationToken)
         {
-            var appServiceCertificateOrderInner = await Inner.GetAsync(resourceGroupName, name, cancellationToken);
-            return WrapModel(appServiceCertificateOrderInner);
+            return await Inner.GetAsync(resourceGroupName, name, cancellationToken);
         }
 
         ///GENMHASH:FCA66BA6767E2497E23A1AF83D62F9F0:0FCD47CBCD9128C3D4A03458C5796741
@@ -42,14 +43,28 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:437A8ECA353AAE23242BFC82A5066CC3
-        public IEnumerable<IAppServiceCertificateOrder> ListByGroup(string resourceGroupName)
+        protected async override Task<IPage<AppServiceCertificateOrderInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(resourceGroupName)
-                                 .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<AppServiceCertificateOrderInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
+        }
+
+        protected async override Task<IPage<AppServiceCertificateOrderInner>> ListInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Inner.ListAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<AppServiceCertificateOrderInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:60ECC4D32A4130D4A0971FBE7432E886
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteCertificateOrderAsync(groupName, name, cancellationToken);
         }

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificatesImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificatesImpl.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.AppService.Fluent
 {
+    using Management.Fluent.Resource.Core;
     using Microsoft.Azure.Management.AppService.Fluent.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+    using Rest.Azure;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -13,7 +15,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmFwcHNlcnZpY2UuaW1wbGVtZW50YXRpb24uQXBwU2VydmljZUNlcnRpZmljYXRlc0ltcGw=
     internal partial class AppServiceCertificatesImpl :
-        GroupableResources<
+        TopLevelModifiableResources<
             IAppServiceCertificate,
             AppServiceCertificateImpl,
             CertificateInner,
@@ -35,22 +37,36 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:437A8ECA353AAE23242BFC82A5066CC3
-        public IEnumerable<IAppServiceCertificate> ListByGroup(string resourceGroupName)
+        protected async override Task<IPage<CertificateInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(resourceGroupName)
-                                 .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<CertificateInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
+        }
+
+        protected async override Task<IPage<CertificateInner>> ListInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Inner.ListAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<CertificateInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:586E2B084878E8767487234B852D8D20
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:AB5235085FE852FA939C192DC80C9EEF
-        public async override Task<IAppServiceCertificate> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<CertificateInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            return WrapModel(await Inner.GetAsync(groupName, name, cancellationToken));
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:5AC27B4C4791A2919F43CCB97C0275BA

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceDomainsImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceDomainsImpl.cs
@@ -10,13 +10,15 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent;
     using System.Linq;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// The implementation for AppServiceDomains.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmFwcHNlcnZpY2UuaW1wbGVtZW50YXRpb24uQXBwU2VydmljZURvbWFpbnNJbXBs
     internal partial class AppServiceDomainsImpl  :
-        GroupableResources<
+        TopLevelModifiableResources<
             IAppServiceDomain,
             AppServiceDomainImpl,
             DomainInner,
@@ -42,29 +44,37 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:437A8ECA353AAE23242BFC82A5066CC3
-        public IEnumerable<IAppServiceDomain> ListByGroup(string resourceGroupName)
+        protected async override Task<IPage<DomainInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(resourceGroupName)
-                                 .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<DomainInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:586E2B084878E8767487234B852D8D20
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:AB5235085FE852FA939C192DC80C9EEF
-        public async override Task<IAppServiceDomain> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<DomainInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            return WrapModel(await Inner.GetAsync(groupName, name, cancellationToken));
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:8CF52FF5A0D0AA245495F311570001AD
-        public IEnumerable<IAppServiceDomain> List()
+        protected async override Task<IPage<DomainInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List()
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<DomainInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:9303C19C6745E77DCF648A0A5F603980:6058FD68A2D3CB7431C37FFF30958B5E

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServicePlansImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServicePlansImpl.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.AppService.Fluent
 {
+    using Management.Fluent.Resource.Core;
     using Microsoft.Azure.Management.AppService.Fluent.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+    using Rest.Azure;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -13,7 +15,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmFwcHNlcnZpY2UuaW1wbGVtZW50YXRpb24uQXBwU2VydmljZVBsYW5zSW1wbA==
     internal partial class AppServicePlansImpl :
-        GroupableResources<
+        TopLevelModifiableResources<
             IAppServicePlan,
             AppServicePlanImpl,
             AppServicePlanInner,
@@ -41,17 +43,36 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             return WrapList(Inner.ListByResourceGroup(resourceGroupName)
                                  .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
         }
+        protected async override Task<IPage<AppServicePlanInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<AppServicePlanInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
+        }
+
+        protected async override Task<IPage<AppServicePlanInner>> ListInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Inner.ListAsync(cancellationToken: cancellationToken);
+        }
+
+        protected async override Task<IPage<AppServicePlanInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
+        }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:586E2B084878E8767487234B852D8D20
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:AB5235085FE852FA939C192DC80C9EEF
-        public async override Task<IAppServicePlan> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<AppServicePlanInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            return WrapModel(await Inner.GetAsync(groupName, name, cancellationToken));
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:C35C270B3C2E9692DFA4DB35882E6EF7

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/DeploymentSlotsImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/DeploymentSlotsImpl.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// The implementation for DeploymentSlots.
@@ -56,16 +57,12 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:21EB605E5FAA6C13D208A1A4CE8C136D:1381FA42DE6ECBD284AA54F76A65CC41
-        public async override Task<IEnumerable<IDeploymentSlot>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
+        public async override Task<IPagedCollection<IDeploymentSlot>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Func<SiteInner, IDeploymentSlot> converter = inner =>
-            {
-                return PopulateModelAsync(inner, parent).ConfigureAwait(false).GetAwaiter().GetResult();
-            };
-
-            return (await Inner.ListSlotsAsync(resourceGroupName, parentName, cancellationToken))
-                              .AsContinuousCollection(link => Inner.ListSlotsNext(link))
-                              .Select(inner => converter(inner));
+            return await PagedCollection<IDeploymentSlot, SiteInner>.LoadPageWithWrapModelAsync(
+                async (cancellation) => await Inner.ListSlotsAsync(resourceGroupName, parentName, cancellation),
+                async (nextLink, cancellation) => await Inner.ListSlotsNextAsync(nextLink, cancellation),
+                async (inner, cancellation) => await PopulateModelAsync(inner, parent, cancellation), true, cancellationToken);
         }
 
         ///GENMHASH:971272FEE209B8A9A552B92179C1F926:09CA495AE0F4F57BBBBDFC250874B0D4
@@ -139,6 +136,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             var slot = WrapModel(inner);
             await ((DeploymentSlotImpl)slot).CacheAppSettingsAndConnectionStringsAsync(cancellationToken);
             return slot;
+        }
+
+        public async Task<IPagedCollection<IDeploymentSlot>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await ListByParentAsync(parent.ResourceGroupName, parent.Name, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificateOrders.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificateOrders.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ISupportsCreating<IBlank>,
         ISupportsDeletingById,
         ISupportsListingByGroup<IAppServiceCertificateOrder>,
+        ISupportsListing<IAppServiceCertificateOrder>,
         ISupportsGettingByGroup<IAppServiceCertificateOrder>,
         ISupportsGettingById<IAppServiceCertificateOrder>,
         ISupportsDeletingByGroup,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificates.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServiceCertificates.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ISupportsCreating<AppServiceCertificate.Definition.IBlank>,
         ISupportsDeletingById,
         ISupportsListingByGroup<Microsoft.Azure.Management.AppService.Fluent.IAppServiceCertificate>,
+        ISupportsListing<Microsoft.Azure.Management.AppService.Fluent.IAppServiceCertificate>,
         ISupportsGettingByGroup<Microsoft.Azure.Management.AppService.Fluent.IAppServiceCertificate>,
         ISupportsGettingById<Microsoft.Azure.Management.AppService.Fluent.IAppServiceCertificate>,
         ISupportsDeletingByGroup,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServicePlans.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IAppServicePlans.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ISupportsCreating<AppServicePlan.Definition.IBlank>,
         ISupportsDeletingById,
         ISupportsListingByGroup<Microsoft.Azure.Management.AppService.Fluent.IAppServicePlan>,
+        ISupportsListing<Microsoft.Azure.Management.AppService.Fluent.IAppServicePlan>,
         ISupportsGettingByGroup<Microsoft.Azure.Management.AppService.Fluent.IAppServicePlan>,
         ISupportsGettingById<Microsoft.Azure.Management.AppService.Fluent.IAppServicePlan>,
         ISupportsDeletingByGroup,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IWebApps.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/IWebApps.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ISupportsCreating<WebApp.Definition.IBlank>,
         ISupportsDeletingById,
         ISupportsListingByGroup<Microsoft.Azure.Management.AppService.Fluent.IWebApp>,
+        ISupportsListing<Microsoft.Azure.Management.AppService.Fluent.IWebApp>,
         ISupportsGettingByGroup<Microsoft.Azure.Management.AppService.Fluent.IWebApp>,
         ISupportsGettingById<Microsoft.Azure.Management.AppService.Fluent.IWebApp>,
         ISupportsDeletingByGroup,

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/InterfaceImpl/AppServiceCertificateOrdersImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/InterfaceImpl/AppServiceCertificateOrdersImpl.cs
@@ -42,6 +42,14 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         /// <summary>
+        /// Lists resources of the specified type in the subscription.
+        /// </summary>
+        IEnumerable<Microsoft.Azure.Management.AppService.Fluent.IAppServiceCertificateOrder> Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListing<Microsoft.Azure.Management.AppService.Fluent.IAppServiceCertificateOrder>.List()
+        {
+            return this.List();
+        }
+
+        /// <summary>
         /// Gets the information about a resource from Azure based on the resource name and the name of its resource group.
         /// </summary>
         /// <param name="resourceGroupName">The name of the resource group the resource is in.</param>

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/InterfaceImpl/AppServiceCertificatesImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/InterfaceImpl/AppServiceCertificatesImpl.cs
@@ -42,6 +42,14 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         /// <summary>
+        /// Lists resources of the specified type in the subscription.
+        /// </summary>
+        IEnumerable<Microsoft.Azure.Management.AppService.Fluent.IAppServiceCertificate> Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListing<Microsoft.Azure.Management.AppService.Fluent.IAppServiceCertificate>.List()
+        {
+            return this.List();
+        }
+
+        /// <summary>
         /// Gets the information about a resource from Azure based on the resource name and the name of its resource group.
         /// </summary>
         /// <param name="resourceGroupName">The name of the resource group the resource is in.</param>

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/InterfaceImpl/AppServicePlansImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/InterfaceImpl/AppServicePlansImpl.cs
@@ -41,6 +41,15 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             return this.ListByGroup(resourceGroupName);
         }
 
+
+        /// <summary>
+        /// Lists resources of the specified type in the subscription.
+        /// </summary>
+        IEnumerable<Microsoft.Azure.Management.AppService.Fluent.IAppServicePlan> Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListing<Microsoft.Azure.Management.AppService.Fluent.IAppServicePlan>.List()
+        {
+            return this.List();
+        }
+
         /// <summary>
         /// Gets the information about a resource from Azure based on the resource name and the name of its resource group.
         /// </summary>

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/project.json
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/project.json
@@ -35,19 +35,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/ResourceManager/GenericResourcesTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/ResourceManager/GenericResourcesTests.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Fluent.Tests.ResourceManager
@@ -17,7 +18,7 @@ namespace Fluent.Tests.ResourceManager
     public class GenericResourcesTests
     {
         [Fact]
-        public void CanCreateUpdateMoveResource()
+        public async Task CanCreateUpdateMoveResource()
         {
             using (var context = FluentMockContext.Start(this.GetType().FullName))
             {
@@ -40,7 +41,7 @@ namespace Fluent.Tests.ResourceManager
                     .Create();
 
                 // List
-                var found = (from r in genericResources.ListByGroup(rgName)
+                var found = (from r in await genericResources.ListByGroupAsync(rgName)
                              where string.Equals(r.Name, resourceName, StringComparison.OrdinalIgnoreCase)
                              select r).FirstOrDefault();
                 Assert.NotNull(found);

--- a/src/ResourceManagement/Azure.Fluent/Microsoft.Azure.Management.Fluent/project.json
+++ b/src/ResourceManagement/Azure.Fluent/Microsoft.Azure.Management.Fluent/project.json
@@ -45,19 +45,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/BatchAccountsImpl.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/BatchAccountsImpl.cs
@@ -3,8 +3,10 @@
 
 namespace Microsoft.Azure.Management.Batch.Fluent
 {
+    using Management.Fluent.Resource.Core;
     using Models;
     using ResourceManager.Fluent.Core;
+    using Rest.Azure;
     using Storage.Fluent;
     using System;
     using System.Collections.Generic;
@@ -16,7 +18,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmJhdGNoLmltcGxlbWVudGF0aW9uLkJhdGNoQWNjb3VudHNJbXBs
     public partial class BatchAccountsImpl :
-        GroupableResources<
+        TopLevelModifiableResources<
             IBatchAccount,
             BatchAccountImpl,
             BatchAccountInner,
@@ -56,17 +58,25 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:6FB4EA69673E1D8A74E1418EB52BB9FE
-        internal IEnumerable<IBatchAccount> List()
+        protected async override Task<IPage<BatchAccountInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List()
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<BatchAccountInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:F27988875BD81EE531DA23D26C675612
-        internal IEnumerable<IBatchAccount> ListByGroup(string resourceGroupName)
+        protected async override Task<IPage<BatchAccountInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(resourceGroupName)
-                                 .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<BatchAccountInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:353632428E49DD5C2FB134FBBB79CA4F:7213377B7C84B2355F61715C95204A42
@@ -91,16 +101,15 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<IBatchAccount> GetByGroupAsync(string resourceGroupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<BatchAccountInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var batchAccount = await Inner.GetAsync(resourceGroupName, name, cancellationToken);
-            return WrapModel(batchAccount);
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:F8EF648D033A93895EA3A4E4EB60B9B2:F0DC62FB7F617AF3C57F4F01580CC827

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/project.json
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/project.json
@@ -35,19 +35,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/CdnProfilesImpl.cs
+++ b/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/CdnProfilesImpl.cs
@@ -7,13 +7,15 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
     using ResourceManager.Fluent.Core;
     using System.Threading;
     using Models;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// Implementation for CdnProfiles.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmNkbi5pbXBsZW1lbnRhdGlvbi5DZG5Qcm9maWxlc0ltcGw=
     internal partial class CdnProfilesImpl  :
-        GroupableResources<ICdnProfile,CdnProfileImpl,ProfileInner,IProfilesOperations,ICdnManager>,
+        TopLevelModifiableResources<ICdnProfile,CdnProfileImpl,ProfileInner,IProfilesOperations,ICdnManager>,
         ICdnProfiles
     {
         ///GENMHASH:2CEB6E35574F5C7F1D19ADAC97C93D65:4CE4EF96A3377BCB6304539746BB262C
@@ -33,10 +35,14 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:6FB4EA69673E1D8A74E1418EB52BB9FE
-        public IEnumerable<ICdnProfile> List()
+        protected async override Task<IPage<ProfileInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List()
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<ProfileInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:B76E119E66FC2C5D09617333DC4FF4E3:5E6BF540BD14D5EE37AC38FE28D3AA9F
@@ -58,10 +64,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(
-            string groupName, 
-            string name, 
-            CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
@@ -91,20 +94,20 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<ICdnProfile> GetByGroupAsync(
-            string groupName, 
-            string name, 
-            CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<ProfileInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            ProfileInner profileInner = await Inner.GetAsync(groupName, name, cancellationToken);
-            return WrapModel(profileInner);
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:BDFF4CB61E8A8D975417EA5FC914921A
-        public IEnumerable<ICdnProfile> ListByGroup(string groupName)
+        protected async override Task<IPage<ProfileInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(groupName)
-                                 .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<ProfileInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:80BCE26D6F015BF71C5D9844E17987C3

--- a/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/project.json
+++ b/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/project.json
@@ -34,19 +34,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/AvailabilitySetsImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/AvailabilitySetsImpl.cs
@@ -9,6 +9,9 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Management.Fluent.Resource.Core;
+using Microsoft.Rest.Azure;
+using System.Reflection;
 
 namespace Microsoft.Azure.Management.Compute.Fluent
 {
@@ -17,7 +20,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmNvbXB1dGUuaW1wbGVtZW50YXRpb24uQXZhaWxhYmlsaXR5U2V0c0ltcGw=
     internal partial class AvailabilitySetsImpl :
-        GroupableResources<
+        TopLevelModifiableResources<
             IAvailabilitySet,
             AvailabilitySetImpl,
             AvailabilitySetInner,
@@ -36,37 +39,59 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:E05BE5112BBF24DC07F63B90A384905C
-        public IEnumerable<IAvailabilitySet> List()
+        public override IEnumerable<IAvailabilitySet> List()
         {
+            // TODO - ans - We should try to check with service team if this is just missing API, if yes, then log a bug with swagger
+            // and make a code change in auto-generated to support this method directly, as this will help implementing async pattern.
+
             // There is no API supporting listing of availability set across subscription so enumerate all RGs and then
             // flatten the "list of list of availability sets" as "list of availability sets" .
             return Manager.ResourceManager.ResourceGroups.List()
                                           .SelectMany(rg => ListByGroup(rg.Name));
         }
 
-        ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:3953AC722DFFCDF40E1EEF787AFD1326
-        public IEnumerable<IAvailabilitySet> ListByGroup(string resourceGroupName)
+        public override async Task<IPagedCollection<IAvailabilitySet>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return WrapList(Inner.List(resourceGroupName));
+            var task = await Manager.ResourceManager.ResourceGroups.ListAsync(true, cancellationToken);
+            return await PagedCollection<IAvailabilitySet, AvailabilitySetInner>.LoadPage(async (cancellation) =>
+            {
+                var resourceGroups = await Manager.ResourceManager.ResourceGroups.ListAsync(true, cancellation);
+                var availabilitySet =  await Task.WhenAll(resourceGroups.Select(async (rg) => await ListInnerByGroupAsync(rg.Name, cancellation)));
+                return availabilitySet.SelectMany(x => x);
+            }, WrapModel, cancellationToken);
         }
 
-        public Task<IEnumerable<IAvailabilitySet>> ListByGroupAsync(string resourceGroupName, CancellationToken cancellationToken = default(CancellationToken))
+
+        protected override Task<IPage<AvailabilitySetInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            // ListByGroupAsync sholud be removed
-            throw new NotSupportedException();
+            throw new NotImplementedException();
+        }
+
+        protected override Task<IPage<AvailabilitySetInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected async override Task<IPage<AvailabilitySetInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
+        {
+            return ConvertToPage(await Inner.ListAsync(groupName, cancellationToken));
+        }
+
+        protected async override Task<IPage<AvailabilitySetInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult<IPage<AvailabilitySetInner>>(null);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7CC0F8C63730735B2D69A34858088DFD
-        public async override Task<IAvailabilitySet> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<AvailabilitySetInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var availabilitySetInner = await Inner.GetAsync(groupName, name, cancellationToken);
-            return WrapModel(availabilitySetInner);
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:08094366E86F6F96174452394778C4F6:ACF6A3952D2A0F720A28B7BE9957D330

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/DisksImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/DisksImpl.cs
@@ -8,13 +8,15 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using Models;
     using Disk.Definition;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// The implementation for Disks.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmNvbXB1dGUuaW1wbGVtZW50YXRpb24uRGlza3NJbXBs
     internal partial class DisksImpl :
-        GroupableResources<IDisk,
+        TopLevelModifiableResources<IDisk,
             DiskImpl,
             DiskInner,
             IDisksOperations, 
@@ -27,7 +29,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:737180B1BC9FBD3E5083EE06E951D489
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
@@ -57,24 +59,31 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:D325A8AE4D96F3AFCF2E542EDFA900C6
-        public async override Task<IDisk> GetByGroupAsync(string resourceGroupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<DiskInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            DiskInner inner = await Inner.GetAsync(resourceGroupName, name, cancellationToken);
-            return WrapModel(inner);
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:6FB4EA69673E1D8A74E1418EB52BB9FE
-        public IEnumerable<IDisk> List()
+        protected async override Task<IPage<DiskInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List()
-                .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<DiskInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:F27988875BD81EE531DA23D26C675612
-        public IEnumerable<IDisk> ListByGroup(string resourceGroupName)
+        protected async override Task<IPage<DiskInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(resourceGroupName)
-                .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<DiskInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:37323FCC616B8746EEBA6B2152BF1DA6

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/SnapshotsImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/SnapshotsImpl.cs
@@ -8,13 +8,15 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using Models;
     using Snapshot.Definition;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// The implementation for Snapshots.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmNvbXB1dGUuaW1wbGVtZW50YXRpb24uU25hcHNob3RzSW1wbA==
     internal partial class SnapshotsImpl :
-        GroupableResources<ISnapshot,
+        TopLevelModifiableResources<ISnapshot,
             SnapshotImpl,
             SnapshotInner, 
             ISnapshotsOperations, 
@@ -27,7 +29,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:737180B1BC9FBD3E5083EE06E951D489
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
@@ -57,24 +59,31 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:B8C153DB909F1EA16660F69BB881AD7A
-        public async override Task<ISnapshot> GetByGroupAsync(string resourceGroupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<SnapshotInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            SnapshotInner inner = await Inner.GetAsync(resourceGroupName, name, cancellationToken);
-            return WrapModel(inner);
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:6FB4EA69673E1D8A74E1418EB52BB9FE
-        public IEnumerable<ISnapshot> List()
+        protected async override Task<IPage<SnapshotInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List()
-                .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<SnapshotInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:F27988875BD81EE531DA23D26C675612
-        public IEnumerable<ISnapshot> ListByGroup(string resourceGroupName)
+        protected async override Task<IPage<SnapshotInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(resourceGroupName)
-                .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<SnapshotInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:3CA46DBF2D9D3E2609846FB4E368F357

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineCustomImagesImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineCustomImagesImpl.cs
@@ -8,13 +8,15 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using VirtualMachineCustomImage.Definition;
     using Models;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// The implementation for VirtualMachineCustomImages.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmNvbXB1dGUuaW1wbGVtZW50YXRpb24uVmlydHVhbE1hY2hpbmVDdXN0b21JbWFnZXNJbXBs
     internal partial class VirtualMachineCustomImagesImpl  :
-        GroupableResources<
+        TopLevelModifiableResources<
             IVirtualMachineCustomImage,
             VirtualMachineCustomImageImpl,
             ImageInner,
@@ -28,7 +30,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:737180B1BC9FBD3E5083EE06E951D489
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
@@ -40,24 +42,31 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:0DA05B447E9373BA84F249FC22D8EDFF
-        public async override Task<IVirtualMachineCustomImage> GetByGroupAsync(string resourceGroupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<ImageInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var inner = await Inner.GetAsync(resourceGroupName, name, null, cancellationToken);
-            return WrapModel(inner);
+            return await Inner.GetAsync(groupName, name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:6FB4EA69673E1D8A74E1418EB52BB9FE
-        public IEnumerable<IVirtualMachineCustomImage> List()
+        protected async override Task<IPage<ImageInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List()
-                .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<ImageInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:F27988875BD81EE531DA23D26C675612
-        public IEnumerable<IVirtualMachineCustomImage> ListByGroup(string resourceGroupName)
+        protected async override Task<IPage<ImageInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(resourceGroupName)
-                .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<ImageInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:EB96DF7C77547AEAC01FB2D702838F18

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineExtensionImageTypesImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineExtensionImageTypesImpl.cs
@@ -6,6 +6,10 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using ResourceManager.Fluent.Core;
     using Models;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// The implementation for VirtualMachineExtensionImageTypes.
@@ -28,6 +32,13 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         public IEnumerable<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtensionImageType> List()
         {
             return WrapList(this.client.ListTypes(this.publisher.Region.Name, this.publisher.Name));
+        }
+
+        public async Task<IPagedCollection<IVirtualMachineExtensionImageType>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IVirtualMachineExtensionImageType, VirtualMachineExtensionImageInner>.LoadPage(
+                async (cancellation) => await this.client.ListTypesAsync(this.publisher.Region.Name, this.publisher.Name, cancellation),
+                WrapModel, cancellationToken);
         }
 
         ///GENMHASH:3823A118AF47AF7328798BEA74521A04:3305DDE8944B084B78FD8F84BA96EEED

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineExtensionImageVersionsImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineExtensionImageVersionsImpl.cs
@@ -6,6 +6,10 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using ResourceManager.Fluent.Core;
     using Models;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// The implementation for VirtualMachineExtensionImageVersions.
@@ -31,6 +35,13 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 type.RegionName,
                 type.Publisher.Name,
                 type.Name));
+        }
+
+        public async Task<IPagedCollection<IVirtualMachineExtensionImageVersion>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IVirtualMachineExtensionImageVersion, VirtualMachineExtensionImageInner>.LoadPage(
+                async (cancellation) => await this.client.ListVersionsAsync(type.RegionName, type.Publisher.Name, type.Name, cancellationToken: cancellation),
+                WrapModel, cancellationToken);
         }
 
         ///GENMHASH:3823A118AF47AF7328798BEA74521A04:3A4CA90FBB86038062B022FC826008A2

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineExtensionsImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineExtensionsImpl.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                     extension = new VirtualMachineExtensionImpl(
                         extensionName,
                         Parent,
-                        await Parent.Manager.Inner.VirtualMachineExtensions.GetAsync(Parent.ResourceGroupName, Parent.Name, extensionName, null, cancellationToken));
+                        await Parent.Manager.Inner.VirtualMachineExtensions.GetAsync(Parent.ResourceGroupName, Parent.Name, extensionName, cancellationToken: cancellationToken));
                 }
                 result.Add(extension);
             }

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineOffersImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineOffersImpl.cs
@@ -6,6 +6,10 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using Models;
     using ResourceManager.Fluent.Core;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// The implementation for VirtualMachineOffers.
@@ -29,6 +33,13 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         public IEnumerable<IVirtualMachineOffer> List()
         {
             return WrapList(innerCollection.ListOffers(publisher.Region.Name, publisher.Name));
+        }
+
+        public async Task<IPagedCollection<IVirtualMachineOffer>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IVirtualMachineOffer, VirtualMachineImageResourceInner>.LoadPage(
+                async (cancellation) => await innerCollection.ListOffersAsync(publisher.Region.Name, publisher.Name, cancellation),
+                WrapModel, cancellationToken);
         }
 
         ///GENMHASH:D48BEF4BAC4C0112B6930D731FFC59BD:C7F4803C2EE7A4D67291D41041502664

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetVMsImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetVMsImpl.cs
@@ -5,6 +5,10 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using ResourceManager.Fluent.Core;
     using Models;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Implementation for VirtualMachineScaleSetVMs.
@@ -49,6 +53,14 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         protected override IVirtualMachineScaleSetVM WrapModel(VirtualMachineScaleSetVMInner inner)
         {
             return new VirtualMachineScaleSetVMImpl(inner, this.scaleSet);
+        }
+
+        public async Task<IPagedCollection<IVirtualMachineScaleSetVM>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IVirtualMachineScaleSetVM, VirtualMachineScaleSetVMInner>.LoadPage(
+                async (cancellation) => await Inner.ListAsync(scaleSet.ResourceGroupName, this.scaleSet.Name, cancellationToken: cancellation),
+                Inner.ListNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetsImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetsImpl.cs
@@ -10,13 +10,14 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using Rest.Azure;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// The implementation for VirtualMachineScaleSets.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmNvbXB1dGUuaW1wbGVtZW50YXRpb24uVmlydHVhbE1hY2hpbmVTY2FsZVNldHNJbXBs
     internal partial class VirtualMachineScaleSetsImpl  :
-        GroupableResources<
+        TopLevelModifiableResources<
             IVirtualMachineScaleSet,
             VirtualMachineScaleSetImpl,
             VirtualMachineScaleSetInner,
@@ -38,32 +39,37 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:3953AC722DFFCDF40E1EEF787AFD1326
-        public IEnumerable<IVirtualMachineScaleSet> ListByGroup(string groupName)
+        protected async override Task<IPage<VirtualMachineScaleSetInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List(groupName)
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<VirtualMachineScaleSetInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:36E25639805611CF89054C004B22BB15
-        public IEnumerable<IVirtualMachineScaleSet> List()
+        protected async override Task<IPage<VirtualMachineScaleSetInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListAll()
-                .AsContinuousCollection(link => Inner.ListAllNext(link)));
+            return await Inner.ListAllAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<VirtualMachineScaleSetInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListAllNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            await Inner.DeleteAsync(groupName,
-                name,
-                cancellationToken);
+            await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<IVirtualMachineScaleSet> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<VirtualMachineScaleSetInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var scaleSet = await Inner.GetAsync(groupName, name, cancellationToken);
-            return WrapModel(scaleSet);
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:2048E8AC80AC022225C462CE7FD14A6F:AB513A3D7E5B1192B76F853CB23CBB12

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineSkusImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineSkusImpl.cs
@@ -4,6 +4,10 @@
 using Microsoft.Azure.Management.Compute.Fluent.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using System.Collections.Generic;
+using Microsoft.Azure.Management.Fluent.Resource.Core;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Management.Compute.Fluent
 {
@@ -30,6 +34,13 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         public IEnumerable<IVirtualMachineSku> List()
         {
             return WrapList(innerCollection.ListSkus(offer.Region.Name, offer.Publisher.Name, offer.Name));
+        }
+
+        public async Task<IPagedCollection<IVirtualMachineSku>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IVirtualMachineSku, VirtualMachineImageResourceInner>.LoadPage(
+                async (cancellation) => await innerCollection.ListSkusAsync(offer.Region.Name, offer.Publisher.Name, offer.Name),
+                WrapModel, cancellationToken);
         }
 
         ///GENMHASH:D48BEF4BAC4C0112B6930D731FFC59BD:3D3DBF6D2E250B46C52C216A27E376BA

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineSkusImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineSkusImpl.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         public async Task<IPagedCollection<IVirtualMachineSku>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await PagedCollection<IVirtualMachineSku, VirtualMachineImageResourceInner>.LoadPage(
-                async (cancellation) => await innerCollection.ListSkusAsync(offer.Region.Name, offer.Publisher.Name, offer.Name),
+                async (cancellation) => await innerCollection.ListSkusAsync(offer.Region.Name, offer.Publisher.Name, offer.Name, cancellation),
                 WrapModel, cancellationToken);
         }
 

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachinesImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachinesImpl.cs
@@ -10,13 +10,15 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using Network.Fluent;
     using Storage.Fluent;
     using System.Collections.Generic;
+    using Rest.Azure;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// The implementation for VirtualMachines.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmNvbXB1dGUuaW1wbGVtZW50YXRpb24uVmlydHVhbE1hY2hpbmVzSW1wbA==
     internal partial class VirtualMachinesImpl :
-        GroupableResources<
+        TopLevelModifiableResources<
             IVirtualMachine,
             VirtualMachineImpl,
             VirtualMachineInner,
@@ -41,21 +43,29 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:36E25639805611CF89054C004B22BB15
-        public IEnumerable<IVirtualMachine> List()
+        protected async override Task<IPage<VirtualMachineInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListAll()
-                .AsContinuousCollection(link => Inner.ListAllNext(link)));
+            return await Inner.ListAllAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<VirtualMachineInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListAllNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:3953AC722DFFCDF40E1EEF787AFD1326
-        public IEnumerable<IVirtualMachine> ListByGroup(string groupName)
+        protected async override Task<IPage<VirtualMachineInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List(groupName)
-                .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<VirtualMachineInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
@@ -160,10 +170,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<IVirtualMachine> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<VirtualMachineInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var data = await Inner.GetAsync(groupName, name, null, cancellationToken);
-            return this.WrapModel(data);
+            return await Inner.GetAsync(groupName, name, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/project.json
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/project.json
@@ -36,19 +36,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/ARecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/ARecordSetsImpl.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
 
     /// <summary>
     /// Implementation of ARecordSets.
@@ -17,6 +19,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         IARecordSets
     {
         private DnsZoneImpl dnsZone;
+        private const RecordType ARecordType = RecordType.A;
 
         public async Task<IARecordSet> GetByNameAsync(string name, CancellationToken cancellationToken)
         {
@@ -24,7 +27,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 dnsZone.ResourceGroupName,
                 dnsZone.Name,
                 name,
-                RecordType.A,
+                ARecordType,
                 cancellationToken);
             return new ARecordSetImpl(dnsZone, inner);
         }
@@ -44,7 +47,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         public IEnumerable<IARecordSet> List()
         {
             return WrapList(dnsZone.Manager.Inner.RecordSets
-                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name,RecordType.A)
+                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name, ARecordType)
                 .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
         }
 
@@ -58,6 +61,14 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         protected override IARecordSet WrapModel(RecordSetInner inner)
         {
             return new ARecordSetImpl(dnsZone, inner);
+        }
+
+        public async Task<IPagedCollection<IARecordSet>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IARecordSet, RecordSetInner>.LoadPage(
+                async (cancellation) => await dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName, dnsZone.Name, ARecordType, cancellationToken: cancellation),
+                dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/AaaaRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/AaaaRecordSetsImpl.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
 
     /// <summary>
     /// Implementation of AaaaRecordSets.
@@ -17,6 +19,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         IAaaaRecordSets
     {
         private DnsZoneImpl dnsZone;
+        private const RecordType AaaaRecordType = RecordType.AAAA;
 
         public async Task<IAaaaRecordSet> GetByNameAsync(string name, CancellationToken cancellationToken)
         {
@@ -24,7 +27,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 dnsZone.ResourceGroupName,
                 dnsZone.Name,
                 name,
-                RecordType.AAAA,
+                AaaaRecordType,
                 cancellationToken);
             return new AaaaRecordSetImpl(dnsZone, inner);
         }
@@ -50,7 +53,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         public IEnumerable<IAaaaRecordSet> List()
         {
             return WrapList(dnsZone.Manager.Inner.RecordSets
-                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name,RecordType.AAAA)
+                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name, AaaaRecordType)
                 .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
         }
 
@@ -58,6 +61,14 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         protected override IAaaaRecordSet WrapModel(RecordSetInner inner)
         {
             return new AaaaRecordSetImpl(dnsZone, inner);
+        }
+
+        public async Task<IPagedCollection<IAaaaRecordSet>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IAaaaRecordSet, RecordSetInner>.LoadPage(
+                async (cancellation) => await dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName, dnsZone.Name, AaaaRecordType, cancellationToken: cancellationToken),
+                dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/CnameRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/CnameRecordSetsImpl.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using System.Threading.Tasks;
     using System.Threading;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
 
     /// <summary>
     /// Implementation of CNameRecordSets.
@@ -17,7 +19,8 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ICNameRecordSets
     {
         private DnsZoneImpl dnsZone;
-        
+        private const RecordType CNameRecordType = RecordType.CNAME;
+
         private DnsZoneImpl Parent()
         {
             return dnsZone;
@@ -29,7 +32,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 dnsZone.ResourceGroupName,
                 dnsZone.Name,
                 name,
-                RecordType.CNAME,
+                CNameRecordType,
                 cancellationToken);
             return new CNameRecordSetImpl(dnsZone, inner);
         }
@@ -50,7 +53,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         public IEnumerable<ICNameRecordSet> List()
         {
             return WrapList(dnsZone.Manager.Inner.RecordSets
-                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name,RecordType.CNAME)
+                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name, CNameRecordType)
                 .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
         }
 
@@ -58,6 +61,14 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         protected override ICNameRecordSet WrapModel(RecordSetInner inner)
         {
             return new CNameRecordSetImpl(dnsZone, inner);
+        }
+
+        public async Task<IPagedCollection<ICNameRecordSet>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<ICNameRecordSet, RecordSetInner>.LoadPage(
+                async (cancellation) => await dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName, dnsZone.Name, CNameRecordType, cancellationToken: cancellation),
+                dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/DnsZonesImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/DnsZonesImpl.cs
@@ -7,19 +7,21 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using ResourceManager.Fluent.Core;
     using Models;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// Implementation of DnsZones.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmRucy5pbXBsZW1lbnRhdGlvbi5EbnNab25lc0ltcGw=
     internal partial class DnsZonesImpl  :
-        GroupableResources<IDnsZone, DnsZoneImpl, ZoneInner, IZonesOperations, IDnsZoneManager>,
+        TopLevelModifiableResources<IDnsZone, DnsZoneImpl, ZoneInner, IZonesOperations, IDnsZoneManager>,
         IDnsZones
     {
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:4C6EFF21E5E730775AFD95DC77DDD7F4
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            await Inner.DeleteAsync(groupName, name, null, cancellationToken);
+            await Inner.DeleteAsync(groupName, name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:8ACFB0E23F5F24AD384313679B65F404:6A5AFD43FB6D60947DE42BF4153B3E35
@@ -29,9 +31,9 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<IDnsZone> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<ZoneInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            return WrapModel(await Inner.GetAsync(groupName, name, cancellationToken));
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:6FA0B6DE5CB193A4650CC6B5966DBC04:345CFB0A0B8A514DED6957391B1D99E5
@@ -40,10 +42,14 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:E29BEEAB8CFC79BEFB042BF8EE0AED00
-        public IEnumerable<IDnsZone> List()
+        protected async override Task<IPage<ZoneInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List()
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(cancellationToken: cancellationToken);
+        }
+
+        protected async override Task<IPage<ZoneInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:D57C6EF7B32D03E7098E2D735EEF70BD:4E951CDE0BF14119F1DB863BEC8121A9
@@ -55,10 +61,14 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:B533AA6052ED2EA7F8D7C96A5C95034C
-        public IEnumerable<IDnsZone> ListByGroup(string groupName)
+        protected async override Task<IPage<ZoneInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(groupName)
-                                 .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken: cancellationToken);
+        }
+
+        protected async override Task<IPage<ZoneInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:F388A69B4ED70BD6EEC04A90B7F6BC69

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/MxRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/MxRecordSetsImpl.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
 
     /// <summary>
     /// Implementation of MXRecordSets.
@@ -18,7 +20,8 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         IMXRecordSets
     {
         private DnsZoneImpl dnsZone;
-        
+        private const RecordType MxRecordType = RecordType.MX;
+
         private DnsZoneImpl Parent()
         {
             return dnsZone;
@@ -30,7 +33,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 dnsZone.ResourceGroupName,
                 dnsZone.Name,
                 name,
-                RecordType.MX,
+                MxRecordType,
                 cancellationToken);
             return new MXRecordSetImpl(dnsZone, inner);
         }
@@ -45,7 +48,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         public IEnumerable<IMXRecordSet> List()
         {
             return WrapList(dnsZone.Manager.Inner.RecordSets
-                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name,RecordType.MX)
+                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name, MxRecordType)
                 .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
         }
 
@@ -53,6 +56,14 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         protected override IMXRecordSet WrapModel(RecordSetInner inner)
         {
             return new MXRecordSetImpl(dnsZone, inner);
+        }
+
+        public async Task<IPagedCollection<IMXRecordSet>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IMXRecordSet, RecordSetInner>.LoadPage(
+                async (cancellation) => await dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName, dnsZone.Name, MxRecordType, cancellationToken: cancellation),
+                dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
 
         ///GENMHASH:6F2FBDD481155D6AAAD51709649A57BB:93DD647D9AB0DB30D017785882D88829

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/NsRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/NsRecordSetsImpl.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
 
     /// <summary>
     /// Implementation of NSRecordSets.
@@ -17,6 +19,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         INSRecordSets
     {
         private DnsZoneImpl dnsZone;
+        private const RecordType NSRecordType = RecordType.NS;
 
         private DnsZoneImpl Parent()
         {
@@ -29,7 +32,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 dnsZone.ResourceGroupName,
                 dnsZone.Name,
                 name,
-                RecordType.NS,
+                NSRecordType,
                 cancellationToken);
             return new NSRecordSetImpl(dnsZone, inner);
         }
@@ -50,7 +53,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         public IEnumerable<INSRecordSet> List()
         {
             return WrapList(dnsZone.Manager.Inner.RecordSets
-                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name,RecordType.NS)
+                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name, NSRecordType)
                 .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
         }
 
@@ -58,6 +61,14 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         protected override INSRecordSet WrapModel(RecordSetInner inner)
         {
             return new NSRecordSetImpl(dnsZone, inner);
+        }
+
+        public async Task<IPagedCollection<INSRecordSet>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<INSRecordSet, RecordSetInner>.LoadPage(
+                async (cancellation) => await dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName, dnsZone.Name, NSRecordType, cancellationToken: cancellation),
+                dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/PtrRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/PtrRecordSetsImpl.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using System.Threading.Tasks;
     using System.Threading;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
 
     /// <summary>
     /// Implementation of PtrRecordSets.
@@ -17,6 +19,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         IPtrRecordSets
     {
         private DnsZoneImpl dnsZone;
+        private const RecordType PtrRecordType = RecordType.PTR;
 
         private DnsZoneImpl Parent()
         {
@@ -29,7 +32,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 dnsZone.ResourceGroupName,
                 dnsZone.Name,
                 name,
-                RecordType.PTR,
+                PtrRecordType,
                 cancellationToken);
             return new PtrRecordSetImpl(dnsZone, inner);
         }
@@ -50,7 +53,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         public IEnumerable<IPtrRecordSet> List()
         {
             return WrapList(dnsZone.Manager.Inner.RecordSets
-                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name,RecordType.PTR)
+                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name, PtrRecordType)
                 .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
         }
 
@@ -58,6 +61,14 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         protected override IPtrRecordSet WrapModel(RecordSetInner inner)
         {
             return new PtrRecordSetImpl(dnsZone, inner);
+        }
+
+        public async Task<IPagedCollection<IPtrRecordSet>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IPtrRecordSet, RecordSetInner>.LoadPage(
+                async (cancellation) => await dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName, dnsZone.Name, PtrRecordType, cancellationToken: cancellation),
+                dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/SrvRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/SrvRecordSetsImpl.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
 
     /// <summary>
     /// Implementation of SrvRecordSets.
@@ -17,6 +19,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ISrvRecordSets
     {
         private DnsZoneImpl dnsZone;
+        private const RecordType SrvRecordType = RecordType.SRV;
 
         private DnsZoneImpl Parent()
         {
@@ -29,7 +32,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 dnsZone.ResourceGroupName,
                 dnsZone.Name,
                 name,
-                RecordType.SRV,
+                SrvRecordType,
                 cancellationToken);
             return new SrvRecordSetImpl(dnsZone, inner);
         }
@@ -50,7 +53,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         public IEnumerable<ISrvRecordSet> List()
         {
             return WrapList(dnsZone.Manager.Inner.RecordSets
-                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name,RecordType.SRV)
+                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name, SrvRecordType)
                 .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
         }
 
@@ -58,6 +61,14 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         protected override ISrvRecordSet WrapModel(RecordSetInner inner)
         {
             return new SrvRecordSetImpl(dnsZone, inner);
+        }
+
+        public async Task<IPagedCollection<ISrvRecordSet>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<ISrvRecordSet, RecordSetInner>.LoadPage(
+                async (cancellation) => await dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName, dnsZone.Name, SrvRecordType, cancellationToken: cancellation),
+                dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/TxtRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/TxtRecordSetsImpl.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using System.Threading.Tasks;
     using System.Threading;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System;
 
     /// <summary>
     /// Implementation of TxtRecordSets.
@@ -17,6 +19,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ITxtRecordSets
     {
         private DnsZoneImpl dnsZone;
+        private const RecordType TxtRecordType = RecordType.TXT;
 
         private DnsZoneImpl Parent()
         {
@@ -35,7 +38,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 dnsZone.ResourceGroupName,
                 dnsZone.Name,
                 name,
-                RecordType.TXT,
+                TxtRecordType,
                 cancellationToken);
             return new TxtRecordSetImpl(dnsZone, inner);
         }
@@ -50,7 +53,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         public IEnumerable<ITxtRecordSet> List()
         {
             return WrapList(dnsZone.Manager.Inner.RecordSets
-                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name,RecordType.TXT)
+                .ListByType(dnsZone.ResourceGroupName,dnsZone.Name, TxtRecordType)
                 .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
         }
 
@@ -58,6 +61,14 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         protected override ITxtRecordSet WrapModel(RecordSetInner inner)
         {
             return new TxtRecordSetImpl(dnsZone, inner);
+        }
+
+        public async Task<IPagedCollection<ITxtRecordSet>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<ITxtRecordSet, RecordSetInner>.LoadPage(
+                async (cancellation) => await dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName, dnsZone.Name, TxtRecordType, cancellationToken: cancellation),
+                dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/project.json
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/project.json
@@ -34,19 +34,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/ServicePrincipalsImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/ServicePrincipalsImpl.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// The implementation of ServicePrincipals and its parent interfaces.
@@ -98,6 +99,14 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             {
                 return new ServicePrincipalImpl(spList.FirstOrDefault(), innerCollection);
             }
+        }
+
+        public async Task<IPagedCollection<IServicePrincipal>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IServicePrincipal, ServicePrincipalInner>.LoadPage(
+                async (cancellation) => await innerCollection.ListAsync(cancellationToken: cancellation),
+                innerCollection.ListNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/project.json
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/project.json
@@ -34,19 +34,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/KeyVault/Microsoft.Azure.Management.KeyVault.Fluent/VaultsImpl.cs
+++ b/src/ResourceManagement/KeyVault/Microsoft.Azure.Management.KeyVault.Fluent/VaultsImpl.cs
@@ -10,14 +10,15 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
     using System;
     using System.Threading.Tasks;
     using System.Threading;
-    using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// The implementation of Vaults and its parent interfaces.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmtleXZhdWx0LmltcGxlbWVudGF0aW9uLlZhdWx0c0ltcGw=
     internal partial class VaultsImpl  :
-        GroupableResources<IVault, VaultImpl, VaultInner, IVaultsOperations, IKeyVaultManager>,
+        TopLevelModifiableResources<IVault, VaultImpl, VaultInner, IVaultsOperations, IKeyVaultManager>,
         IVaults
     {
         private IGraphRbacManager graphRbacManager;
@@ -31,49 +32,35 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:6FB4EA69673E1D8A74E1418EB52BB9FE
-        public IEnumerable<IVault> List ()
+        protected async override Task<IPage<VaultInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List()
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(cancellationToken: cancellationToken);
+        }
+
+        protected async override Task<IPage<VaultInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:BDFF4CB61E8A8D975417EA5FC914921A
-        public IEnumerable<IVault> ListByGroup (string groupName)
+        protected async override Task<IPage<VaultInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(groupName)
-                                 .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken: cancellationToken);
         }
 
-        public async Task<IEnumerable<IVault>> ListByGroupAsync(string resourceGroupName, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<IPage<VaultInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
         {
-            var inner = await Inner.ListByResourceGroupAsync(resourceGroupName, cancellationToken: cancellationToken);
-            return WrapList(inner.AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<IVault> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<VaultInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var inner = await Inner.GetAsync(groupName, name, cancellationToken);
-            return WrapModel(inner);
-        }
-
-        public void Delete (string id)
-        {
-            Delete(ResourceUtils.GroupFromResourceId(id), ResourceUtils.NameFromResourceId(id));
-        }
-
-        public void Delete (string groupName, string name)
-        {
-            Inner.Delete(groupName, name);
-        }
-
-        public async Task DeleteAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            await Inner.DeleteAsync(ResourceUtils.GroupFromResourceId(id), ResourceUtils.NameFromResourceId(id), cancellationToken);
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }

--- a/src/ResourceManagement/KeyVault/Microsoft.Azure.Management.KeyVault.Fluent/project.json
+++ b/src/ResourceManagement/KeyVault/Microsoft.Azure.Management.KeyVault.Fluent/project.json
@@ -35,23 +35,12 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "buildOptions": { "define": [ "PORTABLE" ] },
       "dependencies": {
         "NETStandard.Library": "1.6.1"
       }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewaysImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewaysImpl.cs
@@ -7,13 +7,15 @@ namespace Microsoft.Azure.Management.Network.Fluent
     using ResourceManager.Fluent.Core;
     using Models;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// Implementation for ApplicationGateways.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50Lm5ldHdvcmsuaW1wbGVtZW50YXRpb24uQXBwbGljYXRpb25HYXRld2F5c0ltcGw=
     internal partial class ApplicationGatewaysImpl :
-        GroupableResources<IApplicationGateway, ApplicationGatewayImpl, ApplicationGatewayInner, IApplicationGatewaysOperations, INetworkManager>,
+        TopLevelModifiableResources<IApplicationGateway, ApplicationGatewayImpl, ApplicationGatewayInner, IApplicationGatewaysOperations, INetworkManager>,
         IApplicationGateways
     {
 
@@ -24,16 +26,20 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<IApplicationGateway> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<ApplicationGatewayInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var data = await Inner.GetAsync(groupName, name, cancellationToken);
-            return WrapModel(data);
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:36E25639805611CF89054C004B22BB15
-        public IEnumerable<IApplicationGateway> List()
+        protected override async Task<IPage<ApplicationGatewayInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListAll().AsContinuousCollection(link => Inner.ListAllNext(link)));
+            return await Inner.ListAllAsync(cancellationToken);
+        }
+
+        protected override async Task<IPage<ApplicationGatewayInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListAllNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:DB7CDF51E063E00F632236B9A1581DD7:A55F357967E86E32E70097D1F0B4D25E
@@ -43,9 +49,14 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:3953AC722DFFCDF40E1EEF787AFD1326
-        public IEnumerable<IApplicationGateway> ListByGroup(string groupName)
+        protected override async Task<IPage<ApplicationGatewayInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List(groupName).AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(groupName, cancellationToken);
+        }
+
+        protected override async Task<IPage<ApplicationGatewayInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:4FD24066BFA6ACCBA6BCD17F67645E2A
@@ -62,7 +73,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancersImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancersImpl.cs
@@ -7,13 +7,15 @@ namespace Microsoft.Azure.Management.Network.Fluent
     using System.Threading;
     using Models;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// Implementation for LoadBalancers.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50Lm5ldHdvcmsuaW1wbGVtZW50YXRpb24uTG9hZEJhbGFuY2Vyc0ltcGw=
     internal partial class LoadBalancersImpl  :
-        GroupableResources<
+        TopLevelModifiableResources<
             ILoadBalancer,
             LoadBalancerImpl,
             LoadBalancerInner,
@@ -28,17 +30,25 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:36E25639805611CF89054C004B22BB15
-        internal IEnumerable<ILoadBalancer> List ()
+        protected async override Task<IPage<LoadBalancerInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListAll()
-                                 .AsContinuousCollection(link => Inner.ListAllNext(link)));
+            return await Inner.ListAllAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<LoadBalancerInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListAllNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:3953AC722DFFCDF40E1EEF787AFD1326
-        internal IEnumerable<ILoadBalancer> ListByGroup (string groupName)
+        protected async override Task<IPage<LoadBalancerInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List(groupName)
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<LoadBalancerInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:8ACFB0E23F5F24AD384313679B65F404:AD7C28D26EC1F237B93E54AD31899691
@@ -61,16 +71,15 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<ILoadBalancer> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<LoadBalancerInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var data = await Inner.GetAsync(groupName, name, null, cancellationToken);
-            return WrapModel(data);
+            return await Inner.GetAsync(groupName, name, cancellationToken: cancellationToken);
         }
 
         public void Delete(string id)

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkInterfacesImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkInterfacesImpl.cs
@@ -9,13 +9,15 @@ namespace Microsoft.Azure.Management.Network.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// Implementation for NetworkInterfaces.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50Lm5ldHdvcmsuaW1wbGVtZW50YXRpb24uTmV0d29ya0ludGVyZmFjZXNJbXBs
     internal partial class NetworkInterfacesImpl :
-        GroupableResources<
+        TopLevelModifiableResources<
             INetworkInterface,
             NetworkInterfaceImpl,
             NetworkInterfaceInner,
@@ -49,17 +51,25 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:EA49478191CB500D3891D0EDE475C10E
-        internal IEnumerable<INetworkInterface> List()
+        protected async override Task<IPage<NetworkInterfaceInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListAll()
-                                 .AsContinuousCollection(link => Inner.ListAllNext(link)));
+            return await Inner.ListAllAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<NetworkInterfaceInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListAllNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:C8F667C9694115E8E2EC05A78BB18EDD
-        internal IEnumerable<INetworkInterface> ListByGroup(string groupName)
+        protected async override Task<IPage<NetworkInterfaceInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List(groupName)
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<NetworkInterfaceInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:8ACFB0E23F5F24AD384313679B65F404:AD7C28D26EC1F237B93E54AD31899691
@@ -69,16 +79,15 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<INetworkInterface> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<NetworkInterfaceInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var data = await Inner.GetAsync(groupName, name, null, cancellationToken);
-            return WrapModel(data);
+            return await Inner.GetAsync(groupName, name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:CF1C887C1688AB525BA63FD7B4469714:30A2B5D56CBF3A353B0D9EAE1884CE80

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkSecurityGroupsImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkSecurityGroupsImpl.cs
@@ -8,13 +8,15 @@ namespace Microsoft.Azure.Management.Network.Fluent
     using ResourceManager.Fluent.Core;
     using System.Threading;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// Implementation for NetworkSecurityGroups.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50Lm5ldHdvcmsuaW1wbGVtZW50YXRpb24uTmV0d29ya1NlY3VyaXR5R3JvdXBzSW1wbA==
     internal partial class NetworkSecurityGroupsImpl  :
-        GroupableResources<
+        TopLevelModifiableResources<
             INetworkSecurityGroup,
             NetworkSecurityGroupImpl,
             NetworkSecurityGroupInner,
@@ -28,17 +30,25 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:36E25639805611CF89054C004B22BB15
-        internal IEnumerable<INetworkSecurityGroup> List ()
+        protected async override Task<IPage<NetworkSecurityGroupInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListAll()
-                                 .AsContinuousCollection(link => Inner.ListAllNext(link)));
+            return await Inner.ListAllAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<NetworkSecurityGroupInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListAllNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:3953AC722DFFCDF40E1EEF787AFD1326
-        internal IEnumerable<INetworkSecurityGroup> ListByGroup (string groupName)
+        protected async override Task<IPage<NetworkSecurityGroupInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List(groupName)
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<NetworkSecurityGroupInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:8ACFB0E23F5F24AD384313679B65F404:AD7C28D26EC1F237B93E54AD31899691
@@ -76,14 +86,17 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
+            await DeleteInnerByGroupAsync(groupName, name, cancellationToken);
+        }
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
+        {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<INetworkSecurityGroup> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<NetworkSecurityGroupInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var data = await Inner.GetAsync(groupName, name, null, cancellationToken);
-            return WrapModel(data);
+            return await Inner.GetAsync(groupName, name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:270930AE3F3A3D55E769C7D1E06A71C2

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworksImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworksImpl.cs
@@ -3,8 +3,10 @@
 
 namespace Microsoft.Azure.Management.Network.Fluent
 {
+    using Management.Fluent.Resource.Core;
     using Models;
     using ResourceManager.Fluent.Core;
+    using Rest.Azure;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -14,7 +16,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50Lm5ldHdvcmsuaW1wbGVtZW50YXRpb24uTmV0d29ya3NJbXBs
     internal partial class NetworksImpl  :
-        GroupableResources<
+        TopLevelModifiableResources<
             INetwork,
             NetworkImpl,
             VirtualNetworkInner,
@@ -29,17 +31,25 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:36E25639805611CF89054C004B22BB15
-        internal IEnumerable<INetwork> List ()
+        protected async override Task<IPage<VirtualNetworkInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListAll()
-                                 .AsContinuousCollection(link => Inner.ListAllNext(link)));
+            return await Inner.ListAllAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<VirtualNetworkInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListAllNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:3953AC722DFFCDF40E1EEF787AFD1326
-        internal IEnumerable<INetwork> ListByGroup (string groupName)
+        protected async override Task<IPage<VirtualNetworkInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List(groupName)
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<VirtualNetworkInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:8ACFB0E23F5F24AD384313679B65F404:AD7C28D26EC1F237B93E54AD31899691
@@ -49,16 +59,15 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<INetwork> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<VirtualNetworkInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var data = await Inner.GetAsync(groupName, name, null, cancellationToken);
-            return WrapModel(data);
+            return await Inner.GetAsync(groupName, name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:A3374975BF5618E060C608FF1729A058

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/PublicIpAddressesImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/PublicIpAddressesImpl.cs
@@ -9,13 +9,15 @@ namespace Microsoft.Azure.Management.Network.Fluent
     using ResourceManager.Fluent.Core;
     using System.Threading.Tasks;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// Implementation for PublicIPAddresses.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50Lm5ldHdvcmsuaW1wbGVtZW50YXRpb24uUHVibGljSXBBZGRyZXNzZXNJbXBs
     internal partial class PublicIPAddressesImpl :
-        GroupableResources<
+        TopLevelModifiableResources<
             IPublicIPAddress,
             PublicIPAddressImpl,
             PublicIPAddressInner,
@@ -51,17 +53,25 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:36E25639805611CF89054C004B22BB15
-        internal IEnumerable<IPublicIPAddress> List()
+        protected async override Task<IPage<PublicIPAddressInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListAll()
-                                 .AsContinuousCollection(link => Inner.ListAllNext(link)));
+            return await Inner.ListAllAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<PublicIPAddressInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListAllNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:3953AC722DFFCDF40E1EEF787AFD1326
-        internal IEnumerable<IPublicIPAddress> ListByGroup(string groupName)
+        protected async override Task<IPage<PublicIPAddressInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List(groupName)
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<PublicIPAddressInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:8ACFB0E23F5F24AD384313679B65F404:AD7C28D26EC1F237B93E54AD31899691
@@ -71,16 +81,15 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<IPublicIPAddress> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<PublicIPAddressInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var data = await Inner.GetAsync(groupName, name, null, cancellationToken);
-            return WrapModel(data);
+            return await Inner.GetAsync(groupName, name, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/RouteTablesImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/RouteTablesImpl.cs
@@ -8,18 +8,20 @@ namespace Microsoft.Azure.Management.Network.Fluent
     using ResourceManager.Fluent.Core;
     using Models;
     using System.Collections.Generic;
+    using Rest.Azure;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// Implementation for RouteTables.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50Lm5ldHdvcmsuaW1wbGVtZW50YXRpb24uUm91dGVUYWJsZXNJbXBs
     internal partial class RouteTablesImpl :
-        GroupableResources<IRouteTable, RouteTableImpl, RouteTableInner, IRouteTablesOperations, INetworkManager>,
+        TopLevelModifiableResources<IRouteTable, RouteTableImpl, RouteTableInner, IRouteTablesOperations, INetworkManager>,
         IRouteTables
     {
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
@@ -36,22 +38,31 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<IRouteTable> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<RouteTableInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var data = await Inner.GetAsync(groupName, name, null, cancellationToken);
-            return WrapModel(data);
+            return await Inner.GetAsync(groupName, name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:36E25639805611CF89054C004B22BB15
-        public IEnumerable<IRouteTable> List()
+        protected async override Task<IPage<RouteTableInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListAll().AsContinuousCollection(link => Inner.ListAllNext(link)));
+            return await Inner.ListAllAsync(cancellationToken);
+        }
+
+        protected async override Task<IPage<RouteTableInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListAllNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:3953AC722DFFCDF40E1EEF787AFD1326
-        public IEnumerable<IRouteTable> ListByGroup(string groupName)
+        protected async override Task<IPage<RouteTableInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List(groupName).AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<RouteTableInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:38805A03589651CF73316E5DDCC06E90

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/VirtualMachineScaleSetNetworkInterfacesImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/VirtualMachineScaleSetNetworkInterfacesImpl.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
     using Models;
     using ResourceManager.Fluent.Core;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     internal partial class VirtualMachineScaleSetNetworkInterfacesImpl :
         ReadableWrappers<IVirtualMachineScaleSetNetworkInterface,
@@ -80,6 +83,14 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 resourceGroupName,
                 inner,
                 networkManager);
+        }
+
+        public async Task<IPagedCollection<IVirtualMachineScaleSetNetworkInterface>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IVirtualMachineScaleSetNetworkInterface, NetworkInterfaceInner>.LoadPage(
+                async (cancellation) => await Manager.Inner.NetworkInterfaces.ListVirtualMachineScaleSetNetworkInterfacesAsync(resourceGroupName, scaleSetName, cancellation),
+                Manager.Inner.NetworkInterfaces.ListVirtualMachineScaleSetNetworkInterfacesNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/project.json
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/project.json
@@ -34,19 +34,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent/RedisCachesImpl.cs
+++ b/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent/RedisCachesImpl.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.Redis.Fluent
 {
+    using Management.Fluent.Resource.Core;
     using Microsoft.Azure.Management.Redis.Fluent.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+    using Rest.Azure;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -13,7 +15,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnJlZGlzLmltcGxlbWVudGF0aW9uLlJlZGlzQ2FjaGVzSW1wbA==
     internal partial class RedisCachesImpl :
-        GroupableResources<IRedisCache,
+        TopLevelModifiableResources<IRedisCache,
             RedisCacheImpl,
             RedisResourceInner,
             IRedisOperations,
@@ -21,7 +23,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
         IRedisCaches
     {
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
@@ -39,24 +41,32 @@ namespace Microsoft.Azure.Management.Redis.Fluent
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<IRedisCache> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<RedisResourceInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var RedisResourceInner = await Inner.GetAsync(groupName, name, cancellationToken);
-            return WrapModel(RedisResourceInner);
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:6FB4EA69673E1D8A74E1418EB52BB9FE
-        public IEnumerable<IRedisCache> List()
+        protected async override Task<IPage<RedisResourceInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List()
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(cancellationToken);
         }
 
-        ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:BDFF4CB61E8A8D975417EA5FC914921A
-        public IEnumerable<IRedisCache> ListByGroup(string groupName)
+        protected async override Task<IPage<RedisResourceInner>>ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(groupName)
-                                 .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
+        }
+
+
+        ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:BDFF4CB61E8A8D975417EA5FC914921A
+        protected async override Task<IPage<RedisResourceInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<RedisResourceInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:4A5A2A1EDBB98E8843A388EEBC9C31D6

--- a/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent/project.json
+++ b/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent/project.json
@@ -34,19 +34,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/GroupableResources.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/GroupableResources.cs
@@ -34,7 +34,14 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         #region Implementation of ISupportsGettingByGroup interface
 
-        public abstract Task<IFluentResourceT> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken);
+        protected abstract Task<InnerResourceT> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken);
+
+
+        public virtual async Task<IFluentResourceT> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
+        {
+            return WrapModel(await this.GetInnerByGroupAsync(groupName, name, cancellationToken));
+        }
+
 
         public IFluentResourceT GetByGroup(string groupName, string name)
         {
@@ -63,7 +70,12 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         #region Implementation of ISupportsDeletingByGroup interface
 
-        public abstract Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken));
+        protected abstract Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken);
+
+        public virtual async Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await this.DeleteInnerByGroupAsync(groupName, name, cancellationToken);
+        }
 
         public void DeleteByGroup(string groupName, string name)
         {

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/IPagedCollection.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/IPagedCollection.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Management.Fluent.Resource.Core
+{
+    public interface IPagedCollection<T> : IEnumerable<T>
+    {
+        Task<IPagedCollection<T>> GetNextPageAsync(CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/TopLevelModifiableResources.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/TopLevelModifiableResources.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
+using Microsoft.Rest.Azure;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Microsoft.Azure.Management.Fluent.Resource.Core
+{
+    public abstract class TopLevelModifiableResources<IFluentResourceT, FluentResourceT, InnerResourceT, InnerCollectionT, ManagerT> :
+        GroupableResources<IFluentResourceT, FluentResourceT, InnerResourceT, InnerCollectionT, ManagerT>,
+        ISupportsGettingById<IFluentResourceT>,
+        ISupportsGettingByGroup<IFluentResourceT>,
+        ISupportsDeletingByGroup,
+        IHasManager<ManagerT>,
+        ISupportsListing<IFluentResourceT>,
+        ISupportsListingByGroup<IFluentResourceT>,
+        IHasInner<InnerCollectionT>
+        where IFluentResourceT : class, IGroupableResource<ManagerT, InnerResourceT>
+        where FluentResourceT : IFluentResourceT
+        where ManagerT : IManagerBase
+    {
+        public TopLevelModifiableResources(InnerCollectionT innerCollection, ManagerT manager) : base(innerCollection, manager)
+        {
+        }
+
+        public virtual IEnumerable<IFluentResourceT> List()
+        {
+            return WrapList(this.ListInnerAsync(default(CancellationToken)).GetAwaiter().GetResult().AsContinuousCollection(link => ListInnerNextAsync(link, default(CancellationToken)).GetAwaiter().GetResult()));
+        }
+
+        public virtual IEnumerable<IFluentResourceT> ListByGroup(string resourceGroupName)
+        {
+            return WrapList(this.ListInnerByGroupAsync(resourceGroupName, default(CancellationToken)).GetAwaiter().GetResult().AsContinuousCollection(link => ListInnerByGroupNextAsync(link, default(CancellationToken)).GetAwaiter().GetResult()));
+        }
+
+        public virtual async Task<IPagedCollection<IFluentResourceT>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IFluentResourceT, InnerResourceT>.LoadPage(ListInnerAsync, ListInnerNextAsync, WrapModel, loadAllPages, cancellationToken);
+        }
+
+        public virtual async Task<IPagedCollection<IFluentResourceT>> ListByGroupAsync(string resourceGroupName, bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IFluentResourceT, InnerResourceT>.LoadPage(
+                async(cancellation) => await ListInnerByGroupAsync(resourceGroupName, cancellation),
+                ListInnerByGroupNextAsync, WrapModel, loadAllPages, cancellationToken);
+        }
+
+        protected abstract Task<IPage<InnerResourceT>> ListInnerAsync(CancellationToken cancellationToken);
+
+        protected abstract Task<IPage<InnerResourceT>> ListInnerNextAsync(string link, CancellationToken cancellationToken);
+
+        protected abstract Task<IPage<InnerResourceT>> ListInnerByGroupAsync(string resourceGroupName, CancellationToken cancellationToken);
+
+        protected abstract Task<IPage<InnerResourceT>> ListInnerByGroupNextAsync(string link, CancellationToken cancellationToken);
+
+        protected static IPage<InnerResourceT> ConvertToPage(IEnumerable<InnerResourceT> list)
+        {
+            return Utilities.ConvertToPage(list);
+        }
+    }
+}

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/Utilities.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/Utilities.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Management.ResourceManager.Fluent.Models;
+using Microsoft.Rest.Azure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Management.Fluent.Resource.Core
+{
+    public class Utilities
+    {
+        public static IPage<InnerResourceT> ConvertToPage<InnerResourceT>(IEnumerable<InnerResourceT> list)
+        {
+            var page = new Page<InnerResourceT>();
+            typeof(Page<InnerResourceT>).GetProperty("Items", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(page, list.ToList());
+
+            return page;
+        }
+    }
+}

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsListing.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsListing.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information. 
 
+using Microsoft.Azure.Management.Fluent.Resource.Core;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions
 {
@@ -19,5 +22,11 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActio
         /// </summary>
         /// <returns>list of resources</returns>
         IEnumerable<T> List ();
+
+        /// <summary>
+        /// Lists all the resources of the specified type in the currently selected subscription.
+        /// </summary>
+        /// <returns>list of resources</returns>
+        Task<IPagedCollection<T>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsListingByGroup.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsListingByGroup.cs
@@ -3,7 +3,10 @@
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions
 {
+    using Management.Fluent.Resource.Core;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Provides access to listing Azure resources of a specific type in a specific resource group.
@@ -20,5 +23,12 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActio
         /// <param name="resourceGroupName">resourceGroupName the name of the resource group to list the resources from</param>
         /// <returns>the list of resources</returns>
         IEnumerable<T> ListByGroup (string resourceGroupName);
+
+        /// <summary>
+        /// Lists resources of the specified type in the specified resource group.
+        /// </summary>
+        /// <param name="resourceGroupName">resourceGroupName the name of the resource group to list the resources from</param>
+        /// <returns>the list of resources</returns>
+        Task<IPagedCollection<T>> ListByGroupAsync(string resourceGroupName, bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsListingByParent.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsListingByParent.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions
 {
+    using Management.Fluent.Resource.Core;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using System.Collections.Generic;
     using System.Threading;
@@ -29,7 +30,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActio
         /// <param name="resourceGroupName">The name of the resource group to list the resources from.</param>
         /// <param name="parentName">The name of parent resource.</param>
         /// <return>The list of resources.</return>
-        Task<IEnumerable<T>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken));
+        Task<IPagedCollection<T>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Gets the information about a resource from Azure based on the resource id.
@@ -43,6 +44,6 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActio
         /// </summary>
         /// <param name="parentResource">The instance of parent resource.</param>
         /// <return>An immutable representation of the resource.</return>
-        Task<IEnumerable<T>> ListByParentAsync(ParentT parentResource, CancellationToken cancellationToken = default(CancellationToken));
+        Task<IPagedCollection<T>> ListByParentAsync(ParentT parentResource, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Feature/FeaturesImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Feature/FeaturesImpl.cs
@@ -6,6 +6,10 @@ using Microsoft.Azure.Management.ResourceManager.Fluent.Models;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+using Microsoft.Azure.Management.Fluent.Resource.Core;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent
 {
@@ -23,6 +27,14 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
             return client.ListAll()
                          .AsContinuousCollection(link => client.ListNext(link))
                          .Select(inner => WrapModel(inner));
+        }
+
+        public async Task<IPagedCollection<IFeature>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IFeature, FeatureResultInner>.LoadPage(
+                async(cancellation) => await client.ListAllAsync(cancellation),
+                client.ListNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
 
         public IInResourceProvider ResourceProvider(string resourceProviderName)

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/GenericResource/GenericResourcesImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/GenericResource/GenericResourcesImpl.cs
@@ -10,10 +10,11 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Management.Fluent.Resource.Core;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent
 {
-    internal class GenericResourcesImpl : 
+    internal class GenericResourcesImpl :
         GroupableResources<IGenericResource, GenericResourceImpl, GenericResourceInner, IResourcesOperations, IResourceManager>,
         IGenericResources
     {
@@ -71,7 +72,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
             return resource;
         }
 
-        public override Task<IGenericResource> GetByGroupAsync(string groupName, string name, CancellationToken cancellation = default(CancellationToken))
+        protected override Task<GenericResourceInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellation)
         {
             throw new NotSupportedException("Get just by resource group and name is not supported. Please use other overloads.");
         }
@@ -80,11 +81,6 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         {
             return WrapList(Inner.List()
                                  .AsContinuousCollection(link => Inner.ListNext(link)));
-        }
-
-        public Task<IEnumerable<IGenericResource>> ListByGroupAsync(string resourceGroupName, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            throw new NotSupportedException();
         }
 
         public void MoveResources(string sourceResourceGroupName, IResourceGroup targetResourceGroup, IList<string> resources)
@@ -119,9 +115,16 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
             return model;
         }
 
-        public override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             throw new NotSupportedException("Delete just by resource group and name is not supported. Please use other overloads.");
+        }
+
+        public async Task<IPagedCollection<IGenericResource>> ListByGroupAsync(string resourceGroupName, bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IGenericResource, GenericResourceInner>.LoadPage(
+                async (cancellation) => await Inner.ListAsync(cancellationToken: cancellation),
+                Inner.ListNextAsync, WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/IndependentChildrenImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/IndependentChildrenImpl.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
     using System.Threading.Tasks;
     using System;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnJlc291cmNlcy5mbHVlbnRjb3JlLmFybS5jb2xsZWN0aW9uLmltcGxlbWVudGF0aW9uLkluZGVwZW5kZW50Q2hpbGRyZW5JbXBs
@@ -91,7 +92,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
             return ListByParentAsync(resourceGroupName, parentName).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        public async Task<IEnumerable<T>> ListByParentAsync(ParentT parentResource, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IPagedCollection<T>> ListByParentAsync(ParentT parentResource, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await ListByParentAsync(parentResource.ResourceGroupName, parentResource.Name, cancellationToken);
         }
@@ -117,7 +118,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         public abstract Task<T> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken));
 
-        public abstract Task<IEnumerable<T>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken));
+        public abstract Task<IPagedCollection<T>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken));
 
         public abstract Task DeleteByParentAsync(string groupName, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken));
     }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Provider/ProvidersImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Provider/ProvidersImpl.cs
@@ -8,6 +8,8 @@ using Microsoft.Azure.Management.ResourceManager.Fluent.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Azure.Management.Fluent.Resource.Core;
+using System;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent
 {
@@ -27,7 +29,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public async Task<IProvider> GetByNameAsync(string resourceProviderNamespace, CancellationToken cancellationToken = default(CancellationToken))
         {
-            ProviderInner inner = await client.GetAsync(resourceProviderNamespace, null, cancellationToken);
+            ProviderInner inner = await client.GetAsync(resourceProviderNamespace, cancellationToken: cancellationToken);
             return new ProviderImpl(inner);
         }
 
@@ -36,6 +38,14 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
             return client.List()
                          .AsContinuousCollection(link => client.ListNext(link))
                          .Select(inner => WrapModel(inner));
+        }
+
+        public async Task<IPagedCollection<IProvider>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IProvider, ProviderInner>.LoadPage(
+                async (cancellation) => await client.ListAsync(cancellationToken: cancellation),
+                client.ListNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
 
         public IProvider Register(string resourceProviderNamespace)

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceGroup/ResourceGroupImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceGroup/ResourceGroupImpl.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
             ResourceGroupInner param = new ResourceGroupInner();
             param.Location = Inner.Location;
             param.Tags = Inner.Tags;
-            var response = await client.CreateOrUpdateWithHttpMessagesAsync(Name, param, null, cancellationToken);
+            var response = await client.CreateOrUpdateWithHttpMessagesAsync(Name, param, cancellationToken: cancellationToken);
             SetInner(response.Body);
             return this;
         }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceGroup/ResourceGroupsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceGroup/ResourceGroupsImpl.cs
@@ -8,6 +8,8 @@ using Microsoft.Rest.Azure;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using System.Collections.Generic;
+using Microsoft.Azure.Management.Fluent.Resource.Core;
+using System;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent
 {
@@ -82,6 +84,14 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         protected override IResourceGroup WrapModel(ResourceGroupInner inner)
         {
             return new ResourceGroupImpl(inner, Inner);
+        }
+
+        public async Task<IPagedCollection<IResourceGroup>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IResourceGroup, ResourceGroupInner>.LoadPage(
+                async (cancellation) => await Inner.ListAsync(cancellationToken: cancellationToken),
+                Inner.ListNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Subscription/SubscriptionsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Subscription/SubscriptionsImpl.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Azure.Management.Fluent.Resource.Core;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent
 {
@@ -51,6 +52,14 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         private ISubscription WrapModel(SubscriptionInner innerModel)
         {
             return new SubscriptionImpl(innerModel, innerCollection);
+        }
+
+        public async Task<IPagedCollection<ISubscription>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<ISubscription, SubscriptionInner>.LoadPage(
+                async (cancellation) => await innerCollection.ListAsync(cancellation),
+                innerCollection.ListNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Tenant/TenantsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Tenant/TenantsImpl.cs
@@ -8,6 +8,10 @@ using Microsoft.Azure.Management.ResourceManager.Fluent.Models;
 using Microsoft.Rest.Azure;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Azure.Management.Fluent.Resource.Core;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent
 {
@@ -18,6 +22,14 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         internal TenantsImpl(ITenantsOperations client)
         {
             this.innerCollection = client;
+        }
+
+        public async Task<IPagedCollection<ITenant>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<ITenant, TenantIdDescription>.LoadPage(
+                async (cancellation) => await innerCollection.ListAsync(cancellation),
+                innerCollection.ListNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
         }
 
         IEnumerable<ITenant> ISupportsListing<ITenant>.List()

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/project.json
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/project.json
@@ -34,24 +34,15 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],
       "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
+        "NETStandard.Library": "1.6.1",
+        "System.Reflection.TypeExtensions": "4.3.0"
       }
     }
   }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceAuthorizationRulesImpl.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.Servicebus.Fluent
 {
+    using Management.Fluent.Resource.Core;
     using Management.Fluent.ServiceBus;
     using Management.Fluent.ServiceBus.Models;
     using ResourceManager.Fluent.Core;
@@ -99,7 +100,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:21EB605E5FAA6C13D208A1A4CE8C136D:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<IEnumerable<INamespaceAuthorizationRule>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<IPagedCollection<INamespaceAuthorizationRule>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueAuthorizationRulesImpl.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     using System;
     using Rest.Azure;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// Implementation for QueueAuthorizationRules.
@@ -108,7 +109,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:21EB605E5FAA6C13D208A1A4CE8C136D:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<IEnumerable<IQueueAuthorizationRule>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<IPagedCollection<IQueueAuthorizationRule>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueuesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueuesImpl.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     using System;
     using Rest.Azure;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// Implementation for Queues.
@@ -96,7 +97,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:21EB605E5FAA6C13D208A1A4CE8C136D:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<IEnumerable<IQueue>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<IPagedCollection<IQueue>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespacesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespacesImpl.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.Servicebus.Fluent
 {
+    using Management.Fluent.Resource.Core;
     using Management.Fluent.ServiceBus;
     using Management.Fluent.ServiceBus.Models;
     using ResourceManager.Fluent.Core;
+    using Rest.Azure;
     using ServiceBus.Fluent;
     using System.Collections.Generic;
     using System.Threading;
@@ -15,7 +17,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNlcnZpY2VidXMuaW1wbGVtZW50YXRpb24uU2VydmljZUJ1c05hbWVzcGFjZXNJbXBs
     internal partial class ServiceBusNamespacesImpl  :
-        GroupableResources<IServiceBusNamespace,
+        TopLevelModifiableResources<IServiceBusNamespace,
             ServiceBusNamespaceImpl, 
             NamespaceModelInner,
             INamespacesOperations,
@@ -27,13 +29,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         {
         }
 
-        public async override Task<IServiceBusNamespace> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<NamespaceModelInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            var data = await this.Inner.GetAsync(groupName, name, cancellationToken);
-            return this.WrapModel(data);
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
@@ -73,16 +74,24 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
                 this.Manager);
         }
 
-        public IEnumerable<IServiceBusNamespace> List()
+        protected async override Task<IPage<NamespaceModelInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List()
-                                 .AsContinuousCollection(link => Inner.ListNext(link)));
+            return await Inner.ListAsync(cancellationToken);
         }
 
-        public IEnumerable<IServiceBusNamespace> ListByGroup(string resourceGroupName)
+        protected async override Task<IPage<NamespaceModelInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(resourceGroupName)
-                                 .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return await Inner.ListNextAsync(nextLink, cancellationToken);
+        }
+
+        protected async override Task<IPage<NamespaceModelInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupAsync(groupName, cancellationToken);
+        }
+
+        protected async override Task<IPage<NamespaceModelInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Inner.ListByResourceGroupNextAsync(nextLink, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionsImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionsImpl.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     using ResourceManager.Fluent.Core;
     using System;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// Implementation for Subscriptions.
@@ -107,7 +108,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:21EB605E5FAA6C13D208A1A4CE8C136D:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<IEnumerable<ISubscription>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<IPagedCollection<ISubscription>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicAuthorizationRulesImpl.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.Servicebus.Fluent
 {
+    using Management.Fluent.Resource.Core;
     using Management.Fluent.ServiceBus;
     using Management.Fluent.ServiceBus.Models;
     using ResourceManager.Fluent.Core;
@@ -106,7 +107,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:21EB605E5FAA6C13D208A1A4CE8C136D:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<IEnumerable<ITopicAuthorizationRule>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<IPagedCollection<ITopicAuthorizationRule>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicsImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicsImpl.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     using Rest.Azure;
     using System;
     using System.Collections.Generic;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// Implementation for Topics.
@@ -94,7 +95,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:21EB605E5FAA6C13D208A1A4CE8C136D:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<IEnumerable<ITopic>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<IPagedCollection<ITopic>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/project.json
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/project.json
@@ -34,19 +34,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlDatabasesImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlDatabasesImpl.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// Implementation for SQLDatabases and its parent interfaces.
@@ -42,10 +43,11 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:21EB605E5FAA6C13D208A1A4CE8C136D:7F70CB1AA5FE23578E360B95D229A1C6
-        public async override Task<IEnumerable<ISqlDatabase>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
+        public async override Task<IPagedCollection<ISqlDatabase>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var pagedList = await Inner.ListByServerAsync(resourceGroupName, parentName, cancellationToken);
-            return WrapList(pagedList);
+            return await PagedCollection<ISqlDatabase, DatabaseInner>.LoadPage(
+                async (cancellation) => await Inner.ListByServerAsync(resourceGroupName, parentName, cancellation),
+                WrapModel, cancellationToken);
         }
 
         ///GENMHASH:03C6F391A16F96A5127D98827B5423FA:877F7B73190881879934925547D57EAF
@@ -81,7 +83,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:C32C5A59EBD92E91959156A49A8C1A95:36E87C79062474D6AB62B46DAD7396F9
         public async override Task<ISqlDatabase> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return WrapModel(await Inner.GetAsync(resourceGroup, parentName, name, null, cancellationToken));
+            return WrapModel(await Inner.GetAsync(resourceGroup, parentName, name, cancellationToken: cancellationToken));
         }
 
         ///GENMHASH:8ACFB0E23F5F24AD384313679B65F404:AD7C28D26EC1F237B93E54AD31899691

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlElasticPoolsImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlElasticPoolsImpl.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// Implementation for SQLElasticPools and its parent interfaces.
@@ -44,9 +45,11 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:21EB605E5FAA6C13D208A1A4CE8C136D:7F70CB1AA5FE23578E360B95D229A1C6
-        public async override Task<IEnumerable<ISqlElasticPool>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
+        public async override Task<IPagedCollection<ISqlElasticPool>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return WrapList(await Inner.ListByServerAsync(resourceGroupName, parentName, cancellationToken));
+            return await PagedCollection<ISqlElasticPool, ElasticPoolInner>.LoadPage(
+                async (cancellation) => await Inner.ListByServerAsync(resourceGroupName, parentName, cancellation),
+                WrapModel, cancellationToken);
         }
 
         ///GENMHASH:03C6F391A16F96A5127D98827B5423FA:877F7B73190881879934925547D57EAF

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlFirewallRulesImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlFirewallRulesImpl.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// Implementation for SQLElasticPools and its parent interfaces.
@@ -42,9 +43,11 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:21EB605E5FAA6C13D208A1A4CE8C136D:67032F38ECA8CBB405D18A2581390A32
-        public async override Task<IEnumerable<ISqlFirewallRule>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
+        public async override Task<IPagedCollection<ISqlFirewallRule>> ListByParentAsync(string resourceGroupName, string parentName, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return WrapList(await Inner.ListFirewallRulesAsync(resourceGroupName, parentName, cancellationToken));
+            return await PagedCollection<ISqlFirewallRule, ServerFirewallRuleInner>.LoadPage(
+                async (cancellation) => await Inner.ListFirewallRulesAsync(resourceGroupName, parentName, cancellation),
+                WrapModel, cancellationToken);
         }
 
         ///GENMHASH:03C6F391A16F96A5127D98827B5423FA:877F7B73190881879934925547D57EAF

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlServersImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlServersImpl.cs
@@ -8,13 +8,15 @@ namespace Microsoft.Azure.Management.Sql.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using System.Collections.Generic;
+    using Rest.Azure;
+    using Management.Fluent.Resource.Core;
 
     /// <summary>
     /// Implementation for SqlServers and its parent interfaces.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNxbC5pbXBsZW1lbnRhdGlvbi5TcWxTZXJ2ZXJzSW1wbA==
     internal partial class SqlServersImpl :
-        GroupableResources<ISqlServer, SqlServerImpl, ServerInner, IServersOperations, ISqlManager>,
+        TopLevelModifiableResources<ISqlServer, SqlServerImpl, ServerInner, IServersOperations, ISqlManager>,
         ISqlServers
     {
         ///GENMHASH:01C0FA69267690E3BF39F794FC8D1F05:9CCC9CA468F37F7150A173588C172C02
@@ -24,7 +26,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
@@ -36,15 +38,20 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:92EAC0C15F6E0EE83B7B356CD097B0A0
-        public async override Task<ISqlServer> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<ServerInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            return WrapModel(await Inner.GetByResourceGroupAsync(groupName, name, cancellationToken));
+            return await Inner.GetByResourceGroupAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:6FB4EA69673E1D8A74E1418EB52BB9FE
-        public IEnumerable<ISqlServer> List()
+        protected async override Task<IPage<ServerInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List());
+            return ConvertToPage(await Inner.ListAsync(cancellationToken));
+        }
+
+        protected async override Task<IPage<ServerInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult<IPage<ServerInner>>(null);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:4400109B5DDC2A92920D8D598AB5D8B9
@@ -73,9 +80,14 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:F27988875BD81EE531DA23D26C675612
-        public IEnumerable<ISqlServer> ListByGroup(string resourceGroupName)
+        protected async override Task<IPage<ServerInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListByResourceGroup(resourceGroupName));
+            return ConvertToPage(await Inner.ListByResourceGroupAsync(groupName, cancellationToken));
+        }
+
+        protected async override Task<IPage<ServerInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult<IPage<ServerInner>>(null);
         }
     }
 }

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/project.json
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/project.json
@@ -34,19 +34,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/Storage/Microsoft.Azure.Management.Storage.Fluent/StorageAccount/StorageAccountsImpl.cs
+++ b/src/ResourceManagement/Storage/Microsoft.Azure.Management.Storage.Fluent/StorageAccount/StorageAccountsImpl.cs
@@ -8,11 +8,13 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Rest.Azure;
+using Microsoft.Azure.Management.Fluent.Resource.Core;
 
 namespace Microsoft.Azure.Management.Storage.Fluent
 {
     internal class StorageAccountsImpl :
-        GroupableResources<
+        TopLevelModifiableResources<
                 IStorageAccount,
                 StorageAccountImpl,
                 StorageAccountInner,
@@ -35,33 +37,37 @@ namespace Microsoft.Azure.Management.Storage.Fluent
                    .WithGeneralPurposeAccountKind();
             return wrapped;
         }
-        
-        public IEnumerable<IStorageAccount> List()
+
+        protected async override Task<IPage<StorageAccountInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.List());
-        }
-        
-        public IEnumerable<IStorageAccount> ListByGroup(string groupName)
-        {
-            return WrapList(Inner.ListByResourceGroup(groupName));
+            return ConvertToPage(await Inner.ListAsync(cancellationToken));
         }
 
-        public Task<IEnumerable<IStorageAccount>> ListByGroupAsync(string resourceGroupName, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<IPage<StorageAccountInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
         {
-            throw new NotSupportedException();
+            return await Task.FromResult<IPage<StorageAccountInner>>(null);
         }
-        
-        public async override Task<IStorageAccount> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+
+        protected async override Task<IPage<StorageAccountInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            var storageAccount = await Inner.GetPropertiesAsync(groupName, name, cancellationToken);
-            return WrapModel(storageAccount);
+            return ConvertToPage(await Inner.ListByResourceGroupAsync(groupName, cancellationToken));
         }
-        
-        public async override Task DeleteByGroupAsync(string resourceGroupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+
+        protected async override Task<IPage<StorageAccountInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
         {
-            await Inner.DeleteAsync(resourceGroupName, name, cancellationToken);
+            return await Task.FromResult<IPage<StorageAccountInner>>(null);
         }
-        
+
+        protected async override Task<StorageAccountInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
+        {
+            return await Inner.GetPropertiesAsync(groupName, name, cancellationToken);
+        }
+
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
+        {
+            await Inner.DeleteAsync(groupName, name, cancellationToken);
+        }
+
         protected override IStorageAccount WrapModel(StorageAccountInner inner)
         {
             return new StorageAccountImpl(inner.Name, inner, Manager);

--- a/src/ResourceManagement/Storage/Microsoft.Azure.Management.Storage.Fluent/Usage/UsagesImpl.cs
+++ b/src/ResourceManagement/Storage/Microsoft.Azure.Management.Storage.Fluent/Usage/UsagesImpl.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.Management.Storage.Fluent;
 using Microsoft.Azure.Management.Storage.Fluent.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using System.Collections.Generic;
+using Microsoft.Azure.Management.Fluent.Resource.Core;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Rest.Azure;
 
 namespace Microsoft.Azure.Management.Storage.Fluent
 {
@@ -25,6 +28,11 @@ namespace Microsoft.Azure.Management.Storage.Fluent
                 return new List<IStorageUsage>();
             }
             return WrapList(client.List());
+        }
+
+        public async Task<IPagedCollection<IStorageUsage>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IStorageUsage, Usage>.LoadPage(client.ListAsync, WrapModel, cancellationToken);
         }
 
         protected override IStorageUsage WrapModel(Usage inner)

--- a/src/ResourceManagement/Storage/Microsoft.Azure.Management.Storage.Fluent/project.json
+++ b/src/ResourceManagement/Storage/Microsoft.Azure.Management.Storage.Fluent/project.json
@@ -34,19 +34,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],

--- a/src/ResourceManagement/TrafficManager/Microsoft.Azure.Management.TrafficManager.Fluent/TrafficManagerProfilesImpl.cs
+++ b/src/ResourceManagement/TrafficManager/Microsoft.Azure.Management.TrafficManager.Fluent/TrafficManagerProfilesImpl.cs
@@ -7,13 +7,15 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
     using System.Threading;
     using System.Collections.Generic;
     using Models;
+    using Management.Fluent.Resource.Core;
+    using Rest.Azure;
 
     /// <summary>
     /// Implementation for TrafficManagerProfiles.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnRyYWZmaWNtYW5hZ2VyLmltcGxlbWVudGF0aW9uLlRyYWZmaWNNYW5hZ2VyUHJvZmlsZXNJbXBs
     internal partial class TrafficManagerProfilesImpl  :
-        GroupableResources<ITrafficManagerProfile, TrafficManagerProfileImpl, ProfileInner, IProfilesOperations, ITrafficManager>,
+        TopLevelModifiableResources<ITrafficManagerProfile, TrafficManagerProfileImpl, ProfileInner, IProfilesOperations, ITrafficManager>,
         ITrafficManagerProfiles
     {
         ///GENMHASH:84B6E84F790DD3CF43388254CEEE3609:519A2844AD55FAC6990427C640AC9D4B
@@ -22,7 +24,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
         }
 
         ///GENMHASH:0679DF8CA692D1AC80FC21655835E678:B9B028D620AC932FDF66D2783E476B0D
-        public async override Task DeleteByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task DeleteInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
             await Inner.DeleteAsync(groupName, name, cancellationToken);
         }
@@ -41,16 +43,20 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
         }
 
         ///GENMHASH:AB63F782DA5B8D22523A284DAD664D17:7C0A1D0C3FE28C45F35B565F4AFF751D
-        public async override Task<ITrafficManagerProfile> GetByGroupAsync(string groupName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<ProfileInner> GetInnerByGroupAsync(string groupName, string name, CancellationToken cancellationToken)
         {
-            ProfileInner profileInner = await Inner.GetAsync(groupName, name, cancellationToken);
-            return WrapModel(profileInner);
+            return await Inner.GetAsync(groupName, name, cancellationToken);
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:36E25639805611CF89054C004B22BB15
-        public IEnumerable<ITrafficManagerProfile> List()
+        protected async override Task<IPage<ProfileInner>> ListInnerAsync(CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListAll());
+            return ConvertToPage(await Inner.ListAllAsync(cancellationToken));
+        }
+
+        protected async override Task<IPage<ProfileInner>> ListInnerNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult<IPage<ProfileInner>>(null);
         }
 
         ///GENMHASH:ADB150394F552772047E309EF2616501:6EFED76EB6275BD09D4B902BEDDF03D4
@@ -70,9 +76,14 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
         }
 
         ///GENMHASH:95834C6C7DA388E666B705A62A7D02BF:2A90E64B785A8609460D87572CE513A1
-        public IEnumerable<ITrafficManagerProfile> ListByGroup(string groupName)
+        protected async override Task<IPage<ProfileInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {
-            return WrapList(Inner.ListAllInResourceGroup(groupName));
+            return ConvertToPage(await Inner.ListAllInResourceGroupAsync(groupName, cancellationToken));
+        }
+
+        protected async override Task<IPage<ProfileInner>> ListInnerByGroupNextAsync(string nextLink, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult<IPage<ProfileInner>>(null);
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:12B839BC780AC48D63D16C362B5E2FF5

--- a/src/ResourceManagement/TrafficManager/Microsoft.Azure.Management.TrafficManager.Fluent/project.json
+++ b/src/ResourceManagement/TrafficManager/Microsoft.Azure.Management.TrafficManager.Fluent/project.json
@@ -34,19 +34,9 @@
       "dependencies": {
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "buildOptions": {
-        "define": [ "NETSTANDARD15", "PORTABLE" ],
-        "debugType": "portable"
-      },
-      "imports": [ "dnxcore50" ],
-      "dependencies": {
-        "NETStandard.Library": "1.6.1"
-      }
-    },
-    "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11", "PORTABLE" ],
+        "define": [ "NETSTANDARD13", "PORTABLE" ],
         "debugType": "portable"
       },
       "imports": [ "dnxcore50" ],


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.