### PR TITLE
Added RefreshAsync

### DIFF
--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificateImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificateImpl.cs
@@ -171,10 +171,10 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:24635E3B6AB96D3E6BFB9DA2AF7C6AB5
-        public override IAppServiceCertificate Refresh()
+        protected override async Task<CertificateInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            SetInner(Manager.Inner.Certificates.Get(ResourceGroupName, Name));
-            return this;
+            return await Manager.Inner.Certificates.GetAsync(ResourceGroupName,
+                Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:1CE69EE8CADD589DFF9EE88A8E75ED38:0AC8A05BCD3A6B7CBD7958C57BCC894F

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificateImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificateImpl.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             }
             if (certificateOrder != null)
             {
-                var keyVaultBinding = await certificateOrder.GetKeyVaultBindingAsync();
+                var keyVaultBinding = await certificateOrder.GetKeyVaultBindingAsync(cancellationToken);
                 Inner.KeyVaultId = keyVaultBinding.KeyVaultId;
                 Inner.KeyVaultSecretName = keyVaultBinding.KeyVaultSecretName;
             }

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificateKeyVaultBindingImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificateKeyVaultBindingImpl.cs
@@ -51,10 +51,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:360C34F1E1D3680D56F867742DA72A0F
-        public override IAppServiceCertificateKeyVaultBinding Refresh()
+        protected override async Task<AppServiceCertificateInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            SetInner(Manager.Inner.AppServiceCertificateOrders.GetCertificate(parent.ResourceGroupName, parent.Name, Name));
-            return this;
+            return await Manager.Inner.AppServiceCertificateOrders.GetCertificateAsync(parent.ResourceGroupName, parent.Name, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:D4A5D054CC36457C424453F9336F119D:DF50D77B281002A20A5029B77CA61F76

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificateOrderImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceCertificateOrderImpl.cs
@@ -150,10 +150,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:24635E3B6AB96D3E6BFB9DA2AF7C6AB5
-        public override IAppServiceCertificateOrder Refresh()
+        protected override async Task<AppServiceCertificateOrderInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            this.SetInner(Manager.Inner.AppServiceCertificateOrders.Get(ResourceGroupName, Name));
-            return this;
+            return await Manager.Inner.AppServiceCertificateOrders.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:9FDF35464E02B70B2EF312DAD321B8C2:82C57278EF9D50148F4779BC9B9CEDCF

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceDomainImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceDomainImpl.cs
@@ -150,10 +150,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:24635E3B6AB96D3E6BFB9DA2AF7C6AB5
-        public override IAppServiceDomain Refresh()
+        protected override async Task<DomainInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            this.SetInner(Manager.Inner.Domains.Get(ResourceGroupName, Name));
-            return this;
+            return await Manager.Inner.Domains.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:F68B7C06A96EFE50420CFD0AF40077FB:26EA9A37169A3648217216A1F31DE87A

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServicePlanImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServicePlanImpl.cs
@@ -91,10 +91,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:24635E3B6AB96D3E6BFB9DA2AF7C6AB5
-        public override IAppServicePlan Refresh()
+        protected override async Task<AppServicePlanInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            this.SetInner(Manager.Inner.AppServicePlans.Get(ResourceGroupName, Name));
-            return this;
+            return await Manager.Inner.AppServicePlans.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:5929CFE21A9A83286B8C1C4A12A36B8B:9D4F7490FD2702FB45ED3AC0D12B3775

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/DeploymentSlotImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/DeploymentSlotImpl.cs
@@ -242,9 +242,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:9EC0529BA0D08B75AD65E98A4BA01D5D:44153E55F54D6CEBEDD20C31326CBA9E
-        internal async override Task<Microsoft.Azure.Management.AppService.Fluent.Models.SiteInner> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<Microsoft.Azure.Management.AppService.Fluent.Models.SiteInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            return await Manager.Inner.WebApps.GetSlotAsync(ResourceGroupName, parent.Name, Name());
+            return await Manager.Inner.WebApps.GetSlotAsync(ResourceGroupName, parent.Name, Name(), cancellationToken);
         }
 
         ///GENMHASH:0F38250A3837DF9C2C345D4A038B654B:ACDFDA9555BC8460257AB6B2FB97F4EB

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/DeploymentSlotsImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/DeploymentSlotsImpl.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             siteInner.SiteConfig = await Inner.GetConfigurationSlotAsync(resourceGroup, parentName, name, cancellationToken);
 
             var result = WrapModel(siteInner);
-            await ((DeploymentSlotImpl)result).CacheAppSettingsAndConnectionStringsAsync();
+            await ((DeploymentSlotImpl)result).CacheAppSettingsAndConnectionStringsAsync(cancellationToken);
 
             return result;
         }

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/HostNameBindingImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/HostNameBindingImpl.cs
@@ -257,6 +257,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             return this;
         }
 
+
         IHostNameBinding IRefreshable<IHostNameBinding>.Refresh()
         {
             if (parent is IWebApp)
@@ -266,6 +267,19 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             else
             {
                 SetInner(parent.Manager.Inner.WebApps.GetHostNameBindingSlot(parent.ResourceGroupName, ((IDeploymentSlot)parent).Parent.Name, parent.Name, Name()));
+            }
+            return this;
+        }
+
+        public async Task<IHostNameBinding> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parent is IWebApp)
+            {
+                SetInner(await parent.Manager.Inner.WebApps.GetHostNameBindingAsync(parent.ResourceGroupName, parent.Name, Name(), cancellationToken));
+            }
+            else
+            {
+                SetInner(await parent.Manager.Inner.WebApps.GetHostNameBindingSlotAsync(parent.ResourceGroupName, ((IDeploymentSlot)parent).Parent.Name, parent.Name, Name(), cancellationToken));
             }
             return this;
         }

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/WebAppBaseImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/WebAppBaseImpl.cs
@@ -208,14 +208,14 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:75636395FBDB9C1FA7F5231207B98D55
-        public override FluentT Refresh()
+        public override async Task<FluentT> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             ///GENMHASH:9EC0529BA0D08B75AD65E98A4BA01D5D:27E486AB74A10242FF421C0798DDC450
-            SiteInner inner = GetInnerAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            SiteInner inner = await GetInnerAsync(cancellationToken);
             ///GENMHASH:256905D5B839C64BFE9830503CB5607B:27E486AB74A10242FF421C0798DDC450
-            inner.SiteConfig = GetConfigInnerAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            inner.SiteConfig = await GetConfigInnerAsync();
             SetInner(inner);
-            CacheAppSettingsAndConnectionStringsAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            await CacheAppSettingsAndConnectionStringsAsync();
             return this as FluentT;
         }
 
@@ -446,7 +446,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 return Task.WhenAll(bindingTasks).ContinueWith(bindingt =>
                 {
                     // Refresh after hostname bindings
-                    return GetInnerAsync();
+                    return GetInnerAsync(cancellationToken);
                 }).Unwrap();
             }).Unwrap().ContinueWith(t =>
             {
@@ -910,8 +910,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             }
             return (FluentImplT) this;
         }
-
-        internal abstract Task<Microsoft.Azure.Management.AppService.Fluent.Models.SiteInner> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         ///GENMHASH:C102774B5B56F13DBA5095A48DC5F846:1886C5FB5632B7468462889794AFEA08
         public NetFrameworkVersion NetFrameworkVersion()

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/WebAppBaseImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/WebAppBaseImpl.cs
@@ -213,9 +213,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             ///GENMHASH:9EC0529BA0D08B75AD65E98A4BA01D5D:27E486AB74A10242FF421C0798DDC450
             SiteInner inner = await GetInnerAsync(cancellationToken);
             ///GENMHASH:256905D5B839C64BFE9830503CB5607B:27E486AB74A10242FF421C0798DDC450
-            inner.SiteConfig = await GetConfigInnerAsync();
+            inner.SiteConfig = await GetConfigInnerAsync(cancellationToken);
             SetInner(inner);
-            await CacheAppSettingsAndConnectionStringsAsync();
+            await CacheAppSettingsAndConnectionStringsAsync(cancellationToken);
             return this as FluentT;
         }
 
@@ -251,11 +251,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:A0391A0E086361AE06DB925568A86EB3:C70FCB6ABBA310D8130B4F53160A0440
         public async Task CacheAppSettingsAndConnectionStringsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            Task<StringDictionaryInner> appSettingsTask = ListAppSettingsAsync();
+            Task<StringDictionaryInner> appSettingsTask = ListAppSettingsAsync(cancellationToken);
             ///GENMHASH:0FE78F842439357DA0333AABD3B95D59:27E486AB74A10242FF421C0798DDC450
-            Task<ConnectionStringDictionaryInner> connectionStringsTask = ListConnectionStringsAsync();
+            Task<ConnectionStringDictionaryInner> connectionStringsTask = ListConnectionStringsAsync(cancellationToken);
             ///GENMHASH:62A0C790E618C837459BE1A5103CA0E5:27E486AB74A10242FF421C0798DDC450
-            Task<SlotConfigNamesResourceInner> slotConfigsTask = ListSlotConfigurationsAsync();
+            Task<SlotConfigNamesResourceInner> slotConfigsTask = ListSlotConfigurationsAsync(cancellationToken);
 
             await Task.WhenAll(appSettingsTask, connectionStringsTask, slotConfigsTask);
 
@@ -594,7 +594,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             // convert from Inner
             SetInner(site);
             NormalizeProperties();
-            await CacheAppSettingsAndConnectionStringsAsync();
+            await CacheAppSettingsAndConnectionStringsAsync(cancellationToken);
 
             return this as FluentT;
         }

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/WebAppImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/WebAppImpl.cs
@@ -229,9 +229,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:9EC0529BA0D08B75AD65E98A4BA01D5D:AD50571B7362BCAADE526027DA36B58F
-        internal async override Task<SiteInner> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<SiteInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            return await Manager.Inner.WebApps.GetAsync(ResourceGroupName, Name);
+            return await Manager.Inner.WebApps.GetAsync(ResourceGroupName, Name, cancellationToken);
         }
 
         ///GENMHASH:BC96AA8FDB678157AC1E6F0AA511AB65:20A70C4EEFBA9DE9AD6AA6D9133187D7

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/ApplicationImpl.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/ApplicationImpl.cs
@@ -112,13 +112,18 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:409C31CA8E99C248AA5D2D551769B232
-        public IApplication Refresh()
+        public override async Task<IApplication> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            ApplicationInner inner = Parent.Manager.Inner.Application.Get(Parent.ResourceGroupName, Parent.Name, Inner.Id);
+            ApplicationInner inner = await GetInnerAsync(cancellationToken);
             SetInner(inner);
             applicationPackages.Refresh();
 
             return this;
+        }
+
+        protected override async Task<ApplicationInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Parent.Manager.Inner.Application.GetAsync(Parent.ResourceGroupName, Parent.Name, Inner.Id, cancellationToken);
         }
 
         ///GENMHASH:077EB7776EFFBFAA141C1696E75EF7B3:F50FC9984285FA3EFE81DE58B2255BD1

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/ApplicationPackageImpl.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/ApplicationPackageImpl.cs
@@ -125,12 +125,9 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:1A5A27E52191D0AB303947147157C578
-        public IApplicationPackage Refresh()
+        protected override async Task<ApplicationPackageInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            ///GENMHASH:3E38805ED0E7BA3CAEE31311D032A21C:583937857C93CEEDEFD65D6B38E46ADD
-            ApplicationPackageInner inner = client.Get(Parent.Parent.ResourceGroupName, Parent.Parent.Name, Parent.Name(), Name());
-            SetInner(inner);
-            return this;
+            return await client.GetAsync(Parent.Parent.ResourceGroupName, Parent.Parent.Name, Parent.Name(), Name(), cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/BatchAccountImpl.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/BatchAccountImpl.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using ResourceManager.Fluent.Core;
+    using System;
 
     /// <summary>
     /// Implementation for BatchAccount and its parent interfaces.
@@ -48,11 +49,11 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:7CF0E4D2E689061F164F4E8CBEEE0032
-        public override IBatchAccount Refresh()
+        public override async Task<IBatchAccount> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            BatchAccountInner response = Manager.Inner.BatchAccount.Get(ResourceGroupName, Name);
+            var inner = await GetInnerAsync(cancellationToken);
 
-            SetInner(response);
+            SetInner(inner);
             applicationsImpl.Refresh();
 
             return this;
@@ -255,6 +256,11 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         {
             applicationsImpl.AddApplication(application);
             return this;
+        }
+
+        protected override async Task<BatchAccountInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Manager.Inner.BatchAccount.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/CdnEndpointImpl.cs
+++ b/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/CdnEndpointImpl.cs
@@ -466,12 +466,9 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:F8A6A48920042C49572BFDA9629E1BC7
-        public ICdnEndpoint Refresh()
+        public override async Task<ICdnEndpoint> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            EndpointInner inner = Parent.Manager.Inner.Endpoints.Get(
-                Parent.ResourceGroupName,
-                Parent.Name,
-                Name());
+            EndpointInner inner = await GetInnerAsync(cancellationToken);
             SetInner(inner);
             customDomainList.Clear();
             deletedCustomDomainList.Clear();
@@ -481,6 +478,14 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                     Parent.Name,
                     Name()));
             return this;
+        }
+
+        protected override async Task<EndpointInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Parent.Manager.Inner.Endpoints.GetAsync(
+                Parent.ResourceGroupName,
+                Parent.Name,
+                Name(), cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:64AF8E4C0DC21702ECEBDAB60ABF9E38:B0E2487AEAA046DB40AFBF76759F57B7

--- a/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/CdnProfileImpl.cs
+++ b/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/CdnProfileImpl.cs
@@ -196,11 +196,9 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:99295E9723E2B8FABFB8C4111423E7B2
-        public override ICdnProfile Refresh()
+        protected override async Task<ProfileInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            ProfileInner cdnProfileInner = Manager.Inner.Profiles.Get(ResourceGroupName, Name);
-            SetInner(cdnProfileInner);
-            return this;
+            return await Manager.Inner.Profiles.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:37D0B9659C11E9B4AA5E39DEE4B0AB7D:C83A09045ECA07DB3EC59281710F2DEA

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/AvailabilitySetImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/AvailabilitySetImpl.cs
@@ -82,12 +82,17 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:031612B4E8FDCD8F07810CE8D68580BA
-        public override IAvailabilitySet Refresh()
+        public override async Task<IAvailabilitySet> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            var availabilitySetInner = Manager.Inner.AvailabilitySets.Get(ResourceGroupName, Name);
+            var availabilitySetInner = await GetInnerAsync(cancellationToken);
             SetInner(availabilitySetInner);
             idOfVMsInSet = null;
             return this;
+        }
+
+        protected override async Task<AvailabilitySetInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Manager.Inner.AvailabilitySets.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:CA43B507757943D4A56F8423528A061B:D4173FCB09ADA658582853B4D80CC7E9

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/DiskImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/DiskImpl.cs
@@ -180,11 +180,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:AACFFB1D9582E4E00031423DDDD4036A
-        public override IDisk Refresh()
+        protected override async Task<DiskInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            DiskInner diskInner = Manager.Inner.Disks.Get(ResourceGroupName, Name);
-            SetInner(diskInner);
-            return this;
+            return await Manager.Inner.Disks.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:B0C9EEFDDA443C25158B8F287BDAF3D8:6F1F05D0FB05C43F2A1F954CC1CBE3FB

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/SnapshotImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/SnapshotImpl.cs
@@ -134,11 +134,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:465E0149E0D9FAAA15FE3F675F59732D
-        public override ISnapshot Refresh()
+        protected override async Task<SnapshotInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            SnapshotInner snapshotInner = Manager.Inner.Snapshots.Get(ResourceGroupName, Name);
-            SetInner(snapshotInner);
-            return this;
+            return await Manager.Inner.Snapshots.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:E4F5CCFED775B8C1F10A8019B52CC013:AF82C13C6612DFDED62B43750E8734C8

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineCustomImageImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineCustomImageImpl.cs
@@ -98,11 +98,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:4F402C1981DA7F09CE4549AA85EF82EF
-        public override IVirtualMachineCustomImage Refresh()
+        protected override async Task<ImageInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            ImageInner imageInner = Manager.Inner.Images.Get(ResourceGroupName, Name);
-            SetInner(imageInner);
-            return this;
+            return await Manager.Inner.Images.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:F8F5E034B580C65E1958A4165F6207B3:34DFF336CAE464BA69C47A7AA2362690

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineExtensionImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineExtensionImpl.cs
@@ -217,18 +217,12 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:0A7B0ED028812E214E22EAF2EB753FAB
-        public IVirtualMachineExtension Refresh()
+
+        protected override async Task<VirtualMachineExtensionInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            string name;
-            if (IsReference()) {
-                name = ResourceUtils.NameFromResourceId(Inner.Id);
-            } else {
-                name = Inner.Name;
-            }
-            VirtualMachineExtensionInner inner = Parent.Manager.Inner.VirtualMachineExtensions.Get(
-                Parent.ResourceGroupName, Parent.Name, name);
-            SetInner(inner);
-            return this;
+            var name = IsReference() ? ResourceUtils.NameFromResourceId(Inner.Id) : Inner.Name;
+
+            return await Parent.Manager.Inner.VirtualMachineExtensions.GetAsync(Parent.ResourceGroupName, Parent.Name, name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:32A8B56FE180FA4429482D706189DEA2:C13D0601ACA269F4AA251080A5EAB8A3

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImpl.cs
@@ -79,14 +79,19 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:4C74CDEFBB89F8ADB720DB2B740C1AB3
-        public override IVirtualMachine Refresh()
+
+        public override async Task<IVirtualMachine> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            var response = Manager.Inner.VirtualMachines.Get(ResourceGroupName, Name);
+            var response = await GetInnerAsync(cancellationToken);
             SetInner(response);
             ClearCachedRelatedResources();
             InitializeDataDisks();
             virtualMachineExtensions.Refresh();
             return this;
+        }
+        protected override async Task<VirtualMachineInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Manager.Inner.VirtualMachines.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:667E734583F577A898C6389A3D9F4C09:B1A3725E3B60B26D7F37CA7ABFE371B0

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
@@ -730,13 +730,18 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:9A047B4B22E09AEB6344D4F23EC361E5
-        public override IVirtualMachineScaleSet Refresh()
+        public override async Task<IVirtualMachineScaleSet> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            var response = Manager.Inner.VirtualMachineScaleSets.Get(ResourceGroupName, Name);
+            var response = await GetInnerAsync(cancellationToken);
             SetInner(response);
             ClearCachedProperties();
             InitializeChildrenFromInner();
             return this;
+        }
+
+        protected override async Task<VirtualMachineScaleSetInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Manager.Inner.VirtualMachineScaleSets.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:0B0C2470711F6450D4872789FDEB62A0:27733295CC242C366636316AC58FC2D3

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetVMImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetVMImpl.cs
@@ -504,12 +504,21 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:44ACDDF0B04148CC3F9347EA7C0643B4
         public IVirtualMachineScaleSetVM Refresh()
         {
-            SetInner(Parent.Manager.Inner.VirtualMachineScaleSetVMs.Get(
+            return RefreshAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+        public async Task<IVirtualMachineScaleSetVM> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            SetInner(await GetInnerAsync(cancellationToken));
+            ClearCachedRelatedResources();
+            return this;
+        }
+
+        protected async Task<VirtualMachineScaleSetVMInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Parent.Manager.Inner.VirtualMachineScaleSetVMs.GetAsync(
                 Parent.ResourceGroupName,
                 Parent.Name,
-                InstanceId()));
-                ClearCachedRelatedResources();
-            return this;
+                InstanceId(), cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:0FEDA307DAD2022B36843E8905D26EAD:C5FE9F038576055F219FB734E49D39D9

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/DnsRecordSetImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/DnsRecordSetImpl.cs
@@ -289,14 +289,13 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:4A10213038743768C271AE3184DC5B16
-        public IDnsRecordSet Refresh()
+        protected override async Task<RecordSetInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            this.SetInner(Parent.Manager.Inner.RecordSets.Get(
-                Parent.ResourceGroupName, 
-                Parent.Name, 
-                Name(), 
-                RecordType()));
-            return this;
+            return await Parent.Manager.Inner.RecordSets.GetAsync(
+                Parent.ResourceGroupName,
+                Parent.Name,
+                Name(),
+                RecordType(), cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:0FEDA307DAD2022B36843E8905D26EAD:4983E2059828207A0EBDD76459661F4B

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/DnsZoneImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/DnsZoneImpl.cs
@@ -243,12 +243,18 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:6E114CA661817C270373E8F5D86D84F5
-        public override IDnsZone Refresh()
+        public override async Task<IDnsZone> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            ZoneInner inner = Manager.Inner.Zones.Get(ResourceGroupName, Name);
+            ZoneInner inner = await GetInnerAsync(cancellationToken);
             SetInner(inner);
             InitRecordSets();
             return this;
+        }
+
+        protected override async Task<ZoneInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Manager.Inner.Zones.GetAsync(
+                ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:E10C7FF5C36891D769128853352DD627:C2BD0B555A21A8D13988A3FB8138875D

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/ServicePrincipalImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/ServicePrincipalImpl.cs
@@ -75,11 +75,10 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:6FBD633E7AC3512A3078AD9811DEC068
-        public override IServicePrincipal Refresh()
+        protected override async Task<ServicePrincipalInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var inner = client.List(new Rest.Azure.OData.ODataQuery<ServicePrincipalInner>(string.Format("servicePrincipalNames/any(c:c eq '{0}')", AppId())));
-            SetInner(inner.ToList()[0]);
-            return this;
+            var list = await client.ListAsync(new Rest.Azure.OData.ODataQuery<ServicePrincipalInner>(string.Format("servicePrincipalNames/any(c:c eq '{0}')", AppId())), cancellationToken: cancellationToken);
+            return list.FirstOrDefault();
         }
 
         ///GENMHASH:0202A00A1DCF248D2647DBDBEF2CA865:E9A4DA014B21051979442ACE026C7D1F

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/UserImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent/UserImpl.cs
@@ -120,11 +120,9 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:5074689AB449399B3C11F611FD3EFF94
-        public override IUser Refresh ()
+        protected override async Task<UserInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var inner = client.Get(UserPrincipalName());
-            SetInner(inner);
-            return this;
+            return await client.GetAsync(UserPrincipalName(), cancellationToken);
         }
 
         ///GENMHASH:0202A00A1DCF248D2647DBDBEF2CA865:E9A4DA014B21051979442ACE026C7D1F

--- a/src/ResourceManagement/KeyVault/Microsoft.Azure.Management.KeyVault.Fluent/VaultImpl.cs
+++ b/src/ResourceManagement/KeyVault/Microsoft.Azure.Management.KeyVault.Fluent/VaultImpl.cs
@@ -289,11 +289,9 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:CC9FF17BB935059EB35312593856BE61
-        public override IVault Refresh ()
+        protected override async Task<VaultInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var inner = Manager.Inner.Vaults.Get(ResourceGroupName, Name);
-            SetInner(inner);
-            return this;
+            return await Manager.Inner.Vaults.GetAsync(ResourceGroupName, Name, cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayImpl.cs
@@ -1406,12 +1406,17 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:96A74C51AAF39DA86E198A67D990E237
-        public override IApplicationGateway Refresh()
+        public override async Task<IApplicationGateway> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            var inner = Manager.Inner.ApplicationGateways.Get(this.ResourceGroupName, this.Name);
+            var inner = await GetInnerAsync(cancellationToken);
             SetInner(inner);
             InitializeChildrenFromInner();
             return this;
+        }
+
+        protected override async Task<ApplicationGatewayInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Manager.Inner.ApplicationGateways.GetAsync(this.ResourceGroupName, this.Name, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerImpl.cs
@@ -51,12 +51,17 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:420B9F8BE887CC0E8BEEE7DBFEAED60C
-        override public ILoadBalancer Refresh ()
+        override public async Task<ILoadBalancer> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            var response = Manager.Inner.LoadBalancers.Get(ResourceGroupName, Name);
+            var response = await GetInnerAsync(cancellationToken);
             SetInner(response);
             InitializeChildrenFromInner();
             return this;
+        }
+
+        protected override async Task<LoadBalancerInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Manager.Inner.LoadBalancers.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:6D9F740D6D73C56877B02D9F1C96F6E7:3CAF9C390C7752EBAF91179873ABBC9F

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkImpl.cs
@@ -49,11 +49,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:283E100E0B274CF53096A783583FAE37
-        public override INetwork Refresh()
+        protected override async Task<VirtualNetworkInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var response = Manager.Inner.VirtualNetworks.Get(ResourceGroupName, Name);
-            SetInner(response);
-            return this;
+            return await Manager.Inner.VirtualNetworks.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:F792498DBF3C736E27E066C92C2E7F7A:129071765816A335066AAC27F7CCCEAD

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkInterfaceImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkInterfaceImpl.cs
@@ -71,11 +71,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:BCF4C230F6F0AA0BE6D9C038631B4B67
-        public override INetworkInterface Refresh()
+        protected override async Task<NetworkInterfaceInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var response = Manager.Inner.NetworkInterfaces.Get(ResourceGroupName, nicName);
-            SetInner(response);
-            return this;
+            return await Manager.Inner.NetworkInterfaces.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:C8A4DDE66256242DF61087375BF710B0:78F3FE05E98D67CD9C4262D01BCC8B46

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkSecurityGroupImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkSecurityGroupImpl.cs
@@ -129,12 +129,11 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:7399EBE775B4308D075A8364EF2A490D
-        public override INetworkSecurityGroup Refresh()
+        protected override async Task<NetworkSecurityGroupInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var response = Manager.Inner.NetworkSecurityGroups.Get(ResourceGroupName, Name);
-            SetInner(response);
-            return this;
+            return await Manager.Inner.NetworkSecurityGroups.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
+
         #endregion
 
         #region Accessors

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/PublicIpAddressImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/PublicIpAddressImpl.cs
@@ -183,11 +183,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:46083B525E2D28949C602FA14CD8C6BB
-        public override IPublicIPAddress Refresh()
+        protected override async Task<PublicIPAddressInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var response = Manager.Inner.PublicIPAddresses.Get(ResourceGroupName, Inner.Name);
-            SetInner(response);
-            return this;
+            return await Manager.Inner.PublicIPAddresses.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:7D4EDB8798720C21E834ABC3BEB6E503:C11A523B66806B5E409AF440EE4B612E

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/RouteTableImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/RouteTableImpl.cs
@@ -88,12 +88,17 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:3C24CB44825C9FD8973A23CA91FB4FD1
-        public override IRouteTable Refresh()
+        public override async Task<IRouteTable> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            RouteTableInner inner = Manager.Inner.RouteTables.Get(ResourceGroupName, Name);
+            RouteTableInner inner = await GetInnerAsync(cancellationToken);
             SetInner(inner);
             InitializeChildrenFromInner();
             return this;
+        }
+
+        protected override async Task<RouteTableInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Manager.Inner.RouteTables.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:8200D5EDD19C5D72B80F6841AD9D0FF0:F58B9D6D280E3F1581C12EFC5360F4C9

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/VirtualMachineScaleSetNetworkInterfaceImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/VirtualMachineScaleSetNetworkInterfaceImpl.cs
@@ -187,14 +187,14 @@ namespace Microsoft.Azure.Management.Network.Fluent
             throw new NotSupportedException();
         }
 
-        override public IVirtualMachineScaleSetNetworkInterface Refresh()
+        protected override async Task<NetworkInterfaceInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            SetInner(Manager.Inner.NetworkInterfaces.GetVirtualMachineScaleSetNetworkInterface(
+            return await Manager.Inner.NetworkInterfaces.GetVirtualMachineScaleSetNetworkInterfaceAsync(
                 resourceGroupName,
                 scaleSetName,
                 ResourceUtils.NameFromResourceId(VirtualMachineId()),
-                Name));
-            return this;
+                Name, cancellationToken: cancellationToken);
         }
+
     }
 }

--- a/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent/RedisCacheImpl.cs
+++ b/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent/RedisCacheImpl.cs
@@ -354,11 +354,9 @@ namespace Microsoft.Azure.Management.Redis.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:FEAA566B918E8D6129C37B2AD34F3689
-        public override IRedisCache Refresh()
+        protected override async Task<RedisResourceInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var redisResourceInner = Manager.Inner.Redis.Get(this.ResourceGroupName, this.Name);
-            this.SetInner(redisResourceInner);
-            return this;
+            return await Manager.Inner.Redis.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:99D5BF64EA8AA0E287C9B6F77AAD6FC4:220D4662AAC7DF3BEFAF2B253278E85C

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/CreatableUpdatableResourcesRoot.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/CreatableUpdatableResourcesRoot.cs
@@ -68,6 +68,16 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
         {
             throw new NotImplementedException();
         }
+
+        public override Task<ICreatableUpdatableResourcesRoot<IFluentResourceT>> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override Task<InnerResourceT> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
         #endregion
 
         #region IHasId empty Impl

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExternalChildResource.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExternalChildResource.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
 using System.Threading;
 using System.Threading.Tasks;
+using System;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 {
@@ -23,8 +25,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
     public abstract class ExternalChildResource<FluentModelT,
         InnerModelT,
         IParentT,
-        ParentImplT> : ChildResource<InnerModelT, ParentImplT, IParentT>
-        where FluentModelT : IExternalChildResource<FluentModelT, IParentT>
+        ParentImplT> : ChildResource<InnerModelT, ParentImplT, IParentT>, IRefreshable<FluentModelT>
+        where FluentModelT : class, IExternalChildResource<FluentModelT, IParentT>
         where ParentImplT : IParentT
     {
         private readonly string name;
@@ -78,6 +80,20 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
         /// </summary>
         /// <returns>the task to track the delete action</returns>
         public abstract Task DeleteAsync(CancellationToken cancellationToken);
+
+        public virtual FluentModelT Refresh()
+        {
+            return RefreshAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        public virtual async Task<FluentModelT> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var inner = await GetInnerAsync(cancellationToken);
+            this.SetInner(inner);
+            return this as FluentModelT;
+        }
+
+        protected abstract Task<InnerModelT> GetInnerAsync(CancellationToken cancellationToken);
     }
 
     /// <summary>

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExternalChildResourceCollection.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExternalChildResourceCollection.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 {
     public abstract class ExternalChildResourceCollection<FluentModelTImpl, IFluentModelT, InnerModelT, IParentT, ParentImplT>
         where ParentImplT : IParentT
-        where IFluentModelT : IExternalChildResource<IFluentModelT, IParentT>
+        where IFluentModelT : class, IExternalChildResource<IFluentModelT, IParentT>
         where FluentModelTImpl : ExternalChildResource<IFluentModelT, InnerModelT, IParentT, ParentImplT>, IFluentModelT
     {
         /// <summary>

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExternalChildResourcesCached.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExternalChildResourcesCached.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
     public abstract class ExternalChildResourcesCached<FluentModelTImpl, IFluentModelT, InnerModelT, IParentT, ParentImplT> :
         ExternalChildResourceCollection<FluentModelTImpl, IFluentModelT, InnerModelT, IParentT, ParentImplT>
         where ParentImplT : IParentT
-        where IFluentModelT : IExternalChildResource<IFluentModelT, IParentT>
+        where IFluentModelT : class, IExternalChildResource<IFluentModelT, IParentT>
         where FluentModelTImpl : ExternalChildResource<IFluentModelT, InnerModelT, IParentT, ParentImplT>, IFluentModelT
     {
         /// <summary>

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExternalChildResourcesNonCached.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ExternalChildResourcesNonCached.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
     public abstract class ExternalChildResourcesNonCached<FluentModelTImpl, IFluentModelT, InnerModelT, IParentT, ParentImplT> :
         ExternalChildResourceCollection<FluentModelTImpl, IFluentModelT, InnerModelT, IParentT, ParentImplT>
         where ParentImplT : IParentT
-        where IFluentModelT : IExternalChildResource<IFluentModelT, IParentT>
+        where IFluentModelT : class, IExternalChildResource<IFluentModelT, IParentT>
         where FluentModelTImpl : ExternalChildResource<IFluentModelT, InnerModelT, IParentT, ParentImplT>, IFluentModelT
     {
         /// <summary>

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ResourceActions/IndexableRefreshable.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ResourceActions/IndexableRefreshable.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
@@ -13,5 +14,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
         protected IndexableRefreshable() {}
 
         public abstract IFluentResourceT Refresh();
+
+        public abstract Task<IFluentResourceT> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ResourceActions/IndexableRefreshableWrapper.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ResourceActions/IndexableRefreshableWrapper.cs
@@ -1,9 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
 {
-    public abstract class IndexableRefreshableWrapper<IFluentResourceT, InnerResourceT> : IndexableRefreshable<IFluentResourceT>, IHasInner<InnerResourceT>
+    public abstract class IndexableRefreshableWrapper<IFluentResourceT, InnerResourceT>
+        : IndexableRefreshable<IFluentResourceT>, IHasInner<InnerResourceT>
+        where IFluentResourceT : class
     {
         protected IndexableRefreshableWrapper(string name, InnerResourceT innerObject)
         {
@@ -18,6 +23,20 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
         public virtual void SetInner(InnerResourceT innerObject)
         {
             Inner = innerObject;
+        }
+
+        protected abstract Task<InnerResourceT> GetInnerAsync(CancellationToken cancellationToken);
+
+        public override IFluentResourceT Refresh()
+        {
+            return RefreshAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        public override async Task<IFluentResourceT> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var inner = await GetInnerAsync(cancellationToken);
+            this.SetInner(inner);
+            return this as IFluentResourceT;
         }
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Deployment/DeploymentImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Deployment/DeploymentImpl.cs
@@ -416,17 +416,6 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         #endregion
 
-        #region Implementation of IRefreshable interface
-
-        public override IDeployment Refresh()
-        {
-            DeploymentExtendedInner inner = Manager.Inner.Deployments.Get(ResourceGroupName, Name);
-            SetInner(inner);
-            return this;
-        }
-
-        #endregion
-
         #region Implementation of ICreatable interface 
 
         public new IDeployment Create()
@@ -484,6 +473,11 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
             };
             Manager.Inner.Deployments.CreateOrUpdate(ResourceGroupName, Name, inner);
             return this;
+        }
+
+        protected override async Task<DeploymentExtendedInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Manager.Inner.Deployments.GetAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         #endregion

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Deployment/DeploymentOperationImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Deployment/DeploymentOperationImpl.cs
@@ -6,6 +6,8 @@ using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent
 {
@@ -101,11 +103,9 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         #region Implementation of IRefreshable interface
 
-        public override IDeploymentOperation Refresh()
+        protected override async Task<DeploymentOperationInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var inner = client.Get(resourceGroupName, deploymentName, OperationId);
-            SetInner(inner);
-            return this;
+            return await client.GetAsync(resourceGroupName, deploymentName, OperationId, cancellationToken: cancellationToken);
         }
 
         #endregion

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/ResourceActions/IRefreshable.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/ResourceActions/IRefreshable.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information. 
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
@@ -17,6 +18,12 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
         /// Refreshes the resource to sync with Azure.
         /// </summary>
         /// <returns>the refreshed resource</returns>
-        T Refresh ();
+        T Refresh();
+
+        /// <summary>
+        /// Refreshes the resource to sync with Azure.
+        /// </summary>
+        /// <returns>the refreshed resource</returns>
+        Task<T> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/GenericResource/GenericResourceImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/GenericResource/GenericResourceImpl.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Models;
 using System.Threading;
 using System.Threading.Tasks;
+using System;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent
 {
@@ -104,11 +105,16 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         #endregion
 
-        public override IGenericResource Refresh()
+        protected override async Task<GenericResourceInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            return null;
+            return await Manager.Inner.Resources.GetAsync(ResourceGroupName,
+                resourceProviderNamespace,
+                parentResourceId,
+                resourceType,
+                Name,
+                apiVersion,
+                cancellationToken);
         }
-
 
         public new GenericResource.Update.IWithApiVersion Update()
         {

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceGroup/ResourceGroupImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceGroup/ResourceGroupImpl.cs
@@ -176,11 +176,9 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         #region Implementation of IRefreshable interface
 
-        public override IResourceGroup Refresh()
+        protected override async Task<ResourceGroupInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var result = client.Get(Name);
-            SetInner(result);
-            return this;
+            return await client.GetAsync(Name, cancellationToken: cancellationToken);
         }
 
         #endregion

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/AuthorizationRuleBaseImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/AuthorizationRuleBaseImpl.cs
@@ -51,13 +51,6 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         {
         }
 
-        public override IFluentResourceT Refresh()
-        {
-            var inner = this.GetInnerAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
-            SetInner(inner);
-            return this as IFluentResourceT;
-        }
-
         ///GENMHASH:AB1BA95F78B711F10D574A0046DE17B7:5297C65D2669C5460BC3173EBA6C2F1E
         protected IList<Management.Fluent.ServiceBus.Models.AccessRights> Rights()
         {
@@ -161,8 +154,5 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
 
         ///GENMHASH:1475FAC06F3CDD8B38B0B8B1586C3D7E:27E486AB74A10242FF421C0798DDC450
         protected abstract Task<Management.Fluent.ServiceBus.Models.ResourceListKeysInner> RegenerateKeysInnerAsync(Policykey policykey, CancellationToken cancellationToken = default(CancellationToken));
-
-        /////GENMHASH:5AD91481A0966B059A478CD4E9DD9466:FA8879C614CBDAFC8DA9F2E7FAB9838E
-        protected abstract Task<InnerModelT> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueImpl.cs
@@ -50,13 +50,6 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
             }
         }
 
-        public override IQueue Refresh()
-        {
-            var inner = this.GetInnerAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
-            SetInner(inner);
-            return this as IQueue;
-        }
-
         ///GENMHASH:E3E1FE37EF46DBB99588AC2854B0739F:DA91B2CE4D0B6442C970C7DC794FF87E
         public QueueImpl WithoutDuplicateMessageDetection()
         {
@@ -166,7 +159,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:5AD91481A0966B059A478CD4E9DD9466:338FF71B5ABADE33BE2440EC7B543A5A
-        protected async Task<QueueInner> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task<QueueInner> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return await this.Manager.Inner.Queues
                 .GetAsync(this.ResourceGroupName,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespaceImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespaceImpl.cs
@@ -39,13 +39,6 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         private IList<string> topicsToDelete;
         private IList<string> rulesToDelete;
 
-        public override IServiceBusNamespace Refresh()
-        {
-            var inner = this.GetInnerAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
-            SetInner(inner);
-            return this as IServiceBusNamespace;
-        }
-
         ///GENMHASH:D5F5D7B4ED6C3CD6D1BC4B193E789ED5:DE0F43E4763FD287984BB053E525DD48
         internal ServiceBusNamespaceImpl(string name, NamespaceModelInner inner, IServiceBusManager manager) : base(name, inner, manager)
         {
@@ -110,7 +103,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:5AD91481A0966B059A478CD4E9DD9466:08FB5A6CC72E9C407DAC126C07B38561
-        protected async Task<NamespaceModelInner> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task<NamespaceModelInner> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return await this.Manager.Inner.Namespaces.GetAsync(
                 this.ResourceGroupName,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionImpl.cs
@@ -43,13 +43,6 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
             }
         }
 
-        public override ISubscription Refresh()
-        {
-            var inner = this.GetInnerAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
-            SetInner(inner);
-            return this as ISubscription;
-        }
-
         ///GENMHASH:0528195D56802C53049B175998349788:6A2B15DC582327EF91835262AE29E287
         public SubscriptionImpl WithoutSession()
         {
@@ -173,7 +166,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:5AD91481A0966B059A478CD4E9DD9466:749030CA5C22BFCBAE3439E2BC57EE23
-        protected async Task<SubscriptionInner> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task<SubscriptionInner> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
            return await this.Manager.Inner.Subscriptions
                 .GetAsync(this.ResourceGroupName,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicImpl.cs
@@ -47,13 +47,6 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
             }
         }
 
-        public override ITopic Refresh()
-        {
-            var inner = this.GetInnerAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
-            SetInner(inner);
-            return this as ITopic;
-        }
-
         ///GENMHASH:E3E1FE37EF46DBB99588AC2854B0739F:DA91B2CE4D0B6442C970C7DC794FF87E
         public TopicImpl WithoutDuplicateMessageDetection()
         {
@@ -165,7 +158,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:5AD91481A0966B059A478CD4E9DD9466:5296EC1C2BF632FB405AED151EB16468
-        protected async Task<TopicInner> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task<TopicInner> GetInnerAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return await this.Manager.Inner.Topics
                     .GetAsync(this.ResourceGroupName,

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/RecommendedElasticPoolImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/RecommendedElasticPoolImpl.cs
@@ -7,13 +7,16 @@ namespace Microsoft.Azure.Management.Sql.Fluent
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using ResourceManager.Fluent.Core.ResourceActions;
 
     /// <summary>
     /// Implementation for RecommendedElasticPool and its parent interfaces.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNxbC5pbXBsZW1lbnRhdGlvbi5SZWNvbW1lbmRlZEVsYXN0aWNQb29sSW1wbA==
     internal partial class RecommendedElasticPoolImpl :
-        Wrapper<RecommendedElasticPoolInner>,
+        IndexableRefreshableWrapper<IRecommendedElasticPool, RecommendedElasticPoolInner>,
         IRecommendedElasticPool
     {
         private ResourceId resourceId;
@@ -41,7 +44,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
 
         ///GENMHASH:3C9B0CE07C64DBB8CF2AEF14E330501A:2E8B0A743655F7A17FCDF72496CA11B0
         internal RecommendedElasticPoolImpl(RecommendedElasticPoolInner innerObject, ISqlManager manager)
-            : base(innerObject)
+            : base(innerObject.Name, innerObject)
         {
             resourceId = ResourceId.FromString(Inner.Id);
             Manager = manager;
@@ -82,10 +85,9 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:887D95D040FBCBF81B9BA7419D7F3A39
-        public IRecommendedElasticPool Refresh()
+        protected override async Task<RecommendedElasticPoolInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            SetInner(Manager.Inner.RecommendedElasticPools.Get(ResourceGroupName(), SqlServerName(), Name()));
-            return this;
+            return await Manager.Inner.RecommendedElasticPools.GetAsync(ResourceGroupName(), SqlServerName(), Name(), cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:0A59E82904CE8BB24F650E93009FF62F:554D1CBF22D4FFEB3B544B44B1374357

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/ReplicationLinkImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/ReplicationLinkImpl.cs
@@ -5,15 +5,16 @@ namespace Microsoft.Azure.Management.Sql.Fluent
     using ResourceManager.Fluent.Core;
     using Models;
     using System;
-    using System.Threading;
+    using ResourceManager.Fluent.Core.ResourceActions;
     using System.Threading.Tasks;
+    using System.Threading;
 
     /// <summary>
     /// Implementation for SqlServer and its parent interfaces.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNxbC5pbXBsZW1lbnRhdGlvbi5SZXBsaWNhdGlvbkxpbmtJbXBs
     internal partial class ReplicationLinkImpl :
-        Wrapper<ReplicationLinkInner>,
+        IndexableRefreshableWrapper<IReplicationLink, ReplicationLinkInner>,
         IReplicationLink
     {
         private IDatabasesOperations innerCollection;
@@ -62,15 +63,12 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:A7F868EA1D284A335598127348D0A1AD
-        public IReplicationLink Refresh()
+        protected override async Task<ReplicationLinkInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            this.SetInner(this.innerCollection.GetReplicationLink(
-            this.ResourceGroupName(),
+            return await this.innerCollection.GetReplicationLinkAsync(this.ResourceGroupName(),
             this.SqlServerName(),
             this.DatabaseName(),
-            this.Name()));
-
-            return this;
+            this.Name(), cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:64FDD7DAC0F2CAB9406652DA7545E8AA:3F5BF88EAEB847CE67B8C16A5FDD2D28
@@ -106,7 +104,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
 
         ///GENMHASH:EE0BD4E72D19A69170DA4CD2D7DA10B4:271A8BBAC31D775322091915FE56A406
         internal ReplicationLinkImpl(ReplicationLinkInner innerObject, IDatabasesOperations innerCollection)
-            : base(innerObject)
+            : base(innerObject.Name, innerObject)
         {
             this.resourceId = ResourceId.FromString(Inner.Id);
             this.innerCollection = innerCollection;

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/ServiceObjectiveImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/ServiceObjectiveImpl.cs
@@ -4,13 +4,16 @@ namespace Microsoft.Azure.Management.Sql.Fluent
 {
     using ResourceManager.Fluent.Core;
     using Models;
+    using ResourceManager.Fluent.Core.ResourceActions;
+    using System.Threading.Tasks;
+    using System.Threading;
 
     /// <summary>
     /// Implementation for Azure SQL Server's Service Objective.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNxbC5pbXBsZW1lbnRhdGlvbi5TZXJ2aWNlT2JqZWN0aXZlSW1wbA==
     internal partial class ServiceObjectiveImpl :
-        Wrapper<ServiceObjectiveInner>,
+        IndexableRefreshableWrapper<IServiceObjective, ServiceObjectiveInner>,
         IServiceObjective
     {
         private ResourceId resourceId;
@@ -59,10 +62,9 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:D6BF73A4CFB4DF465653CAFA9E2F5177
-        public IServiceObjective Refresh()
+        protected override async Task<ServiceObjectiveInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            this.SetInner(this.serversInner.GetServiceObjective(this.ResourceGroupName(), this.SqlServerName(), this.Name()));
-            return this;
+            return await serversInner.GetServiceObjectiveAsync(this.ResourceGroupName(), this.SqlServerName(), this.Name(), cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:ACA2D5620579D8158A29586CA1FF4BC6:899F2B088BBBD76CCBC31221756265BC
@@ -73,7 +75,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
 
         ///GENMHASH:1AB678115EC14BC6A56602D164114315:BE55E38683913BEF23106A037A3E9F1C
         internal ServiceObjectiveImpl(ServiceObjectiveInner innerObject, IServersOperations serversInner)
-            : base(innerObject)
+            : base(innerObject.Name, innerObject)
         {
             this.resourceId = ResourceId.FromString(Inner.Id);
             this.serversInner = serversInner;

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/ServiceTierAdvisorImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/ServiceTierAdvisorImpl.cs
@@ -7,13 +7,16 @@ namespace Microsoft.Azure.Management.Sql.Fluent
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using ResourceManager.Fluent.Core.ResourceActions;
+    using System.Threading.Tasks;
+    using System.Threading;
 
     /// <summary>
     /// Implementation for Azure SQL Database's service tier advisor.
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNxbC5pbXBsZW1lbnRhdGlvbi5TZXJ2aWNlVGllckFkdmlzb3JJbXBs
     internal partial class ServiceTierAdvisorImpl :
-        Wrapper<ServiceTierAdvisorInner>,
+        IndexableRefreshableWrapper<IServiceTierAdvisor, ServiceTierAdvisorInner>,
         IServiceTierAdvisor
     {
         private ResourceId resourceId;
@@ -89,7 +92,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
 
         ///GENMHASH:51288492BC30C9FE517ADAF1E48564C7:A677B0C455E56513C192E43F117D71E1
         internal ServiceTierAdvisorImpl(ServiceTierAdvisorInner innerObject, IDatabasesOperations databasesInner)
-            : base(innerObject)
+            : base(innerObject.Name, innerObject)
         {
             this.resourceId = ResourceId.FromString(Inner.Id);
             this.databasesInner = databasesInner;
@@ -120,11 +123,11 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:B7D07437BD9F8D06E149C9BD7B0F32C2
-        public IServiceTierAdvisor Refresh()
+        protected override async Task<ServiceTierAdvisorInner> GetInnerAsync(CancellationToken cancellationToken)
         {
             sloUsageMetrics = null;
-            this.SetInner(this.databasesInner.GetServiceTierAdvisor(this.ResourceGroupName(), this.SqlServerName(), this.DatabaseName(), this.Name()));
-            return this;
+            return await databasesInner.GetServiceTierAdvisorAsync(this.ResourceGroupName(), this.SqlServerName(),
+                this.DatabaseName(), this.Name(), cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:784C4BB3169D35BF6AAE0AF9F79505C7:115090F0342C88D04EA4B5C6E7311E9C

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlDatabaseImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlDatabaseImpl.cs
@@ -244,18 +244,14 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:D460F07553280DBC1866880BA0BD8AEF
-        public override ISqlDatabase Refresh()
+        protected override async Task<DatabaseInner> GetInnerAsync(CancellationToken cancellationToken)
         {
             if (Inner.UpgradeHint != null)
             {
-                SetInner(Manager.Inner.Databases.Get(ResourceGroupName, SqlServerName(), Name));
-            }
-            else
-            {
-                SetInner(Manager.Inner.Databases.Get(ResourceGroupName, SqlServerName(), Name, "upgradeHint"));
+                return await Manager.Inner.Databases.GetAsync(ResourceGroupName, SqlServerName(), Name, cancellationToken: cancellationToken);
             }
 
-            return this;
+            return await Manager.Inner.Databases.GetAsync(ResourceGroupName, SqlServerName(), Name, "upgradeHint", cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:495111B1D55D7AA3C4EA4E49042FA05A:81AF1DB897B99ED47A56E01F499D4D5A

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlElasticPoolImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlElasticPoolImpl.cs
@@ -127,10 +127,9 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:1ACD6B53BB71F7548B6ACD87115C57CE
-        public override ISqlElasticPool Refresh()
+        protected override async Task<ElasticPoolInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            Manager.Inner.ElasticPools.Get(ResourceGroupName, SqlServerName(), Name);
-            return this;
+            return await Manager.Inner.ElasticPools.GetAsync(ResourceGroupName, SqlServerName(), Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:ED7351448838F0ED89C6E4AE8FB19EAE:E3FFCB76DD3743CD850897669FC40D12

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlFirewallRuleImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlFirewallRuleImpl.cs
@@ -63,10 +63,9 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:8B499834886805DF649E8FE559911199
-        public override ISqlFirewallRule Refresh()
+        protected override async Task<ServerFirewallRuleInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            Manager.Inner.Servers.GetFirewallRule(ResourceGroupName, SqlServerName(), Name);
-            return this;
+            return await Manager.Inner.Servers.GetFirewallRuleAsync(ResourceGroupName, SqlServerName(), Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:F447869988CA4FAC84328D668E8C3E63:FC2F4AB7336D8B5FBACF1012628B157F

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlServerImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlServerImpl.cs
@@ -205,14 +205,10 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:62957758FC09C0990CF1236E4DBFE16D
-        public override ISqlServer Refresh()
+        protected override async Task<ServerInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var response = Manager.Inner.Servers.GetByResourceGroup(
-                ResourceGroupName, 
-                Name);
-            SetInner(response);
-
-            return this;
+            return await Manager.Inner.Servers.GetByResourceGroupAsync(ResourceGroupName,
+                Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:7D636B43F636D47A310AB1AF99E3C582:8AD037D8825930A5FDA5752A92895784

--- a/src/ResourceManagement/Storage/Microsoft.Azure.Management.Storage.Fluent/StorageAccount/StorageAccountImpl.cs
+++ b/src/ResourceManagement/Storage/Microsoft.Azure.Management.Storage.Fluent/StorageAccount/StorageAccountImpl.cs
@@ -280,11 +280,9 @@ namespace Microsoft.Azure.Management.Storage.Fluent
             return cachedAccountKeys;
         }
 
-        public override IStorageAccount Refresh()
+        protected override async Task<StorageAccountInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            var response = Manager.Inner.StorageAccounts.GetProperties(ResourceGroupName, Name);
-            SetInner(response);
-            return this;
+            return await Manager.Inner.StorageAccounts.GetPropertiesAsync(ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         public override IUpdate Update()

--- a/src/ResourceManagement/TrafficManager/Microsoft.Azure.Management.TrafficManager.Fluent/TrafficManagerEndpointImpl.cs
+++ b/src/ResourceManagement/TrafficManager/Microsoft.Azure.Management.TrafficManager.Fluent/TrafficManagerEndpointImpl.cs
@@ -68,15 +68,13 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:C47C4325FAE65E493A947196909A8664
-        public ITrafficManagerEndpoint Refresh()
+        protected override async Task<EndpointInner> GetInnerAsync(CancellationToken cancellationToken)
         {
-            EndpointInner inner = Parent.Manager.Inner.Endpoints.Get(
+            return await Parent.Manager.Inner.Endpoints.GetAsync(
                 Parent.ResourceGroupName,
                 Parent.Name,
                 EndpointType().ToString(),
-                Name());
-            SetInner(inner);
-            return this;
+                Name(), cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:0FEDA307DAD2022B36843E8905D26EAD:E3744107BCA5CCCE4C7486E0C86460B6

--- a/src/ResourceManagement/TrafficManager/Microsoft.Azure.Management.TrafficManager.Fluent/TrafficManagerProfileImpl.cs
+++ b/src/ResourceManagement/TrafficManager/Microsoft.Azure.Management.TrafficManager.Fluent/TrafficManagerProfileImpl.cs
@@ -170,12 +170,18 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:280DEDDFDA82FD8E8EA83F4139D8C99A
-        public override ITrafficManagerProfile Refresh()
+        public override async Task<ITrafficManagerProfile> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            ProfileInner inner = Manager.Inner.Profiles.Get(ResourceGroupName, Name);
+            ProfileInner inner = await GetInnerAsync(cancellationToken);
             SetInner(inner);
             endpoints.Refresh();
             return this;
+        }
+
+        protected override async Task<ProfileInner> GetInnerAsync(CancellationToken cancellationToken)
+        {
+            return await Manager.Inner.Profiles.GetAsync(
+                ResourceGroupName, Name, cancellationToken: cancellationToken);
         }
 
         ///GENMHASH:4AF52DA6D7309E03BCF9F21C532F19E0:DEF2407DA0E866749EF9CC5952427470


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.