### PR TITLE
Fixed missed license headers.

### DIFF
--- a/Samples/Common/Utilities.cs
+++ b/Samples/Common/Utilities.cs
@@ -27,6 +27,7 @@ using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage;
 using Renci.SshNet;
 using Microsoft.Azure.Management.Servicebus.Fluent;
+using Microsoft.Azure.ServiceBus;
 
 namespace Microsoft.Azure.Management.Samples.Common
 {
@@ -1681,6 +1682,38 @@ namespace Microsoft.Azure.Management.Samples.Common
         public static string GetCertificatePath(string certificateName)
         {
             return Path.Combine(Utilities.ProjectPath, "Asset", certificateName);
+        }
+
+        public static void SendMessageToTopic(string connectionString, string topicName, string message)
+        {
+            if (!IsRunningMocked)
+            {
+                try
+                {
+                    var topicClient = new TopicClient(connectionString, topicName);
+                    topicClient.SendAsync(new Message(Encoding.UTF8.GetBytes(message))).Wait();
+                    topicClient.Close();
+                }
+                catch (Exception)
+                {
+                }
+            }
+        }
+
+        public static void SendMessageToQueue(string connectionString, string queueName, string message)
+        {
+            if (!IsRunningMocked)
+            {
+                try
+                {
+                    var queueClient = new QueueClient(connectionString, queueName, ReceiveMode.PeekLock);
+                    queueClient.SendAsync(new Message(Encoding.UTF8.GetBytes(message))).Wait();
+                    queueClient.Close();
+                }
+                catch (Exception)
+                {
+                }
+            }
         }
     }
 }

--- a/Samples/Common/project.json
+++ b/Samples/Common/project.json
@@ -7,6 +7,7 @@
       "type": "build"
     },
     "CoreFTP": "1.2.0",
+    "Microsoft.Azure.ServiceBus": "0.0.2-preview",
     "SSH.NET": "2016.0.0"
   },
   

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/Program.cs
@@ -3,15 +3,12 @@
 
 
 using Microsoft.Azure.Management.Fluent;
-using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
 using Microsoft.Azure.Management.Servicebus.Fluent;
-using Microsoft.Azure.ServiceBus;
 using System;
 using System.Linq;
-using System.Text;
 
 namespace ServiceBusPublishSubscribeAdvanceFeatures
 {
@@ -154,15 +151,7 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
 
                 //=============================================================
                 // Send a message to topic.
-                try
-                {
-                    var topicClient = new TopicClient(keys.PrimaryConnectionString, topic1Name);
-                    topicClient.SendAsync(new Message(Encoding.UTF8.GetBytes("Hello"))).Wait();
-                    topicClient.Close();
-                }
-                catch (Exception)
-                {
-                }
+                Utilities.SendMessageToTopic(keys.PrimaryConnectionString, topic1Name, "Hello");
                 //=============================================================
                 // Delete a topic and namespace
                 Console.WriteLine("Deleting topic " + topic1Name + "in namespace " + namespaceName + "...");
@@ -175,7 +164,7 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
                 {
                     azure.ServiceBusNamespaces.DeleteById(serviceBusNamespace.Id);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                 }
                 Console.WriteLine("Deleted namespace " + namespaceName + "...");

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/Program.cs
@@ -43,7 +43,7 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
                 //============================================================
                 // Create a namespace.
 
-                Console.WriteLine("Creating name space " + namespaceName + " in resource group " + rgName + "...");
+                Utilities.Log("Creating name space " + namespaceName + " in resource group " + rgName + "...");
 
                 var serviceBusNamespace = azure.ServiceBusNamespaces
                         .Define(namespaceName)
@@ -53,10 +53,10 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
                         .WithNewTopic(topic1Name, 1024)
                         .Create();
 
-                Console.WriteLine("Created service bus " + serviceBusNamespace.Name);
+                Utilities.Log("Created service bus " + serviceBusNamespace.Name);
                 Utilities.Print(serviceBusNamespace);
 
-                Console.WriteLine("Created topic following topic along with namespace " + namespaceName);
+                Utilities.Log("Created topic following topic along with namespace " + namespaceName);
 
                 var firstTopic = serviceBusNamespace.Topics.GetByName(topic1Name);
                 Utilities.Print(firstTopic);
@@ -64,7 +64,7 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
                 //============================================================
                 // Create a service bus subscription in the topic with session and dead-letter enabled.
 
-                Console.WriteLine("Creating subscription " + subscription1Name + " in topic " + topic1Name + "...");
+                Utilities.Log("Creating subscription " + subscription1Name + " in topic " + topic1Name + "...");
                 var firstSubscription = firstTopic.Subscriptions.Define(subscription1Name)
                         .WithSession()
                         .WithDefaultMessageTTL(TimeSpan.FromMinutes(20))
@@ -72,26 +72,26 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
                         .WithExpiredMessageMovedToDeadLetterSubscription()
                         .WithMessageMovedToDeadLetterSubscriptionOnFilterEvaluationException()
                         .Create();
-                Console.WriteLine("Created subscription " + subscription1Name + " in topic " + topic1Name + "...");
+                Utilities.Log("Created subscription " + subscription1Name + " in topic " + topic1Name + "...");
 
                 Utilities.Print(firstSubscription);
 
                 //============================================================
                 // Create another subscription in the topic with auto deletion of idle entities.
-                Console.WriteLine("Creating another subscription " + subscription2Name + " in topic " + topic1Name + "...");
+                Utilities.Log("Creating another subscription " + subscription2Name + " in topic " + topic1Name + "...");
 
                 var secondSubscription = firstTopic.Subscriptions.Define(subscription2Name)
                         .WithSession()
                         .WithDeleteOnIdleDurationInMinutes(20)
                         .Create();
-                Console.WriteLine("Created subscription " + subscription2Name + " in topic " + topic1Name + "...");
+                Utilities.Log("Created subscription " + subscription2Name + " in topic " + topic1Name + "...");
 
                 Utilities.Print(secondSubscription);
 
                 //============================================================
                 // Create second topic with new Send Authorization rule, partitioning enabled and a new Service bus Subscription.
 
-                Console.WriteLine("Creating second topic " + topic2Name + ", with De-duplication and AutoDeleteOnIdle features...");
+                Utilities.Log("Creating second topic " + topic2Name + ", with De-duplication and AutoDeleteOnIdle features...");
 
                 var secondTopic = serviceBusNamespace.Topics.Define(topic2Name)
                         .WithNewSendRule(sendRuleName)
@@ -99,11 +99,11 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
                         .WithNewSubscription(subscription3Name)
                         .Create();
 
-                Console.WriteLine("Created second topic in namespace");
+                Utilities.Log("Created second topic in namespace");
 
                 Utilities.Print(secondTopic);
 
-                Console.WriteLine("Creating following authorization rules in second topic ");
+                Utilities.Log("Creating following authorization rules in second topic ");
 
                 var authorizationRules = secondTopic.AuthorizationRules.List();
                 foreach (var authorizationRule in authorizationRules)
@@ -113,7 +113,7 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
 
                 //============================================================
                 // Update second topic to change time for AutoDeleteOnIdle time, without Send rule and with a new manage authorization rule.
-                Console.WriteLine("Updating second topic " + topic2Name + "...");
+                Utilities.Log("Updating second topic " + topic2Name + "...");
 
                 secondTopic = secondTopic.Update()
                         .WithDeleteOnIdleDurationInMinutes(5)
@@ -121,10 +121,10 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
                         .WithNewManageRule(manageRuleName)
                         .Apply();
 
-                Console.WriteLine("Updated second topic to change its auto deletion time");
+                Utilities.Log("Updated second topic to change its auto deletion time");
 
                 Utilities.Print(secondTopic);
-                Console.WriteLine("Updated  following authorization rules in second topic, new list of authorization rules are ");
+                Utilities.Log("Updated  following authorization rules in second topic, new list of authorization rules are ");
 
                 authorizationRules = secondTopic.AuthorizationRules.List();
                 foreach (var authorizationRule in  authorizationRules)
@@ -136,7 +136,7 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
                 // Get connection string for default authorization rule of namespace
 
                 var namespaceAuthorizationRules = serviceBusNamespace.AuthorizationRules.List();
-                Console.WriteLine("Number of authorization rule for namespace :" + namespaceAuthorizationRules.Count());
+                Utilities.Log("Number of authorization rule for namespace :" + namespaceAuthorizationRules.Count());
 
 
                 foreach (var namespaceAuthorizationRule in  namespaceAuthorizationRules)
@@ -144,7 +144,7 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
                     Utilities.Print(namespaceAuthorizationRule);
                 }
 
-                Console.WriteLine("Getting keys for authorization rule ...");
+                Utilities.Log("Getting keys for authorization rule ...");
 
                 var keys = namespaceAuthorizationRules.FirstOrDefault().GetKeys();
                 Utilities.Print(keys);
@@ -154,11 +154,11 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
                 Utilities.SendMessageToTopic(keys.PrimaryConnectionString, topic1Name, "Hello");
                 //=============================================================
                 // Delete a topic and namespace
-                Console.WriteLine("Deleting topic " + topic1Name + "in namespace " + namespaceName + "...");
+                Utilities.Log("Deleting topic " + topic1Name + "in namespace " + namespaceName + "...");
                 serviceBusNamespace.Topics.DeleteByName(topic1Name);
-                Console.WriteLine("Deleted topic " + topic1Name + "...");
+                Utilities.Log("Deleted topic " + topic1Name + "...");
 
-                Console.WriteLine("Deleting namespace " + namespaceName + "...");
+                Utilities.Log("Deleting namespace " + namespaceName + "...");
                 // This will delete the namespace and topic within it.
                 try
                 {
@@ -167,20 +167,20 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
                 catch (Exception)
                 {
                 }
-                Console.WriteLine("Deleted namespace " + namespaceName + "...");
+                Utilities.Log("Deleted namespace " + namespaceName + "...");
 
             }
             finally
             {
                 try
                 {
-                    Console.WriteLine("Deleting Resource Group: " + rgName);
+                    Utilities.Log("Deleting Resource Group: " + rgName);
                     azure.ResourceGroups.BeginDeleteByName(rgName);
-                    Console.WriteLine("Deleted Resource Group: " + rgName);
+                    Utilities.Log("Deleted Resource Group: " + rgName);
                 }
                 catch (NullReferenceException)
                 {
-                    Console.WriteLine("Did not create any resources in Azure. No clean up is necessary");
+                    Utilities.Log("Did not create any resources in Azure. No clean up is necessary");
                 }
                 catch (Exception g)
                 {

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/Properties/AssemblyInfo.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/project.json
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/project.json
@@ -10,7 +10,6 @@
       "target": "project",
       "type": "build"
     },
-    "Microsoft.Azure.ServiceBus": "0.0.2-preview",
     "Microsoft.NETCore.App": {
       "type": "platform",
       "version": "1.0.1"

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Program.cs
@@ -44,7 +44,7 @@ namespace ServiceBusPublishSubscribeBasic
                 //============================================================
                 // Create a namespace.
 
-                Console.WriteLine("Creating name space " + namespaceName + " in resource group " + rgName + "...");
+                Utilities.Log("Creating name space " + namespaceName + " in resource group " + rgName + "...");
 
                 var serviceBusNamespace = azure.ServiceBusNamespaces
                         .Define(namespaceName)
@@ -53,32 +53,32 @@ namespace ServiceBusPublishSubscribeBasic
                         .WithSku(NamespaceSku.PremiumCapacity1)
                         .Create();
 
-                Console.WriteLine("Created service bus " + serviceBusNamespace.Name);
+                Utilities.Log("Created service bus " + serviceBusNamespace.Name);
                 Utilities.Print(serviceBusNamespace);
 
                 //============================================================
                 // Create a topic in namespace
 
-                Console.WriteLine("Creating topic " + topicName + " in namespace " + namespaceName + "...");
+                Utilities.Log("Creating topic " + topicName + " in namespace " + namespaceName + "...");
 
                 var topic = serviceBusNamespace.Topics.Define(topicName)
                         .WithSizeInMB(2048)
                         .Create();
 
-                Console.WriteLine("Created second queue in namespace");
+                Utilities.Log("Created second queue in namespace");
 
                 Utilities.Print(topic);
 
                 //============================================================
                 // Get and update topic with new size and a subscription
-                Console.WriteLine("Updating topic " + topicName + " with new size and a subscription...");
+                Utilities.Log("Updating topic " + topicName + " with new size and a subscription...");
                 topic = serviceBusNamespace.Topics.GetByName(topicName);
                 topic = topic.Update()
                         .WithNewSubscription(subscription1Name)
                         .WithSizeInMB(3072)
                         .Apply();
 
-                Console.WriteLine("Updated topic to change its size in MB along with a subscription");
+                Utilities.Log("Updated topic to change its size in MB along with a subscription");
 
                 Utilities.Print(topic);
 
@@ -86,9 +86,9 @@ namespace ServiceBusPublishSubscribeBasic
                 Utilities.Print(firstSubscription);
                 //============================================================
                 // Create a subscription
-                Console.WriteLine("Adding second subscription" + subscription2Name + " to topic " + topicName + "...");
+                Utilities.Log("Adding second subscription" + subscription2Name + " to topic " + topicName + "...");
                 var secondSubscription = topic.Subscriptions.Define(subscription2Name).WithDeleteOnIdleDurationInMinutes(10).Create();
-                Console.WriteLine("Added second subscription" + subscription2Name + " to topic " + topicName + "...");
+                Utilities.Log("Added second subscription" + subscription2Name + " to topic " + topicName + "...");
 
                 Utilities.Print(secondSubscription);
 
@@ -96,7 +96,7 @@ namespace ServiceBusPublishSubscribeBasic
                 // List topics in namespaces
 
                 var topics = serviceBusNamespace.Topics.List();
-                Console.WriteLine("Number of topics in namespace :" + topics.Count());
+                Utilities.Log("Number of topics in namespace :" + topics.Count());
 
                 foreach (var topicInNamespace  in  topics)
                 {
@@ -107,7 +107,7 @@ namespace ServiceBusPublishSubscribeBasic
                 // List all subscriptions for topic in namespaces
 
                 var subscriptions = topic.Subscriptions.List();
-                Console.WriteLine("Number of subscriptions to topic: " + subscriptions.Count());
+                Utilities.Log("Number of subscriptions to topic: " + subscriptions.Count());
 
                 foreach (var subscription  in  subscriptions)
                 {
@@ -118,7 +118,7 @@ namespace ServiceBusPublishSubscribeBasic
                 // Get connection string for default authorization rule of namespace
 
                 var namespaceAuthorizationRules = serviceBusNamespace.AuthorizationRules.List();
-                Console.WriteLine("Number of authorization rule for namespace :" + namespaceAuthorizationRules.Count());
+                Utilities.Log("Number of authorization rule for namespace :" + namespaceAuthorizationRules.Count());
 
 
                 foreach (var namespaceAuthorizationRule in  namespaceAuthorizationRules)
@@ -126,11 +126,11 @@ namespace ServiceBusPublishSubscribeBasic
                     Utilities.Print(namespaceAuthorizationRule);
                 }
 
-                Console.WriteLine("Getting keys for authorization rule ...");
+                Utilities.Log("Getting keys for authorization rule ...");
 
                 var keys = namespaceAuthorizationRules.FirstOrDefault().GetKeys();
                 Utilities.Print(keys);
-                Console.WriteLine("Regenerating secondary key for authorization rule ...");
+                Utilities.Log("Regenerating secondary key for authorization rule ...");
                 keys = namespaceAuthorizationRules.FirstOrDefault().RegenerateKey(Policykey.SecondaryKey);
                 Utilities.Print(keys);
 
@@ -139,13 +139,13 @@ namespace ServiceBusPublishSubscribeBasic
                 Utilities.SendMessageToTopic(keys.PrimaryConnectionString, topicName, "Hello");
                 //=============================================================
                 // Delete a queue and namespace
-                Console.WriteLine("Deleting subscription " + subscription1Name + " in topic " + topicName + " via update flow...");
+                Utilities.Log("Deleting subscription " + subscription1Name + " in topic " + topicName + " via update flow...");
                 topic = topic.Update().WithoutSubscription(subscription1Name).Apply();
-                Console.WriteLine("Deleted subscription " + subscription1Name + "...");
+                Utilities.Log("Deleted subscription " + subscription1Name + "...");
 
-                Console.WriteLine("Number of subscriptions in the topic after deleting first subscription: " + topic.SubscriptionCount);
+                Utilities.Log("Number of subscriptions in the topic after deleting first subscription: " + topic.SubscriptionCount);
 
-                Console.WriteLine("Deleting namespace " + namespaceName + "...");
+                Utilities.Log("Deleting namespace " + namespaceName + "...");
                 // This will delete the namespace and queue within it.
                 try
                 {
@@ -154,23 +154,23 @@ namespace ServiceBusPublishSubscribeBasic
                 catch (Exception)
                 {
                 }
-                Console.WriteLine("Deleted namespace " + namespaceName + "...");
+                Utilities.Log("Deleted namespace " + namespaceName + "...");
             }
             finally
             {
                 try
                 {
-                    Console.WriteLine("Deleting Resource Group: " + rgName);
+                    Utilities.Log("Deleting Resource Group: " + rgName);
                     azure.ResourceGroups.BeginDeleteByName(rgName);
-                    Console.WriteLine("Deleted Resource Group: " + rgName);
+                    Utilities.Log("Deleted Resource Group: " + rgName);
                 }
                 catch (NullReferenceException)
                 {
-                    Console.WriteLine("Did not create any resources in Azure. No clean up is necessary");
+                    Utilities.Log("Did not create any resources in Azure. No clean up is necessary");
                 }
                 catch (Exception g)
                 {
-                    Console.WriteLine(g);
+                    Utilities.Log(g);
                 }
             }
         }

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Program.cs
@@ -8,7 +8,6 @@ using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
 using Microsoft.Azure.Management.Servicebus.Fluent;
-using Microsoft.Azure.ServiceBus;
 using System;
 using System.Linq;
 using System.Text;
@@ -137,16 +136,7 @@ namespace ServiceBusPublishSubscribeBasic
 
                 //=============================================================
                 // Send a message to topic.
-                try
-                {
-                    var topicClient = new TopicClient(keys.PrimaryConnectionString, topicName);
-                    topicClient.SendAsync(new Message(Encoding.UTF8.GetBytes("Hello"))).Wait();
-                    topicClient.Close();
-                }
-                catch (Exception)
-                {
-                }
-
+                Utilities.SendMessageToTopic(keys.PrimaryConnectionString, topicName, "Hello");
                 //=============================================================
                 // Delete a queue and namespace
                 Console.WriteLine("Deleting subscription " + subscription1Name + " in topic " + topicName + " via update flow...");

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Properties/AssemblyInfo.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/project.json
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/project.json
@@ -10,7 +10,6 @@
       "target": "project",
       "type": "build"
     },
-    "Microsoft.Azure.ServiceBus": "0.0.2-preview",
     "Microsoft.NETCore.App": {
       "type": "platform",
       "version": "1.0.1"

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/Program.cs
@@ -44,7 +44,7 @@ namespace ServiceBusQueueAdvanceFeatures
                 //============================================================
                 // Create a namespace.
 
-                Console.WriteLine("Creating name space " + namespaceName + " in resource group " + rgName + "...");
+                Utilities.Log("Creating name space " + namespaceName + " in resource group " + rgName + "...");
 
                 var serviceBusNamespace = azure.ServiceBusNamespaces
                         .Define(namespaceName)
@@ -53,12 +53,12 @@ namespace ServiceBusQueueAdvanceFeatures
                         .WithSku(NamespaceSku.PremiumCapacity1)
                         .Create();
 
-                Console.WriteLine("Created service bus " + serviceBusNamespace.Name);
+                Utilities.Log("Created service bus " + serviceBusNamespace.Name);
                 Utilities.Print(serviceBusNamespace);
 
                 //============================================================
                 // Add a queue in namespace with features session and dead-lettering.
-                Console.WriteLine("Creating first queue " + queue1Name + ", with session, time to live and move to dead-letter queue features...");
+                Utilities.Log("Creating first queue " + queue1Name + ", with session, time to live and move to dead-letter queue features...");
 
                 var firstQueue = serviceBusNamespace.Queues.Define(queue1Name)
                         .WithSession()
@@ -71,7 +71,7 @@ namespace ServiceBusQueueAdvanceFeatures
                 //============================================================
                 // Create second queue with Deduplication and AutoDeleteOnIdle feature
 
-                Console.WriteLine("Creating second queue " + queue2Name + ", with De-duplication and AutoDeleteOnIdle features...");
+                Utilities.Log("Creating second queue " + queue2Name + ", with De-duplication and AutoDeleteOnIdle features...");
 
                 var secondQueue = serviceBusNamespace.Queues.Define(queue2Name)
                         .WithSizeInMB(2048)
@@ -79,7 +79,7 @@ namespace ServiceBusQueueAdvanceFeatures
                         .WithDeleteOnIdleDurationInMinutes(10)
                         .Create();
 
-                Console.WriteLine("Created second queue in namespace");
+                Utilities.Log("Created second queue in namespace");
 
                 Utilities.Print(secondQueue);
 
@@ -90,7 +90,7 @@ namespace ServiceBusQueueAdvanceFeatures
                         .WithDeleteOnIdleDurationInMinutes(5)
                         .Apply();
 
-                Console.WriteLine("Updated second queue to change its auto deletion time");
+                Utilities.Log("Updated second queue to change its auto deletion time");
 
                 Utilities.Print(secondQueue);
 
@@ -101,7 +101,7 @@ namespace ServiceBusQueueAdvanceFeatures
                         .WithNewSendRule(sendRuleName)
                         .Apply();
 
-                Console.WriteLine("Updated first queue to change dead-letter forwarding");
+                Utilities.Log("Updated first queue to change dead-letter forwarding");
 
                 Utilities.Print(secondQueue);
 
@@ -109,7 +109,7 @@ namespace ServiceBusQueueAdvanceFeatures
                 // Get connection string for default authorization rule of namespace
 
                 var namespaceAuthorizationRules = serviceBusNamespace.AuthorizationRules.List();
-                Console.WriteLine("Number of authorization rule for namespace :" + namespaceAuthorizationRules.Count());
+                Utilities.Log("Number of authorization rule for namespace :" + namespaceAuthorizationRules.Count());
 
 
                 foreach (var namespaceAuthorizationRule in namespaceAuthorizationRules)
@@ -117,7 +117,7 @@ namespace ServiceBusQueueAdvanceFeatures
                     Utilities.Print(namespaceAuthorizationRule);
                 }
 
-                Console.WriteLine("Getting keys for authorization rule ...");
+                Utilities.Log("Getting keys for authorization rule ...");
 
                 var keys = namespaceAuthorizationRules.FirstOrDefault().GetKeys();
                 Utilities.Print(keys);
@@ -132,11 +132,11 @@ namespace ServiceBusQueueAdvanceFeatures
 
                 //=============================================================
                 // Delete a queue and namespace
-                Console.WriteLine("Deleting queue " + queue1Name + "in namespace " + namespaceName + "...");
+                Utilities.Log("Deleting queue " + queue1Name + "in namespace " + namespaceName + "...");
                 serviceBusNamespace.Queues.DeleteByName(queue1Name);
-                Console.WriteLine("Deleted queue " + queue1Name + "...");
+                Utilities.Log("Deleted queue " + queue1Name + "...");
 
-                Console.WriteLine("Deleting namespace " + namespaceName + "...");
+                Utilities.Log("Deleting namespace " + namespaceName + "...");
                 // This will delete the namespace and queue within it.
                 try
                 {
@@ -145,20 +145,20 @@ namespace ServiceBusQueueAdvanceFeatures
                 catch (Exception)
                 {
                 }
-                Console.WriteLine("Deleted namespace " + namespaceName + "...");
+                Utilities.Log("Deleted namespace " + namespaceName + "...");
 
             }
             finally
             {
                 try
                 {
-                    Console.WriteLine("Deleting Resource Group: " + rgName);
+                    Utilities.Log("Deleting Resource Group: " + rgName);
                     azure.ResourceGroups.BeginDeleteByName(rgName);
-                    Console.WriteLine("Deleted Resource Group: " + rgName);
+                    Utilities.Log("Deleted Resource Group: " + rgName);
                 }
                 catch (NullReferenceException)
                 {
-                    Console.WriteLine("Did not create any resources in Azure. No clean up is necessary");
+                    Utilities.Log("Did not create any resources in Azure. No clean up is necessary");
                 }
                 catch (Exception g)
                 {

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/Program.cs
@@ -3,12 +3,10 @@
 
 
 using Microsoft.Azure.Management.Fluent;
-using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
 using Microsoft.Azure.Management.Servicebus.Fluent;
-using Microsoft.Azure.ServiceBus;
 using System;
 using System.Linq;
 using System.Text;
@@ -130,16 +128,7 @@ namespace ServiceBusQueueAdvanceFeatures
 
                 //=============================================================
                 // Send a message to queue.
-
-                try
-                {
-                    var queueClient = new QueueClient(keys.PrimaryConnectionString, queue1Name, ReceiveMode.PeekLock);
-                    queueClient.SendAsync(new Message(Encoding.UTF8.GetBytes("Hello"))).Wait();
-                    queueClient.Close();
-                }
-                catch (Exception)
-                {
-                }
+                Utilities.SendMessageToQueue(keys.PrimaryConnectionString, queue1Name, "Hello");
 
                 //=============================================================
                 // Delete a queue and namespace

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/Properties/AssemblyInfo.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/project.json
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/project.json
@@ -10,7 +10,6 @@
       "target": "project",
       "type": "build"
     },
-    "Microsoft.Azure.ServiceBus": "0.0.2-preview",
     "Microsoft.NETCore.App": {
       "type": "platform",
       "version": "1.0.1"

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Program.cs
@@ -8,7 +8,6 @@ using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
 using Microsoft.Azure.Management.Servicebus.Fluent;
-using Microsoft.Azure.ServiceBus;
 using System;
 using System.Linq;
 using System.Text;
@@ -136,16 +135,7 @@ namespace ServiceBusQueueBasic
 
                 //=============================================================
                 // Send a message to queue.
-                try
-                {
-                    var queueClient = new QueueClient(keys.PrimaryConnectionString, queue1Name, ReceiveMode.PeekLock);
-                    queueClient.SendAsync(new Message(Encoding.UTF8.GetBytes("Hello"))).Wait();
-                    queueClient.Close();
-                }
-                catch (Exception)
-                {
-                }
-
+                Utilities.SendMessageToQueue(keys.PrimaryConnectionString, queue1Name, "Hello");
                 //=============================================================
                 // Delete a queue and namespace
                 Console.WriteLine("Deleting queue " + queue1Name + "in namespace " + namespaceName + "...");

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Program.cs
@@ -42,7 +42,7 @@ namespace ServiceBusQueueBasic
                 //============================================================
                 // Create a namespace.
 
-                Console.WriteLine("Creating name space " + namespaceName + " in resource group " + rgName + "...");
+                Utilities.Log("Creating name space " + namespaceName + " in resource group " + rgName + "...");
 
                 var serviceBusNamespace = azure.ServiceBusNamespaces
                         .Define(namespaceName)
@@ -52,7 +52,7 @@ namespace ServiceBusQueueBasic
                         .WithNewQueue(queue1Name, 1024)
                         .Create();
 
-                Console.WriteLine("Created service bus " + serviceBusNamespace.Name);
+                Utilities.Log("Created service bus " + serviceBusNamespace.Name);
                 Utilities.Print(serviceBusNamespace);
 
                 var firstQueue = serviceBusNamespace.Queues.GetByName(queue1Name);
@@ -61,7 +61,7 @@ namespace ServiceBusQueueBasic
                 //============================================================
                 // Create a second queue in same namespace
 
-                Console.WriteLine("Creating second queue " + queue2Name + " in namespace " + namespaceName + "...");
+                Utilities.Log("Creating second queue " + queue2Name + " in namespace " + namespaceName + "...");
 
                 var secondQueue = serviceBusNamespace.Queues.Define(queue2Name)
                         .WithExpiredMessageMovedToDeadLetterQueue()
@@ -69,7 +69,7 @@ namespace ServiceBusQueueBasic
                         .WithMessageLockDurationInSeconds(20)
                         .Create();
 
-                Console.WriteLine("Created second queue in namespace");
+                Utilities.Log("Created second queue in namespace");
 
                 Utilities.Print(secondQueue);
 
@@ -79,24 +79,24 @@ namespace ServiceBusQueueBasic
                 secondQueue = serviceBusNamespace.Queues.GetByName(queue2Name);
                 secondQueue = secondQueue.Update().WithSizeInMB(3072).Apply();
 
-                Console.WriteLine("Updated second queue to change its size in MB");
+                Utilities.Log("Updated second queue to change its size in MB");
 
                 Utilities.Print(secondQueue);
 
                 //=============================================================
                 // Update namespace
-                Console.WriteLine("Updating sku of namespace " + serviceBusNamespace.Name + "...");
+                Utilities.Log("Updating sku of namespace " + serviceBusNamespace.Name + "...");
 
                 serviceBusNamespace = serviceBusNamespace
                         .Update()
                         .WithSku(NamespaceSku.PremiumCapacity1)
                         .Apply();
-                Console.WriteLine("Updated sku of namespace " + serviceBusNamespace.Name);
+                Utilities.Log("Updated sku of namespace " + serviceBusNamespace.Name);
 
                 //=============================================================
                 // List namespaces
 
-                Console.WriteLine("List of namespaces in resource group " + rgName + "...");
+                Utilities.Log("List of namespaces in resource group " + rgName + "...");
 
                 foreach (var serviceBusNamespace1  in  azure.ServiceBusNamespaces.ListByResourceGroup(rgName))
                 {
@@ -107,7 +107,7 @@ namespace ServiceBusQueueBasic
                 // List queues in namespaces
 
                 var queues = serviceBusNamespace.Queues.List();
-                Console.WriteLine("Number of queues in namespace :" + queues.Count());
+                Utilities.Log("Number of queues in namespace :" + queues.Count());
 
                 foreach (var queue in queues)
                 {
@@ -118,18 +118,18 @@ namespace ServiceBusQueueBasic
                 // Get connection string for default authorization rule of namespace
 
                 var namespaceAuthorizationRules = serviceBusNamespace.AuthorizationRules.List();
-                Console.WriteLine("Number of authorization rule for namespace :" + namespaceAuthorizationRules.Count());
+                Utilities.Log("Number of authorization rule for namespace :" + namespaceAuthorizationRules.Count());
 
                 foreach (var namespaceAuthorizationRule in namespaceAuthorizationRules)
                 {
                     Utilities.Print(namespaceAuthorizationRule);
                 }
 
-                Console.WriteLine("Getting keys for authorization rule ...");
+                Utilities.Log("Getting keys for authorization rule ...");
 
                 var keys = namespaceAuthorizationRules.FirstOrDefault().GetKeys();
                 Utilities.Print(keys);
-                Console.WriteLine("Regenerating secondary key for authorization rule ...");
+                Utilities.Log("Regenerating secondary key for authorization rule ...");
                 keys = namespaceAuthorizationRules.FirstOrDefault().RegenerateKey(Policykey.SecondaryKey);
                 Utilities.Print(keys);
 
@@ -138,11 +138,11 @@ namespace ServiceBusQueueBasic
                 Utilities.SendMessageToQueue(keys.PrimaryConnectionString, queue1Name, "Hello");
                 //=============================================================
                 // Delete a queue and namespace
-                Console.WriteLine("Deleting queue " + queue1Name + "in namespace " + namespaceName + "...");
+                Utilities.Log("Deleting queue " + queue1Name + "in namespace " + namespaceName + "...");
                 serviceBusNamespace.Queues.DeleteByName(queue1Name);
-                Console.WriteLine("Deleted queue " + queue1Name + "...");
+                Utilities.Log("Deleted queue " + queue1Name + "...");
 
-                Console.WriteLine("Deleting namespace " + namespaceName + "...");
+                Utilities.Log("Deleting namespace " + namespaceName + "...");
                 // This will delete the namespace and queue within it.
                 try
                 {
@@ -151,23 +151,23 @@ namespace ServiceBusQueueBasic
                 catch (Exception)
                 {
                 }
-                Console.WriteLine("Deleted namespace " + namespaceName + "...");
+                Utilities.Log("Deleted namespace " + namespaceName + "...");
             }
             finally
             {
                 try
                 {
-                    Console.WriteLine("Deleting Resource Group: " + rgName);
+                    Utilities.Log("Deleting Resource Group: " + rgName);
                     azure.ResourceGroups.BeginDeleteByName(rgName);
-                    Console.WriteLine("Deleted Resource Group: " + rgName);
+                    Utilities.Log("Deleted Resource Group: " + rgName);
                 }
                 catch (NullReferenceException)
                 {
-                    Console.WriteLine("Did not create any resources in Azure. No clean up is necessary");
+                    Utilities.Log("Did not create any resources in Azure. No clean up is necessary");
                 }
                 catch (Exception g)
                 {
-                    Console.WriteLine(g);
+                    Utilities.Log(g);
                 }
             }
         }

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Properties/AssemblyInfo.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/project.json
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/project.json
@@ -10,7 +10,6 @@
       "target": "project",
       "type": "build"
     },
-    "Microsoft.Azure.ServiceBus": "0.0.2-preview",
     "Microsoft.NETCore.App": {
       "type": "platform",
       "version": "1.0.1"

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Program.cs
@@ -8,7 +8,7 @@ using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
 using Microsoft.Azure.Management.Servicebus.Fluent;
-using Microsoft.Azure.ServiceBus;
+
 using System;
 using System.Linq;
 using System.Text;
@@ -88,28 +88,10 @@ namespace ServiceBusWithClaimBasedAuthorization
 
                 //=============================================================
                 // Send a message to queue.
-                try
-                {
-                    var queueClient = new QueueClient(keys.PrimaryConnectionString, queueName, ReceiveMode.PeekLock);
-                    queueClient.SendAsync(new Message(Encoding.UTF8.GetBytes("Hello"))).Wait();
-                    queueClient.Close();
-                }
-                catch (Exception)
-                {
-                }
-
+                Utilities.SendMessageToQueue(keys.PrimaryConnectionString, queueName, "Hello");
                 //=============================================================
                 // Send a message to topic.
-                try
-                {
-                    var topicClient = new TopicClient(keys.PrimaryConnectionString, topicName);
-                    topicClient.SendAsync(new Message(Encoding.UTF8.GetBytes("Hello"))).Wait();
-                    topicClient.Close();
-                }
-                catch (Exception)
-                {
-                }
-
+                Utilities.SendMessageToTopic(keys.PrimaryConnectionString, topicName, "Hello");
                 //=============================================================
                 // Delete a namespace
                 Console.WriteLine("Deleting namespace " + namespaceName + " [topic, queues and subscription will delete along with that]...");

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Program.cs
@@ -43,7 +43,7 @@ namespace ServiceBusWithClaimBasedAuthorization
                 //============================================================
                 // Create a namespace.
 
-                Console.WriteLine("Creating name space " + namespaceName + " along with a queue " + queueName + " and a topic " + topicName + " in resource group " + rgName + "...");
+                Utilities.Log("Creating name space " + namespaceName + " along with a queue " + queueName + " and a topic " + topicName + " in resource group " + rgName + "...");
 
                 var serviceBusNamespace = azure.ServiceBusNamespaces
                         .Define(namespaceName)
@@ -54,7 +54,7 @@ namespace ServiceBusWithClaimBasedAuthorization
                         .WithNewTopic(topicName, 1024)
                         .Create();
 
-                Console.WriteLine("Created service bus " + serviceBusNamespace.Name + " (with queue and topic)");
+                Utilities.Log("Created service bus " + serviceBusNamespace.Name + " (with queue and topic)");
                 Utilities.Print(serviceBusNamespace);
 
                 var queue = serviceBusNamespace.Queues.GetByName(queueName);
@@ -65,12 +65,12 @@ namespace ServiceBusWithClaimBasedAuthorization
 
                 //============================================================
                 // Create 2 subscriptions in topic using different methods.
-                Console.WriteLine("Creating a subscription in the topic using update on topic");
+                Utilities.Log("Creating a subscription in the topic using update on topic");
                 topic = topic.Update().WithNewSubscription(subscription1Name).Apply();
 
                 var subscription1 = topic.Subscriptions.GetByName(subscription1Name);
 
-                Console.WriteLine("Creating another subscription in the topic using direct create method for subscription");
+                Utilities.Log("Creating another subscription in the topic using direct create method for subscription");
                 var subscription2 = topic.Subscriptions.Define(subscription2Name).Create();
 
                 Utilities.Print(subscription1);
@@ -78,11 +78,11 @@ namespace ServiceBusWithClaimBasedAuthorization
 
                 //=============================================================
                 // Create new authorization rule for queue to send message.
-                Console.WriteLine("Create authorization rule for queue ...");
+                Utilities.Log("Create authorization rule for queue ...");
                 var sendQueueAuthorizationRule = serviceBusNamespace.AuthorizationRules.Define("SendRule").WithSendingEnabled().Create();
                 Utilities.Print(sendQueueAuthorizationRule);
 
-                Console.WriteLine("Getting keys for authorization rule ...");
+                Utilities.Log("Getting keys for authorization rule ...");
                 var keys = sendQueueAuthorizationRule.GetKeys();
                 Utilities.Print(keys);
 
@@ -94,7 +94,7 @@ namespace ServiceBusWithClaimBasedAuthorization
                 Utilities.SendMessageToTopic(keys.PrimaryConnectionString, topicName, "Hello");
                 //=============================================================
                 // Delete a namespace
-                Console.WriteLine("Deleting namespace " + namespaceName + " [topic, queues and subscription will delete along with that]...");
+                Utilities.Log("Deleting namespace " + namespaceName + " [topic, queues and subscription will delete along with that]...");
                 // This will delete the namespace and queue within it.
                 try
                 {
@@ -103,19 +103,19 @@ namespace ServiceBusWithClaimBasedAuthorization
                 catch (Exception)
                 {
                 }
-                Console.WriteLine("Deleted namespace " + namespaceName + "...");
+                Utilities.Log("Deleted namespace " + namespaceName + "...");
             }
             finally
             {
                 try
                 {
-                    Console.WriteLine("Deleting Resource Group: " + rgName);
+                    Utilities.Log("Deleting Resource Group: " + rgName);
                     azure.ResourceGroups.BeginDeleteByName(rgName);
-                    Console.WriteLine("Deleted Resource Group: " + rgName);
+                    Utilities.Log("Deleted Resource Group: " + rgName);
                 }
                 catch (NullReferenceException)
                 {
-                    Console.WriteLine("Did not create any resources in Azure. No clean up is necessary");
+                    Utilities.Log("Did not create any resources in Azure. No clean up is necessary");
                 }
                 catch (Exception g)
                 {

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Properties/AssemblyInfo.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/project.json
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/project.json
@@ -10,7 +10,6 @@
       "target": "project",
       "type": "build"
     },
-    "Microsoft.Azure.ServiceBus": "0.0.2-preview",
     "Microsoft.NETCore.App": {
       "type": "platform",
       "version": "1.0.1"

--- a/Samples/Tests/ServiceBus.cs
+++ b/Samples/Tests/ServiceBus.cs
@@ -1,4 +1,7 @@
-﻿using Azure.Tests;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Azure.Tests;
 using Fluent.Tests.Common;
 using System;
 using System.Collections.Generic;

--- a/Samples/Tests/project.json
+++ b/Samples/Tests/project.json
@@ -133,14 +133,10 @@
     "ManageWebAppStorageAccountConnection": "1.0.0-*",
     "ManageWebAppWithDomainSsl": "1.0.0-*",
     "ManageWebAppWithTrafficManager": "1.0.0-*",
-    "ConvertVirtualMachineToManagedDisks": "1.0.0-*",
-    "ManageVirtualMachineScaleSet": "1.0.0-*",
-    "ManageVirtualMachine": "1.0.0-*",
-    "ManageManagedDisks": "1.0.0-*",
     "ServiceBusPublishSubscribeAdvanceFeatures": "1.0.0-*",
     "ServiceBusPublishSubscribeBasic": "1.0.0-*",
-    "ServiceBusQueueBasic": "1.0.0-*",
     "ServiceBusQueueAdvanceFeatures": "1.0.0-*",
+    "ServiceBusQueueBasic": "1.0.0-*",
     "ServiceBusWithClaimBasedAuthorization": "1.0.0-*"
   }
 }

--- a/global.json
+++ b/global.json
@@ -25,9 +25,9 @@
       "Samples/ResourceManagement/Network",
       "Samples/ResourceManagement/RedisCache",
       "Samples/ResourceManagement/ResourceManager",
+      "Samples/ResourceManagement/ServiceBus",
       "Samples/ResourceManagement/Sql",
       "Samples/ResourceManagement/Storage",
-      "Samples/ResourceManagement/TrafficManager",
-      "Samples/ResourceManagement/ServiceBus"
+      "Samples/ResourceManagement/TrafficManager"
     ]
 }

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/TestHelper.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/TestHelper.cs
@@ -322,13 +322,13 @@ namespace Fluent.Tests.Common
             }
             using (var sshClient = new SshClient(host, port, userName, password))
             {
-                Console.WriteLine("Trying to de-provision: " + host);
+                TestHelper.WriteLine("Trying to de-provision: " + host);
                 sshClient.Connect();
                 var commandToExecute = "sudo waagent -deprovision+user --force";
                 using (var command = sshClient.CreateCommand(commandToExecute))
                 {
                     var commandOutput = command.Execute();
-                    Console.WriteLine(commandOutput);
+                    TestHelper.WriteLine(commandOutput);
                 }
                 sshClient.Disconnect();
             }

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineEncryptionOperationsTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineEncryptionOperationsTests.cs
@@ -83,7 +83,7 @@ namespace Azure.Tests.Compute
                     Assert.True(monitor1.DataDiskStatus.Equals(monitor2.DataDiskStatus));
                     monitor2.Refresh();
                     Assert.True(monitor2.OsDiskStatus.Equals(EncryptionStatus.EncryptionInProgress));
-                    Console.WriteLine(virtualMachine.Id);
+                    TestHelper.WriteLine(virtualMachine.Id);
                 }
                 finally
                 {

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineManagedDiskOperationsTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Compute/VirtualMachineManagedDiskOperationsTests.cs
@@ -322,7 +322,6 @@ namespace Fluent.Tests.Compute
                             .WithSize(VirtualMachineSizeTypes.StandardD5V2)
                             .WithOSDiskCaching(CachingTypes.ReadWrite)
                             .Create();
-                    Console.WriteLine("Waiting for some time before de-provision");
                     TestHelper.Delay(60 * 1000); // Wait for some time to ensure vm is publicly accessible
                     TestHelper.DeprovisionAgentInLinuxVM(virtualMachine1.GetPrimaryPublicIPAddress().Fqdn,
                             22,


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.