### PR TITLE
Test comments, fixing ManageVirtualMachineAsync sample, renaming *Os* as *OS* in VM/VMSS

### DIFF
--- a/Samples/ResourceManagement/Compute/CreateVMsUsingCustomImageOrSpecializedVHD/Program.cs
+++ b/Samples/ResourceManagement/Compute/CreateVMsUsingCustomImageOrSpecializedVHD/Program.cs
@@ -149,7 +149,7 @@ namespace CreateVMsUsingCustomImageOrSpecializedVHD
                         .WithNewPrimaryNetwork("10.0.0.0/28")
                         .WithPrimaryPrivateIPAddressDynamic()
                         .WithoutPrimaryPublicIPAddress()
-                        .WithSpecializedOsUnmanagedDisk(specializedVhd, OperatingSystemTypes.Linux) // New user credentials cannot be specified
+                        .WithSpecializedOSUnmanagedDisk(specializedVhd, OperatingSystemTypes.Linux) // New user credentials cannot be specified
                         .WithSize(VirtualMachineSizeTypes.StandardD3V2)         // when attaching a specialized VHD
                         .Create();
 

--- a/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingSpecializedDiskFromSnapshot/Program.cs
+++ b/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingSpecializedDiskFromSnapshot/Program.cs
@@ -179,7 +179,7 @@ namespace CreateVirtualMachineUsingSpecializedDiskFromSnapshot
                         .WithNewPrimaryNetwork("10.0.0.0/28")
                         .WithPrimaryPrivateIPAddressDynamic()
                         .WithoutPrimaryPublicIPAddress()
-                        .WithSpecializedOsDisk(newOSDisk, OperatingSystemTypes.Linux)
+                        .WithSpecializedOSDisk(newOSDisk, OperatingSystemTypes.Linux)
                         .WithExistingDataDisk(newDataDisks[0])
                         .WithExistingDataDisk(newDataDisks[1], 1, CachingTypes.ReadWrite)
                         .WithSize(VirtualMachineSizeTypes.StandardD3V2)

--- a/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingSpecializedDiskFromVhd/Program.cs
+++ b/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingSpecializedDiskFromVhd/Program.cs
@@ -144,7 +144,7 @@ namespace CreateVirtualMachineUsingSpecializedDiskFromVhd
                         .WithNewPrimaryNetwork("10.0.0.0/28")
                         .WithPrimaryPrivateIPAddressDynamic()
                         .WithoutPrimaryPublicIPAddress()
-                        .WithSpecializedOsDisk(osDisk, OperatingSystemTypes.Linux)
+                        .WithSpecializedOSDisk(osDisk, OperatingSystemTypes.Linux)
                         .WithExistingDataDisk(dataDisks[0])
                         .WithExistingDataDisk(dataDisks[1], 1, CachingTypes.ReadWrite)
                         .WithSize(VirtualMachineSizeTypes.StandardD3V2)

--- a/Samples/ResourceManagement/Compute/ManageManagedDisks/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageManagedDisks/Program.cs
@@ -179,7 +179,7 @@ namespace ManageManagedDisks
                         .WithNewPrimaryNetwork("10.0.0.0/28")
                         .WithPrimaryPrivateIPAddressDynamic()
                         .WithoutPrimaryPublicIPAddress()
-                        .WithSpecializedOsUnmanagedDisk(specializedVhd, OperatingSystemTypes.Linux)
+                        .WithSpecializedOSUnmanagedDisk(specializedVhd, OperatingSystemTypes.Linux)
                         .WithSize(VirtualMachineSizeTypes.StandardD3V2)
                         .Create();
 
@@ -264,7 +264,7 @@ namespace ManageManagedDisks
                         .WithNewPrimaryNetwork("10.0.0.0/28")
                         .WithPrimaryPrivateIPAddressDynamic()
                         .WithoutPrimaryPublicIPAddress()
-                        .WithSpecializedOsDisk(newOSDisk, OperatingSystemTypes.Linux)
+                        .WithSpecializedOSDisk(newOSDisk, OperatingSystemTypes.Linux)
                         .WithExistingDataDisk(newDataDisk)
                         .WithSize(VirtualMachineSizeTypes.StandardD3V2)
                         .Create();

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachineAsync/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachineAsync/Program.cs
@@ -23,7 +23,7 @@ namespace ManageVirtualMachineAsync
          *      - add Tag
          *    - for Windows based:
          *      - deallocate the virtual machine
-         *      - resize (expand) the data disks
+         *      - add a data disk
          *      - start the virtual machine
          *  - List virtual machines and print details
          *  - Delete all virtual machines.
@@ -115,36 +115,17 @@ namespace ManageVirtualMachineAsync
                         .WithTag("where", "on azure")
                         .ApplyAsync();
 
-                Utilities.Log("Tagged Linux VM: " + windowsVM.Id);
+                Utilities.Log("Tagged Windows VM: " + windowsVM.Id);
 
                 //=============================================================
-                // First, deallocate the virtual machine and then proceed with resize
-
-                Utilities.Log("De-allocating VM: " + windowsVM.Id);
-
-                await windowsVM.DeallocateAsync();
-
-                Utilities.Log("De-allocated VM: " + windowsVM.Id + "; state = ");
-
-                //=============================================================
-                // Update - Resize (expand) the data disk on Windows VM.
+                // Update - Add a data disk on Windows VM.
 
                 await windowsVM.Update()
-                        .WithOSDiskSizeInGB(200)
+                        .WithNewDataDisk(200)
                         .ApplyAsync();
 
                 Utilities.Log("Expanded VM " + windowsVM.Id + "'s OS and data disks");
                 Utilities.PrintVirtualMachine(windowsVM);
-                
-                //=============================================================
-                // Start the virtual machine
-
-                Utilities.Log("Starting VM: " + windowsVM.Id);
-
-                await windowsVM.StartAsync();
-
-                Utilities.Log("Started VM: " + windowsVM.Id + "; state = " + windowsVM.PowerState);
-
                 
                 //=============================================================
                 // List virtual machines in the resource group

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachineAsync/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachineAsync/Program.cs
@@ -115,7 +115,7 @@ namespace ManageVirtualMachineAsync
                         .WithTag("where", "on azure")
                         .ApplyAsync();
 
-                Utilities.Log("Tagged Windows VM: " + windowsVM.Id);
+                Utilities.Log("Tagged Linux VM: " + linuxVM.Id);
 
                 //=============================================================
                 // Update - Add a data disk on Windows VM.

--- a/Samples/Tests/Compute.cs
+++ b/Samples/Tests/Compute.cs
@@ -226,7 +226,7 @@ namespace Samples.Tests
             }
         }
 
-        [Fact(Skip = "Recording fails due to a failure on Managed disks backend")]
+        [Fact(Skip = "Rerecord: Recording fails due to a failure on Managed disks backend")]
         [Trait("Samples", "Compute")]
         public void ManageVirtualMachineAsyncTest()
         {

--- a/Samples/Tests/Compute.cs
+++ b/Samples/Tests/Compute.cs
@@ -226,7 +226,7 @@ namespace Samples.Tests
             }
         }
 
-        [Fact(Skip = "Rerecord: Recording fails due to a failure on Managed disks backend")]
+        [Fact]
         [Trait("Samples", "Compute")]
         public void ManageVirtualMachineAsyncTest()
         {

--- a/Samples/Tests/Dns.cs
+++ b/Samples/Tests/Dns.cs
@@ -15,7 +15,7 @@ namespace Samples.Tests
         {
         }
 
-        [Fact(Skip = "Investigae -- may require us to own a domain: Record test with pre-configured DNS")]
+        [Fact(Skip = "Investigate -- may require us to own a domain: Record test with pre-configured DNS")]
         [Trait("Samples", "Dns")]
         public void ManageDnsTest()
         {

--- a/Samples/Tests/Dns.cs
+++ b/Samples/Tests/Dns.cs
@@ -15,7 +15,7 @@ namespace Samples.Tests
         {
         }
 
-        [Fact(Skip = "TODO: Record test with pre-configured DNS")]
+        [Fact(Skip = "Investigae -- may require us to own a domain: Record test with pre-configured DNS")]
         [Trait("Samples", "Dns")]
         public void ManageDnsTest()
         {

--- a/Samples/Tests/SessionRecords/Samples.Tests.Compute/ManageVirtualMachineAsyncTest.json
+++ b/Samples/Tests/SessionRecords/Samples.Tests.Compute/ManageVirtualMachineAsyncTest.json
@@ -1,8 +1,8 @@
 {
   "Entries": [
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rgcomvbd92926049251846?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDY/YXBpLXZlcnNpb249MjAxNi0wMi0wMQ==",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourcegroups/rgcomv2be28164d26d2f2b?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlZ3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmI/YXBpLXZlcnNpb249MjAxNi0wMi0wMQ==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"location\": \"westcentralus\"\r\n}",
       "RequestHeaders": {
@@ -13,7 +13,7 @@
           "35"
         ],
         "x-ms-client-request-id": [
-          "57177565-e2e6-4d8d-9403-75b890f6a02e"
+          "17897210-bef4-4280-977d-af47f446f50f"
         ],
         "accept-language": [
           "en-US"
@@ -23,7 +23,7 @@
           "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846\",\r\n  \"name\": \"rgcomvbd92926049251846\",\r\n  \"location\": \"westcentralus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b\",\r\n  \"name\": \"rgcomv2be28164d26d2f2b\",\r\n  \"location\": \"westcentralus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "204"
@@ -38,7 +38,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:26:05 GMT"
+          "Tue, 11 Apr 2017 19:49:01 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -47,13 +47,13 @@
           "1199"
         ],
         "x-ms-request-id": [
-          "bad1dcf8-12bd-4448-95b1-9714b2439775"
+          "b273c92d-05a2-4354-a9b8-3a30776afc9d"
         ],
         "x-ms-correlation-request-id": [
-          "bad1dcf8-12bd-4448-95b1-9714b2439775"
+          "b273c92d-05a2-4354-a9b8-3a30776afc9d"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232606Z:bad1dcf8-12bd-4448-95b1-9714b2439775"
+          "WESTUS2:20170411T194902Z:b273c92d-05a2-4354-a9b8-3a30776afc9d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -62,8 +62,8 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rgcomvbd92926049251846?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDY/YXBpLXZlcnNpb249MjAxNi0wMi0wMQ==",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourcegroups/rgcomv2be28164d26d2f2b?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlZ3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmI/YXBpLXZlcnNpb249MjAxNi0wMi0wMQ==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"location\": \"westcentralus\"\r\n}",
       "RequestHeaders": {
@@ -74,7 +74,7 @@
           "35"
         ],
         "x-ms-client-request-id": [
-          "0796bb63-7716-4b4c-a060-f8fac6a13f75"
+          "263ee59c-3a3c-4e13-9bc2-db7016859a4b"
         ],
         "accept-language": [
           "en-US"
@@ -84,7 +84,7 @@
           "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846\",\r\n  \"name\": \"rgcomvbd92926049251846\",\r\n  \"location\": \"westcentralus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b\",\r\n  \"name\": \"rgcomv2be28164d26d2f2b\",\r\n  \"location\": \"westcentralus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -96,7 +96,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:26:37 GMT"
+          "Tue, 11 Apr 2017 19:49:33 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -111,13 +111,13 @@
           "1197"
         ],
         "x-ms-request-id": [
-          "abd86b6b-0550-4c3d-aca9-daecec69c121"
+          "b68be899-993d-4e78-844a-9de7c6b247a3"
         ],
         "x-ms-correlation-request-id": [
-          "abd86b6b-0550-4c3d-aca9-daecec69c121"
+          "b68be899-993d-4e78-844a-9de7c6b247a3"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232637Z:abd86b6b-0550-4c3d-aca9-daecec69c121"
+          "WESTUS2:20170411T194933Z:b68be899-993d-4e78-844a-9de7c6b247a3"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -126,8 +126,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-5a9789569075af552?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL2Rpc2tzL2Rzay01YTk3ODk1NjkwNzVhZjU1Mj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-f3958901328006b28?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL2Rpc2tzL2Rzay1mMzk1ODkwMTMyODAwNmIyOD9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"properties\": {\r\n    \"creationData\": {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 50\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
@@ -138,7 +138,7 @@
           "159"
         ],
         "x-ms-client-request-id": [
-          "4b131b65-9d42-45a8-903d-a28c0559e605"
+          "eceb8c28-afcb-489b-97b1-acb713ee1221"
         ],
         "accept-language": [
           "en-US"
@@ -163,45 +163,45 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:26:05 GMT"
+          "Tue, 11 Apr 2017 19:49:02 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/efc83b7d-ece2-4be1-ba71-e2510994c622?monitor=true&api-version=2016-04-30-preview"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/1cfa0e1d-94d7-4073-9cd7-2be47624f3cb?monitor=true&api-version=2016-04-30-preview"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/efc83b7d-ece2-4be1-ba71-e2510994c622?api-version=2016-04-30-preview"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/1cfa0e1d-94d7-4073-9cd7-2be47624f3cb?api-version=2016-04-30-preview"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "5ecd89cd-321e-4e92-be81-2b22c081951a_131219903224752288"
+          "4880eb97-9883-4875-bc0f-d976655c6469_131219904714663549"
         ],
         "x-ms-request-id": [
-          "efc83b7d-ece2-4be1-ba71-e2510994c622"
+          "1cfa0e1d-94d7-4073-9cd7-2be47624f3cb"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1198"
         ],
         "x-ms-correlation-request-id": [
-          "970f7041-e318-4216-a982-2b01fcf9d80a"
+          "9b2d7389-e7fc-45f5-a984-d3db6eecb161"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232606Z:970f7041-e318-4216-a982-2b01fcf9d80a"
+          "WESTUS2:20170411T194902Z:9b2d7389-e7fc-45f5-a984-d3db6eecb161"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/efc83b7d-ece2-4be1-ba71-e2510994c622?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9EaXNrT3BlcmF0aW9ucy9lZmM4M2I3ZC1lY2UyLTRiZTEtYmE3MS1lMjUxMDk5NGM2MjI/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/1cfa0e1d-94d7-4073-9cd7-2be47624f3cb?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9EaXNrT3BlcmF0aW9ucy8xY2ZhMGUxZC05NGQ3LTQwNzMtOWNkNy0yYmU0NzYyNGYzY2I/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -210,7 +210,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:26:07.3842132-07:00\",\r\n  \"endTime\": \"2017-04-10T16:26:07.5560866-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\r\n      \"properties\": {\r\n        \"accountType\": \"Standard_LRS\",\r\n        \"creationData\": {\r\n          \"createOption\": \"Empty\"\r\n        },\r\n        \"diskSizeGB\": 50,\r\n        \"timeCreated\": \"2017-04-10T16:26:07.3842132-07:00\",\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"diskState\": \"Unattached\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/disks\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-5a9789569075af552\",\r\n      \"name\": \"dsk-5a9789569075af552\"\r\n    }\r\n  },\r\n  \"name\": \"efc83b7d-ece2-4be1-ba71-e2510994c622\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:49:04.6044341-07:00\",\r\n  \"endTime\": \"2017-04-11T12:49:04.807563-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\r\n      \"properties\": {\r\n        \"accountType\": \"Standard_LRS\",\r\n        \"creationData\": {\r\n          \"createOption\": \"Empty\"\r\n        },\r\n        \"diskSizeGB\": 50,\r\n        \"timeCreated\": \"2017-04-11T12:49:04.6200604-07:00\",\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"diskState\": \"Unattached\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/disks\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-f3958901328006b28\",\r\n      \"name\": \"dsk-f3958901328006b28\"\r\n    }\r\n  },\r\n  \"name\": \"1cfa0e1d-94d7-4073-9cd7-2be47624f3cb\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -222,7 +222,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:26:36 GMT"
+          "Tue, 11 Apr 2017 19:49:32 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -241,26 +241,26 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "5ecd89cd-321e-4e92-be81-2b22c081951a_131219903224752288"
+          "4880eb97-9883-4875-bc0f-d976655c6469_131219904714663549"
         ],
         "x-ms-request-id": [
-          "55dcabd9-ebe8-480c-9083-251aa5cf42f4"
+          "21a30b37-9994-4889-a3aa-8ee11d6915a8"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14983"
         ],
         "x-ms-correlation-request-id": [
-          "7c606aa3-e610-4973-8362-37a6c6fa6f0c"
+          "53cb5769-97a8-450f-bce4-a4440296a8dc"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232636Z:7c606aa3-e610-4973-8362-37a6c6fa6f0c"
+          "WESTUS2:20170411T194933Z:53cb5769-97a8-450f-bce4-a4440296a8dc"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-5a9789569075af552?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL2Rpc2tzL2Rzay01YTk3ODk1NjkwNzVhZjU1Mj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-f3958901328006b28?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL2Rpc2tzL2Rzay1mMzk1ODkwMTMyODAwNmIyOD9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -269,7 +269,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"accountType\": \"Standard_LRS\",\r\n    \"creationData\": {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 50,\r\n    \"timeCreated\": \"2017-04-10T16:26:07.3842132-07:00\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-5a9789569075af552\",\r\n  \"name\": \"dsk-5a9789569075af552\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"accountType\": \"Standard_LRS\",\r\n    \"creationData\": {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 50,\r\n    \"timeCreated\": \"2017-04-11T12:49:04.6200604-07:00\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-f3958901328006b28\",\r\n  \"name\": \"dsk-f3958901328006b28\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -281,7 +281,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:26:36 GMT"
+          "Tue, 11 Apr 2017 19:49:32 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -300,97 +300,26 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "5ecd89cd-321e-4e92-be81-2b22c081951a_131219903224752288"
+          "4880eb97-9883-4875-bc0f-d976655c6469_131219904714663549"
         ],
         "x-ms-request-id": [
-          "b8410969-c08d-4f00-8d60-e38a532a77e7"
+          "208b46dc-2c6b-4dd8-ad01-1cd5aec81985"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14982"
         ],
         "x-ms-correlation-request-id": [
-          "f8508cee-5dd2-40fe-85e1-53696f1d37ac"
+          "fed1fe31-0310-4900-a88e-e0413f3db940"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232637Z:f8508cee-5dd2-40fe-85e1-53696f1d37ac"
+          "WESTUS2:20170411T194933Z:fed1fe31-0310-4900-a88e-e0413f3db940"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3ZpcnR1YWxOZXR3b3Jrcy92bmV0YTQ5MTQ2NDAwZGY3P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
-      "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/28\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"properties\": {\r\n          \"addressPrefix\": \"10.0.0.0/28\"\r\n        },\r\n        \"name\": \"subnet1\"\r\n      }\r\n    ]\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "369"
-        ],
-        "x-ms-client-request-id": [
-          "acaf9e7d-344d-4268-ba57-00b1a3df0fe8"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"vneta49146400df7\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7\",\r\n  \"etag\": \"W/\\\"bc24d8da-e195-48f2-b291-d597cbc5f696\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"9de9812f-e0f6-408e-aa1f-c63ea6e52731\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/28\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"subnet1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7/subnets/subnet1\",\r\n        \"etag\": \"W/\\\"bc24d8da-e195-48f2-b291-d597cbc5f696\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"addressPrefix\": \"10.0.0.0/28\"\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "1094"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:26:37 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Retry-After": [
-          "3"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-request-id": [
-          "5a2bd797-4310-4c46-9e71-bd6ae587a7d9"
-        ],
-        "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/5a2bd797-4310-4c46-9e71-bd6ae587a7d9?api-version=2016-12-01"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1196"
-        ],
-        "x-ms-correlation-request-id": [
-          "032af4cc-4072-4aca-863a-50de610790f4"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232637Z:032af4cc-4072-4aca-863a-50de610790f4"
-        ]
-      },
-      "StatusCode": 201
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-c2a86293b05c3ba6d?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL2Rpc2tzL2Rzay1jMmE4NjI5M2IwNWMzYmE2ZD9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-6c89576046cdd10f3?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL2Rpc2tzL2Rzay02Yzg5NTc2MDQ2Y2RkMTBmMz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"properties\": {\r\n    \"creationData\": {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 100\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
@@ -401,7 +330,7 @@
           "160"
         ],
         "x-ms-client-request-id": [
-          "379d1844-9d64-40be-b0cb-f3a6df87600e"
+          "c198a034-a592-4486-880b-4dc659b6275f"
         ],
         "accept-language": [
           "en-US"
@@ -426,45 +355,116 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:26:37 GMT"
+          "Tue, 11 Apr 2017 19:49:33 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/67975eb2-b833-43ec-9402-56b5894518b1?monitor=true&api-version=2016-04-30-preview"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/f298f48a-86f8-4870-90ec-b422be21e5d6?monitor=true&api-version=2016-04-30-preview"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/67975eb2-b833-43ec-9402-56b5894518b1?api-version=2016-04-30-preview"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/f298f48a-86f8-4870-90ec-b422be21e5d6?api-version=2016-04-30-preview"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "5ecd89cd-321e-4e92-be81-2b22c081951a_131219903224752288"
+          "4880eb97-9883-4875-bc0f-d976655c6469_131219904714663549"
         ],
         "x-ms-request-id": [
-          "67975eb2-b833-43ec-9402-56b5894518b1"
+          "f298f48a-86f8-4870-90ec-b422be21e5d6"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1199"
         ],
         "x-ms-correlation-request-id": [
-          "fa42d0c6-d717-40d8-825b-2504d8c219d6"
+          "8c9e8b37-5bd3-4050-a4f5-970dc6089836"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232638Z:fa42d0c6-d717-40d8-825b-2504d8c219d6"
+          "WESTUS2:20170411T194933Z:8c9e8b37-5bd3-4050-a4f5-970dc6089836"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/67975eb2-b833-43ec-9402-56b5894518b1?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9EaXNrT3BlcmF0aW9ucy82Nzk3NWViMi1iODMzLTQzZWMtOTQwMi01NmI1ODk0NTE4YjE/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3ZpcnR1YWxOZXR3b3Jrcy92bmV0YzAwMDMxNTY2OWNhP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/28\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"properties\": {\r\n          \"addressPrefix\": \"10.0.0.0/28\"\r\n        },\r\n        \"name\": \"subnet1\"\r\n      }\r\n    ]\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "369"
+        ],
+        "x-ms-client-request-id": [
+          "bbcb1541-6eee-4435-9a23-03a0114b0757"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"vnetc000315669ca\",\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca\",\r\n  \"etag\": \"W/\\\"117ffad4-2243-4eb6-8341-e1d96ee1b7f6\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"f85f242e-234a-456c-a5b9-346ba50f061d\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/28\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"subnet1\",\r\n        \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca/subnets/subnet1\",\r\n        \"etag\": \"W/\\\"117ffad4-2243-4eb6-8341-e1d96ee1b7f6\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"addressPrefix\": \"10.0.0.0/28\"\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "1094"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:49:33 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "3"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "775835f7-42c3-4b1b-b75a-957bc3ce18c5"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Network/locations/westcentralus/operations/775835f7-42c3-4b1b-b75a-957bc3ce18c5?api-version=2016-12-01"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1196"
+        ],
+        "x-ms-correlation-request-id": [
+          "09a802f9-5a81-4890-9791-e2ab67666d73"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T194934Z:09a802f9-5a81-4890-9791-e2ab67666d73"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/DiskOperations/f298f48a-86f8-4870-90ec-b422be21e5d6?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9EaXNrT3BlcmF0aW9ucy9mMjk4ZjQ4YS04NmY4LTQ4NzAtOTBlYy1iNDIyYmUyMWU1ZDY/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -473,7 +473,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:26:38.6525166-07:00\",\r\n  \"endTime\": \"2017-04-10T16:26:38.8400355-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\r\n      \"properties\": {\r\n        \"accountType\": \"Standard_LRS\",\r\n        \"creationData\": {\r\n          \"createOption\": \"Empty\"\r\n        },\r\n        \"diskSizeGB\": 100,\r\n        \"timeCreated\": \"2017-04-10T16:26:38.6525166-07:00\",\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"diskState\": \"Unattached\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/disks\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-c2a86293b05c3ba6d\",\r\n      \"name\": \"dsk-c2a86293b05c3ba6d\"\r\n    }\r\n  },\r\n  \"name\": \"67975eb2-b833-43ec-9402-56b5894518b1\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:49:35.8222934-07:00\",\r\n  \"endTime\": \"2017-04-11T12:49:35.9785774-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"properties\": {\r\n    \"output\": {\r\n      \"properties\": {\r\n        \"accountType\": \"Standard_LRS\",\r\n        \"creationData\": {\r\n          \"createOption\": \"Empty\"\r\n        },\r\n        \"diskSizeGB\": 100,\r\n        \"timeCreated\": \"2017-04-11T12:49:35.8222934-07:00\",\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"diskState\": \"Unattached\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/disks\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-6c89576046cdd10f3\",\r\n      \"name\": \"dsk-6c89576046cdd10f3\"\r\n    }\r\n  },\r\n  \"name\": \"f298f48a-86f8-4870-90ec-b422be21e5d6\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -485,7 +485,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:27:07 GMT"
+          "Tue, 11 Apr 2017 19:50:03 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -504,85 +504,26 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "5ecd89cd-321e-4e92-be81-2b22c081951a_131219903224752288"
+          "4880eb97-9883-4875-bc0f-d976655c6469_131219904714663549"
         ],
         "x-ms-request-id": [
-          "49c123e6-c879-4739-be56-517a0089de08"
+          "7ee70347-171a-42c8-b7cb-a2095c9d4312"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14981"
+          "14985"
         ],
         "x-ms-correlation-request-id": [
-          "0ed3bf0d-ebc8-4322-a0f0-a6ee4f405882"
+          "284b4b4e-48c5-43d8-88f0-07a9631d12f4"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232708Z:0ed3bf0d-ebc8-4322-a0f0-a6ee4f405882"
+          "WESTUS2:20170411T195004Z:284b4b4e-48c5-43d8-88f0-07a9631d12f4"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-c2a86293b05c3ba6d?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL2Rpc2tzL2Rzay1jMmE4NjI5M2IwNWMzYmE2ZD9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"accountType\": \"Standard_LRS\",\r\n    \"creationData\": {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 100,\r\n    \"timeCreated\": \"2017-04-10T16:26:38.6525166-07:00\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-c2a86293b05c3ba6d\",\r\n  \"name\": \"dsk-c2a86293b05c3ba6d\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:27:07 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "5ecd89cd-321e-4e92-be81-2b22c081951a_131219903224752288"
-        ],
-        "x-ms-request-id": [
-          "9700dede-7c16-499b-b1fc-b5fe1d4f6c0b"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14980"
-        ],
-        "x-ms-correlation-request-id": [
-          "13ddfa0a-c980-4640-908b-ada71a8fb87c"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232708Z:13ddfa0a-c980-4640-908b-ada71a8fb87c"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/5a2bd797-4310-4c46-9e71-bd6ae587a7d9?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzVhMmJkNzk3LTQzMTAtNGM0Ni05ZTcxLWJkNmFlNTg3YTdkOT9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Network/locations/westcentralus/operations/775835f7-42c3-4b1b-b75a-957bc3ce18c5?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzc3NTgzNWY3LTQyYzMtNGIxYi1iNzVhLTk1N2JjM2NlMThjNT9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -603,7 +544,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:27:08 GMT"
+          "Tue, 11 Apr 2017 19:50:03 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -619,7 +560,125 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "c9ce9ff7-175d-48f5-b8e9-102b6bab8175"
+          "a21d4b6e-baa1-45b4-90f8-d9c15d8a77cb"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14981"
+        ],
+        "x-ms-correlation-request-id": [
+          "336879d8-95a3-4fff-a3be-24e8e477fea4"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195004Z:336879d8-95a3-4fff-a3be-24e8e477fea4"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-6c89576046cdd10f3?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL2Rpc2tzL2Rzay02Yzg5NTc2MDQ2Y2RkMTBmMz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"accountType\": \"Standard_LRS\",\r\n    \"creationData\": {\r\n      \"createOption\": \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 100,\r\n    \"timeCreated\": \"2017-04-11T12:49:35.8222934-07:00\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Unattached\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-6c89576046cdd10f3\",\r\n  \"name\": \"dsk-6c89576046cdd10f3\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:50:03 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "4880eb97-9883-4875-bc0f-d976655c6469_131219904714663549"
+        ],
+        "x-ms-request-id": [
+          "39f06c51-e0d7-4a72-a941-550a42bc02ef"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14984"
+        ],
+        "x-ms-correlation-request-id": [
+          "8699881e-417f-4d07-a5b2-0c3c17d1ea6e"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195004Z:8699881e-417f-4d07-a5b2-0c3c17d1ea6e"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3ZpcnR1YWxOZXR3b3Jrcy92bmV0YzAwMDMxNTY2OWNhP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"vnetc000315669ca\",\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca\",\r\n  \"etag\": \"W/\\\"042ed391-ad7b-4035-af9d-24390c3a64ba\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"f85f242e-234a-456c-a5b9-346ba50f061d\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/28\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"subnet1\",\r\n        \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca/subnets/subnet1\",\r\n        \"etag\": \"W/\\\"042ed391-ad7b-4035-af9d-24390c3a64ba\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"addressPrefix\": \"10.0.0.0/28\"\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:50:03 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "ETag": [
+          "W/\"042ed391-ad7b-4035-af9d-24390c3a64ba\""
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "830a1391-3916-45ad-998d-97498cf76ef9"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -628,81 +687,22 @@
           "14980"
         ],
         "x-ms-correlation-request-id": [
-          "5a518321-4233-4a7b-abc7-133c9efac1aa"
+          "94e654ef-0bca-498d-b786-d4ac01f22feb"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232708Z:5a518321-4233-4a7b-abc7-133c9efac1aa"
+          "WESTUS2:20170411T195004Z:94e654ef-0bca-498d-b786-d4ac01f22feb"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3ZpcnR1YWxOZXR3b3Jrcy92bmV0YTQ5MTQ2NDAwZGY3P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"vneta49146400df7\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7\",\r\n  \"etag\": \"W/\\\"3eb5ab03-6c86-4dff-a1c8-e4ebc3aaf73f\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"9de9812f-e0f6-408e-aa1f-c63ea6e52731\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/28\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"subnet1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7/subnets/subnet1\",\r\n        \"etag\": \"W/\\\"3eb5ab03-6c86-4dff-a1c8-e4ebc3aaf73f\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"addressPrefix\": \"10.0.0.0/28\"\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:27:08 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "ETag": [
-          "W/\"3eb5ab03-6c86-4dff-a1c8-e4ebc3aaf73f\""
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "a070ee2f-cae3-4f43-9894-1c0399c78db8"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14979"
-        ],
-        "x-ms-correlation-request-id": [
-          "883aa699-a933-408c-b41f-a464cac48b31"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232708Z:883aa699-a933-408c-b41f-a464cac48b31"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3ZpcnR1YWxOZXR3b3Jrcy92bmV0YTQ5MTQ2NDAwZGY3P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3ZpcnR1YWxOZXR3b3Jrcy92bmV0YzAwMDMxNTY2OWNhP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "4b1c4f36-38ac-4456-90f3-b2612d7e973c"
+          "150d6e20-c468-490d-887c-d4e2fb07cf62"
         ],
         "accept-language": [
           "en-US"
@@ -712,7 +712,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"vneta49146400df7\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7\",\r\n  \"etag\": \"W/\\\"25dc1b33-0693-4004-a676-eba830de84da\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"9de9812f-e0f6-408e-aa1f-c63ea6e52731\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/28\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"subnet1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7/subnets/subnet1\",\r\n        \"etag\": \"W/\\\"25dc1b33-0693-4004-a676-eba830de84da\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"addressPrefix\": \"10.0.0.0/28\",\r\n          \"ipConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846/ipConfigurations/primary\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"vnetc000315669ca\",\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca\",\r\n  \"etag\": \"W/\\\"7de35a4c-8edf-4c35-a7b3-b8b542c965c6\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"f85f242e-234a-456c-a5b9-346ba50f061d\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/28\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"subnet1\",\r\n        \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca/subnets/subnet1\",\r\n        \"etag\": \"W/\\\"7de35a4c-8edf-4c35-a7b3-b8b542c965c6\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"addressPrefix\": \"10.0.0.0/28\",\r\n          \"ipConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4/ipConfigurations/primary\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -724,7 +724,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:30:10 GMT"
+          "Tue, 11 Apr 2017 19:52:36 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -733,7 +733,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"25dc1b33-0693-4004-a676-eba830de84da\""
+          "W/\"7de35a4c-8edf-4c35-a7b3-b8b542c965c6\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -743,28 +743,28 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "7d26f835-ca31-4849-b42d-fbdfcb54441b"
+          "cc93aa75-e163-4662-936b-24eaf9c18815"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14969"
+          "14971"
         ],
         "x-ms-correlation-request-id": [
-          "cefd50c0-4e9d-4647-805d-1dc31d1aaa84"
+          "cd532092-41cb-4550-a3d0-d2cc06a8f233"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233010Z:cefd50c0-4e9d-4647-805d-1dc31d1aaa84"
+          "WESTUS2:20170411T195237Z:cd532092-41cb-4550-a3d0-d2cc06a8f233"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL25ldHdvcmtJbnRlcmZhY2VzL25pYzc4MTUzYWFjODQ2P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL25ldHdvcmtJbnRlcmZhY2VzL25pYzQzMTU1ODBkYmU0P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"properties\": {\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7/subnets/subnet1\"\r\n          }\r\n        },\r\n        \"name\": \"primary\"\r\n      }\r\n    ],\r\n    \"dnsSettings\": {}\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"properties\": {\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca/subnets/subnet1\"\r\n          }\r\n        },\r\n        \"name\": \"primary\"\r\n      }\r\n    ],\r\n    \"dnsSettings\": {}\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -773,7 +773,7 @@
           "490"
         ],
         "x-ms-client-request-id": [
-          "31a864ed-182e-4d90-b7df-dfdfa18a1969"
+          "b0ceb444-64c9-4142-b38d-4e403cede9a8"
         ],
         "accept-language": [
           "en-US"
@@ -783,7 +783,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"nic78153aac846\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846\",\r\n  \"etag\": \"W/\\\"fcc39e98-1af3-4383-8594-541c220b39be\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1386897d-9591-40eb-a54a-7dc0a35bc810\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"fcc39e98-1af3-4383-8594-541c220b39be\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"f4a4thpw2chebkq5yy5knzjhgb.yx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"nic4315580dbe4\",\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4\",\r\n  \"etag\": \"W/\\\"1f814385-04e3-4daa-8ce1-634d4878d124\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"a9e02de9-1cb3-4f77-8e00-18110139e22b\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"1f814385-04e3-4daa-8ce1-634d4878d124\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"fysf54ckenweljnzgrv0kdygdf.yx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "1537"
@@ -798,7 +798,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:27:08 GMT"
+          "Tue, 11 Apr 2017 19:50:04 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -808,10 +808,10 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "6cd0eb12-1bee-4357-a7b3-dc790468fa16"
+          "6bd50570-672f-4ee2-85bc-9ea1e3a1e4ae"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/6cd0eb12-1bee-4357-a7b3-dc790468fa16?api-version=2016-12-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Network/locations/westcentralus/operations/6bd50570-672f-4ee2-85bc-9ea1e3a1e4ae?api-version=2016-12-01"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -820,17 +820,17 @@
           "1198"
         ],
         "x-ms-correlation-request-id": [
-          "8b0e71f2-c5a0-4749-a81f-8a7f5525e370"
+          "d640fc14-e335-462c-9776-9fee2540cea4"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232709Z:8b0e71f2-c5a0-4749-a81f-8a7f5525e370"
+          "WESTUS2:20170411T195005Z:d640fc14-e335-462c-9776-9fee2540cea4"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL25ldHdvcmtJbnRlcmZhY2VzL25pYzc4MTUzYWFjODQ2P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL25ldHdvcmtJbnRlcmZhY2VzL25pYzQzMTU1ODBkYmU0P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -839,7 +839,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"nic78153aac846\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846\",\r\n  \"etag\": \"W/\\\"fcc39e98-1af3-4383-8594-541c220b39be\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1386897d-9591-40eb-a54a-7dc0a35bc810\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"fcc39e98-1af3-4383-8594-541c220b39be\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"f4a4thpw2chebkq5yy5knzjhgb.yx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"nic4315580dbe4\",\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4\",\r\n  \"etag\": \"W/\\\"1f814385-04e3-4daa-8ce1-634d4878d124\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"a9e02de9-1cb3-4f77-8e00-18110139e22b\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"1f814385-04e3-4daa-8ce1-634d4878d124\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"fysf54ckenweljnzgrv0kdygdf.yx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -851,7 +851,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:27:09 GMT"
+          "Tue, 11 Apr 2017 19:50:04 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -860,7 +860,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"fcc39e98-1af3-4383-8594-541c220b39be\""
+          "W/\"1f814385-04e3-4daa-8ce1-634d4878d124\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -870,31 +870,31 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "f7c177cc-1d44-4e48-91dc-949d368d98d3"
+          "b183fed4-280c-4f8c-8503-2091c600698d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14978"
+          "14979"
         ],
         "x-ms-correlation-request-id": [
-          "a5b6401f-f5a9-4d3d-b310-6b38b3be91c2"
+          "1fb18b67-fbad-4ff1-bad5-1a4771889519"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232709Z:a5b6401f-f5a9-4d3d-b310-6b38b3be91c2"
+          "WESTUS2:20170411T195005Z:1fb18b67-fbad-4ff1-bad5-1a4771889519"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL25ldHdvcmtJbnRlcmZhY2VzL25pYzc4MTUzYWFjODQ2P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL25ldHdvcmtJbnRlcmZhY2VzL25pYzQzMTU1ODBkYmU0P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "8997d62b-8881-4226-be30-632637d1831d"
+          "c3b6ef6f-dcfa-47d3-94a1-bb0795614af4"
         ],
         "accept-language": [
           "en-US"
@@ -904,7 +904,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"nic78153aac846\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846\",\r\n  \"etag\": \"W/\\\"9dccee96-83d5-44b0-94d8-591f2f04f455\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1386897d-9591-40eb-a54a-7dc0a35bc810\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"9dccee96-83d5-44b0-94d8-591f2f04f455\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"f4a4thpw2chebkq5yy5knzjhgb.yx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\": \"00-0D-3A-F8-27-43\",\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/wvm00888296b97d513d1\"\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"nic4315580dbe4\",\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4\",\r\n  \"etag\": \"W/\\\"b79def0a-4116-4cef-b23f-1ba8b6546e32\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"a9e02de9-1cb3-4f77-8e00-18110139e22b\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"b79def0a-4116-4cef-b23f-1ba8b6546e32\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"fysf54ckenweljnzgrv0kdygdf.yx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\": \"00-0D-3A-F8-37-5E\",\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94\"\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -916,7 +916,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:30:10 GMT"
+          "Tue, 11 Apr 2017 19:52:36 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -925,7 +925,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"9dccee96-83d5-44b0-94d8-591f2f04f455\""
+          "W/\"b79def0a-4116-4cef-b23f-1ba8b6546e32\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -935,28 +935,28 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "aa4f3389-fe0a-428f-8b73-f69ce11f6aa4"
+          "242bcfbf-06af-46f6-a896-b448e744d342"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14970"
+          "14972"
         ],
         "x-ms-correlation-request-id": [
-          "73ff46fb-a874-4b5b-8404-7214d1662569"
+          "258053c8-1bd4-4b27-ac59-53d95d9ede4c"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233010Z:73ff46fb-a874-4b5b-8404-7214d1662569"
+          "WESTUS2:20170411T195237Z:258053c8-1bd4-4b27-ac59-53d95d9ede4c"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/wvm00888296b97d513d1?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy93dm0wMDg4ODI5NmI5N2Q1MTNkMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy93dm0wMjQwMzg4NDM0MTJhY2U5ND9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"caching\": \"ReadWrite\",\r\n        \"createOption\": \"fromImage\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\r\n        }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\": 0,\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"attach\",\r\n          \"managedDisk\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-c2a86293b05c3ba6d\"\r\n          }\r\n        },\r\n        {\r\n          \"lun\": 1,\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"attach\",\r\n          \"managedDisk\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-5a9789569075af552\"\r\n          }\r\n        },\r\n        {\r\n          \"lun\": 2,\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"empty\",\r\n          \"diskSizeGB\": 10,\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vmb9c85326d1\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"adminPassword\": \"12NewPA$$w0rd!\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true\r\n      }\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"properties\": {\r\n            \"primary\": true\r\n          },\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846\"\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"caching\": \"ReadWrite\",\r\n        \"createOption\": \"fromImage\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\r\n        }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\": 0,\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"attach\",\r\n          \"managedDisk\": {\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-6c89576046cdd10f3\"\r\n          }\r\n        },\r\n        {\r\n          \"lun\": 1,\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"attach\",\r\n          \"managedDisk\": {\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-f3958901328006b28\"\r\n          }\r\n        },\r\n        {\r\n          \"lun\": 2,\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"empty\",\r\n          \"diskSizeGB\": 10,\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2ff6843534\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"adminPassword\": \"12NewPA$$w0rd!\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true\r\n      }\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"properties\": {\r\n            \"primary\": true\r\n          },\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4\"\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -965,7 +965,7 @@
           "2058"
         ],
         "x-ms-client-request-id": [
-          "1980a095-1a04-442f-8fb6-2774700a8856"
+          "f5666029-aa12-4e45-b512-a82745b1af32"
         ],
         "accept-language": [
           "en-US"
@@ -975,7 +975,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"6b724a92-bff7-4645-91a5-d8218714f772\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\r\n        }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"dsk-c2a86293b05c3ba6d\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-c2a86293b05c3ba6d\"\r\n          },\r\n          \"diskSizeGB\": 100\r\n        },\r\n        {\r\n          \"lun\": 1,\r\n          \"name\": \"dsk-5a9789569075af552\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-5a9789569075af552\"\r\n          },\r\n          \"diskSizeGB\": 50\r\n        },\r\n        {\r\n          \"lun\": 2,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          },\r\n          \"diskSizeGB\": 10\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vmb9c85326d1\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/wvm00888296b97d513d1\",\r\n  \"name\": \"wvm00888296b97d513d1\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"bb6b86f5-6fe3-4593-ba19-08857a2d070f\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\r\n        }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"dsk-6c89576046cdd10f3\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-6c89576046cdd10f3\"\r\n          },\r\n          \"diskSizeGB\": 100\r\n        },\r\n        {\r\n          \"lun\": 1,\r\n          \"name\": \"dsk-f3958901328006b28\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-f3958901328006b28\"\r\n          },\r\n          \"diskSizeGB\": 50\r\n        },\r\n        {\r\n          \"lun\": 2,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          },\r\n          \"diskSizeGB\": 10\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2ff6843534\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94\",\r\n  \"name\": \"wvm024038843412ace94\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "2562"
@@ -990,7 +990,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:27:09 GMT"
+          "Tue, 11 Apr 2017 19:50:05 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1000,43 +1000,43 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/2f1ee3a5-72f3-4937-a784-5dcce894e5b9?api-version=2016-04-30-preview"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/284e5ea6-24f0-408f-980a-1a3b2d01686f?api-version=2016-04-30-preview"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "2f1ee3a5-72f3-4937-a784-5dcce894e5b9"
+          "284e5ea6-24f0-408f-980a-1a3b2d01686f"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1197"
         ],
         "x-ms-correlation-request-id": [
-          "e197f299-2236-4b27-9d45-a89a50412d6c"
+          "3199780e-774b-49c2-86d5-87d4eb71e9f5"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232709Z:e197f299-2236-4b27-9d45-a89a50412d6c"
+          "WESTUS2:20170411T195005Z:3199780e-774b-49c2-86d5-87d4eb71e9f5"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/wvm00888296b97d513d1?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy93dm0wMDg4ODI5NmI5N2Q1MTNkMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy93dm0wMjQwMzg4NDM0MTJhY2U5ND9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\": \"wvm00888296b97d513d1_OsDisk_1_a82841dc524647999e76923a57fbca5e\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"createOption\": \"fromImage\",\r\n        \"diskSizeGB\": 200,\r\n        \"managedDisk\": {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/wvm00888296b97d513d1_OsDisk_1_a82841dc524647999e76923a57fbca5e\"\r\n        }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"dsk-c2a86293b05c3ba6d\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"attach\",\r\n          \"managedDisk\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-c2a86293b05c3ba6d\"\r\n          }\r\n        },\r\n        {\r\n          \"lun\": 1,\r\n          \"name\": \"dsk-5a9789569075af552\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"attach\",\r\n          \"managedDisk\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-5a9789569075af552\"\r\n          }\r\n        },\r\n        {\r\n          \"lun\": 2,\r\n          \"name\": \"wvm00888296b97d513d1_disk4_4c9bc3b9c00746658ea2c466b9505da7\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"empty\",\r\n          \"managedDisk\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/wvm00888296b97d513d1_disk4_4c9bc3b9c00746658ea2c466b9505da7\"\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vmb9c85326d1\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"properties\": {\r\n            \"primary\": true\r\n          },\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846\"\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/wvm00888296b97d513d1\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\": \"wvm024038843412ace94_OsDisk_1_51be9f3d300342a1b4795d94592e431c\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"createOption\": \"fromImage\",\r\n        \"diskSizeGB\": 128,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_OsDisk_1_51be9f3d300342a1b4795d94592e431c\"\r\n        }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"dsk-6c89576046cdd10f3\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"attach\",\r\n          \"diskSizeGB\": 100,\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-6c89576046cdd10f3\"\r\n          }\r\n        },\r\n        {\r\n          \"lun\": 1,\r\n          \"name\": \"dsk-f3958901328006b28\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"attach\",\r\n          \"diskSizeGB\": 50,\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-f3958901328006b28\"\r\n          }\r\n        },\r\n        {\r\n          \"lun\": 2,\r\n          \"name\": \"wvm024038843412ace94_disk4_58ab71d8b9e24c829b40d209f4f164cf\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"empty\",\r\n          \"diskSizeGB\": 10,\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_disk4_58ab71d8b9e24c829b40d209f4f164cf\"\r\n          }\r\n        },\r\n        {\r\n          \"lun\": 3,\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"empty\",\r\n          \"diskSizeGB\": 200,\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2ff6843534\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"properties\": {\r\n            \"primary\": true\r\n          },\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4\"\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "2800"
+          "3326"
         ],
         "x-ms-client-request-id": [
-          "94f62a30-9ad0-4ea8-af62-08d24bcf79a8"
+          "12c8ae37-6ca7-4656-a060-58c848150165"
         ],
         "accept-language": [
           "en-US"
@@ -1046,11 +1046,8 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"ResizeDiskError\",\r\n    \"target\": \"disk.diskSizeGB\",\r\n    \"message\": \"Managed disk resize via Virtual Machine 'wvm00888296b97d513d1' is not allowed. Please resize disk resource at /subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/wvm00888296b97d513d1_OsDisk_1_a82841dc524647999e76923a57fbca5e.\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"bb6b86f5-6fe3-4593-ba19-08857a2d070f\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\": \"wvm024038843412ace94_OsDisk_1_51be9f3d300342a1b4795d94592e431c\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_OsDisk_1_51be9f3d300342a1b4795d94592e431c\"\r\n        },\r\n        \"diskSizeGB\": 128\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"dsk-6c89576046cdd10f3\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-6c89576046cdd10f3\"\r\n          },\r\n          \"diskSizeGB\": 100\r\n        },\r\n        {\r\n          \"lun\": 1,\r\n          \"name\": \"dsk-f3958901328006b28\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-f3958901328006b28\"\r\n          },\r\n          \"diskSizeGB\": 50\r\n        },\r\n        {\r\n          \"lun\": 2,\r\n          \"name\": \"wvm024038843412ace94_disk4_58ab71d8b9e24c829b40d209f4f164cf\",\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_disk4_58ab71d8b9e24c829b40d209f4f164cf\"\r\n          },\r\n          \"diskSizeGB\": 10\r\n        },\r\n        {\r\n          \"lun\": 3,\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          },\r\n          \"diskSizeGB\": 200\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2ff6843534\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94\",\r\n  \"name\": \"wvm024038843412ace94\"\r\n}",
       "ResponseHeaders": {
-        "Content-Length": [
-          "405"
-        ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
@@ -1061,39 +1058,48 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:35:14 GMT"
+          "Tue, 11 Apr 2017 19:54:40 GMT"
         ],
         "Pragma": [
           "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
           "Microsoft-HTTPAPI/2.0"
         ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/3724bf36-6183-494e-a38f-38e813310f21?api-version=2016-04-30-preview"
+        ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "809095a5-0a3b-4b87-a7b3-bc2d1946815c"
+          "3724bf36-6183-494e-a38f-38e813310f21"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1192"
         ],
         "x-ms-correlation-request-id": [
-          "1c2312e5-f833-4332-bc7a-e4f72fcdfaf2"
+          "379cea6c-13ea-45ce-8be7-9e7b996cece9"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233514Z:1c2312e5-f833-4332-bc7a-e4f72fcdfaf2"
+          "WESTUS2:20170411T195440Z:379cea6c-13ea-45ce-8be7-9e7b996cece9"
         ]
       },
-      "StatusCode": 400
+      "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/2f1ee3a5-72f3-4937-a784-5dcce894e5b9?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzJmMWVlM2E1LTcyZjMtNDkzNy1hNzg0LTVkY2NlODk0ZTViOT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/284e5ea6-24f0-408f-980a-1a3b2d01686f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI4NGU1ZWE2LTI0ZjAtNDA4Zi05ODBhLTFhM2IyZDAxNjg2Zj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -1102,7 +1108,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:27:10.4473725-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"2f1ee3a5-72f3-4937-a784-5dcce894e5b9\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:50:05.7518735-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"284e5ea6-24f0-408f-980a-1a3b2d01686f\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1114,7 +1120,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:27:40 GMT"
+          "Tue, 11 Apr 2017 19:50:35 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1133,26 +1139,85 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "ba1fe48e-0250-4ff0-bd6d-72dfed029f0d"
+          "17385055-c24a-486a-81d6-66ecaecb9efa"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14978"
+        ],
+        "x-ms-correlation-request-id": [
+          "65a6c263-9210-4d85-b521-75cdabf58d61"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195036Z:65a6c263-9210-4d85-b521-75cdabf58d61"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/284e5ea6-24f0-408f-980a-1a3b2d01686f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI4NGU1ZWE2LTI0ZjAtNDA4Zi05ODBhLTFhM2IyZDAxNjg2Zj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:50:05.7518735-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"284e5ea6-24f0-408f-980a-1a3b2d01686f\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:51:06 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "79622c94-2bd0-4a10-a500-7c94380c8d64"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14977"
         ],
         "x-ms-correlation-request-id": [
-          "aced8444-c639-4bb3-b51b-6206d490bf06"
+          "f8b9fe86-f471-4f22-a1a0-00c1789c52d1"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232740Z:aced8444-c639-4bb3-b51b-6206d490bf06"
+          "WESTUS2:20170411T195106Z:f8b9fe86-f471-4f22-a1a0-00c1789c52d1"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/2f1ee3a5-72f3-4937-a784-5dcce894e5b9?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzJmMWVlM2E1LTcyZjMtNDkzNy1hNzg0LTVkY2NlODk0ZTViOT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/284e5ea6-24f0-408f-980a-1a3b2d01686f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI4NGU1ZWE2LTI0ZjAtNDA4Zi05ODBhLTFhM2IyZDAxNjg2Zj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -1161,7 +1226,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:27:10.4473725-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"2f1ee3a5-72f3-4937-a784-5dcce894e5b9\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:50:05.7518735-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"284e5ea6-24f0-408f-980a-1a3b2d01686f\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1173,7 +1238,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:28:09 GMT"
+          "Tue, 11 Apr 2017 19:51:36 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1192,26 +1257,26 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "f4938a66-f8a0-43c4-ba4a-b80bcc730cfd"
+          "38690795-a80e-4572-ae76-b4806b4064d8"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14976"
         ],
         "x-ms-correlation-request-id": [
-          "7070a132-1b17-493c-a2be-b20adb0eb8ea"
+          "8f875199-b740-4605-a5be-ad73d6f58910"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232810Z:7070a132-1b17-493c-a2be-b20adb0eb8ea"
+          "WESTUS2:20170411T195136Z:8f875199-b740-4605-a5be-ad73d6f58910"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/2f1ee3a5-72f3-4937-a784-5dcce894e5b9?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzJmMWVlM2E1LTcyZjMtNDkzNy1hNzg0LTVkY2NlODk0ZTViOT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/284e5ea6-24f0-408f-980a-1a3b2d01686f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI4NGU1ZWE2LTI0ZjAtNDA4Zi05ODBhLTFhM2IyZDAxNjg2Zj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -1220,7 +1285,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:27:10.4473725-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"2f1ee3a5-72f3-4937-a784-5dcce894e5b9\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:50:05.7518735-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"284e5ea6-24f0-408f-980a-1a3b2d01686f\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1232,7 +1297,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:28:39 GMT"
+          "Tue, 11 Apr 2017 19:52:05 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1251,26 +1316,85 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "48f6e542-9b34-4c55-bcf9-6512e1bbca67"
+          "3078e498-3ee1-4c4f-8428-c2a9e0f1f875"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14975"
+        ],
+        "x-ms-correlation-request-id": [
+          "3014dccc-5986-42a6-a429-596fc1da59e5"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195206Z:3014dccc-5986-42a6-a429-596fc1da59e5"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/284e5ea6-24f0-408f-980a-1a3b2d01686f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI4NGU1ZWE2LTI0ZjAtNDA4Zi05ODBhLTFhM2IyZDAxNjg2Zj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:50:05.7518735-07:00\",\r\n  \"endTime\": \"2017-04-11T12:52:25.8457155-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"284e5ea6-24f0-408f-980a-1a3b2d01686f\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:52:35 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "8f8d6baa-f9e3-4d53-b7b8-f53640d08adf"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14974"
         ],
         "x-ms-correlation-request-id": [
-          "99a1fd67-8e13-4f4d-a158-803c13fc8e88"
+          "38f97383-c92f-48e1-928c-a2756854ce2c"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232840Z:99a1fd67-8e13-4f4d-a158-803c13fc8e88"
+          "WESTUS2:20170411T195236Z:38f97383-c92f-48e1-928c-a2756854ce2c"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/2f1ee3a5-72f3-4937-a784-5dcce894e5b9?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzJmMWVlM2E1LTcyZjMtNDkzNy1hNzg0LTVkY2NlODk0ZTViOT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy93dm0wMjQwMzg4NDM0MTJhY2U5ND9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -1279,7 +1403,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:27:10.4473725-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"2f1ee3a5-72f3-4937-a784-5dcce894e5b9\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"bb6b86f5-6fe3-4593-ba19-08857a2d070f\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\": \"wvm024038843412ace94_OsDisk_1_51be9f3d300342a1b4795d94592e431c\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_OsDisk_1_51be9f3d300342a1b4795d94592e431c\"\r\n        },\r\n        \"diskSizeGB\": 128\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"dsk-6c89576046cdd10f3\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-6c89576046cdd10f3\"\r\n          },\r\n          \"diskSizeGB\": 100\r\n        },\r\n        {\r\n          \"lun\": 1,\r\n          \"name\": \"dsk-f3958901328006b28\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-f3958901328006b28\"\r\n          },\r\n          \"diskSizeGB\": 50\r\n        },\r\n        {\r\n          \"lun\": 2,\r\n          \"name\": \"wvm024038843412ace94_disk4_58ab71d8b9e24c829b40d209f4f164cf\",\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_disk4_58ab71d8b9e24c829b40d209f4f164cf\"\r\n          },\r\n          \"diskSizeGB\": 10\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2ff6843534\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94\",\r\n  \"name\": \"wvm024038843412ace94\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1291,7 +1415,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:29:09 GMT"
+          "Tue, 11 Apr 2017 19:52:36 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1310,26 +1434,26 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "3b55763e-06aa-4d0d-ac6d-a17fcea67281"
+          "071a13ab-80d9-46fc-9302-f55bfe65570d"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14973"
         ],
         "x-ms-correlation-request-id": [
-          "257d4692-32a7-4d19-a974-ad473d4da323"
+          "9a14f511-4ffc-4f86-b4be-10ff4001398f"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232910Z:257d4692-32a7-4d19-a974-ad473d4da323"
+          "WESTUS2:20170411T195236Z:9a14f511-4ffc-4f86-b4be-10ff4001398f"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/2f1ee3a5-72f3-4937-a784-5dcce894e5b9?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzJmMWVlM2E1LTcyZjMtNDkzNy1hNzg0LTVkY2NlODk0ZTViOT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy93dm0wMjQwMzg4NDM0MTJhY2U5ND9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -1338,7 +1462,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:27:10.4473725-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"2f1ee3a5-72f3-4937-a784-5dcce894e5b9\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"bb6b86f5-6fe3-4593-ba19-08857a2d070f\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\": \"wvm024038843412ace94_OsDisk_1_51be9f3d300342a1b4795d94592e431c\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_OsDisk_1_51be9f3d300342a1b4795d94592e431c\"\r\n        },\r\n        \"diskSizeGB\": 128\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"dsk-6c89576046cdd10f3\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-6c89576046cdd10f3\"\r\n          },\r\n          \"diskSizeGB\": 100\r\n        },\r\n        {\r\n          \"lun\": 1,\r\n          \"name\": \"dsk-f3958901328006b28\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-f3958901328006b28\"\r\n          },\r\n          \"diskSizeGB\": 50\r\n        },\r\n        {\r\n          \"lun\": 2,\r\n          \"name\": \"wvm024038843412ace94_disk4_58ab71d8b9e24c829b40d209f4f164cf\",\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_disk4_58ab71d8b9e24c829b40d209f4f164cf\"\r\n          },\r\n          \"diskSizeGB\": 10\r\n        },\r\n        {\r\n          \"lun\": 3,\r\n          \"name\": \"wvm024038843412ace94_disk5_025641727ace4898bd6ab0359163c6ff\",\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_disk5_025641727ace4898bd6ab0359163c6ff\"\r\n          },\r\n          \"diskSizeGB\": 200\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm2ff6843534\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94\",\r\n  \"name\": \"wvm024038843412ace94\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1350,7 +1474,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:29:40 GMT"
+          "Tue, 11 Apr 2017 19:55:39 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1369,211 +1493,28 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "83bcc1e3-67fe-4fb8-9ecd-dbd0bce59649"
+          "d2bedf75-f0a8-4dca-98e8-66017c2d5a57"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14972"
+          "14965"
         ],
         "x-ms-correlation-request-id": [
-          "435cd0d1-6152-4df1-9470-68d928dce28b"
+          "b9a3041c-7476-428f-9a41-12c90761c036"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T232940Z:435cd0d1-6152-4df1-9470-68d928dce28b"
+          "WESTUS2:20170411T195540Z:b9a3041c-7476-428f-9a41-12c90761c036"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/2f1ee3a5-72f3-4937-a784-5dcce894e5b9?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzJmMWVlM2E1LTcyZjMtNDkzNy1hNzg0LTVkY2NlODk0ZTViOT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:27:10.4473725-07:00\",\r\n  \"endTime\": \"2017-04-10T16:29:57.5397521-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"2f1ee3a5-72f3-4937-a784-5dcce894e5b9\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:30:10 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "d3d0349f-7c80-44a8-8402-ed3dc099e9b6"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14972"
-        ],
-        "x-ms-correlation-request-id": [
-          "44d4022b-a702-4f92-9a64-1be0f3163e8d"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233010Z:44d4022b-a702-4f92-9a64-1be0f3163e8d"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/wvm00888296b97d513d1?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy93dm0wMDg4ODI5NmI5N2Q1MTNkMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"6b724a92-bff7-4645-91a5-d8218714f772\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\": \"wvm00888296b97d513d1_OsDisk_1_a82841dc524647999e76923a57fbca5e\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/wvm00888296b97d513d1_OsDisk_1_a82841dc524647999e76923a57fbca5e\"\r\n        },\r\n        \"diskSizeGB\": 128\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"dsk-c2a86293b05c3ba6d\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-c2a86293b05c3ba6d\"\r\n          },\r\n          \"diskSizeGB\": 100\r\n        },\r\n        {\r\n          \"lun\": 1,\r\n          \"name\": \"dsk-5a9789569075af552\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-5a9789569075af552\"\r\n          },\r\n          \"diskSizeGB\": 50\r\n        },\r\n        {\r\n          \"lun\": 2,\r\n          \"name\": \"wvm00888296b97d513d1_disk4_4c9bc3b9c00746658ea2c466b9505da7\",\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\",\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/wvm00888296b97d513d1_disk4_4c9bc3b9c00746658ea2c466b9505da7\"\r\n          },\r\n          \"diskSizeGB\": 10\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vmb9c85326d1\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/wvm00888296b97d513d1\",\r\n  \"name\": \"wvm00888296b97d513d1\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:30:10 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "5be2b853-29e7-4449-8b82-caebfd514cf8"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14971"
-        ],
-        "x-ms-correlation-request-id": [
-          "76ced48a-9859-457e-8e43-ddb06f2b589b"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233010Z:76ced48a-9859-457e-8e43-ddb06f2b589b"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/wvm00888296b97d513d1?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy93dm0wMDg4ODI5NmI5N2Q1MTNkMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "6db1298c-5dfe-478a-a1ca-e391b96eaa03"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"6b724a92-bff7-4645-91a5-d8218714f772\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\": \"wvm00888296b97d513d1_OsDisk_1_a82841dc524647999e76923a57fbca5e\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/wvm00888296b97d513d1_OsDisk_1_a82841dc524647999e76923a57fbca5e\"\r\n        }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\": 0,\r\n          \"name\": \"dsk-c2a86293b05c3ba6d\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-c2a86293b05c3ba6d\"\r\n          }\r\n        },\r\n        {\r\n          \"lun\": 1,\r\n          \"name\": \"dsk-5a9789569075af552\",\r\n          \"createOption\": \"Attach\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/dsk-5a9789569075af552\"\r\n          }\r\n        },\r\n        {\r\n          \"lun\": 2,\r\n          \"name\": \"wvm00888296b97d513d1_disk4_4c9bc3b9c00746658ea2c466b9505da7\",\r\n          \"createOption\": \"Empty\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/wvm00888296b97d513d1_disk4_4c9bc3b9c00746658ea2c466b9505da7\"\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vmb9c85326d1\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic78153aac846\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/wvm00888296b97d513d1\",\r\n  \"name\": \"wvm00888296b97d513d1\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:35:14 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "d5c0dd33-a751-4aa1-9aac-3d8ae7302235"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14959"
-        ],
-        "x-ms-correlation-request-id": [
-          "856dd939-967f-4fb8-ada3-bc7d2cbb8a47"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233514Z:856dd939-967f-4fb8-ada3-bc7d2cbb8a47"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL25ldHdvcmtJbnRlcmZhY2VzL25pYzU2NzgxNjMwMGYxP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL25ldHdvcmtJbnRlcmZhY2VzL25pYzg2NzA0NjdiNjAxP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"properties\": {\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7/subnets/subnet1\"\r\n          }\r\n        },\r\n        \"name\": \"primary\"\r\n      }\r\n    ],\r\n    \"dnsSettings\": {}\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"properties\": {\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca/subnets/subnet1\"\r\n          }\r\n        },\r\n        \"name\": \"primary\"\r\n      }\r\n    ],\r\n    \"dnsSettings\": {}\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1582,7 +1523,7 @@
           "490"
         ],
         "x-ms-client-request-id": [
-          "1780a934-9980-474f-b837-e9263953ee20"
+          "1fd3f8dc-2347-49de-a727-3a0ce735eb1d"
         ],
         "accept-language": [
           "en-US"
@@ -1592,7 +1533,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"nic567816300f1\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1\",\r\n  \"etag\": \"W/\\\"0135e964-271b-40da-87f3-28871e7dce78\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"19e32e40-34e6-4c7e-bf45-68c609cc79be\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"0135e964-271b-40da-87f3-28871e7dce78\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"f4a4thpw2chebkq5yy5knzjhgb.yx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"nic8670467b601\",\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601\",\r\n  \"etag\": \"W/\\\"6797fdb2-2a89-4617-8c6d-ce400520b055\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"644dd200-d6b0-4989-b00e-3a1878b1bff5\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"6797fdb2-2a89-4617-8c6d-ce400520b055\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"fysf54ckenweljnzgrv0kdygdf.yx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "1537"
@@ -1607,7 +1548,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:30:11 GMT"
+          "Tue, 11 Apr 2017 19:52:37 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1617,29 +1558,29 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "6cdaa565-b1d9-4a20-9b5e-2f975be5b591"
+          "3495d02a-853d-4cc3-a524-25000c5a0ab8"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/6cdaa565-b1d9-4a20-9b5e-2f975be5b591?api-version=2016-12-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Network/locations/westcentralus/operations/3495d02a-853d-4cc3-a524-25000c5a0ab8?api-version=2016-12-01"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1196"
+          "1195"
         ],
         "x-ms-correlation-request-id": [
-          "622dbc02-18a0-4c04-bd9a-592abec408fa"
+          "70e4100a-a575-413e-ad79-d5deb03fce3f"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233011Z:622dbc02-18a0-4c04-bd9a-592abec408fa"
+          "WESTUS2:20170411T195238Z:70e4100a-a575-413e-ad79-d5deb03fce3f"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL25ldHdvcmtJbnRlcmZhY2VzL25pYzU2NzgxNjMwMGYxP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL25ldHdvcmtJbnRlcmZhY2VzL25pYzg2NzA0NjdiNjAxP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -1648,7 +1589,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"nic567816300f1\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1\",\r\n  \"etag\": \"W/\\\"0135e964-271b-40da-87f3-28871e7dce78\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"19e32e40-34e6-4c7e-bf45-68c609cc79be\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"0135e964-271b-40da-87f3-28871e7dce78\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/virtualNetworks/vneta49146400df7/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"f4a4thpw2chebkq5yy5knzjhgb.yx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"nic8670467b601\",\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601\",\r\n  \"etag\": \"W/\\\"6797fdb2-2a89-4617-8c6d-ce400520b055\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"644dd200-d6b0-4989-b00e-3a1878b1bff5\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"6797fdb2-2a89-4617-8c6d-ce400520b055\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/virtualNetworks/vnetc000315669ca/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"fysf54ckenweljnzgrv0kdygdf.yx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1660,7 +1601,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:30:11 GMT"
+          "Tue, 11 Apr 2017 19:52:37 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1669,7 +1610,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"0135e964-271b-40da-87f3-28871e7dce78\""
+          "W/\"6797fdb2-2a89-4617-8c6d-ce400520b055\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -1679,28 +1620,28 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "2b623476-3f99-4cf4-8305-38dad43aed8a"
+          "6a11f1b9-abb9-44ee-a5b5-31c845902b12"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14968"
+          "14970"
         ],
         "x-ms-correlation-request-id": [
-          "07a29690-f276-4b18-b2ad-589202d33e77"
+          "6dd8a432-9a90-4bb7-a8d3-c8341bad0fa3"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233011Z:07a29690-f276-4b18-b2ad-589202d33e77"
+          "WESTUS2:20170411T195238Z:6dd8a432-9a90-4bb7-a8d3-c8341bad0fa3"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/lvmcb167080f8d1a419d?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy9sdm1jYjE2NzA4MGY4ZDFhNDE5ZD9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/lvmfaa27967616d4cf5c?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy9sdm1mYWEyNzk2NzYxNmQ0Y2Y1Yz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"caching\": \"ReadWrite\",\r\n        \"createOption\": \"fromImage\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\r\n        }\r\n      }\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm34398038f8\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"adminPassword\": \"12NewPA$$w0rd!\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      }\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"properties\": {\r\n            \"primary\": true\r\n          },\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1\"\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"caching\": \"ReadWrite\",\r\n        \"createOption\": \"fromImage\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\r\n        }\r\n      }\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm8c2061179e\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"adminPassword\": \"12NewPA$$w0rd!\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      }\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"properties\": {\r\n            \"primary\": true\r\n          },\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601\"\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1709,7 +1650,7 @@
           "1094"
         ],
         "x-ms-client-request-id": [
-          "2c6c0928-c303-408a-bd3b-2dd538350e23"
+          "6e523e22-7692-4aad-beea-63b4c201fab0"
         ],
         "accept-language": [
           "en-US"
@@ -1719,7 +1660,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"1a6d9d15-9de5-4999-a40e-9d0179e03d20\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\r\n        }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm34398038f8\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/lvmcb167080f8d1a419d\",\r\n  \"name\": \"lvmcb167080f8d1a419d\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"f40d99c7-e660-4b2f-9de5-513bc0434cdd\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\r\n        }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm8c2061179e\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/lvmfaa27967616d4cf5c\",\r\n  \"name\": \"lvmfaa27967616d4cf5c\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "1371"
@@ -1734,7 +1675,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:30:12 GMT"
+          "Tue, 11 Apr 2017 19:52:37 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1744,34 +1685,34 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/cbc9a7e8-5994-4f22-9089-4dc46a105f34?api-version=2016-04-30-preview"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/9431bc1e-1f3b-4cfd-bfd6-249e8b06fed1?api-version=2016-04-30-preview"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "cbc9a7e8-5994-4f22-9089-4dc46a105f34"
+          "9431bc1e-1f3b-4cfd-bfd6-249e8b06fed1"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1195"
+          "1194"
         ],
         "x-ms-correlation-request-id": [
-          "86cc9f9c-8a78-498b-b53d-e45468b49434"
+          "4b50e135-0b2f-497c-83b4-765b7fdd3106"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233012Z:86cc9f9c-8a78-498b-b53d-e45468b49434"
+          "WESTUS2:20170411T195238Z:4b50e135-0b2f-497c-83b4-765b7fdd3106"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/lvmcb167080f8d1a419d?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy9sdm1jYjE2NzA4MGY4ZDFhNDE5ZD9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/lvmfaa27967616d4cf5c?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy9sdm1mYWEyNzk2NzYxNmQ0Y2Y1Yz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"lvmcb167080f8d1a419d_OsDisk_1_bac7661c8eb94a3b964a8fb13800fddc\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"createOption\": \"fromImage\",\r\n        \"diskSizeGB\": 30,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/lvmcb167080f8d1a419d_OsDisk_1_bac7661c8eb94a3b964a8fb13800fddc\"\r\n        }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm34398038f8\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"properties\": {\r\n            \"primary\": true\r\n          },\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1\"\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/lvmcb167080f8d1a419d\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {\r\n    \"who-rocks-on-linux\": \"java\",\r\n    \"where\": \"on azure\"\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"lvmfaa27967616d4cf5c_OsDisk_1_50bdf91495d54480a04818ab873ccfc6\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"createOption\": \"fromImage\",\r\n        \"diskSizeGB\": 30,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/lvmfaa27967616d4cf5c_OsDisk_1_50bdf91495d54480a04818ab873ccfc6\"\r\n        }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm8c2061179e\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"properties\": {\r\n            \"primary\": true\r\n          },\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601\"\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/lvmfaa27967616d4cf5c\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {\r\n    \"who-rocks-on-linux\": \"java\",\r\n    \"where\": \"on azure\"\r\n  }\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1780,7 +1721,7 @@
           "1674"
         ],
         "x-ms-client-request-id": [
-          "039147cb-7f84-4e01-9912-6d7d51d73b78"
+          "8001afd8-c0d2-4931-9ce4-d7bf739eb4af"
         ],
         "accept-language": [
           "en-US"
@@ -1790,7 +1731,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"1a6d9d15-9de5-4999-a40e-9d0179e03d20\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"lvmcb167080f8d1a419d_OsDisk_1_bac7661c8eb94a3b964a8fb13800fddc\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/lvmcb167080f8d1a419d_OsDisk_1_bac7661c8eb94a3b964a8fb13800fddc\"\r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm34398038f8\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {\r\n    \"who-rocks-on-linux\": \"java\",\r\n    \"where\": \"on azure\"\r\n  },\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/lvmcb167080f8d1a419d\",\r\n  \"name\": \"lvmcb167080f8d1a419d\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"f40d99c7-e660-4b2f-9de5-513bc0434cdd\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"lvmfaa27967616d4cf5c_OsDisk_1_50bdf91495d54480a04818ab873ccfc6\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/lvmfaa27967616d4cf5c_OsDisk_1_50bdf91495d54480a04818ab873ccfc6\"\r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm8c2061179e\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Updating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {\r\n    \"who-rocks-on-linux\": \"java\",\r\n    \"where\": \"on azure\"\r\n  },\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/lvmfaa27967616d4cf5c\",\r\n  \"name\": \"lvmfaa27967616d4cf5c\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1802,7 +1743,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:32:13 GMT"
+          "Tue, 11 Apr 2017 19:54:08 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1818,510 +1759,634 @@
           "Accept-Encoding"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/fbcb43fe-07c2-4885-a6f0-d0910c1be63a?api-version=2016-04-30-preview"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/cf291459-d692-493b-9616-9f4802786b21?api-version=2016-04-30-preview"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "fbcb43fe-07c2-4885-a6f0-d0910c1be63a"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1194"
-        ],
-        "x-ms-correlation-request-id": [
-          "8b39a9f9-37d1-419b-8737-5b935c7ea346"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233213Z:8b39a9f9-37d1-419b-8737-5b935c7ea346"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/cbc9a7e8-5994-4f22-9089-4dc46a105f34?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2NiYzlhN2U4LTU5OTQtNGYyMi05MDg5LTRkYzQ2YTEwNWYzND9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:30:12.8209031-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"cbc9a7e8-5994-4f22-9089-4dc46a105f34\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:30:41 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "030c82e0-de09-43f3-a733-87eb2231f5a8"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14967"
-        ],
-        "x-ms-correlation-request-id": [
-          "539d0b24-8a69-4ea6-8344-a4f93fa6715b"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233042Z:539d0b24-8a69-4ea6-8344-a4f93fa6715b"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/cbc9a7e8-5994-4f22-9089-4dc46a105f34?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2NiYzlhN2U4LTU5OTQtNGYyMi05MDg5LTRkYzQ2YTEwNWYzND9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:30:12.8209031-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"cbc9a7e8-5994-4f22-9089-4dc46a105f34\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:31:11 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "94deaac0-daf7-4a89-8e33-7eac7113d444"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14966"
-        ],
-        "x-ms-correlation-request-id": [
-          "764b1df1-0c14-4def-a4d0-4e9d84a87b8f"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233112Z:764b1df1-0c14-4def-a4d0-4e9d84a87b8f"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/cbc9a7e8-5994-4f22-9089-4dc46a105f34?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2NiYzlhN2U4LTU5OTQtNGYyMi05MDg5LTRkYzQ2YTEwNWYzND9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:30:12.8209031-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"cbc9a7e8-5994-4f22-9089-4dc46a105f34\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:31:41 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "5bd0c84a-c1ef-4a94-a2e2-675ae64ac397"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14965"
-        ],
-        "x-ms-correlation-request-id": [
-          "fdbb192a-1fd6-43da-9196-c31efed1c318"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233142Z:fdbb192a-1fd6-43da-9196-c31efed1c318"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/cbc9a7e8-5994-4f22-9089-4dc46a105f34?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2NiYzlhN2U4LTU5OTQtNGYyMi05MDg5LTRkYzQ2YTEwNWYzND9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:30:12.8209031-07:00\",\r\n  \"endTime\": \"2017-04-10T16:31:59.3883886-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"cbc9a7e8-5994-4f22-9089-4dc46a105f34\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:32:12 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "23151cb7-fa3a-41a7-b63c-e7e10ffa2828"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14964"
-        ],
-        "x-ms-correlation-request-id": [
-          "f4c3add4-e73e-44d5-9f7e-16add0caa76e"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233212Z:f4c3add4-e73e-44d5-9f7e-16add0caa76e"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/lvmcb167080f8d1a419d?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy9sdm1jYjE2NzA4MGY4ZDFhNDE5ZD9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"1a6d9d15-9de5-4999-a40e-9d0179e03d20\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"lvmcb167080f8d1a419d_OsDisk_1_bac7661c8eb94a3b964a8fb13800fddc\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/lvmcb167080f8d1a419d_OsDisk_1_bac7661c8eb94a3b964a8fb13800fddc\"\r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm34398038f8\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/lvmcb167080f8d1a419d\",\r\n  \"name\": \"lvmcb167080f8d1a419d\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:32:12 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "0de41f59-b82e-492e-b71a-4fc3527921cf"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14963"
-        ],
-        "x-ms-correlation-request-id": [
-          "ece4ab58-9010-41f5-8363-9337d887b9bd"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233212Z:ece4ab58-9010-41f5-8363-9337d887b9bd"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/lvmcb167080f8d1a419d?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy9sdm1jYjE2NzA4MGY4ZDFhNDE5ZD9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"1a6d9d15-9de5-4999-a40e-9d0179e03d20\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"lvmcb167080f8d1a419d_OsDisk_1_bac7661c8eb94a3b964a8fb13800fddc\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/disks/lvmcb167080f8d1a419d_OsDisk_1_bac7661c8eb94a3b964a8fb13800fddc\"\r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm34398038f8\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Network/networkInterfaces/nic567816300f1\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {\r\n    \"who-rocks-on-linux\": \"java\",\r\n    \"where\": \"on azure\"\r\n  },\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/lvmcb167080f8d1a419d\",\r\n  \"name\": \"lvmcb167080f8d1a419d\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:32:43 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "2c9ece11-aa24-43ce-92d3-7820fa1e8a1e"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14961"
-        ],
-        "x-ms-correlation-request-id": [
-          "4caef197-b4e3-4861-80bf-d48223f74238"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233244Z:4caef197-b4e3-4861-80bf-d48223f74238"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/fbcb43fe-07c2-4885-a6f0-d0910c1be63a?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2ZiY2I0M2ZlLTA3YzItNDg4NS1hNmYwLWQwOTEwYzFiZTYzYT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:32:14.3570149-07:00\",\r\n  \"endTime\": \"2017-04-10T16:32:14.5288718-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"fbcb43fe-07c2-4885-a6f0-d0910c1be63a\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:32:43 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "88e856ec-24e4-4f6d-997f-13e8c4d34e24"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14962"
-        ],
-        "x-ms-correlation-request-id": [
-          "53ed3271-edb1-48d1-8f10-eab72b4f1410"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233244Z:53ed3271-edb1-48d1-8f10-eab72b4f1410"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcomvbd92926049251846/providers/Microsoft.Compute/virtualMachines/wvm00888296b97d513d1/deallocate?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDYvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy93dm0wMDg4ODI5NmI5N2Q1MTNkMS9kZWFsbG9jYXRlP2FwaS12ZXJzaW9uPTIwMTYtMDQtMzAtcHJldmlldw==",
-      "RequestMethod": "POST",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "4829d23b-26de-4d74-bb45-e22b67613a13"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "0"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:32:43 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/68e5a2fe-5932-4ba8-bd29-74c41317aba1?monitor=true&api-version=2016-04-30-preview"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/68e5a2fe-5932-4ba8-bd29-74c41317aba1?api-version=2016-04-30-preview"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "68e5a2fe-5932-4ba8-bd29-74c41317aba1"
+          "cf291459-d692-493b-9616-9f4802786b21"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1193"
         ],
         "x-ms-correlation-request-id": [
-          "f80de5db-ce5a-4dc5-8519-6a8aa5ed8532"
+          "2cc07062-6f97-4571-99bf-e2bfe08a9e9a"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233244Z:f80de5db-ce5a-4dc5-8519-6a8aa5ed8532"
+          "WESTUS2:20170411T195409Z:2cc07062-6f97-4571-99bf-e2bfe08a9e9a"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/9431bc1e-1f3b-4cfd-bfd6-249e8b06fed1?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzk0MzFiYzFlLTFmM2ItNGNmZC1iZmQ2LTI0OWU4YjA2ZmVkMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:52:38.4394691-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"9431bc1e-1f3b-4cfd-bfd6-249e8b06fed1\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:53:08 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "a8aadff9-5f89-44e1-a0ad-c406033f7038"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14969"
+        ],
+        "x-ms-correlation-request-id": [
+          "18effb9a-4a83-4987-b0b4-d43acc64e640"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195308Z:18effb9a-4a83-4987-b0b4-d43acc64e640"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/9431bc1e-1f3b-4cfd-bfd6-249e8b06fed1?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzk0MzFiYzFlLTFmM2ItNGNmZC1iZmQ2LTI0OWU4YjA2ZmVkMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:52:38.4394691-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"9431bc1e-1f3b-4cfd-bfd6-249e8b06fed1\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:53:38 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "b884300a-f34c-4087-a743-b98cd384f8a4"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14968"
+        ],
+        "x-ms-correlation-request-id": [
+          "3803d653-f9b2-430e-b0e0-07624b9407ca"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195338Z:3803d653-f9b2-430e-b0e0-07624b9407ca"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/9431bc1e-1f3b-4cfd-bfd6-249e8b06fed1?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzk0MzFiYzFlLTFmM2ItNGNmZC1iZmQ2LTI0OWU4YjA2ZmVkMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:52:38.4394691-07:00\",\r\n  \"endTime\": \"2017-04-11T12:54:01.8770428-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"9431bc1e-1f3b-4cfd-bfd6-249e8b06fed1\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:54:08 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "79b7d7a2-7d20-4744-8497-2efc6656fee9"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14967"
+        ],
+        "x-ms-correlation-request-id": [
+          "ffb65e21-baed-43b8-91dc-e949115c97df"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195408Z:ffb65e21-baed-43b8-91dc-e949115c97df"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/lvmfaa27967616d4cf5c?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy9sdm1mYWEyNzk2NzYxNmQ0Y2Y1Yz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"f40d99c7-e660-4b2f-9de5-513bc0434cdd\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"lvmfaa27967616d4cf5c_OsDisk_1_50bdf91495d54480a04818ab873ccfc6\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/lvmfaa27967616d4cf5c_OsDisk_1_50bdf91495d54480a04818ab873ccfc6\"\r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm8c2061179e\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/lvmfaa27967616d4cf5c\",\r\n  \"name\": \"lvmfaa27967616d4cf5c\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:54:08 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "d2206f28-e6b2-4f1a-8fe1-731c07dc2b51"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14966"
+        ],
+        "x-ms-correlation-request-id": [
+          "1e1b1484-c97b-4348-9ebe-1fca126d23c4"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195408Z:1e1b1484-c97b-4348-9ebe-1fca126d23c4"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/lvmfaa27967616d4cf5c?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy9sdm1mYWEyNzk2NzYxNmQ0Y2Y1Yz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"f40d99c7-e660-4b2f-9de5-513bc0434cdd\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D3_v2\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"16.04.0-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"lvmfaa27967616d4cf5c_OsDisk_1_50bdf91495d54480a04818ab873ccfc6\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/lvmfaa27967616d4cf5c_OsDisk_1_50bdf91495d54480a04818ab873ccfc6\"\r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm8c2061179e\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {\r\n    \"who-rocks-on-linux\": \"java\",\r\n    \"where\": \"on azure\"\r\n  },\r\n  \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/lvmfaa27967616d4cf5c\",\r\n  \"name\": \"lvmfaa27967616d4cf5c\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:54:39 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "567a70a0-0225-4a6f-9022-b710895e56ab"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14964"
+        ],
+        "x-ms-correlation-request-id": [
+          "2bc9f072-69b7-4c68-bc2e-fdd985cbffb4"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195439Z:2bc9f072-69b7-4c68-bc2e-fdd985cbffb4"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/cf291459-d692-493b-9616-9f4802786b21?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2NmMjkxNDU5LWQ2OTItNDkzYi05NjE2LTlmNDgwMjc4NmIyMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:54:09.3614535-07:00\",\r\n  \"endTime\": \"2017-04-11T12:54:09.4708313-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"cf291459-d692-493b-9616-9f4802786b21\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:54:39 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "1f113649-ea19-46df-b224-61df4f3800b3"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14965"
+        ],
+        "x-ms-correlation-request-id": [
+          "11aa8612-3287-4fd0-98e2-362d5173456b"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195439Z:11aa8612-3287-4fd0-98e2-362d5173456b"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/3724bf36-6183-494e-a38f-38e813310f21?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzM3MjRiZjM2LTYxODMtNDk0ZS1hMzhmLTM4ZTgxMzMxMGYyMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:54:40.06454-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"3724bf36-6183-494e-a38f-38e813310f21\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:55:09 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "698e3b2a-bb8b-4ab7-9797-b95f0a58250a"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14967"
+        ],
+        "x-ms-correlation-request-id": [
+          "011cedc8-1ac9-4393-bbd8-8a44e00d1594"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195510Z:011cedc8-1ac9-4393-bbd8-8a44e00d1594"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/3724bf36-6183-494e-a38f-38e813310f21?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzM3MjRiZjM2LTYxODMtNDk0ZS1hMzhmLTM4ZTgxMzMxMGYyMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:54:40.06454-07:00\",\r\n  \"endTime\": \"2017-04-11T12:55:32.8458365-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"3724bf36-6183-494e-a38f-38e813310f21\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:55:39 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "bea3f7c4-0861-4c33-a20d-9c9aee5ee101"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14966"
+        ],
+        "x-ms-correlation-request-id": [
+          "e2af8e4a-84e1-450f-9e14-b6f7cd446861"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195540Z:e2af8e4a-84e1-450f-9e14-b6f7cd446861"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "91c1db71-44ed-4ba6-9445-925357d78c93"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"properties\": {\r\n        \"vmId\": \"f40d99c7-e660-4b2f-9de5-513bc0434cdd\",\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Standard_D3_v2\"\r\n        },\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"16.04.0-LTS\",\r\n            \"version\": \"latest\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"lvmfaa27967616d4cf5c_OsDisk_1_50bdf91495d54480a04818ab873ccfc6\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/lvmfaa27967616d4cf5c_OsDisk_1_50bdf91495d54480a04818ab873ccfc6\"\r\n            },\r\n            \"diskSizeGB\": 30\r\n          },\r\n          \"dataDisks\": []\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vm8c2061179e\",\r\n          \"adminUsername\": \"tirekicker\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\": false\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\r\n          \"networkInterfaces\": [\r\n            {\r\n              \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic8670467b601\",\r\n              \"properties\": {\r\n                \"primary\": true\r\n              }\r\n            }\r\n          ]\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {\r\n        \"who-rocks-on-linux\": \"java\",\r\n        \"where\": \"on azure\"\r\n      },\r\n      \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/lvmfaa27967616d4cf5c\",\r\n      \"name\": \"lvmfaa27967616d4cf5c\"\r\n    },\r\n    {\r\n      \"properties\": {\r\n        \"vmId\": \"bb6b86f5-6fe3-4593-ba19-08857a2d070f\",\r\n        \"hardwareProfile\": {\r\n          \"vmSize\": \"Standard_D3_v2\"\r\n        },\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"publisher\": \"MicrosoftWindowsServer\",\r\n            \"offer\": \"WindowsServer\",\r\n            \"sku\": \"2012-R2-Datacenter\",\r\n            \"version\": \"latest\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Windows\",\r\n            \"name\": \"wvm024038843412ace94_OsDisk_1_51be9f3d300342a1b4795d94592e431c\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_OsDisk_1_51be9f3d300342a1b4795d94592e431c\"\r\n            },\r\n            \"diskSizeGB\": 128\r\n          },\r\n          \"dataDisks\": [\r\n            {\r\n              \"lun\": 0,\r\n              \"name\": \"dsk-6c89576046cdd10f3\",\r\n              \"createOption\": \"Attach\",\r\n              \"caching\": \"ReadWrite\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-6c89576046cdd10f3\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 1,\r\n              \"name\": \"dsk-f3958901328006b28\",\r\n              \"createOption\": \"Attach\",\r\n              \"caching\": \"ReadWrite\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/dsk-f3958901328006b28\"\r\n              },\r\n              \"diskSizeGB\": 50\r\n            },\r\n            {\r\n              \"lun\": 2,\r\n              \"name\": \"wvm024038843412ace94_disk4_58ab71d8b9e24c829b40d209f4f164cf\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"ReadWrite\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_disk4_58ab71d8b9e24c829b40d209f4f164cf\"\r\n              },\r\n              \"diskSizeGB\": 10\r\n            },\r\n            {\r\n              \"lun\": 3,\r\n              \"name\": \"wvm024038843412ace94_disk5_025641727ace4898bd6ab0359163c6ff\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"ReadWrite\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/disks/wvm024038843412ace94_disk5_025641727ace4898bd6ab0359163c6ff\"\r\n              },\r\n              \"diskSizeGB\": 200\r\n            }\r\n          ]\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vm2ff6843534\",\r\n          \"adminUsername\": \"tirekicker\",\r\n          \"windowsConfiguration\": {\r\n            \"provisionVMAgent\": true,\r\n            \"enableAutomaticUpdates\": true\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\r\n          \"networkInterfaces\": [\r\n            {\r\n              \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Network/networkInterfaces/nic4315580dbe4\",\r\n              \"properties\": {\r\n                \"primary\": true\r\n              }\r\n            }\r\n          ]\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/virtualMachines\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94\",\r\n      \"name\": \"wvm024038843412ace94\"\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:55:39 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "bcd178be-f14f-4bdc-bd71-3cb0f0713d81"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14964"
+        ],
+        "x-ms-correlation-request-id": [
+          "0b7e970c-79ff-4ef4-9d6c-abb27f2f36e8"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195540Z:0b7e970c-79ff-4ef4-9d6c-abb27f2f36e8"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/rgcomv2be28164d26d2f2b/providers/Microsoft.Compute/virtualMachines/wvm024038843412ace94?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlR3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmIvcHJvdmlkZXJzL01pY3Jvc29mdC5Db21wdXRlL3ZpcnR1YWxNYWNoaW5lcy93dm0wMjQwMzg4NDM0MTJhY2U5ND9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "4f7b0ab2-df7b-4ddd-a8e7-f80c67b14c3b"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:55:40 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/024470f5-674d-4a5d-a020-61ab5ceb2d53?monitor=true&api-version=2016-04-30-preview"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/024470f5-674d-4a5d-a020-61ab5ceb2d53?api-version=2016-04-30-preview"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "024470f5-674d-4a5d-a020-61ab5ceb2d53"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1191"
+        ],
+        "x-ms-correlation-request-id": [
+          "0a8f6bcf-9efb-4664-a46b-6e0324ee3364"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195540Z:0a8f6bcf-9efb-4664-a46b-6e0324ee3364"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/68e5a2fe-5932-4ba8-bd29-74c41317aba1?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzY4ZTVhMmZlLTU5MzItNGJhOC1iZDI5LTc0YzQxMzE3YWJhMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/024470f5-674d-4a5d-a020-61ab5ceb2d53?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzAyNDQ3MGY1LTY3NGQtNGE1ZC1hMDIwLTYxYWI1Y2ViMmQ1Mz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -2330,7 +2395,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:32:44.9505406-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"68e5a2fe-5932-4ba8-bd29-74c41317aba1\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:55:40.8458686-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"024470f5-674d-4a5d-a020-61ab5ceb2d53\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -2342,7 +2407,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:33:13 GMT"
+          "Tue, 11 Apr 2017 19:56:10 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -2361,26 +2426,26 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "2b9f4c1d-a1c5-4261-8918-2298e2cfb07c"
+          "634cafae-0502-4948-a81e-e48e37768596"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14959"
+          "14963"
         ],
         "x-ms-correlation-request-id": [
-          "1fa894a7-0782-4468-80da-f7d7f0a6ebbf"
+          "21a7e902-b8d1-41e1-a7a7-a2752721da93"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233314Z:1fa894a7-0782-4468-80da-f7d7f0a6ebbf"
+          "WESTUS2:20170411T195610Z:21a7e902-b8d1-41e1-a7a7-a2752721da93"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/68e5a2fe-5932-4ba8-bd29-74c41317aba1?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzY4ZTVhMmZlLTU5MzItNGJhOC1iZDI5LTc0YzQxMzE3YWJhMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/024470f5-674d-4a5d-a020-61ab5ceb2d53?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzAyNDQ3MGY1LTY3NGQtNGE1ZC1hMDIwLTYxYWI1Y2ViMmQ1Mz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -2389,7 +2454,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:32:44.9505406-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"68e5a2fe-5932-4ba8-bd29-74c41317aba1\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:55:40.8458686-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"024470f5-674d-4a5d-a020-61ab5ceb2d53\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -2401,7 +2466,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:33:44 GMT"
+          "Tue, 11 Apr 2017 19:56:40 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -2420,26 +2485,26 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "0030a6ea-b4d0-47ac-b0db-f67dc9c818b6"
+          "d5be5a13-917d-4ddb-ade7-b2dcd114cd58"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14958"
+          "14962"
         ],
         "x-ms-correlation-request-id": [
-          "6ca596f8-a230-4cfe-bf30-a84f1c56d720"
+          "283e1afa-d17a-43f4-8f07-b258ebf5af74"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233344Z:6ca596f8-a230-4cfe-bf30-a84f1c56d720"
+          "WESTUS2:20170411T195641Z:283e1afa-d17a-43f4-8f07-b258ebf5af74"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/68e5a2fe-5932-4ba8-bd29-74c41317aba1?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzY4ZTVhMmZlLTU5MzItNGJhOC1iZDI5LTc0YzQxMzE3YWJhMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/024470f5-674d-4a5d-a020-61ab5ceb2d53?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzAyNDQ3MGY1LTY3NGQtNGE1ZC1hMDIwLTYxYWI1Y2ViMmQ1Mz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -2448,7 +2513,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:32:44.9505406-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"68e5a2fe-5932-4ba8-bd29-74c41317aba1\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:55:40.8458686-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"024470f5-674d-4a5d-a020-61ab5ceb2d53\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -2460,7 +2525,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:34:14 GMT"
+          "Tue, 11 Apr 2017 19:57:10 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -2479,26 +2544,26 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "87452c56-61aa-4668-b044-191eab1edc17"
+          "d60bc07d-ac16-4f5e-adf5-65c56be5e358"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14957"
+          "14961"
         ],
         "x-ms-correlation-request-id": [
-          "d16b87ff-90a3-449c-b6a3-f8c2f90306fb"
+          "ed1b94f5-f4eb-40c2-9b5b-39fe680e624a"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233414Z:d16b87ff-90a3-449c-b6a3-f8c2f90306fb"
+          "WESTUS2:20170411T195711Z:ed1b94f5-f4eb-40c2-9b5b-39fe680e624a"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/68e5a2fe-5932-4ba8-bd29-74c41317aba1?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzY4ZTVhMmZlLTU5MzItNGJhOC1iZDI5LTc0YzQxMzE3YWJhMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/024470f5-674d-4a5d-a020-61ab5ceb2d53?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzAyNDQ3MGY1LTY3NGQtNGE1ZC1hMDIwLTYxYWI1Y2ViMmQ1Mz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -2507,7 +2572,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:32:44.9505406-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"68e5a2fe-5932-4ba8-bd29-74c41317aba1\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:55:40.8458686-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"024470f5-674d-4a5d-a020-61ab5ceb2d53\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -2519,7 +2584,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:34:44 GMT"
+          "Tue, 11 Apr 2017 19:57:41 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -2538,90 +2603,90 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
         ],
         "x-ms-request-id": [
-          "7a8ba167-5a2e-45b5-be9b-97ffefae6900"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14956"
-        ],
-        "x-ms-correlation-request-id": [
-          "98cf678c-d570-4c00-b697-13488946fd20"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233444Z:98cf678c-d570-4c00-b697-13488946fd20"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/68e5a2fe-5932-4ba8-bd29-74c41317aba1?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzY4ZTVhMmZlLTU5MzItNGJhOC1iZDI5LTc0YzQxMzE3YWJhMT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T16:32:44.9505406-07:00\",\r\n  \"endTime\": \"2017-04-10T16:35:10.8865331-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"68e5a2fe-5932-4ba8-bd29-74c41317aba1\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:35:14 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "88cf0366-162e-46dc-b8c2-32f823d976cb"
+          "41350508-4c17-480b-9825-4cc2fecbdf8c"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14960"
         ],
         "x-ms-correlation-request-id": [
-          "94c1fc77-4924-431e-aa9a-2d8876db456c"
+          "5bae2603-f391-4432-ac43-dd16bb919d82"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233514Z:94c1fc77-4924-431e-aa9a-2d8876db456c"
+          "WESTUS2:20170411T195741Z:5bae2603-f391-4432-ac43-dd16bb919d82"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rgcomvbd92926049251846?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL3JnY29tdmJkOTI5MjYwNDkyNTE4NDY/YXBpLXZlcnNpb249MjAxNi0wMi0wMQ==",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/providers/Microsoft.Compute/locations/westcentralus/operations/024470f5-674d-4a5d-a020-61ab5ceb2d53?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzAyNDQ3MGY1LTY3NGQtNGE1ZC1hMDIwLTYxYWI1Y2ViMmQ1Mz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-11T12:55:40.8458686-07:00\",\r\n  \"endTime\": \"2017-04-11T12:57:48.9865187-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"024470f5-674d-4a5d-a020-61ab5ceb2d53\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 19:58:11 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "b9a85f54-0d59-4290-8cc5-8d8b300978bb_131139682228523734"
+        ],
+        "x-ms-request-id": [
+          "f293cd9c-6fb4-4091-9d34-aae80ae1c6dc"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14959"
+        ],
+        "x-ms-correlation-request-id": [
+          "5459ca15-ba7d-4e5a-9b7d-0e39514dead4"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T195811Z:5459ca15-ba7d-4e5a-9b7d-0e39514dead4"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourcegroups/rgcomv2be28164d26d2f2b?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L3Jlc291cmNlZ3JvdXBzL3JnY29tdjJiZTI4MTY0ZDI2ZDJmMmI/YXBpLXZlcnNpb249MjAxNi0wMi0wMQ==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "f5f42d50-a22b-4fa7-8bb8-bd635e2d129d"
+          "148a65aa-df3b-4555-9694-8491075a9128"
         ],
         "accept-language": [
           "en-US"
@@ -2643,28 +2708,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:35:14 GMT"
+          "Tue, 11 Apr 2017 19:58:11 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1191"
+          "1190"
         ],
         "x-ms-request-id": [
-          "b6649286-39f1-4a49-9764-f005aa825fbd"
+          "34bd2331-783b-447f-9519-c94f37f75e8c"
         ],
         "x-ms-correlation-request-id": [
-          "b6649286-39f1-4a49-9764-f005aa825fbd"
+          "34bd2331-783b-447f-9519-c94f37f75e8c"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233515Z:b6649286-39f1-4a49-9764-f005aa825fbd"
+          "WESTUS2:20170411T195812Z:34bd2331-783b-447f-9519-c94f37f75e8c"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -2673,8 +2738,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -2695,28 +2760,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:35:44 GMT"
+          "Tue, 11 Apr 2017 19:58:41 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14958"
+          "14957"
         ],
         "x-ms-request-id": [
-          "342f3585-4376-440d-9835-a94b713bc2b4"
+          "50015ac9-f8bb-434f-abe8-3a47992df48a"
         ],
         "x-ms-correlation-request-id": [
-          "342f3585-4376-440d-9835-a94b713bc2b4"
+          "50015ac9-f8bb-434f-abe8-3a47992df48a"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233545Z:342f3585-4376-440d-9835-a94b713bc2b4"
+          "WESTUS2:20170411T195842Z:50015ac9-f8bb-434f-abe8-3a47992df48a"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -2725,8 +2790,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -2747,13 +2812,13 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:36:14 GMT"
+          "Tue, 11 Apr 2017 19:59:11 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
@@ -2762,13 +2827,13 @@
           "14956"
         ],
         "x-ms-request-id": [
-          "27b3213b-2f15-454d-942e-b063f339e5f4"
+          "60c8b0ed-6602-4b7d-bd59-bcd9ea5f1313"
         ],
         "x-ms-correlation-request-id": [
-          "27b3213b-2f15-454d-942e-b063f339e5f4"
+          "60c8b0ed-6602-4b7d-bd59-bcd9ea5f1313"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233615Z:27b3213b-2f15-454d-942e-b063f339e5f4"
+          "WESTUS2:20170411T195912Z:60c8b0ed-6602-4b7d-bd59-bcd9ea5f1313"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -2777,8 +2842,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -2799,65 +2864,13 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:36:45 GMT"
+          "Tue, 11 Apr 2017 19:59:41 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14955"
-        ],
-        "x-ms-request-id": [
-          "1eadda80-ef80-4f08-9ab4-caf146c8a60c"
-        ],
-        "x-ms-correlation-request-id": [
-          "1eadda80-ef80-4f08-9ab4-caf146c8a60c"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233645Z:1eadda80-ef80-4f08-9ab4-caf146c8a60c"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "0"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:37:15 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
@@ -2866,13 +2879,13 @@
           "14954"
         ],
         "x-ms-request-id": [
-          "c24d26a9-cf87-41b4-a273-02f7aebaaa86"
+          "aec60758-3535-4850-a6ee-2a10cf0c3aa8"
         ],
         "x-ms-correlation-request-id": [
-          "c24d26a9-cf87-41b4-a273-02f7aebaaa86"
+          "aec60758-3535-4850-a6ee-2a10cf0c3aa8"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233715Z:c24d26a9-cf87-41b4-a273-02f7aebaaa86"
+          "WESTUS2:20170411T195942Z:aec60758-3535-4850-a6ee-2a10cf0c3aa8"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -2881,8 +2894,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -2903,13 +2916,65 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:37:45 GMT"
+          "Tue, 11 Apr 2017 20:00:11 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14954"
+        ],
+        "x-ms-request-id": [
+          "5d081062-5232-4a94-934b-26c66cfdf524"
+        ],
+        "x-ms-correlation-request-id": [
+          "5d081062-5232-4a94-934b-26c66cfdf524"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170411T200012Z:5d081062-5232-4a94-934b-26c66cfdf524"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 11 Apr 2017 20:00:42 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
@@ -2918,13 +2983,13 @@
           "14953"
         ],
         "x-ms-request-id": [
-          "fab9ee81-f95e-4b42-8be0-fe89df99712a"
+          "c9c17290-f8b3-461e-8a93-977a3446598c"
         ],
         "x-ms-correlation-request-id": [
-          "fab9ee81-f95e-4b42-8be0-fe89df99712a"
+          "c9c17290-f8b3-461e-8a93-977a3446598c"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233745Z:fab9ee81-f95e-4b42-8be0-fe89df99712a"
+          "WESTUS2:20170411T200042Z:c9c17290-f8b3-461e-8a93-977a3446598c"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -2933,8 +2998,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -2955,13 +3020,13 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:38:15 GMT"
+          "Tue, 11 Apr 2017 20:01:12 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
@@ -2970,13 +3035,13 @@
           "14952"
         ],
         "x-ms-request-id": [
-          "154d55f3-3dd5-4b12-970b-65c4a205cca4"
+          "3013287a-450d-460a-926a-4d46914d1796"
         ],
         "x-ms-correlation-request-id": [
-          "154d55f3-3dd5-4b12-970b-65c4a205cca4"
+          "3013287a-450d-460a-926a-4d46914d1796"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233815Z:154d55f3-3dd5-4b12-970b-65c4a205cca4"
+          "WESTUS2:20170411T200112Z:3013287a-450d-460a-926a-4d46914d1796"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -2985,8 +3050,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3007,65 +3072,13 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:38:46 GMT"
+          "Tue, 11 Apr 2017 20:01:42 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14951"
-        ],
-        "x-ms-request-id": [
-          "1ab53193-84b5-4c9c-894e-05f4eb2c661f"
-        ],
-        "x-ms-correlation-request-id": [
-          "1ab53193-84b5-4c9c-894e-05f4eb2c661f"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233846Z:1ab53193-84b5-4c9c-894e-05f4eb2c661f"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "0"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 23:39:15 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
@@ -3074,13 +3087,13 @@
           "14950"
         ],
         "x-ms-request-id": [
-          "4c51eaa2-495b-45c9-8459-65258f43cca7"
+          "3625d81d-c0da-4479-b9be-620aa218a505"
         ],
         "x-ms-correlation-request-id": [
-          "4c51eaa2-495b-45c9-8459-65258f43cca7"
+          "3625d81d-c0da-4479-b9be-620aa218a505"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233916Z:4c51eaa2-495b-45c9-8459-65258f43cca7"
+          "WESTUS2:20170411T200142Z:3625d81d-c0da-4479-b9be-620aa218a505"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3089,8 +3102,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3111,13 +3124,13 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:39:45 GMT"
+          "Tue, 11 Apr 2017 20:02:12 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
@@ -3126,13 +3139,13 @@
           "14949"
         ],
         "x-ms-request-id": [
-          "ef0334d1-bd2b-45a8-9aa6-fd17c2212703"
+          "b7e69228-4f10-464c-91ba-05711a4e870b"
         ],
         "x-ms-correlation-request-id": [
-          "ef0334d1-bd2b-45a8-9aa6-fd17c2212703"
+          "b7e69228-4f10-464c-91ba-05711a4e870b"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T233946Z:ef0334d1-bd2b-45a8-9aa6-fd17c2212703"
+          "WESTUS2:20170411T200212Z:b7e69228-4f10-464c-91ba-05711a4e870b"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3141,8 +3154,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3163,13 +3176,13 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:40:15 GMT"
+          "Tue, 11 Apr 2017 20:02:42 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
@@ -3178,13 +3191,13 @@
           "14948"
         ],
         "x-ms-request-id": [
-          "25097cd7-656c-4eff-942a-227d5a78a382"
+          "474fb3fb-b436-49e0-be43-8609fd866383"
         ],
         "x-ms-correlation-request-id": [
-          "25097cd7-656c-4eff-942a-227d5a78a382"
+          "474fb3fb-b436-49e0-be43-8609fd866383"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T234016Z:25097cd7-656c-4eff-942a-227d5a78a382"
+          "WESTUS2:20170411T200243Z:474fb3fb-b436-49e0-be43-8609fd866383"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3193,8 +3206,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3215,13 +3228,13 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:40:45 GMT"
+          "Tue, 11 Apr 2017 20:03:12 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
@@ -3230,13 +3243,13 @@
           "14947"
         ],
         "x-ms-request-id": [
-          "391aa9a6-73d3-4c1c-8f73-74a60c7c5f5c"
+          "df5e2cab-177f-4ade-b961-6d47b84d9af6"
         ],
         "x-ms-correlation-request-id": [
-          "391aa9a6-73d3-4c1c-8f73-74a60c7c5f5c"
+          "df5e2cab-177f-4ade-b961-6d47b84d9af6"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T234046Z:391aa9a6-73d3-4c1c-8f73-74a60c7c5f5c"
+          "WESTUS2:20170411T200313Z:df5e2cab-177f-4ade-b961-6d47b84d9af6"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3245,8 +3258,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3267,13 +3280,13 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:41:16 GMT"
+          "Tue, 11 Apr 2017 20:03:42 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
@@ -3282,13 +3295,13 @@
           "14946"
         ],
         "x-ms-request-id": [
-          "82a44461-ca6e-47f0-8461-28df50eabad2"
+          "fb9e7b44-7cd6-46fb-b1de-b3c69ec92497"
         ],
         "x-ms-correlation-request-id": [
-          "82a44461-ca6e-47f0-8461-28df50eabad2"
+          "fb9e7b44-7cd6-46fb-b1de-b3c69ec92497"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T234116Z:82a44461-ca6e-47f0-8461-28df50eabad2"
+          "WESTUS2:20170411T200343Z:fb9e7b44-7cd6-46fb-b1de-b3c69ec92497"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3297,8 +3310,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3319,13 +3332,13 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:41:46 GMT"
+          "Tue, 11 Apr 2017 20:04:12 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
@@ -3334,13 +3347,13 @@
           "14945"
         ],
         "x-ms-request-id": [
-          "01ba3761-05a4-4be5-a2b9-ce6954d2d212"
+          "8460854a-d20d-4141-a406-b78573d786c1"
         ],
         "x-ms-correlation-request-id": [
-          "01ba3761-05a4-4be5-a2b9-ce6954d2d212"
+          "8460854a-d20d-4141-a406-b78573d786c1"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T234146Z:01ba3761-05a4-4be5-a2b9-ce6954d2d212"
+          "WESTUS2:20170411T200413Z:8460854a-d20d-4141-a406-b78573d786c1"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3349,8 +3362,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVZCRDkyOTI2MDQ5MjUxODQ2LVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWkNSRGt5T1RJMk1EUTVNalV4T0RRMkxWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPTVYyQkUyODE2NEQyNkQyRjJCLVdFU1RDRU5UUkFMVVMiLCJqb2JMb2NhdGlvbiI6Indlc3RjZW50cmFsdXMifQ?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMWM2MzhjZjQtNjA4Zi00ZWU2LWI2ODAtYzMyOWU4MjRjM2E4L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFRWWXlRa1V5T0RFMk5FUXlOa1F5UmpKQ0xWZEZVMVJEUlU1VVVrRk1WVk1pTENKcWIySk1iMk5oZEdsdmJpSTZJbmRsYzNSalpXNTBjbUZzZFhNaWZRP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3371,7 +3384,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 23:42:16 GMT"
+          "Tue, 11 Apr 2017 20:04:43 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -3380,13 +3393,13 @@
           "14944"
         ],
         "x-ms-request-id": [
-          "1b1d9888-fa1d-48f2-bee8-dfe9b885bed8"
+          "d87472f4-da67-4ee0-9ef4-683442e4bfda"
         ],
         "x-ms-correlation-request-id": [
-          "1b1d9888-fa1d-48f2-bee8-dfe9b885bed8"
+          "d87472f4-da67-4ee0-9ef4-683442e4bfda"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T234216Z:1b1d9888-fa1d-48f2-bee8-dfe9b885bed8"
+          "WESTUS2:20170411T200443Z:d87472f4-da67-4ee0-9ef4-683442e4bfda"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3397,21 +3410,21 @@
   ],
   "Names": {
     "ManageVirtualMachineAsyncTest": [
-      "wvm00888296b97d513d1",
-      "lvmcb167080f8d1a419d",
-      "rgcomvbd92926049251846",
-      "dsk-c2a86293b05c3ba6d",
-      "dsk-5a9789569075af552",
-      "nic78153aac846",
-      "vneta49146400df7",
-      "vmb9c85326d1",
-      "nic567816300f1",
-      "vm34398038f8"
+      "wvm024038843412ace94",
+      "lvmfaa27967616d4cf5c",
+      "rgcomv2be28164d26d2f2b",
+      "dsk-6c89576046cdd10f3",
+      "dsk-f3958901328006b28",
+      "nic4315580dbe4",
+      "vnetc000315669ca",
+      "vm2ff6843534",
+      "nic8670467b601",
+      "vm8c2061179e"
     ]
   },
   "Variables": {
-    "ServicePrincipal": "db2b2faa-5626-455b-ac5a-0ee3e9337312",
+    "ServicePrincipal": "c49b355d-adab-44ef-9141-54401c159b5e",
     "AADTenant": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-    "SubscriptionId": "c549f475-dee8-428c-bb19-829a55e52f77"
+    "SubscriptionId": "1c638cf4-608f-4ee6-b680-c329e824c3a8"
   }
 }

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineEncryptionOperationsTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineEncryptionOperationsTests.cs
@@ -17,7 +17,7 @@ namespace Azure.Tests.Compute
 {
     public class VirtualMachineEncryptionOperationsTests
     {
-        [Fact(Skip = "Requires ServicePrincipal, KeyVault creation and association, requires SSH to vm and perform mounting")]
+        [Fact(Skip = "Manual only: Requires ServicePrincipal, KeyVault creation and association, requires SSH to vm and perform mounting")]
         public void CanEncryptVirtualMachine()
         {
             using (var context = FluentMockContext.Start(GetType().FullName))

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineManagedDiskOperationsTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineManagedDiskOperationsTests.cs
@@ -584,7 +584,7 @@ namespace Fluent.Tests.Compute
                             .WithNewPrimaryNetwork("10.0.0.0/28")
                             .WithPrimaryPrivateIPAddressDynamic()
                             .WithoutPrimaryPublicIPAddress()
-                            .WithSpecializedOsDisk(osDisk, OperatingSystemTypes.Linux)
+                            .WithSpecializedOSDisk(osDisk, OperatingSystemTypes.Linux)
                             .WithSize(VirtualMachineSizeTypes.StandardD5V2)
                             .WithOSDiskCaching(CachingTypes.ReadWrite)
                             .Create();

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineTests.cs
@@ -49,7 +49,7 @@ namespace Fluent.Tests.Compute
                         .WithUnmanagedDisks()
                         .WithOSDiskCaching(CachingTypes.ReadWrite)
                         .WithSize(VirtualMachineSizeTypes.StandardD3)
-                        .WithOsDiskName("javatest")
+                        .WithOSDiskName("javatest")
                         .Create();
 
                     var foundedVM = computeManager.VirtualMachines.ListByResourceGroup(GroupName)

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Miscellaneous/RestClientTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Miscellaneous/RestClientTests.cs
@@ -19,7 +19,7 @@ namespace Fluent.Tests.Miscellaneous
 {
     public class RestClientTests
     {
-        [Fact(Skip="This code tries to connect in the playback mode")]
+        [Fact(Skip="Investigate: This code tries to connect in the playback mode")]
         public void CanSetMultipleDelegateHandlers()
         {
             using (var context = FluentMockContext.Start(GetType().FullName))

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Sql/SqlTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Sql/SqlTests.cs
@@ -70,7 +70,7 @@ namespace Azure.Tests.Sql
             }
         }
 
-        [Fact(Skip = "This test require existing SQL server so that there can be recommended elastic pools")]
+        [Fact(Skip = "Manual only: This test require existing SQL server so that there can be recommended elastic pools")]
         public void CanListRecommendedElasticPools()
         {
             using (var context = FluentMockContext.Start(this.GetType().FullName))

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Storage/StorageAccountsTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Storage/StorageAccountsTests.cs
@@ -14,7 +14,7 @@ namespace Fluent.Tests.Storage
 {
     public class StorageAccountsTests
     {
-        [Fact(Skip="Update on storage account is using patch and tags are not properly handled there.")]
+        [Fact(Skip="Investigate: Update on storage account is using patch and tags are not properly handled there.")]
         public void CanCRUDStorageAccount()
         {
             using (var context = FluentMockContext.Start(this.GetType().FullName))

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/CertificateOrdersTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/CertificateOrdersTests.cs
@@ -13,7 +13,7 @@ namespace Azure.Tests.WebApp
         private static string GroupName = "javacsmrg9b9912262";
         private static string CertificateName = "graphdmcert7720";
 
-        [Fact(Skip = "Test requires javacsmrg9b9912262 RG to be configured manually")]
+        [Fact(Skip = "Manual only: ($300) Test requires javacsmrg9b9912262 RG to be configured manually")]
         public void CanCRUDCertificateOrder()
         {
             using (var context = FluentMockContext.Start(this.GetType().FullName))

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/CertificatesTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/CertificatesTests.cs
@@ -14,7 +14,7 @@ namespace Azure.Tests.WebApp
         private static readonly string GroupName = "javacsmrg319";
         private static readonly string CertificateName = "javagoodcert319";
 
-        [Fact(Skip = "Test requires javacsmrg319 RG to be configured manually")]
+        [Fact(Skip = "Manual only: Test requires javacsmrg319 RG to be configured manually")]
         public void CanCRDCertificate()
         {
             using (var context = FluentMockContext.Start(this.GetType().FullName))

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/DomainsTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/DomainsTests.cs
@@ -13,7 +13,7 @@ namespace Azure.Tests.WebApp
         private static readonly string GroupName = "javacsmrg9b9912262";
         private static readonly string DomainName = "graph-dm7720.com";
 
-        [Fact(Skip = "Test requires javacsmrg9b9912262 RG to be configured manually")]
+        [Fact(Skip = "TODO: Automate - Test requires javacsmrg9b9912262 RG to be configured manually")]
         public void CanCRUDDomain()
         {
             using (var context = FluentMockContext.Start(this.GetType().FullName))

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/HostnameSslTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/WebApp/HostnameSslTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Tests.WebApp
 {
     public class HostnameSslTests
     {
-        [Fact(Skip = "Test requires javacsmrg9b9912262 RG to be configured manually")]
+        [Fact(Skip = "Manual only - Test requires javacsmrg9b9912262 RG to be configured manually")]
         public async Task CanBindHostnameAndSsl()
         {
             using (var context = FluentMockContext.Start(this.GetType().FullName))

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// <param name="containerName">The name of the container in the selected storage account.</param>
         /// <param name="vhdName">The name for the OS Disk vhd.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        VirtualMachine.Definition.IWithUnmanagedCreate VirtualMachine.Definition.IWithUnmanagedCreate.WithOsDiskVhdLocation(string containerName, string vhdName)
+        VirtualMachine.Definition.IWithUnmanagedCreate VirtualMachine.Definition.IWithUnmanagedCreate.WithOSDiskVhdLocation(string containerName, string vhdName)
         {
             return this.WithOsDiskVhdLocation(containerName, vhdName) as VirtualMachine.Definition.IWithUnmanagedCreate;
         }
@@ -643,7 +643,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// </summary>
         /// <param name="accountType">The storage account type.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        VirtualMachine.Definition.IWithManagedCreate VirtualMachine.Definition.IWithManagedCreate.WithOsDiskStorageAccountType(StorageAccountTypes accountType)
+        VirtualMachine.Definition.IWithManagedCreate VirtualMachine.Definition.IWithManagedCreate.WithOSDiskStorageAccountType(StorageAccountTypes accountType)
         {
             return this.WithOsDiskStorageAccountType(accountType) as VirtualMachine.Definition.IWithManagedCreate;
         }

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
@@ -1077,7 +1077,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// </summary>
         /// <param name="cachingType">The caching type.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        VirtualMachine.Definition.IWithCreate VirtualMachine.Definition.IWithOsDiskSettings.WithOSDiskCaching(CachingTypes cachingType)
+        VirtualMachine.Definition.IWithCreate VirtualMachine.Definition.IWithOSDiskSettings.WithOSDiskCaching(CachingTypes cachingType)
         {
             return this.WithOSDiskCaching(cachingType) as VirtualMachine.Definition.IWithCreate;
         }
@@ -1087,7 +1087,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// </summary>
         /// <param name="size">The VHD size.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        VirtualMachine.Definition.IWithCreate VirtualMachine.Definition.IWithOsDiskSettings.WithOSDiskSizeInGB(int size)
+        VirtualMachine.Definition.IWithCreate VirtualMachine.Definition.IWithOSDiskSettings.WithOSDiskSizeInGB(int size)
         {
             return this.WithOSDiskSizeInGB(size) as VirtualMachine.Definition.IWithCreate;
         }
@@ -1097,9 +1097,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// </summary>
         /// <param name="name">The OS Disk name.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        VirtualMachine.Definition.IWithCreate VirtualMachine.Definition.IWithOsDiskSettings.WithOsDiskName(string name)
+        VirtualMachine.Definition.IWithCreate VirtualMachine.Definition.IWithOSDiskSettings.WithOSDiskName(string name)
         {
-            return this.WithOsDiskName(name) as VirtualMachine.Definition.IWithCreate;
+            return this.WithOSDiskName(name) as VirtualMachine.Definition.IWithCreate;
         }
 
         /// <summary>
@@ -1107,9 +1107,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// </summary>
         /// <param name="settings">The encryption settings.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        VirtualMachine.Definition.IWithCreate VirtualMachine.Definition.IWithOsDiskSettings.WithOsDiskEncryptionSettings(DiskEncryptionSettings settings)
+        VirtualMachine.Definition.IWithCreate VirtualMachine.Definition.IWithOSDiskSettings.WithOSDiskEncryptionSettings(DiskEncryptionSettings settings)
         {
-            return this.WithOsDiskEncryptionSettings(settings) as VirtualMachine.Definition.IWithCreate;
+            return this.WithOSDiskEncryptionSettings(settings) as VirtualMachine.Definition.IWithCreate;
         }
 
         /// <summary>
@@ -1117,9 +1117,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// </summary>
         /// <param name="settings">The encryption settings.</param>
         /// <return>The stage representing creatable VM update.</return>
-        VirtualMachine.Update.IUpdate VirtualMachine.Update.IUpdate.WithOsDiskEncryptionSettings(DiskEncryptionSettings settings)
+        VirtualMachine.Update.IUpdate VirtualMachine.Update.IUpdate.WithOSDiskEncryptionSettings(DiskEncryptionSettings settings)
         {
-            return this.WithOsDiskEncryptionSettings(settings) as VirtualMachine.Update.IUpdate;
+            return this.WithOSDiskEncryptionSettings(settings) as VirtualMachine.Update.IUpdate;
         }
 
         /// <summary>

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
@@ -499,6 +499,26 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         /// <summary>
+        /// Specifies the caching type for the Operating System disk.
+        /// </summary>
+        /// <param name="cachingType">The caching type.</param>
+        /// <return>The stage representing updatable VM definition.</return>
+        VirtualMachine.Update.IUpdate VirtualMachine.Update.IUpdate.WithOSDiskCaching(CachingTypes cachingType)
+        {
+            return this.WithOSDiskCaching(cachingType) as VirtualMachine.Update.IUpdate;
+        }
+
+        /// <summary>
+        /// Specifies the size of the OSDisk in GB.
+        /// </summary>
+        /// <param name="size">The disk size.</param>
+        /// <return>The stage representing updatable VM definition.</return>
+        VirtualMachine.Update.IUpdate VirtualMachine.Update.IUpdate.WithOSDiskSizeInGB(int size)
+        {
+            return this.WithOSDiskSizeInGB(size) as VirtualMachine.Update.IUpdate;
+        }
+
+        /// <summary>
         /// Specifies the default caching type for the managed data disks.
         /// </summary>
         /// <param name="storageAccountType">The storage account type.</param>

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// <param name="osDiskUrl">OsDiskUrl the url to the OS disk in the Azure Storage account.</param>
         /// <param name="osType">The OS type.</param>
         /// <return>The next stage of the Windows virtual machine definition.</return>
-        VirtualMachine.Definition.IWithUnmanagedCreate VirtualMachine.Definition.IWithOS.WithSpecializedOsUnmanagedDisk(string osDiskUrl, OperatingSystemTypes osType)
+        VirtualMachine.Definition.IWithUnmanagedCreate VirtualMachine.Definition.IWithOS.WithSpecializedOSUnmanagedDisk(string osDiskUrl, OperatingSystemTypes osType)
         {
             return this.WithSpecializedOsUnmanagedDisk(osDiskUrl, osType) as VirtualMachine.Definition.IWithUnmanagedCreate;
         }
@@ -463,7 +463,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// <param name="disk">The managed disk to attach.</param>
         /// <param name="osType">The OS type.</param>
         /// <return>The next stage of the Windows virtual machine definition.</return>
-        VirtualMachine.Definition.IWithManagedCreate VirtualMachine.Definition.IWithOS.WithSpecializedOsDisk(IDisk disk, OperatingSystemTypes osType)
+        VirtualMachine.Definition.IWithManagedCreate VirtualMachine.Definition.IWithOS.WithSpecializedOSDisk(IDisk disk, OperatingSystemTypes osType)
         {
             return this.WithSpecializedOsDisk(disk, osType) as VirtualMachine.Definition.IWithManagedCreate;
         }

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineImpl.cs
@@ -499,26 +499,6 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         /// <summary>
-        /// Specifies the caching type for the Operating System disk.
-        /// </summary>
-        /// <param name="cachingType">The caching type.</param>
-        /// <return>The stage representing updatable VM definition.</return>
-        VirtualMachine.Update.IUpdate VirtualMachine.Update.IUpdate.WithOSDiskCaching(CachingTypes cachingType)
-        {
-            return this.WithOSDiskCaching(cachingType) as VirtualMachine.Update.IUpdate;
-        }
-
-        /// <summary>
-        /// Specifies the size of the OSDisk in GB.
-        /// </summary>
-        /// <param name="size">The disk size.</param>
-        /// <return>The stage representing updatable VM definition.</return>
-        VirtualMachine.Update.IUpdate VirtualMachine.Update.IUpdate.WithOSDiskSizeInGB(int size)
-        {
-            return this.WithOSDiskSizeInGB(size) as VirtualMachine.Update.IUpdate;
-        }
-
-        /// <summary>
         /// Specifies the default caching type for the managed data disks.
         /// </summary>
         /// <param name="storageAccountType">The storage account type.</param>

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineScaleSetImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/InterfaceImpl/VirtualMachineScaleSetImpl.cs
@@ -1069,7 +1069,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// </summary>
         /// <param name="accountType">The storage account type.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        VirtualMachineScaleSet.Definition.IWithManagedCreate VirtualMachineScaleSet.Definition.IWithManagedDiskOptionals.WithOsDiskStorageAccountType(StorageAccountTypes accountType)
+        VirtualMachineScaleSet.Definition.IWithManagedCreate VirtualMachineScaleSet.Definition.IWithManagedDiskOptionals.WithOSDiskStorageAccountType(StorageAccountTypes accountType)
         {
             return this.WithOsDiskStorageAccountType(accountType) as VirtualMachineScaleSet.Definition.IWithManagedCreate;
         }
@@ -1142,7 +1142,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// </summary>
         /// <param name="name">The OS disk name.</param>
         /// <return>The next stage of the definition.</return>
-        VirtualMachineScaleSet.Definition.IWithCreate VirtualMachineScaleSet.Definition.IWithOsDiskSettings.WithOsDiskName(string name)
+        VirtualMachineScaleSet.Definition.IWithCreate VirtualMachineScaleSet.Definition.IWithOSDiskSettings.WithOSDiskName(string name)
         {
             return this.WithOsDiskName(name) as VirtualMachineScaleSet.Definition.IWithCreate;
         }
@@ -1152,7 +1152,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         /// </summary>
         /// <param name="cachingType">The caching type.</param>
         /// <return>The next stage of the definition.</return>
-        VirtualMachineScaleSet.Definition.IWithCreate VirtualMachineScaleSet.Definition.IWithOsDiskSettings.WithOsDiskCaching(CachingTypes cachingType)
+        VirtualMachineScaleSet.Definition.IWithCreate VirtualMachineScaleSet.Definition.IWithOSDiskSettings.WithOSDiskCaching(CachingTypes cachingType)
         {
             return this.WithOsDiskCaching(cachingType) as VirtualMachineScaleSet.Definition.IWithCreate;
         }

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Definition/IDefinition.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Definition/IDefinition.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         /// <param name="osDiskUrl">OsDiskUrl the url to the OS disk in the Azure Storage account.</param>
         /// <param name="osType">The OS type.</param>
         /// <return>The next stage of the Windows virtual machine definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithUnmanagedCreate WithSpecializedOsUnmanagedDisk(string osDiskUrl, OperatingSystemTypes osType);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithUnmanagedCreate WithSpecializedOSUnmanagedDisk(string osDiskUrl, OperatingSystemTypes osType);
 
         /// <summary>
         /// Specifies the id of a Linux custom image to be used.
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         /// <param name="disk">The managed disk to attach.</param>
         /// <param name="osType">The OS type.</param>
         /// <return>The next stage of the Windows virtual machine definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithManagedCreate WithSpecializedOsDisk(IDisk disk, OperatingSystemTypes osType);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithManagedCreate WithSpecializedOSDisk(IDisk disk, OperatingSystemTypes osType);
     }
 
     /// <summary>

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Definition/IDefinition.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Definition/IDefinition.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         /// <summary>
         /// Specifies the specialized operating system unmanaged disk to be attached to the virtual machine.
         /// </summary>
-        /// <param name="osDiskUrl">OsDiskUrl the url to the OS disk in the Azure Storage account.</param>
+        /// <param name="osDiskUrl">osDiskUrl the url to the OS disk in the Azure Storage account.</param>
         /// <param name="osType">The OS type.</param>
         /// <return>The next stage of the Windows virtual machine definition.</return>
         Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithUnmanagedCreate WithSpecializedOSUnmanagedDisk(string osDiskUrl, OperatingSystemTypes osType);
@@ -460,7 +460,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         /// <param name="containerName">The name of the container in the selected storage account.</param>
         /// <param name="vhdName">The name for the OS Disk vhd.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithUnmanagedCreate WithOsDiskVhdLocation(string containerName, string vhdName);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithUnmanagedCreate WithOSDiskVhdLocation(string containerName, string vhdName);
     }
 
     /// <summary>
@@ -575,11 +575,11 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithManagedCreate WithDataDiskDefaultCachingType(CachingTypes cachingType);
 
         /// <summary>
-        /// Specifies the storage account type for managed Os disk.
+        /// Specifies the storage account type for managed OS disk.
         /// </summary>
         /// <param name="accountType">The storage account type.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithManagedCreate WithOsDiskStorageAccountType(StorageAccountTypes accountType);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithManagedCreate WithOSDiskStorageAccountType(StorageAccountTypes accountType);
     }
 
     /// <summary>

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Definition/IDefinition.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Definition/IDefinition.cs
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
     public interface IWithCreate  :
         ICreatable<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachine>,
         IDefinitionWithTags<Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithCreate>,
-        IWithOsDiskSettings,
+        IWithOSDiskSettings,
         IWithVMSize,
         IWithStorageAccount,
         IWithAvailabilitySet,
@@ -940,7 +940,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
     /// <summary>
     /// The stage of the virtual machine definition allowing to specify OS disk configurations.
     /// </summary>
-    public interface IWithOsDiskSettings 
+    public interface IWithOSDiskSettings 
     {
         /// <summary>
         /// Specifies the size of the OSDisk in GB.
@@ -961,14 +961,14 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         /// </summary>
         /// <param name="name">The OS Disk name.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithCreate WithOsDiskName(string name);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithCreate WithOSDiskName(string name);
 
         /// <summary>
         /// Specifies the encryption settings for the OS Disk.
         /// </summary>
         /// <param name="settings">The encryption settings.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithCreate WithOsDiskEncryptionSettings(DiskEncryptionSettings settings);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithCreate WithOSDiskEncryptionSettings(DiskEncryptionSettings settings);
     }
 
     /// <summary>

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Update/IUpdate.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Update/IUpdate.cs
@@ -33,11 +33,25 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update
         Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update.IUpdate WithDataDiskDefaultStorageAccountType(StorageAccountTypes storageAccountType);
 
         /// <summary>
+        /// Specifies the size of the OSDisk in GB. This can be modified only for non-managed disks.
+        /// </summary>
+        /// <param name="size">The disk size.</param>
+        /// <return>The stage representing updatable VM definition.</return>
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update.IUpdate WithOSDiskSizeInGB(int size);
+
+        /// <summary>
         /// Specifies the default caching type for the managed data disks.
         /// </summary>
         /// <param name="cachingType">The caching type.</param>
         /// <return>The stage representing updatable VM definition.</return>
         Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update.IUpdate WithDataDiskDefaultCachingType(CachingTypes cachingType);
+
+        /// <summary>
+        /// Specifies the caching type for the Operating System disk.
+        /// </summary>
+        /// <param name="cachingType">The caching type.</param>
+        /// <return>The stage representing updatable VM definition.</return>
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update.IUpdate WithOSDiskCaching(CachingTypes cachingType);
 
         /// <summary>
         /// Specifies the new size for the virtual machine.

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Update/IUpdate.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Update/IUpdate.cs
@@ -33,25 +33,11 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update
         Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update.IUpdate WithDataDiskDefaultStorageAccountType(StorageAccountTypes storageAccountType);
 
         /// <summary>
-        /// Specifies the size of the OSDisk in GB. This can be modified only for non-managed disks.
-        /// </summary>
-        /// <param name="size">The disk size.</param>
-        /// <return>The stage representing updatable VM definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update.IUpdate WithOSDiskSizeInGB(int size);
-
-        /// <summary>
         /// Specifies the default caching type for the managed data disks.
         /// </summary>
         /// <param name="cachingType">The caching type.</param>
         /// <return>The stage representing updatable VM definition.</return>
         Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update.IUpdate WithDataDiskDefaultCachingType(CachingTypes cachingType);
-
-        /// <summary>
-        /// Specifies the caching type for the Operating System disk.
-        /// </summary>
-        /// <param name="cachingType">The caching type.</param>
-        /// <return>The stage representing updatable VM definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update.IUpdate WithOSDiskCaching(CachingTypes cachingType);
 
         /// <summary>
         /// Specifies the new size for the virtual machine.

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Update/IUpdate.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachine/Update/IUpdate.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update
         /// </summary>
         /// <param name="settings">The encryption settings.</param>
         /// <return>The stage representing creatable VM update.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update.IUpdate WithOsDiskEncryptionSettings(DiskEncryptionSettings settings);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Update.IUpdate WithOSDiskEncryptionSettings(DiskEncryptionSettings settings);
     }
 
     /// <summary>

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachineScaleSet/Definition/IDefinition.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/Domain/VirtualMachineScaleSet/Definition/IDefinition.cs
@@ -61,21 +61,21 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Defin
     /// <summary>
     /// The stage of a virtual machine scale set definition allowing to specify OS disk configurations.
     /// </summary>
-    public interface IWithOsDiskSettings 
+    public interface IWithOSDiskSettings 
     {
         /// <summary>
         /// Specifies the name for the OS disk.
         /// </summary>
         /// <param name="name">The OS disk name.</param>
         /// <return>The next stage of the definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithCreate WithOsDiskName(string name);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithCreate WithOSDiskName(string name);
 
         /// <summary>
         /// Specifies the caching type for the operating system disk.
         /// </summary>
         /// <param name="cachingType">The caching type.</param>
         /// <return>The next stage of the definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithCreate WithOsDiskCaching(CachingTypes cachingType);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithCreate WithOSDiskCaching(CachingTypes cachingType);
     }
 
     /// <summary>
@@ -827,7 +827,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Defin
     /// </summary>
     public interface IWithCreate  :
         ICreatable<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineScaleSet>,
-        IWithOsDiskSettings,
+        IWithOSDiskSettings,
         IWithComputerNamePrefix,
         IWithCapacity,
         IWithUpgradePolicy,
@@ -859,10 +859,10 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Defin
         Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithManagedCreate WithDataDiskDefaultCachingType(CachingTypes cachingType);
 
         /// <summary>
-        /// Specifies the storage account type for managed Os disk.
+        /// Specifies the storage account type for managed OS disk.
         /// </summary>
         /// <param name="accountType">The storage account type.</param>
         /// <return>The stage representing creatable VM definition.</return>
-        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithManagedCreate WithOsDiskStorageAccountType(StorageAccountTypes accountType);
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachineScaleSet.Definition.IWithManagedCreate WithOSDiskStorageAccountType(StorageAccountTypes accountType);
     }
 }

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineEncryptionHelper.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineEncryptionHelper.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
             var diskEncryptionSettings = encryptConfig.StorageProfileEncryptionSettings();
             diskEncryptionSettings.DiskEncryptionKey.SecretUrl = encryptionSecretKeyVaultUrl;
             return await virtualMachine.Update()
-                .WithOsDiskEncryptionSettings(diskEncryptionSettings)
+                .WithOSDiskEncryptionSettings(diskEncryptionSettings)
                 .ApplyAsync(cancellationToken);
         }
 
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         {
             DiskEncryptionSettings diskEncryptionSettings = encryptConfig.StorageProfileEncryptionSettings();
             return await virtualMachine.Update()
-                .WithOsDiskEncryptionSettings(diskEncryptionSettings)
+                .WithOSDiskEncryptionSettings(diskEncryptionSettings)
                 .ApplyAsync(cancellationToken);
         }
 

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImpl.cs
@@ -691,7 +691,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:75485319699D66A3C75429B0EB7E0665:AE8D3788AAA49304D58C3DFB3E942C15
-        public VirtualMachineImpl WithOsDiskEncryptionSettings(DiskEncryptionSettings settings)
+        public VirtualMachineImpl WithOSDiskEncryptionSettings(DiskEncryptionSettings settings)
         {
             Inner.StorageProfile.OsDisk.EncryptionSettings = settings;
             return this;
@@ -705,7 +705,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:C5EB453493B1100152604C49B4350246:28D2B19DAE6A4D168B24165D74135721
-        public VirtualMachineImpl WithOsDiskName(string name)
+        public VirtualMachineImpl WithOSDiskName(string name)
         {
             Inner.StorageProfile.OsDisk.Name = name;
             return this;
@@ -1493,7 +1493,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                     }
                     if (osDisk.Name == null)
                     {
-                        WithOsDiskName(this.vmName + "-os-disk");
+                        WithOSDiskName(this.vmName + "-os-disk");
                     }
                 }
             }
@@ -1517,7 +1517,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                     osDisk.ManagedDisk = null;
                     if (osDisk.Name == null)
                     {
-                        WithOsDiskName(this.vmName + "-os-disk");
+                        WithOSDiskName(this.vmName + "-os-disk");
                     }
                 }
             }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/AzureCredentialsFactory.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/AzureCredentialsFactory.cs
@@ -92,7 +92,11 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
             File.ReadLines(authFile)
                 .All(line =>
                 {
+                    if (line.Trim().StartsWith("#"))
+                        return true; // Ignore comments
                     var keyVal = line.Trim().Split(new char[] { '=' }, 2);
+                    if(keyVal.Length < 2)
+                        return true; // Ignore lines that don't look like $$$=$$$
                     config[keyVal[0].ToLowerInvariant()] = keyVal[1];
                     return true;
                 });


### PR DESCRIPTION
...also: enabling authfile reader to skip comments and empty lines (and other invalid lines)

compat breaks from beta5:
- renaming all withers that contain `*Os*` as `*OS*` to use the correct casing for 2-letter acronyms, per .NET guidelines, within `IVirtualMachine` and `IVirtualMachineScaleSet` models