### PR TITLE
Fixed more issues in Generic Resource

### DIFF
--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ResourceUtils.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/ResourceUtils.cs
@@ -74,5 +74,21 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                     resourceType,
                     resourceName);
         }
+
+        public static string CreateODataFilterForTags(string tagName, string tagValue)
+        {
+            if (tagName == null)
+            {
+                return null;
+            }
+            else if (tagValue == null)
+            {
+                return $"tagname eq {tagName}";
+            }
+            else
+            {
+                return $"tagname eq {tagName} and tagvalue eq {tagValue}";
+            }
+        }
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsBeginDeletingByName.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsBeginDeletingByName.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions
+{
+    /// <summary>
+    /// Provides access to deleting a resource from Azure, identifying it by its resource ID.
+    /// </summary>
+    public interface ISupportsBeginDeletingByName
+    {
+        /// <summary>
+        /// Begins deleting a resource from Azure, identifying it by its resource name. The
+        /// resource will stay until get() returns null.
+        /// </summary>
+        /// <param name="name">the name of the resource to delete</param>
+        void BeginDeleteByName(string name);
+
+        /// <summary>
+        /// Begins deleting a resource from Azure, identifying it by its resource name. The
+        /// resource will stay until get() returns null.
+        /// </summary>
+        /// <param name="name">the name of the resource to delete</param>
+        /// <param name="cancellationToken">cancellationToken the cancellation token</param>
+        /// <return>A await-able Task for asynchronous operation.</return>
+        Task BeginDeleteByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsListingByTag.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsListingByTag.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions
+{
+    /// <summary>
+    /// Provides access to listing Azure resources of a specific type based on their tag.
+    /// </summary>
+    public interface ISupportsListingByTag<T>
+    {
+        /// <summary>
+        /// Lists all the resources with the specified tag.
+        /// </summary>
+        /// <param name="tagName">tag's name as the key</param>
+        /// <param name="tagValue">tag's value</param>
+        /// <return>The list of resources.</return>
+        IEnumerable<T> ListByTag(string tagName, string tagValue);
+
+        /// <summary>
+        /// Lists all the resources with the specified tag.
+        /// </summary>
+        /// <param name="tagName">tag's name as the key</param>
+        /// <param name="tagValue">tag's value</param>
+        /// <param name="cancellationToken">cancellationToken the cancellation token</param>
+        /// <return>A await-able Task for asynchronous operation which will have PagedCollection of the resources.</return>
+        Task<IPagedCollection<T>> ListByTagAsync(string tagName, string tagValue, bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsListingInResourceGroupByTag.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/Core/CollectionActions/ISupportsListingInResourceGroupByTag.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions
+{
+    /// <summary>
+    /// Provides access to listing Azure resources of a specific type based on their tag.
+    /// </summary>
+    public interface ISupportsListingInResourceGroupByTag<T>
+    {
+        /// <summary>
+        /// Lists all the resources with the specified tag.
+        /// </summary>
+        /// <param name="resourceGroupName">The name of the resource group to list the resources from.</param>
+        /// <param name="tagName">tag's name as the key</param>
+        /// <param name="tagValue">tag's value</param>
+        /// <return>The list of resources.</return>
+        IEnumerable<T> ListByTag(string resourceGroupName, string tagName, string tagValue);
+
+        /// <summary>
+        /// Lists all the resources with the specified tag.
+        /// </summary>
+        /// <param name="resourceGroupName">The name of the resource group to list the resources from.</param>
+        /// <param name="tagName">tag's name as the key</param>
+        /// <param name="tagValue">tag's value</param>
+        /// <param name="loadAllPages">Specify true to load all pages, false to get paginated result</param>
+        /// <param name="cancellationToken">cancellationToken the cancellation token</param>
+        /// <return>A await-able Task for asynchronous operation which will have PagedCollection of the resources.</return>
+        Task<IPagedCollection<T>> ListByTagAsync(string resourceGroupName, string tagName, string tagValue, bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/IGenericResources.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/IGenericResources.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
     public interface IGenericResources  :
         ISupportsListing<IGenericResource>,
         ISupportsListingByResourceGroup<IGenericResource>,
+        ISupportsListingInResourceGroupByTag<IGenericResource>,
         ISupportsGettingByResourceGroup<IGenericResource>,
         ISupportsGettingById<IGenericResource>,
         ISupportsCreating<GenericResource.Definition.IBlank>,

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/IResourceGroups.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Domain/IResourceGroups.cs
@@ -14,9 +14,11 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
     /// </summary>
     public interface IResourceGroups  :
         ISupportsListing<IResourceGroup>,
+        ISupportsListingByTag<IResourceGroup>,
         ISupportsGettingByName<IResourceGroup>,
         ISupportsCreating<IBlank>,
         ISupportsDeletingByName,
+        ISupportsBeginDeletingByName,
         ISupportsBatchCreation<IResourceGroup>
     {
         /// <summary>

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Feature/FeaturesImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Feature/FeaturesImpl.cs
@@ -5,7 +5,6 @@ using Microsoft.Azure.Management.ResourceManager.Fluent.Models;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/GenericResource/GenericResourcesImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/GenericResource/GenericResourcesImpl.cs
@@ -168,5 +168,21 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         {
             return await Manager.Inner.ResourceGroups.ListResourcesNextAsync(link, cancellationToken);
         }
+
+        public IEnumerable<IGenericResource> ListByTag(string resourceGroupName, string tagName, string tagValue)
+        {
+            return WrapList(Manager.Inner.ResourceGroups.ListResources(
+                    resourceGroupName, ResourceUtils.CreateODataFilterForTags(tagName, tagValue))
+                    .AsContinuousCollection((nextLink) => Manager.Inner.ResourceGroups.ListResourcesNext(nextLink)));
+        }
+
+        public async Task<IPagedCollection<IGenericResource>> ListByTagAsync(string resourceGroupName, string tagName, string tagValue, bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IGenericResource, GenericResourceInner>.LoadPage(
+                async (cancellation) => await Manager.Inner.ResourceGroups.ListResourcesAsync(
+                    resourceGroupName, ResourceUtils.CreateODataFilterForTags(tagName, tagValue), cancellationToken: cancellation),
+                Manager.Inner.ResourceGroups.ListResourcesNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
+        }
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceGroup/ResourceGroupsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/ResourceGroup/ResourceGroupsImpl.cs
@@ -97,5 +97,31 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 Inner.ListNextAsync,
                 WrapModel, loadAllPages, cancellationToken);
         }
+
+        public IEnumerable<IResourceGroup> ListByTag(string tagName, string tagValue)
+        {
+            return WrapList(Inner.List(
+                    ResourceUtils.CreateODataFilterForTags(tagName, tagValue))
+                    .AsContinuousCollection((nextLink) => Inner.ListNext(nextLink)));
+        }
+
+        public async Task<IPagedCollection<IResourceGroup>> ListByTagAsync(string tagName, string tagValue, bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await PagedCollection<IResourceGroup, ResourceGroupInner>.LoadPage(
+                async (cancellation) => await Inner.ListAsync(
+                    ResourceUtils.CreateODataFilterForTags(tagName, tagValue), cancellationToken: cancellation),
+                Inner.ListNextAsync,
+                WrapModel, loadAllPages, cancellationToken);
+        }
+
+        public void BeginDeleteByName(string name)
+        {
+            BeginDeleteByNameAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        public async Task BeginDeleteByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await Inner.BeginDeleteAsync(name, cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.