### PR TITLE
Changed Servicebus to ServiceBus

### DIFF
--- a/Samples/Common/Utilities.cs
+++ b/Samples/Common/Utilities.cs
@@ -26,7 +26,7 @@ using CoreFtp;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage;
 using Renci.SshNet;
-using Microsoft.Azure.Management.Servicebus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent;
 using Microsoft.Azure.ServiceBus;
 
 namespace Microsoft.Azure.Management.Samples.Common
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.Management.Samples.Common
             Log(builder.ToString());
         }
 
-        public static void Print(Servicebus.Fluent.ISubscription serviceBusSubscription)
+        public static void Print(ServiceBus.Fluent.ISubscription serviceBusSubscription)
         {
             StringBuilder builder = new StringBuilder()
                     .Append("Service bus subscription: ").Append(serviceBusSubscription.Id)

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/Program.cs
@@ -6,7 +6,7 @@ using Microsoft.Azure.Management.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
-using Microsoft.Azure.Management.Servicebus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent;
 using System;
 using System.Linq;
 

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Program.cs
@@ -7,7 +7,7 @@ using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
-using Microsoft.Azure.Management.Servicebus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent;
 using System;
 using System.Linq;
 using System.Text;

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/Program.cs
@@ -6,7 +6,7 @@ using Microsoft.Azure.Management.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
-using Microsoft.Azure.Management.Servicebus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent;
 using System;
 using System.Linq;
 using System.Text;

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Program.cs
@@ -7,7 +7,7 @@ using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
-using Microsoft.Azure.Management.Servicebus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent;
 using System;
 using System.Linq;
 using System.Text;

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Program.cs
@@ -7,7 +7,7 @@ using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
-using Microsoft.Azure.Management.Servicebus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent;
 
 using System;
 using System.Linq;

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/ServiceBus/ServiceBusTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/ServiceBus/ServiceBusTests.cs
@@ -4,7 +4,7 @@
 using Fluent.Tests.Common;
 using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-using Microsoft.Azure.Management.Servicebus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent;
 using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
 using System;
 using System.Collections.Generic;

--- a/src/ResourceManagement/Azure.Fluent/Microsoft.Azure.Management.Fluent/Azure.cs
+++ b/src/ResourceManagement/Azure.Fluent/Microsoft.Azure.Management.Fluent/Azure.cs
@@ -12,7 +12,7 @@ using Microsoft.Azure.Management.Redis.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-using Microsoft.Azure.Management.Servicebus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent;
 using Microsoft.Azure.Management.Sql.Fluent;
 using Microsoft.Azure.Management.Storage.Fluent;
 using Microsoft.Azure.Management.TrafficManager.Fluent;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/AuthorizationKeysImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/AuthorizationKeysImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Management.Fluent.ServiceBus.Models;
     using ResourceManager.Fluent.Core;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/AuthorizationRuleBaseImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/AuthorizationRuleBaseImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <param name="policykey">The key to regenerate.</param>
         /// <return>Stream that emits primary, secondary keys and connection strings.</return>
         ///GENMHASH:4A88585D14A1F4B57527C071D5C0C394:8DF2BBCDED7039A4F19381688F737A50
-        protected async Task<Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationKeys> RegenerateKeyAsync(Policykey policykey, CancellationToken cancellationToken = default(CancellationToken))
+        protected async Task<Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationKeys> RegenerateKeyAsync(Policykey policykey, CancellationToken cancellationToken = default(CancellationToken))
         {
             var inner = await this.RegenerateKeysInnerAsync(policykey, cancellationToken);
             return new AuthorizationKeysImpl(inner);
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
 
         /// <return>Stream that emits primary, secondary keys and connection strings.</return>
         ///GENMHASH:2751D8683222AD34691166D915065302:AD0DF6429EFF7A0256E5287F769C0BD5
-        protected async Task<Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationKeys> GetKeysAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected async Task<Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationKeys> GetKeysAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var inner = await this.GetKeysInnerAsync(cancellationToken);
             return new AuthorizationKeysImpl(inner);

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/CheckNameAvailabilityResultImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/CheckNameAvailabilityResultImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Management.Fluent.ServiceBus.Models;
     using ResourceManager.Fluent.Core;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/AuthorizationRule/Definition/IDefinition.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/AuthorizationRule/Definition/IDefinition.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition
 {
     /// <summary>
     /// The stage of the Service Bus authorization rule definition allowing to enable listen, send or manage policy.
     /// </summary>
     /// <typeparam name="T">The next stage of the definition.</typeparam>
     public interface IWithListenOrSendOrManage<T>  :
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition.IWithListen<T>,
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition.IWithSendOrManage<T>
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition.IWithListen<T>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition.IWithSendOrManage<T>
     {
     }
 
@@ -27,8 +27,8 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definit
     /// </summary>
     /// <typeparam name="T">The next stage of the definition.</typeparam>
     public interface IWithSendOrManage<T>  :
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition.IWithSend<T>,
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition.IWithManage<T>
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition.IWithSend<T>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition.IWithManage<T>
     {
     }
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/AuthorizationRule/Update/IUpdate.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/AuthorizationRule/Update/IUpdate.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update
 {
     /// <summary>
     /// The stage of the Service Bus authorization rule update allowing to enable send policy.
@@ -17,8 +17,8 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update
     /// </summary>
     /// <typeparam name="T">The next stage of the update.</typeparam>
     public interface IWithListenOrSendOrManage<T>  :
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update.IWithListen<T>,
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update.IWithSendOrManage<T>
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update.IWithListen<T>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update.IWithSendOrManage<T>
     {
     }
 
@@ -27,8 +27,8 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update
     /// </summary>
     /// <typeparam name="T">The next stage of the update.</typeparam>
     public interface IWithSendOrManage<T>  :
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update.IWithSend<T>,
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update.IWithManage<T>
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update.IWithSend<T>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update.IWithManage<T>
     {
     }
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationKeys.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationKeys.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Management.Fluent.ServiceBus.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationRule.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationRule.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -24,10 +24,10 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IRefreshable<RuleT>
     {
         /// <return>Stream that emits primary, secondary keys and connection strings.</return>
-        Task<Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationKeys> GetKeysAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationKeys> GetKeysAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <return>The primary, secondary keys and connection strings.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationKeys GetKeys();
+        Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationKeys GetKeys();
 
         /// <summary>
         /// Gets rights associated with the rule.
@@ -39,13 +39,13 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// </summary>
         /// <param name="policykey">The key to regenerate.</param>
         /// <return>Stream that emits primary, secondary keys and connection strings.</return>
-        Task<Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationKeys> RegenerateKeyAsync(Policykey policykey, CancellationToken cancellationToken = default(CancellationToken));
+        Task<Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationKeys> RegenerateKeyAsync(Policykey policykey, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Regenerates primary or secondary keys.
         /// </summary>
         /// <param name="policykey">The key to regenerate.</param>
         /// <return>Primary, secondary keys and connection strings.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationKeys RegenerateKey(Policykey policykey);
+        Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationKeys RegenerateKey(Policykey policykey);
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationRules.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationRules.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ICheckNameAvailabilityResult.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ICheckNameAvailabilityResult.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Management.Fluent.ServiceBus.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/INamespaceAuthorizationRule.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/INamespaceAuthorizationRule.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Update;
 
     /// <summary>
     /// Type representing authorization rule defined for namespace.
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// version number.).
     /// </remarks>
     public interface INamespaceAuthorizationRule  :
-        Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationRule<Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRule>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationRule<Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRule>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IUpdatable<NamespaceAuthorizationRule.Update.IUpdate>
     {
         /// <summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/INamespaceAuthorizationRules.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/INamespaceAuthorizationRules.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Definition;
     using Management.Fluent.ServiceBus.Models;
     using Management.Fluent.ServiceBus;
 
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// version number.).
     /// </remarks>
     public interface INamespaceAuthorizationRules  :
-        Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationRules<Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRule>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationRules<Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRule>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsCreating<NamespaceAuthorizationRule.Definition.IBlank>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasInner<INamespacesOperations>
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueue.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueue.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update;
     using System;
     using ServiceBus.Fluent;
     using Management.Fluent.ServiceBus.Models;
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </remarks>
     public interface IQueue  :
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IIndependentChildResource<IServiceBusManager, QueueInner>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IRefreshable<Microsoft.Azure.Management.Servicebus.Fluent.IQueue>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IRefreshable<Microsoft.Azure.Management.ServiceBus.Fluent.IQueue>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IUpdatable<Queue.Update.IUpdate>
     {
         /// <summary>
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets entry point to manage authorization rules for the Service Bus queue.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRules AuthorizationRules { get; }
+        Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRules AuthorizationRules { get; }
 
         /// <summary>
         /// Gets indicates whether server-side batched operations are enabled.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueueAuthorizationRule.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueueAuthorizationRule.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Update;
 
     /// <summary>
     /// Type representing authorization rule defined for queue.
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// version number.).
     /// </remarks>
     public interface IQueueAuthorizationRule  :
-        Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationRule<Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationRule<Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IUpdatable<QueueAuthorizationRule.Update.IUpdate>
     {
         /// <summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueueAuthorizationRules.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueueAuthorizationRules.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Definition;
     using Management.Fluent.ServiceBus;
 
     /// <summary>
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// version number.).
     /// </remarks>
     public interface IQueueAuthorizationRules  :
-        Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationRules<Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationRules<Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsCreating<QueueAuthorizationRule.Definition.IBlank>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasInner<IQueuesOperations>
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueues.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueues.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition;
     using ServiceBus.Fluent;
     using Management.Fluent.ServiceBus.Models;
     using Management.Fluent.ServiceBus;
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </remarks>
     public interface IQueues  :
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsCreating<Queue.Definition.IBlank>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListing<Microsoft.Azure.Management.Servicebus.Fluent.IQueue>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsGettingByName<Microsoft.Azure.Management.Servicebus.Fluent.IQueue>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListing<Microsoft.Azure.Management.ServiceBus.Fluent.IQueue>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsGettingByName<Microsoft.Azure.Management.ServiceBus.Fluent.IQueue>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsDeletingByName,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasManager<IServiceBusManager>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasInner<IQueuesOperations>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespace.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespace.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Management.Fluent.ServiceBus.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update;
     using ServiceBus.Fluent;
     using System;
 
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </remarks>
     public interface IServiceBusNamespace  :
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IGroupableResource<IServiceBusManager, NamespaceModelInner>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IRefreshable<Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IRefreshable<Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IUpdatable<ServiceBusNamespace.Update.IUpdate>
     {
         /// <summary>
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets entry point to manage topics entities in the Service Bus namespace.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.ITopics Topics { get; }
+        Microsoft.Azure.Management.ServiceBus.Fluent.ITopics Topics { get; }
 
         /// <summary>
         /// Gets the relative DNS name of the Service Bus namespace.
@@ -45,17 +45,17 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets entry point to manage authorization rules for the Service Bus namespace.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRules AuthorizationRules { get; }
+        Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRules AuthorizationRules { get; }
 
         /// <summary>
         /// Gets entry point to manage queue entities in the Service Bus namespace.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.IQueues Queues { get; }
+        Microsoft.Azure.Management.ServiceBus.Fluent.IQueues Queues { get; }
 
         /// <summary>
         /// Gets sku value.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.NamespaceSku Sku { get; }
+        Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceSku Sku { get; }
 
         /// <summary>
         /// Gets fully qualified domain name (FQDN) of the Service Bus namespace.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespaces.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespaces.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition;
     using Microsoft.Rest;
     using ServiceBus.Fluent;
     using Management.Fluent.ServiceBus;
@@ -21,12 +21,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </remarks>
     public interface IServiceBusNamespaces  :
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsCreating<ServiceBusNamespace.Definition.IBlank>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsBatchCreation<Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsBatchCreation<Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsBatchDeletion,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListing<Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListingByResourceGroup<Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsGettingByResourceGroup<Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsGettingById<Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListing<Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListingByResourceGroup<Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsGettingByResourceGroup<Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsGettingById<Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsDeletingById,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsDeletingByResourceGroup,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasManager<IServiceBusManager>,
@@ -37,13 +37,13 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// </summary>
         /// <param name="name">The namespace name to check.</param>
         /// <return>Whether the name is available and other info if not.</return>
-        Task<Microsoft.Azure.Management.Servicebus.Fluent.ICheckNameAvailabilityResult> CheckNameAvailabilityAsync(string name, CancellationToken cancellationToken = default(CancellationToken));
+        Task<Microsoft.Azure.Management.ServiceBus.Fluent.ICheckNameAvailabilityResult> CheckNameAvailabilityAsync(string name, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Checks if namespace name is valid and is not in use.
         /// </summary>
         /// <param name="name">The account name to check.</param>
         /// <return>Whether the name is available and other info if not.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ICheckNameAvailabilityResult CheckNameAvailability(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ICheckNameAvailabilityResult CheckNameAvailability(string name);
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscription.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscription.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update;
     using System;
     using ServiceBus.Fluent;
     using Management.Fluent.ServiceBus.Models;
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </remarks>
     public interface ISubscription  :
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IIndependentChildResource<IServiceBusManager, SubscriptionInner>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IRefreshable<Microsoft.Azure.Management.Servicebus.Fluent.ISubscription>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IRefreshable<Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IUpdatable<Subscription.Update.IUpdate>
     {
         /// <summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscriptions.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscriptions.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition;
     using ServiceBus.Fluent;
     using Management.Fluent.ServiceBus;
 
@@ -18,8 +18,8 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </remarks>
     public interface ISubscriptions  :
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsCreating<Subscription.Definition.IBlank>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListing<Microsoft.Azure.Management.Servicebus.Fluent.ISubscription>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsGettingByName<Microsoft.Azure.Management.Servicebus.Fluent.ISubscription>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListing<Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsGettingByName<Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsDeletingByName,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasManager<IServiceBusManager>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasInner<ISubscriptionsOperations>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopic.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopic.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Management.Fluent.ServiceBus.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update;
     using ServiceBus.Fluent;
     using System;
 
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </remarks>
     public interface ITopic  :
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IIndependentChildResource<IServiceBusManager, TopicInner>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IRefreshable<Microsoft.Azure.Management.Servicebus.Fluent.ITopic>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IRefreshable<Microsoft.Azure.Management.ServiceBus.Fluent.ITopic>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IUpdatable<Topic.Update.IUpdate>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasInner<TopicInner>
     {
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets entry point to manage subscriptions associated with the topic.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.ISubscriptions Subscriptions { get; }
+        Microsoft.Azure.Management.ServiceBus.Fluent.ISubscriptions Subscriptions { get; }
 
         /// <summary>
         /// Gets the current status of the topic.
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets entry point to manage authorization rules for the Service Bus topic.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRules AuthorizationRules { get; }
+        Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRules AuthorizationRules { get; }
 
         /// <summary>
         /// Gets indicates whether server-side batched operations are enabled.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopicAuthorizationRule.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopicAuthorizationRule.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Update;
 
     /// <summary>
     /// Type representing authorization rule defined for topic.
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// version number.).
     /// </remarks>
     public interface ITopicAuthorizationRule  :
-        Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationRule<Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationRule<Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRule>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IUpdatable<TopicAuthorizationRule.Update.IUpdate>
     {
         /// <summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopicAuthorizationRules.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopicAuthorizationRules.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Definition;
     using Management.Fluent.ServiceBus;
 
     /// <summary>
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// version number.).
     /// </remarks>
     public interface ITopicAuthorizationRules  :
-        Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationRules<Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationRules<Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRule>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsCreating<TopicAuthorizationRule.Definition.IBlank>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasInner<ITopicsOperations>
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopics.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopics.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition;
     using ServiceBus.Fluent;
     using Management.Fluent.ServiceBus;
 
@@ -18,8 +18,8 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </remarks>
     public interface ITopics  :
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsCreating<Topic.Definition.IBlank>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListing<Microsoft.Azure.Management.Servicebus.Fluent.ITopic>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsGettingByName<Microsoft.Azure.Management.Servicebus.Fluent.ITopic>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsListing<Microsoft.Azure.Management.ServiceBus.Fluent.ITopic>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsGettingByName<Microsoft.Azure.Management.ServiceBus.Fluent.ITopic>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions.ISupportsDeletingByName,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasManager<IServiceBusManager>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.IHasInner<ITopicsOperations>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/AuthorizationKeysImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/AuthorizationKeysImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets secondary connection string.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationKeys.SecondaryConnectionString
+        string Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationKeys.SecondaryConnectionString
         {
             get
             {
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets secondary key associated with the rule.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationKeys.SecondaryKey
+        string Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationKeys.SecondaryKey
         {
             get
             {
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets primary connection string.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationKeys.PrimaryConnectionString
+        string Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationKeys.PrimaryConnectionString
         {
             get
             {
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets primary key associated with the rule.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.IAuthorizationKeys.PrimaryKey
+        string Microsoft.Azure.Management.ServiceBus.Fluent.IAuthorizationKeys.PrimaryKey
         {
             get
             {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/AuthorizationRuleBaseImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/AuthorizationRuleBaseImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/CheckNameAvailabilityResultImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/CheckNameAvailabilityResultImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Management.Fluent.ServiceBus.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// Gets the unavailabilityReason that a namespace name could not be used. The
         /// Reason element is only returned if NameAvailable is false.
         /// </summary>
-        UnavailableReason Microsoft.Azure.Management.Servicebus.Fluent.ICheckNameAvailabilityResult.UnavailabilityReason
+        UnavailableReason Microsoft.Azure.Management.ServiceBus.Fluent.ICheckNameAvailabilityResult.UnavailabilityReason
         {
             get
             {
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// you to use. If true, the name is available. If false, the name has
         /// already been taken or invalid and cannot be used.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.ICheckNameAvailabilityResult.IsAvailable
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.ICheckNameAvailabilityResult.IsAvailable
         {
             get
             {
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets an error message explaining the Reason value in more detail.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.ICheckNameAvailabilityResult.UnavailabilityMessage
+        string Microsoft.Azure.Management.ServiceBus.Fluent.ICheckNameAvailabilityResult.UnavailabilityMessage
         {
             get
             {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/NamespaceAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/NamespaceAuthorizationRuleImpl.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition;
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update;
-    using Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRule.Definition;
-    using Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Update;
     using ServiceBus.Fluent;
     using Management.Fluent.ServiceBus.Models;
 
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the name of the parent namespace name.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRule.NamespaceName
+        string Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRule.NamespaceName
         {
             get
             {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/NamespaceAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/NamespaceAuthorizationRulesImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/NamespaceSku.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/NamespaceSku.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     public sealed partial class NamespaceSku 
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueueAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueueAuthorizationRuleImpl.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition;
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update;
-    using Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.Definition;
-    using Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Update;
     using Management.Fluent.ServiceBus.Models;
     using ServiceBus.Fluent;
 
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the name of the parent queue name.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule.QueueName
+        string Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule.QueueName
         {
             get
             {
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the name of the namespace that the parent queue belongs to.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule.NamespaceName
+        string Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule.NamespaceName
         {
             get
             {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueueAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueueAuthorizationRulesImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueueImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueueImpl.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update;
     using System.Collections.Generic;
     using System;
     using ServiceBus.Fluent;
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of messages transferred to another queue, topic, or subscription.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.IQueue.TransferMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.TransferMessageCount
         {
             get
             {
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the maximum size of memory allocated for the queue in megabytes.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.IQueue.MaxSizeInMB
+        long Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.MaxSizeInMB
         {
             get
             {
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the exact time the queue was created.
         /// </summary>
-        System.DateTime Microsoft.Azure.Management.Servicebus.Fluent.IQueue.CreatedAt
+        System.DateTime Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.CreatedAt
         {
             get
             {
@@ -401,7 +401,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// Gets number of messages sent to the queue that are yet to be released
         /// for consumption.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.IQueue.ScheduledMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.ScheduledMessageCount
         {
             get
             {
@@ -412,7 +412,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether express entities are enabled.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.IQueue.IsExpressEnabled
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.IsExpressEnabled
         {
             get
             {
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets current size of the queue, in bytes.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.IQueue.CurrentSizeInBytes
+        long Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.CurrentSizeInBytes
         {
             get
             {
@@ -434,7 +434,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of active messages in the queue.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.IQueue.ActiveMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.ActiveMessageCount
         {
             get
             {
@@ -445,7 +445,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the current status of the queue.
         /// </summary>
-        EntityStatus Microsoft.Azure.Management.Servicebus.Fluent.IQueue.Status
+        EntityStatus Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.Status
         {
             get
             {
@@ -456,7 +456,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the duration after which the message expires, starting from when the message is sent to queue.
         /// </summary>
-        TimeSpan Microsoft.Azure.Management.Servicebus.Fluent.IQueue.DefaultMessageTtlDuration
+        TimeSpan Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.DefaultMessageTtlDuration
         {
             get
             {
@@ -467,18 +467,18 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets entry point to manage authorization rules for the Service Bus queue.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRules Microsoft.Azure.Management.Servicebus.Fluent.IQueue.AuthorizationRules
+        Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRules Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.AuthorizationRules
         {
             get
             {
-                return this.AuthorizationRules() as Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRules;
+                return this.AuthorizationRules() as Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRules;
             }
         }
 
         /// <summary>
         /// Gets the number of messages in the queue.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.IQueue.MessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.MessageCount
         {
             get
             {
@@ -489,7 +489,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the duration of peek-lock which is the amount of time that the message is locked for other receivers.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.IQueue.LockDurationInSeconds
+        long Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.LockDurationInSeconds
         {
             get
             {
@@ -500,7 +500,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets last time a message was sent, or the last time there was a receive request to this queue.
         /// </summary>
-        System.DateTime Microsoft.Azure.Management.Servicebus.Fluent.IQueue.AccessedAt
+        System.DateTime Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.AccessedAt
         {
             get
             {
@@ -511,7 +511,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether the queue is to be partitioned across multiple message brokers.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.IQueue.IsPartitioningEnabled
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.IsPartitioningEnabled
         {
             get
             {
@@ -522,7 +522,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of messages transferred into dead letters.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.IQueue.TransferDeadLetterMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.TransferDeadLetterMessageCount
         {
             get
             {
@@ -533,7 +533,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the idle duration after which the queue is automatically deleted.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.IQueue.DeleteOnIdleDurationInMinutes
+        long Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.DeleteOnIdleDurationInMinutes
         {
             get
             {
@@ -544,7 +544,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether this queue has dead letter support when a message expires.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.IQueue.IsDeadLetteringEnabledForExpiredMessages
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.IsDeadLetteringEnabledForExpiredMessages
         {
             get
             {
@@ -555,7 +555,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether server-side batched operations are enabled.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.IQueue.IsBatchedOperationsEnabled
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.IsBatchedOperationsEnabled
         {
             get
             {
@@ -566,7 +566,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates if this queue requires duplicate detection.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.IQueue.IsDuplicateDetectionEnabled
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.IsDuplicateDetectionEnabled
         {
             get
             {
@@ -577,7 +577,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of messages in the dead-letter queue.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.IQueue.DeadLetterMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.DeadLetterMessageCount
         {
             get
             {
@@ -588,7 +588,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the exact time the queue was updated.
         /// </summary>
-        System.DateTime Microsoft.Azure.Management.Servicebus.Fluent.IQueue.UpdatedAt
+        System.DateTime Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.UpdatedAt
         {
             get
             {
@@ -599,7 +599,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the maximum number of a message delivery before marking it as dead-lettered.
         /// </summary>
-        int Microsoft.Azure.Management.Servicebus.Fluent.IQueue.MaxDeliveryCountBeforeDeadLetteringMessage
+        int Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.MaxDeliveryCountBeforeDeadLetteringMessage
         {
             get
             {
@@ -610,7 +610,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the duration of the duplicate detection history.
         /// </summary>
-        TimeSpan Microsoft.Azure.Management.Servicebus.Fluent.IQueue.DuplicateMessageDetectionHistoryDuration
+        TimeSpan Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.DuplicateMessageDetectionHistoryDuration
         {
             get
             {
@@ -621,7 +621,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether the queue supports sessions.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.IQueue.IsSessionEnabled
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.IQueue.IsSessionEnabled
         {
             get
             {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueuesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueuesImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/ServiceBusChildResourcesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/ServiceBusChildResourcesImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/ServiceBusNamespaceImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/ServiceBusNamespaceImpl.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Management.ResourceManager.Fluent;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition;
-    using Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update;
     using System.Collections.Generic;
     using System;
 
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the relative DNS name of the Service Bus namespace.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace.DnsLabel
+        string Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace.DnsLabel
         {
             get
             {
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets fully qualified domain name (FQDN) of the Service Bus namespace.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace.Fqdn
+        string Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace.Fqdn
         {
             get
             {
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets time the namespace was created.
         /// </summary>
-        System.DateTime Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace.CreatedAt
+        System.DateTime Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace.CreatedAt
         {
             get
             {
@@ -183,29 +183,29 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets sku value.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.NamespaceSku Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace.Sku
+        Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceSku Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace.Sku
         {
             get
             {
-                return this.Sku() as Microsoft.Azure.Management.Servicebus.Fluent.NamespaceSku;
+                return this.Sku() as Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceSku;
             }
         }
 
         /// <summary>
         /// Gets entry point to manage authorization rules for the Service Bus namespace.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRules Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace.AuthorizationRules
+        Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRules Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace.AuthorizationRules
         {
             get
             {
-                return this.AuthorizationRules() as Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRules;
+                return this.AuthorizationRules() as Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRules;
             }
         }
 
         /// <summary>
         /// Gets time the namespace was updated.
         /// </summary>
-        System.DateTime Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace.UpdatedAt
+        System.DateTime Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace.UpdatedAt
         {
             get
             {
@@ -216,22 +216,22 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets entry point to manage topics entities in the Service Bus namespace.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.ITopics Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace.Topics
+        Microsoft.Azure.Management.ServiceBus.Fluent.ITopics Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace.Topics
         {
             get
             {
-                return this.Topics() as Microsoft.Azure.Management.Servicebus.Fluent.ITopics;
+                return this.Topics() as Microsoft.Azure.Management.ServiceBus.Fluent.ITopics;
             }
         }
 
         /// <summary>
         /// Gets entry point to manage queue entities in the Service Bus namespace.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.IQueues Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace.Queues
+        Microsoft.Azure.Management.ServiceBus.Fluent.IQueues Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace.Queues
         {
             get
             {
-                return this.Queues() as Microsoft.Azure.Management.Servicebus.Fluent.IQueues;
+                return this.Queues() as Microsoft.Azure.Management.ServiceBus.Fluent.IQueues;
             }
         }
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/ServiceBusNamespacesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/ServiceBusNamespacesImpl.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition;
     using Microsoft.Rest;
 
     internal partial class ServiceBusNamespacesImpl 
@@ -35,9 +35,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// </summary>
         /// <param name="name">The account name to check.</param>
         /// <return>Whether the name is available and other info if not.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ICheckNameAvailabilityResult Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespaces.CheckNameAvailability(string name)
+        Microsoft.Azure.Management.ServiceBus.Fluent.ICheckNameAvailabilityResult Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespaces.CheckNameAvailability(string name)
         {
-            return this.CheckNameAvailability(name) as Microsoft.Azure.Management.Servicebus.Fluent.ICheckNameAvailabilityResult;
+            return this.CheckNameAvailability(name) as Microsoft.Azure.Management.ServiceBus.Fluent.ICheckNameAvailabilityResult;
         }
 
         /// <summary>
@@ -45,9 +45,9 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// </summary>
         /// <param name="name">The namespace name to check.</param>
         /// <return>Whether the name is available and other info if not.</return>
-        async Task<Microsoft.Azure.Management.Servicebus.Fluent.ICheckNameAvailabilityResult> Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespaces.CheckNameAvailabilityAsync(string name, CancellationToken cancellationToken)
+        async Task<Microsoft.Azure.Management.ServiceBus.Fluent.ICheckNameAvailabilityResult> Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespaces.CheckNameAvailabilityAsync(string name, CancellationToken cancellationToken)
         {
-            return await this.CheckNameAvailabilityAsync(name, cancellationToken) as Microsoft.Azure.Management.Servicebus.Fluent.ICheckNameAvailabilityResult;
+            return await this.CheckNameAvailabilityAsync(name, cancellationToken) as Microsoft.Azure.Management.ServiceBus.Fluent.ICheckNameAvailabilityResult;
         }
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/SubscriptionImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/SubscriptionImpl.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update;
     using System;
     using ServiceBus.Fluent;
     using Management.Fluent.ServiceBus.Models;
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether subscription has dead letter support on filter evaluation exceptions.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.IsDeadLetteringEnabledForFilterEvaluationFailedMessages
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.IsDeadLetteringEnabledForFilterEvaluationFailedMessages
         {
             get
             {
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the idle duration after which the subscription is automatically deleted.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.DeleteOnIdleDurationInMinutes
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.DeleteOnIdleDurationInMinutes
         {
             get
             {
@@ -312,7 +312,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of active messages in the subscription.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.ActiveMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.ActiveMessageCount
         {
             get
             {
@@ -323,7 +323,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the exact time the message was created.
         /// </summary>
-        System.DateTime Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.CreatedAt
+        System.DateTime Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.CreatedAt
         {
             get
             {
@@ -334,7 +334,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether this subscription has dead letter support when a message expires.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.IsDeadLetteringEnabledForExpiredMessages
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.IsDeadLetteringEnabledForExpiredMessages
         {
             get
             {
@@ -345,7 +345,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether server-side batched operations are enabled.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.IsBatchedOperationsEnabled
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.IsBatchedOperationsEnabled
         {
             get
             {
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the number of messages in the subscription.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.MessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.MessageCount
         {
             get
             {
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of messages transferred to another queue, topic, or subscription.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.TransferMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.TransferMessageCount
         {
             get
             {
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the duration after which the message expires, starting from when the message is sent to subscription.
         /// </summary>
-        TimeSpan Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.DefaultMessageTtlDuration
+        TimeSpan Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.DefaultMessageTtlDuration
         {
             get
             {
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether the subscription supports sessions.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.IsSessionEnabled
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.IsSessionEnabled
         {
             get
             {
@@ -400,7 +400,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the current status of the subscription.
         /// </summary>
-        EntityStatus Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.Status
+        EntityStatus Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.Status
         {
             get
             {
@@ -412,7 +412,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// Gets number of messages sent to the subscription that are yet to be released
         /// for consumption.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.ScheduledMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.ScheduledMessageCount
         {
             get
             {
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the exact time the message was updated.
         /// </summary>
-        System.DateTime Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.UpdatedAt
+        System.DateTime Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.UpdatedAt
         {
             get
             {
@@ -434,7 +434,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets last time there was a receive request to this subscription.
         /// </summary>
-        System.DateTime Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.AccessedAt
+        System.DateTime Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.AccessedAt
         {
             get
             {
@@ -445,7 +445,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of messages transferred into dead letters.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.TransferDeadLetterMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.TransferDeadLetterMessageCount
         {
             get
             {
@@ -456,7 +456,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the maximum number of a message delivery before marking it as dead-lettered.
         /// </summary>
-        int Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.MaxDeliveryCountBeforeDeadLetteringMessage
+        int Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.MaxDeliveryCountBeforeDeadLetteringMessage
         {
             get
             {
@@ -467,7 +467,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the duration of peek-lock which is the amount of time that the message is locked for other receivers.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.LockDurationInSeconds
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.LockDurationInSeconds
         {
             get
             {
@@ -478,7 +478,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of messages in the dead-letter subscription.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ISubscription.DeadLetterMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription.DeadLetterMessageCount
         {
             get
             {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/SubscriptionsImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/SubscriptionsImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicAuthorizationRuleImpl.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition;
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update;
-    using Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.Definition;
-    using Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Update;
     using ServiceBus.Fluent;
     using Management.Fluent.ServiceBus.Models;
 
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the name of the namespace that the parent topic belongs to.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule.NamespaceName
+        string Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRule.NamespaceName
         {
             get
             {
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the name of the parent topic name.
         /// </summary>
-        string Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule.TopicName
+        string Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRule.TopicName
         {
             get
             {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicAuthorizationRulesImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicImpl.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition;
-    using Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update;
     using System.Collections.Generic;
     using System;
     using ServiceBus.Fluent;
@@ -274,7 +274,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of subscriptions for the topic.
         /// </summary>
-        int Microsoft.Azure.Management.Servicebus.Fluent.ITopic.SubscriptionCount
+        int Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.SubscriptionCount
         {
             get
             {
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of messages transferred to another topic, topic, or subscription.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ITopic.TransferMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.TransferMessageCount
         {
             get
             {
@@ -296,7 +296,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the maximum size of memory allocated for the topic in megabytes.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ITopic.MaxSizeInMB
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.MaxSizeInMB
         {
             get
             {
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the exact time the topic was created.
         /// </summary>
-        System.DateTime Microsoft.Azure.Management.Servicebus.Fluent.ITopic.CreatedAt
+        System.DateTime Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.CreatedAt
         {
             get
             {
@@ -319,7 +319,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// Gets number of messages sent to the topic that are yet to be released
         /// for consumption.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ITopic.ScheduledMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.ScheduledMessageCount
         {
             get
             {
@@ -330,7 +330,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether express entities are enabled.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.ITopic.IsExpressEnabled
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.IsExpressEnabled
         {
             get
             {
@@ -341,7 +341,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets current size of the topic, in bytes.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ITopic.CurrentSizeInBytes
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.CurrentSizeInBytes
         {
             get
             {
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of active messages in the topic.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ITopic.ActiveMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.ActiveMessageCount
         {
             get
             {
@@ -363,18 +363,18 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets entry point to manage subscriptions associated with the topic.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.ISubscriptions Microsoft.Azure.Management.Servicebus.Fluent.ITopic.Subscriptions
+        Microsoft.Azure.Management.ServiceBus.Fluent.ISubscriptions Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.Subscriptions
         {
             get
             {
-                return this.Subscriptions() as Microsoft.Azure.Management.Servicebus.Fluent.ISubscriptions;
+                return this.Subscriptions() as Microsoft.Azure.Management.ServiceBus.Fluent.ISubscriptions;
             }
         }
 
         /// <summary>
         /// Gets the current status of the topic.
         /// </summary>
-        EntityStatus Microsoft.Azure.Management.Servicebus.Fluent.ITopic.Status
+        EntityStatus Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.Status
         {
             get
             {
@@ -385,7 +385,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the duration after which the message expires, starting from when the message is sent to topic.
         /// </summary>
-        TimeSpan Microsoft.Azure.Management.Servicebus.Fluent.ITopic.DefaultMessageTtlDuration
+        TimeSpan Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.DefaultMessageTtlDuration
         {
             get
             {
@@ -396,18 +396,18 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets entry point to manage authorization rules for the Service Bus topic.
         /// </summary>
-        Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRules Microsoft.Azure.Management.Servicebus.Fluent.ITopic.AuthorizationRules
+        Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRules Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.AuthorizationRules
         {
             get
             {
-                return this.AuthorizationRules() as Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRules;
+                return this.AuthorizationRules() as Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRules;
             }
         }
 
         /// <summary>
         /// Gets last time a message was sent, or the last time there was a receive request to this topic.
         /// </summary>
-        System.DateTime Microsoft.Azure.Management.Servicebus.Fluent.ITopic.AccessedAt
+        System.DateTime Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.AccessedAt
         {
             get
             {
@@ -418,7 +418,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether the topic is to be partitioned across multiple message brokers.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.ITopic.IsPartitioningEnabled
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.IsPartitioningEnabled
         {
             get
             {
@@ -429,7 +429,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of messages transferred into dead letters.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ITopic.TransferDeadLetterMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.TransferDeadLetterMessageCount
         {
             get
             {
@@ -440,7 +440,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the idle duration after which the topic is automatically deleted.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ITopic.DeleteOnIdleDurationInMinutes
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.DeleteOnIdleDurationInMinutes
         {
             get
             {
@@ -451,7 +451,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates whether server-side batched operations are enabled.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.ITopic.IsBatchedOperationsEnabled
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.IsBatchedOperationsEnabled
         {
             get
             {
@@ -462,7 +462,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets indicates if this topic requires duplicate detection.
         /// </summary>
-        bool Microsoft.Azure.Management.Servicebus.Fluent.ITopic.IsDuplicateDetectionEnabled
+        bool Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.IsDuplicateDetectionEnabled
         {
             get
             {
@@ -473,7 +473,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets number of messages in the dead-letter topic.
         /// </summary>
-        long Microsoft.Azure.Management.Servicebus.Fluent.ITopic.DeadLetterMessageCount
+        long Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.DeadLetterMessageCount
         {
             get
             {
@@ -484,7 +484,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the exact time the topic was updated.
         /// </summary>
-        System.DateTime Microsoft.Azure.Management.Servicebus.Fluent.ITopic.UpdatedAt
+        System.DateTime Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.UpdatedAt
         {
             get
             {
@@ -495,7 +495,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         /// <summary>
         /// Gets the duration of the duplicate detection history.
         /// </summary>
-        TimeSpan Microsoft.Azure.Management.Servicebus.Fluent.ITopic.DuplicateMessageDetectionHistoryDuration
+        TimeSpan Microsoft.Azure.Management.ServiceBus.Fluent.ITopic.DuplicateMessageDetectionHistoryDuration
         {
             get
             {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicsImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicsImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/NamespaceAuthorizationRule/Definition/IDefinition.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/NamespaceAuthorizationRule/Definition/IDefinition.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRule.Definition
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Definition
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition;
 
     /// <summary>
     /// The stage of the definition which contains all the minimum required inputs for
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRul
     /// for any other optional settings to be specified.
     /// </summary>
     public interface IWithCreate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRule>
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRule>
     {
     }
 
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRul
     /// The first stage of namespace authorization rule definition.
     /// </summary>
     public interface IBlank  :
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition.IWithListenOrSendOrManage<Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRule.Definition.IWithCreate>
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition.IWithListenOrSendOrManage<Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Definition.IWithCreate>
     {
     }
 
@@ -28,8 +28,8 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRul
     /// The entirety of the namespace authorization rule definition.
     /// </summary>
     public interface IDefinition  :
-        Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRule.Definition.IBlank,
-        Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRule.Definition.IWithCreate
+        Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Definition.IBlank,
+        Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Definition.IWithCreate
     {
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/NamespaceAuthorizationRule/Update/IUpdate.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/NamespaceAuthorizationRule/Update/IUpdate.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRule.Update
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Update
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
 
     /// <summary>
     /// The entirety of the namespace authorization rule update.
     /// </summary>
     public interface IUpdate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRule>,
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update.IWithListenOrSendOrManage<Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRule.Update.IUpdate>
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRule>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update.IWithListenOrSendOrManage<Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Update.IUpdate>
     {
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Queue/Definition/IDefinition.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Queue/Definition/IDefinition.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using System;
 
     /// <summary>
@@ -17,21 +17,21 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithNewListenRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithNewListenRule(string name);
 
         /// <summary>
         /// Creates a manage authorization rule for the queue.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithNewManageRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithNewManageRule(string name);
 
         /// <summary>
         /// Creates a send authorization rule for the queue.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithNewSendRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithNewSendRule(string name);
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// </summary>
         /// <param name="durationInSeconds">Duration of a lock in seconds.</param>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithMessageLockDurationInSeconds(int durationInSeconds);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithMessageLockDurationInSeconds(int durationInSeconds);
     }
 
     /// <summary>
@@ -55,19 +55,19 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
     /// for any other optional settings to be specified.
     /// </summary>
     public interface IWithCreate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.Servicebus.Fluent.IQueue>,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithSize,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithPartitioning,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithDeleteOnIdle,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithMessageLockDuration,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithDefaultMessageTTL,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithSession,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithExpressMessage,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithMessageBatching,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithDuplicateMessageDetection,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithExpiredMessageMovedToDeadLetterQueue,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithMessageMovedToDeadLetterQueueOnMaxDeliveryCount,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithAuthorizationRule
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.ServiceBus.Fluent.IQueue>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithSize,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithPartitioning,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithDeleteOnIdle,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithMessageLockDuration,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithDefaultMessageTTL,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithSession,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithExpressMessage,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithMessageBatching,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithDuplicateMessageDetection,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithExpiredMessageMovedToDeadLetterQueue,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithMessageMovedToDeadLetterQueueOnMaxDeliveryCount,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithAuthorizationRule
     {
     }
 
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// from it's internal store.
         /// </summary>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithoutMessageBatching();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithoutMessageBatching();
     }
 
     /// <summary>
@@ -97,14 +97,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// </summary>
         /// <param name="durationInMinutes">Idle duration in minutes.</param>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
     }
 
     /// <summary>
     /// The first stage of a queue definition.
     /// </summary>
     public interface IBlank  :
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate
     {
     }
 
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// Note: By default queue is not express.
         /// </summary>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithExpressMessage();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithExpressMessage();
     }
 
     /// <summary>
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// </summary>
         /// <param name="deliveryCount">Maximum delivery count.</param>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithMessageMovedToDeadLetterQueueOnMaxDeliveryCount(int deliveryCount);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithMessageMovedToDeadLetterQueueOnMaxDeliveryCount(int deliveryCount);
     }
 
     /// <summary>
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// Specifies that expired message must be moved to dead-letter queue.
         /// </summary>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithExpiredMessageMovedToDeadLetterQueue();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithExpiredMessageMovedToDeadLetterQueue();
     }
 
     /// <summary>
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// </summary>
         /// <param name="ttl">Time to live duration.</param>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithDefaultMessageTTL(TimeSpan ttl);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithDefaultMessageTTL(TimeSpan ttl);
     }
 
     /// <summary>
@@ -173,15 +173,15 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// Specifies that session support should be enabled for the queue.
         /// </summary>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithSession();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithSession();
     }
 
     /// <summary>
     /// The entirety of the Service Bus queue definition.
     /// </summary>
     public interface IDefinition  :
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IBlank,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IBlank,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate
     {
     }
 
@@ -196,13 +196,13 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// disabled.
         /// </summary>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithoutPartitioning();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithoutPartitioning();
 
         /// <summary>
         /// Specifies that partitioning should be enabled on this queue.
         /// </summary>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithPartitioning();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithPartitioning();
     }
 
     /// <summary>
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// </summary>
         /// <param name="duplicateDetectionHistoryDuration">Duration of the history.</param>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithDuplicateMessageDetection(TimeSpan duplicateDetectionHistoryDuration);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithDuplicateMessageDetection(TimeSpan duplicateDetectionHistoryDuration);
     }
 
     /// <summary>
@@ -229,6 +229,6 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition
         /// </summary>
         /// <param name="sizeInMB">Size in MB.</param>
         /// <return>The next stage of queue definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Definition.IWithCreate WithSizeInMB(long sizeInMB);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition.IWithCreate WithSizeInMB(long sizeInMB);
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Queue/Update/IUpdate.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Queue/Update/IUpdate.cs
@@ -1,27 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using System;
 
     /// <summary>
     /// The template for Service Bus queue update operation, containing all the settings that can be modified.
     /// </summary>
     public interface IUpdate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.Servicebus.Fluent.IQueue>,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IWithSize,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IWithDeleteOnIdle,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IWithMessageLockDuration,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IWithDefaultMessageTTL,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IWithSession,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IWithExpressMessage,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IWithMessageBatching,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IWithDuplicateMessageDetection,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IWithExpiredMessageMovedToDeadLetterQueue,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IWithMessageMovedToDeadLetterQueueOnMaxDeliveryCount,
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IWithAuthorizationRule
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.ServiceBus.Fluent.IQueue>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IWithSize,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IWithDeleteOnIdle,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IWithMessageLockDuration,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IWithDefaultMessageTTL,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IWithSession,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IWithExpressMessage,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IWithMessageBatching,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IWithDuplicateMessageDetection,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IWithExpiredMessageMovedToDeadLetterQueue,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IWithMessageMovedToDeadLetterQueueOnMaxDeliveryCount,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IWithAuthorizationRule
     {
     }
 
@@ -34,13 +34,13 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
         /// Specifies that session support should be disabled for the queue.
         /// </summary>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithoutSession();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithoutSession();
 
         /// <summary>
         /// Specifies that session support should be enabled for the queue.
         /// </summary>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithSession();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithSession();
     }
 
     /// <summary>
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
         /// </summary>
         /// <param name="durationInMinutes">Idle duration in minutes.</param>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
     }
 
     /// <summary>
@@ -66,14 +66,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
         /// Specifies that messages in this queue are not express hence they should be cached in memory.
         /// </summary>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithoutExpressMessage();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithoutExpressMessage();
 
         /// <summary>
         /// Specifies that messages in this queue are express hence they can be cached in memory
         /// for some time before storing it in messaging store.
         /// </summary>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithExpressMessage();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithExpressMessage();
     }
 
     /// <summary>
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
         /// </summary>
         /// <param name="ttl">Time to live duration.</param>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithDefaultMessageTTL(TimeSpan ttl);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithDefaultMessageTTL(TimeSpan ttl);
     }
 
     /// <summary>
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
         /// </summary>
         /// <param name="deliveryCount">Maximum delivery count.</param>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithMessageMovedToDeadLetterQueueOnMaxDeliveryCount(int deliveryCount);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithMessageMovedToDeadLetterQueueOnMaxDeliveryCount(int deliveryCount);
     }
 
     /// <summary>
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
         /// </summary>
         /// <param name="sizeInMB">Size in MB.</param>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithSizeInMB(long sizeInMB);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithSizeInMB(long sizeInMB);
     }
 
     /// <summary>
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
         /// </summary>
         /// <param name="durationInSeconds">Duration of a lock in seconds.</param>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithMessageLockDurationInSeconds(int durationInSeconds);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithMessageLockDurationInSeconds(int durationInSeconds);
     }
 
     /// <summary>
@@ -140,14 +140,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
         /// Specifies that duplicate message detection needs to be disabled.
         /// </summary>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithoutDuplicateMessageDetection();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithoutDuplicateMessageDetection();
 
         /// <summary>
         /// Specifies the duration of the duplicate message detection history.
         /// </summary>
         /// <param name="duration">Duration of the history.</param>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithDuplicateMessageDetectionHistoryDuration(TimeSpan duration);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithDuplicateMessageDetectionHistoryDuration(TimeSpan duration);
     }
 
     /// <summary>
@@ -161,28 +161,28 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithNewListenRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithNewListenRule(string name);
 
         /// <summary>
         /// Creates a manage authorization rule for the queue.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithNewManageRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithNewManageRule(string name);
 
         /// <summary>
         /// Removes an authorization rule for the queue.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithoutAuthorizationRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithoutAuthorizationRule(string name);
 
         /// <summary>
         /// Creates a send authorization rule for the queue.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithNewSendRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithNewSendRule(string name);
     }
 
     /// <summary>
@@ -195,13 +195,13 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
         /// Specifies that expired message should not be moved to dead-letter queue.
         /// </summary>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithoutExpiredMessageMovedToDeadLetterQueue();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithoutExpiredMessageMovedToDeadLetterQueue();
 
         /// <summary>
         /// Specifies that expired message must be moved to dead-letter queue.
         /// </summary>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithExpiredMessageMovedToDeadLetterQueue();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithExpiredMessageMovedToDeadLetterQueue();
     }
 
     /// <summary>
@@ -214,13 +214,13 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update
         /// messages from it's internal store. This increases the throughput.
         /// </summary>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithMessageBatching();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithMessageBatching();
 
         /// <summary>
         /// Specifies that batching of messages should be disabled when Service Bus write messages to
         /// or delete messages from it's internal store.
         /// </summary>
         /// <return>The next stage of queue update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Queue.Update.IUpdate WithoutMessageBatching();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update.IUpdate WithoutMessageBatching();
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/QueueAuthorizationRule/Definition/IDefinition.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/QueueAuthorizationRule/Definition/IDefinition.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.Definition
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Definition
 {
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
 
     /// <summary>
     /// The entirety of the queue authorization rule definition.
     /// </summary>
     public interface IDefinition  :
-        Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.Definition.IBlank,
-        Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.Definition.IWithCreate
+        Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Definition.IBlank,
+        Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Definition.IWithCreate
     {
     }
 
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.De
     /// The first stage of queue authorization rule definition.
     /// </summary>
     public interface IBlank  :
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition.IWithListenOrSendOrManage<Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.Definition.IWithCreate>
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition.IWithListenOrSendOrManage<Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Definition.IWithCreate>
     {
     }
 
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.De
     /// for any other optional settings to be specified.
     /// </summary>
     public interface IWithCreate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule>
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule>
     {
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/QueueAuthorizationRule/Update/IUpdate.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/QueueAuthorizationRule/Update/IUpdate.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.Update
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Update
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
 
     /// <summary>
     /// The entirety of the queue authorization rule update.
     /// </summary>
     public interface IUpdate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule>,
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update.IWithListenOrSendOrManage<Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRule.Update.IUpdate>
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update.IWithListenOrSendOrManage<Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Update.IUpdate>
     {
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ServiceBusNamespace/Definition/IDefinition.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ServiceBusNamespace/Definition/IDefinition.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
-    using Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.GroupableResource.Definition;
 
     /// <summary>
@@ -19,16 +19,16 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Defin
         /// <param name="name">Topic name.</param>
         /// <param name="maxSizeInMB">Maximum size of memory allocated for the topic entity.</param>
         /// <return>Next stage of the Service Bus namespace definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithNewTopic(string name, int maxSizeInMB);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithNewTopic(string name, int maxSizeInMB);
     }
 
     /// <summary>
     /// The entirety of the Service Bus namespace definition.
     /// </summary>
     public interface IDefinition  :
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IBlank,
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithGroup,
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithCreate
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IBlank,
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithGroup,
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithCreate
     {
     }
 
@@ -38,12 +38,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Defin
     /// for any other optional settings to be specified.
     /// </summary>
     public interface IWithCreate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace>,
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition.IDefinitionWithTags<IWithCreate>,
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithSku,
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithQueue,
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithTopic,
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithAuthorizationRule
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithSku,
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithQueue,
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithTopic,
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithAuthorizationRule
     {
     }
 
@@ -58,14 +58,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Defin
         /// <param name="name">Queue name.</param>
         /// <param name="maxSizeInMB">Maximum size of memory allocated for the queue entity.</param>
         /// <return>Next stage of the Service Bus namespace definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithNewQueue(string name, int maxSizeInMB);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithNewQueue(string name, int maxSizeInMB);
     }
 
     /// <summary>
     /// The stage of the Service Bus namespace definition allowing to specify the resource group.
     /// </summary>
     public interface IWithGroup  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.GroupableResource.Definition.IWithGroup<Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithCreate>
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.GroupableResource.Definition.IWithGroup<Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithCreate>
     {
     }
 
@@ -80,28 +80,28 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Defin
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the Service Bus namespace definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithNewListenRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithNewListenRule(string name);
 
         /// <summary>
         /// Creates a manage authorization rule for the Service Bus namespace.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the Service Bus namespace definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithNewManageRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithNewManageRule(string name);
 
         /// <summary>
         /// Creates a send authorization rule for the Service Bus namespace.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the Service Bus namespace definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithNewSendRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithNewSendRule(string name);
     }
 
     /// <summary>
     /// The first stage of a Service Bus namespace definition.
     /// </summary>
     public interface IBlank  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition.IDefinitionWithRegion<Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithGroup>
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition.IDefinitionWithRegion<Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithGroup>
     {
     }
 
@@ -115,6 +115,6 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Defin
         /// </summary>
         /// <param name="namespaceSku">The sku.</param>
         /// <return>Next stage of the Service Bus namespace definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithSku(NamespaceSku namespaceSku);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition.IWithCreate WithSku(NamespaceSku namespaceSku);
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ServiceBusNamespace/Update/IUpdate.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ServiceBusNamespace/Update/IUpdate.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Update;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
 
     /// <summary>
     /// The stage of the Service Bus namespace update allowing to manage topics in the namespace.
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Updat
         /// </summary>
         /// <param name="name">Topic name.</param>
         /// <return>Next stage of the Service Bus namespace update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IUpdate WithoutTopic(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IUpdate WithoutTopic(string name);
 
         /// <summary>
         /// Creates a topic entity in the Service Bus namespace.
@@ -24,19 +24,19 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Updat
         /// <param name="name">Topic name.</param>
         /// <param name="maxSizeInMB">Maximum size of memory allocated for the topic entity.</param>
         /// <return>Next stage of the Service Bus namespace update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IUpdate WithNewTopic(string name, int maxSizeInMB);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IUpdate WithNewTopic(string name, int maxSizeInMB);
     }
 
     /// <summary>
     /// The template for a Service Bus namespace update operation, containing all the settings that can be modified.
     /// </summary>
     public interface IUpdate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Update.IUpdateWithTags<Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IUpdate>,
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IWithSku,
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IWithQueue,
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IWithTopic,
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IWithAuthorizationRule
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Update.IUpdateWithTags<Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IUpdate>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IWithSku,
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IWithQueue,
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IWithTopic,
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IWithAuthorizationRule
     {
     }
 
@@ -51,14 +51,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Updat
         /// <param name="name">Queue name.</param>
         /// <param name="maxSizeInMB">Maximum size of memory allocated for the queue entity.</param>
         /// <return>Next stage of the Service Bus namespace update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IUpdate WithNewQueue(string name, int maxSizeInMB);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IUpdate WithNewQueue(string name, int maxSizeInMB);
 
         /// <summary>
         /// Removes a queue entity from the Service Bus namespace.
         /// </summary>
         /// <param name="name">Queue name.</param>
         /// <return>Next stage of the Service Bus namespace update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IUpdate WithoutQueue(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IUpdate WithoutQueue(string name);
     }
 
     /// <summary>
@@ -72,28 +72,28 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Updat
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the Service Bus namespace update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IUpdate WithNewListenRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IUpdate WithNewListenRule(string name);
 
         /// <summary>
         /// Creates a manage authorization rule for the Service Bus namespace.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the Service Bus namespace update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IUpdate WithNewManageRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IUpdate WithNewManageRule(string name);
 
         /// <summary>
         /// Removes an authorization rule from the Service Bus namespace.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the Service Bus namespace update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IUpdate WithoutAuthorizationRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IUpdate WithoutAuthorizationRule(string name);
 
         /// <summary>
         /// Creates a send authorization rule for the Service Bus namespace.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the Service Bus namespace update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IUpdate WithNewSendRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IUpdate WithNewSendRule(string name);
     }
 
     /// <summary>
@@ -106,6 +106,6 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Updat
         /// </summary>
         /// <param name="namespaceSku">The sku.</param>
         /// <return>Next stage of the Service Bus namespace update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespace.Update.IUpdate WithSku(NamespaceSku namespaceSku);
+        Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update.IUpdate WithSku(NamespaceSku namespaceSku);
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Subscription/Definition/IDefinition.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Subscription/Definition/IDefinition.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition
 {
     using Management.Fluent.ServiceBus.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using System;
 
     /// <summary>
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition
         /// from it's internal store.
         /// </summary>
         /// <return>The next stage of subscription definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate WithoutMessageBatching();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate WithoutMessageBatching();
     }
 
     /// <summary>
@@ -33,15 +33,15 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition
         /// </summary>
         /// <param name="deliveryCount">Maximum delivery count.</param>
         /// <return>The next stage of subscription definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate WithMessageMovedToDeadLetterSubscriptionOnMaxDeliveryCount(int deliveryCount);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate WithMessageMovedToDeadLetterSubscriptionOnMaxDeliveryCount(int deliveryCount);
     }
 
     /// <summary>
     /// The entirety of the subscription definition.
     /// </summary>
     public interface IDefinition  :
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IBlank,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IBlank,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate
     {
     }
 
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition
         /// </summary>
         /// <param name="ttl">Time to live duration.</param>
         /// <return>The next stage of subscription definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate WithDefaultMessageTTL(TimeSpan ttl);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate WithDefaultMessageTTL(TimeSpan ttl);
     }
 
     /// <summary>
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition
         /// </summary>
         /// <param name="durationInSeconds">Duration of a lock in seconds.</param>
         /// <return>The next stage of subscription definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate WithMessageLockDurationInSeconds(int durationInSeconds);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate WithMessageLockDurationInSeconds(int durationInSeconds);
     }
 
     /// <summary>
@@ -80,15 +80,15 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition
     /// for any other optional settings to be specified.
     /// </summary>
     public interface IWithCreate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.Servicebus.Fluent.ISubscription>,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithDeleteOnIdle,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithMessageLockDuration,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithDefaultMessageTTL,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithSession,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithMessageBatching,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithExpiredMessageMovedToDeadLetterSubscription,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithMessageMovedToDeadLetterSubscriptionOnMaxDeliveryCount,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithMessageMovedToDeadLetterSubscriptionOnFilterEvaluationException
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithDeleteOnIdle,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithMessageLockDuration,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithDefaultMessageTTL,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithSession,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithMessageBatching,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithExpiredMessageMovedToDeadLetterSubscription,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithMessageMovedToDeadLetterSubscriptionOnMaxDeliveryCount,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithMessageMovedToDeadLetterSubscriptionOnFilterEvaluationException
     {
     }
 
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition
         /// Specifies that session support should be enabled for the subscription.
         /// </summary>
         /// <return>The next stage of subscription definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate WithSession();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate WithSession();
     }
 
     /// <summary>
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition
         /// </summary>
         /// <param name="durationInMinutes">Idle duration in minutes.</param>
         /// <return>The next stage of subscription definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
     }
 
     /// <summary>
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition
         /// <param name="name">Rule name.</param>
         /// <param name="rights">Rule rights.</param>
         /// <return>Next stage of the subscription definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate WithNewAuthorizationRule(string name, params AccessRights[] rights);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate WithNewAuthorizationRule(string name, params AccessRights[] rights);
     }
 
     /// <summary>
@@ -144,14 +144,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition
         /// Specifies that filter evaluation failed message must be moved to dead-letter subscription.
         /// </summary>
         /// <return>The next stage of subscription definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate WithMessageMovedToDeadLetterSubscriptionOnFilterEvaluationException();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate WithMessageMovedToDeadLetterSubscriptionOnFilterEvaluationException();
     }
 
     /// <summary>
     /// The first stage of a subscription definition.
     /// </summary>
     public interface IBlank  :
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate
     {
     }
 
@@ -165,12 +165,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition
         /// Specifies that expired message must be moved to dead-letter subscription.
         /// </summary>
         /// <return>The next stage of subscription definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate WithExpiredMessageMovedToDeadLetterSubscription();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate WithExpiredMessageMovedToDeadLetterSubscription();
 
         /// <summary>
         /// Specifies that expired message should not be moved to dead-letter subscription.
         /// </summary>
         /// <return>The next stage of subscription definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Definition.IWithCreate WithoutExpiredMessageMovedToDeadLetterSubscription();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition.IWithCreate WithoutExpiredMessageMovedToDeadLetterSubscription();
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Subscription/Update/IUpdate.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Subscription/Update/IUpdate.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update
 {
     using Management.Fluent.ServiceBus.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using System;
 
     /// <summary>
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update
         /// </summary>
         /// <param name="deliveryCount">Maximum delivery subscription.</param>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithMessageMovedToDeadLetterQueueOnMaxDeliveryCount(int deliveryCount);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithMessageMovedToDeadLetterQueueOnMaxDeliveryCount(int deliveryCount);
     }
 
     /// <summary>
@@ -32,14 +32,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update
         /// messages from it's internal store. This increases the throughput.
         /// </summary>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithMessageBatching();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithMessageBatching();
 
         /// <summary>
         /// Specifies that batching of messages should be disabled when service bus write messages to
         /// or delete messages from it's internal store.
         /// </summary>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithoutMessageBatching();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithoutMessageBatching();
     }
 
     /// <summary>
@@ -52,22 +52,22 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update
         /// </summary>
         /// <param name="ttl">Time to live duration.</param>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithDefaultMessageTTL(TimeSpan ttl);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithDefaultMessageTTL(TimeSpan ttl);
     }
 
     /// <summary>
     /// The template for a subscription update operation, containing all the settings that can be modified.
     /// </summary>
     public interface IUpdate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.Servicebus.Fluent.ISubscription>,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IWithDeleteOnIdle,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IWithMessageLockDuration,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IWithDefaultMessageTTL,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IWithSession,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IWithMessageBatching,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IWithExpiredMessageMovedToDeadLetterSubscription,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IWithMessageMovedToDeadLetterQueueOnMaxDeliveryCount,
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IWithMessageMovedToDeadLetterSubscriptionOnFilterEvaluationException
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IWithDeleteOnIdle,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IWithMessageLockDuration,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IWithDefaultMessageTTL,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IWithSession,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IWithMessageBatching,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IWithExpiredMessageMovedToDeadLetterSubscription,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IWithMessageMovedToDeadLetterQueueOnMaxDeliveryCount,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IWithMessageMovedToDeadLetterSubscriptionOnFilterEvaluationException
     {
     }
 
@@ -83,14 +83,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update
         /// <param name="name">Rule name.</param>
         /// <param name="rights">Rule rights.</param>
         /// <return>Next stage of the subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithNewAuthorizationRule(string name, params AccessRights[] rights);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithNewAuthorizationRule(string name, params AccessRights[] rights);
 
         /// <summary>
         /// Removes an authorization rule for the subscription.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithoutNewAuthorizationRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithoutNewAuthorizationRule(string name);
     }
 
     /// <summary>
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update
         /// </summary>
         /// <param name="durationInSeconds">Duration of a lock in seconds.</param>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithMessageLockDurationInSeconds(int durationInSeconds);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithMessageLockDurationInSeconds(int durationInSeconds);
     }
 
     /// <summary>
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update
         /// </summary>
         /// <param name="durationInMinutes">Idle duration in minutes.</param>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
     }
 
     /// <summary>
@@ -129,13 +129,13 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update
         /// Specifies that expired message must be moved to dead-letter subscription.
         /// </summary>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithExpiredMessageMovedToDeadLetterSubscription();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithExpiredMessageMovedToDeadLetterSubscription();
 
         /// <summary>
         /// Specifies that expired message should not be moved to dead-letter subscription.
         /// </summary>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithoutExpiredMessageMovedToDeadLetterSubscription();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithoutExpiredMessageMovedToDeadLetterSubscription();
     }
 
     /// <summary>
@@ -147,13 +147,13 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update
         /// Specifies that session support should be disabled for the subscription.
         /// </summary>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithoutSession();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithoutSession();
 
         /// <summary>
         /// Specifies that session support should be enabled for the subscription.
         /// </summary>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithSession();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithSession();
     }
 
     /// <summary>
@@ -166,12 +166,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update
         /// Specifies that filter evaluation failed message should not be moved to dead-letter subscription.
         /// </summary>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithoutMessageMovedToDeadLetterSubscriptionOnFilterEvaluationException();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithoutMessageMovedToDeadLetterSubscriptionOnFilterEvaluationException();
 
         /// <summary>
         /// Specifies that filter evaluation failed message must be moved to dead-letter subscription.
         /// </summary>
         /// <return>The next stage of subscription update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Subscription.Update.IUpdate WithMessageMovedToDeadLetterSubscriptionOnFilterEvaluationException();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update.IUpdate WithMessageMovedToDeadLetterSubscriptionOnFilterEvaluationException();
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Topic/Definition/IDefinition.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Topic/Definition/IDefinition.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using System;
 
     /// <summary>
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
         /// </summary>
         /// <param name="ttl">Time to live duration.</param>
         /// <return>The next stage of topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithDefaultMessageTTL(TimeSpan ttl);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithDefaultMessageTTL(TimeSpan ttl);
     }
 
     /// <summary>
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
         /// </summary>
         /// <param name="duplicateDetectionHistoryDuration">Duration of the history.</param>
         /// <return>The next stage of topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithDuplicateMessageDetection(TimeSpan duplicateDetectionHistoryDuration);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithDuplicateMessageDetection(TimeSpan duplicateDetectionHistoryDuration);
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
         /// </summary>
         /// <param name="durationInMinutes">Idle duration in minutes.</param>
         /// <return>The next stage of topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
     }
 
     /// <summary>
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
         /// </summary>
         /// <param name="sizeInMB">Size in MB.</param>
         /// <return>The next stage of topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithSizeInMB(long sizeInMB);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithSizeInMB(long sizeInMB);
     }
 
     /// <summary>
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
         /// </summary>
         /// <param name="name">Queue name.</param>
         /// <return>The next stage of topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithNewSubscription(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithNewSubscription(string name);
     }
 
     /// <summary>
@@ -86,21 +86,21 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithNewListenRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithNewListenRule(string name);
 
         /// <summary>
         /// Creates a manage authorization rule for the topic.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithNewManageRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithNewManageRule(string name);
 
         /// <summary>
         /// Creates a send authorization rule for the topic.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithNewSendRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithNewSendRule(string name);
     }
 
     /// <summary>
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
         /// Note: By default topic is not express.
         /// </summary>
         /// <return>The next stage of topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithExpressMessage();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithExpressMessage();
     }
 
     /// <summary>
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
         /// from it's internal store.
         /// </summary>
         /// <return>The next stage of topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithoutMessageBatching();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithoutMessageBatching();
     }
 
     /// <summary>
@@ -137,16 +137,16 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
     /// for any other optional settings to be specified.
     /// </summary>
     public interface IWithCreate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.Servicebus.Fluent.ITopic>,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithSize,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithPartitioning,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithDeleteOnIdle,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithDefaultMessageTTL,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithExpressMessage,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithMessageBatching,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithDuplicateMessageDetection,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithSubscription,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithAuthorizationRule
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.ServiceBus.Fluent.ITopic>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithSize,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithPartitioning,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithDeleteOnIdle,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithDefaultMessageTTL,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithExpressMessage,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithMessageBatching,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithDuplicateMessageDetection,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithSubscription,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithAuthorizationRule
     {
     }
 
@@ -154,8 +154,8 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
     /// The entirety of the Service Bus topic definition.
     /// </summary>
     public interface IDefinition  :
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IBlank,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IBlank,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate
     {
     }
 
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
     /// The first stage of a topic definition.
     /// </summary>
     public interface IBlank  :
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate
     {
     }
 
@@ -178,12 +178,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition
         /// disabled.
         /// </summary>
         /// <return>The next stage of topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithoutPartitioning();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithoutPartitioning();
 
         /// <summary>
         /// Specifies that partitioning should be enabled on this topic.
         /// </summary>
         /// <return>The next stage of topic definition.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Definition.IWithCreate WithPartitioning();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition.IWithCreate WithPartitioning();
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Topic/Update/IUpdate.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Topic/Update/IUpdate.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using System;
 
     /// <summary>
@@ -16,14 +16,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update
         /// messages from it's internal store. This increases the throughput.
         /// </summary>
         /// <return>The next stage of topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithMessageBatching();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithMessageBatching();
 
         /// <summary>
         /// Specifies that batching of messages should be disabled when Service Bus write messages to
         /// or delete messages from it's internal store.
         /// </summary>
         /// <return>The next stage of topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithoutMessageBatching();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithoutMessageBatching();
     }
 
     /// <summary>
@@ -36,22 +36,22 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update
         /// </summary>
         /// <param name="sizeInMB">Size in MB.</param>
         /// <return>The next stage of topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithSizeInMB(long sizeInMB);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithSizeInMB(long sizeInMB);
     }
 
     /// <summary>
     /// The template for a Service Bus topic update operation, containing all the settings that can be modified.
     /// </summary>
     public interface IUpdate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.Servicebus.Fluent.ITopic>,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IWithSize,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IWithDeleteOnIdle,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IWithDefaultMessageTTL,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IWithExpressMessage,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IWithMessageBatching,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IWithDuplicateMessageDetection,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IWithSubscription,
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IWithAuthorizationRule
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.ServiceBus.Fluent.ITopic>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IWithSize,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IWithDeleteOnIdle,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IWithDefaultMessageTTL,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IWithExpressMessage,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IWithMessageBatching,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IWithDuplicateMessageDetection,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IWithSubscription,
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IWithAuthorizationRule
     {
     }
 
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update
         /// </summary>
         /// <param name="ttl">Time to live duration.</param>
         /// <return>The next stage of topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithDefaultMessageTTL(TimeSpan ttl);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithDefaultMessageTTL(TimeSpan ttl);
     }
 
     /// <summary>
@@ -78,14 +78,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update
         /// </summary>
         /// <param name="name">Subscription name.</param>
         /// <return>Next stage of the Service Bus topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithoutSubscription(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithoutSubscription(string name);
 
         /// <summary>
         /// Creates a subscription entity for the Service Bus topic.
         /// </summary>
         /// <param name="name">Queue name.</param>
         /// <return>Next stage of the Service Bus topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithNewSubscription(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithNewSubscription(string name);
     }
 
     /// <summary>
@@ -98,14 +98,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update
         /// Specifies that duplicate message detection needs to be disabled.
         /// </summary>
         /// <return>The next stage of topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithoutDuplicateMessageDetection();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithoutDuplicateMessageDetection();
 
         /// <summary>
         /// Specifies the duration of the duplicate message detection history.
         /// </summary>
         /// <param name="duration">Duration of the history.</param>
         /// <return>The next stage of topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithDuplicateMessageDetectionHistoryDuration(TimeSpan duration);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithDuplicateMessageDetectionHistoryDuration(TimeSpan duration);
     }
 
     /// <summary>
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update
         /// </summary>
         /// <param name="durationInMinutes">Idle duration in minutes.</param>
         /// <return>The next stage of topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithDeleteOnIdleDurationInMinutes(int durationInMinutes);
     }
 
     /// <summary>
@@ -131,14 +131,14 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update
         /// Specifies that messages in this topic are not express hence they should be cached in memory.
         /// </summary>
         /// <return>The next stage of topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithoutExpressMessage();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithoutExpressMessage();
 
         /// <summary>
         /// Specifies that messages in this topic are express hence they can be cached in memory
         /// for some time before storing it in messaging store.
         /// </summary>
         /// <return>The next stage of topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithExpressMessage();
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithExpressMessage();
     }
 
     /// <summary>
@@ -152,27 +152,27 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithNewListenRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithNewListenRule(string name);
 
         /// <summary>
         /// Creates a manage authorization rule for the topic.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithNewManageRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithNewManageRule(string name);
 
         /// <summary>
         /// Removes an authorization rule for the topic.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithoutAuthorizationRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithoutAuthorizationRule(string name);
 
         /// <summary>
         /// Creates a send authorization rule for the topic.
         /// </summary>
         /// <param name="name">Rule name.</param>
         /// <return>Next stage of the topic update.</return>
-        Microsoft.Azure.Management.Servicebus.Fluent.Topic.Update.IUpdate WithNewSendRule(string name);
+        Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update.IUpdate WithNewSendRule(string name);
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/TopicAuthorizationRule/Definition/IDefinition.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/TopicAuthorizationRule/Definition/IDefinition.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.Definition
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Definition
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition;
 
     /// <summary>
     /// The stage of the definition which contains all the minimum required inputs for
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.De
     /// for any other optional settings to be specified.
     /// </summary>
     public interface IWithCreate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule>
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRule>
     {
     }
 
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.De
     /// The first stage of topic authorization rule definition.
     /// </summary>
     public interface IBlank  :
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Definition.IWithListenOrSendOrManage<Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.Definition.IWithCreate>
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Definition.IWithListenOrSendOrManage<Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Definition.IWithCreate>
     {
     }
 
@@ -28,8 +28,8 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.De
     /// The entirety of the topic authorization rule definition.
     /// </summary>
     public interface IDefinition  :
-        Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.Definition.IBlank,
-        Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.Definition.IWithCreate
+        Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Definition.IBlank,
+        Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Definition.IWithCreate
     {
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/TopicAuthorizationRule/Update/IUpdate.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/TopicAuthorizationRule/Update/IUpdate.cs
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.Update
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Update
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update;
-    using Microsoft.Azure.Management.Servicebus.Fluent;
+    using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
 
     /// <summary>
     /// The entirety of the topic authorization rule update.
     /// </summary>
     public interface IUpdate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule>,
-        Microsoft.Azure.Management.Servicebus.Fluent.AuthorizationRule.Update.IWithListenOrSendOrManage<Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRule.Update.IUpdate>
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRule>,
+        Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update.IWithListenOrSendOrManage<Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Update.IUpdate>
     {
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceAuthorizationRuleImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -17,10 +17,10 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNlcnZpY2VidXMuaW1wbGVtZW50YXRpb24uTmFtZXNwYWNlQXV0aG9yaXphdGlvblJ1bGVJbXBs
     internal partial class NamespaceAuthorizationRuleImpl  :
-            AuthorizationRuleBaseImpl<Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRule,
-            Microsoft.Azure.Management.Servicebus.Fluent.ServiceBusNamespaceImpl,
+            AuthorizationRuleBaseImpl<Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRule,
+            Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespaceImpl,
             SharedAccessAuthorizationRuleInner,
-            Microsoft.Azure.Management.Servicebus.Fluent.NamespaceAuthorizationRuleImpl,
+            Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRuleImpl,
             IHasId,
             NamespaceAuthorizationRule.Update.IUpdate,
             ServiceBus.Fluent.IServiceBusManager>,
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:B2EB74D988CD2A7EFC551E57BE9B48BB:60710D4DE8BBAA25BEA3436DAE67B2F8
-        protected async override Task<Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRule> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRule> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var inner = await this.Manager.Inner.Namespaces.CreateOrUpdateAuthorizationRuleAsync(this.ResourceGroupName,
                 this.NamespaceName(),

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceAuthorizationRulesImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Management.Fluent.ServiceBus;
     using Management.Fluent.ServiceBus.Models;
@@ -16,12 +16,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNlcnZpY2VidXMuaW1wbGVtZW50YXRpb24uTmFtZXNwYWNlQXV0aG9yaXphdGlvblJ1bGVzSW1wbA==
     internal partial class NamespaceAuthorizationRulesImpl :
-        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRule,
+        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRule,
             NamespaceAuthorizationRuleImpl,
             SharedAccessAuthorizationRuleInner,
             INamespacesOperations,
             IServiceBusManager,
-            Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,
+            Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace>,
             INamespaceAuthorizationRules
     {
         private string resourceGroupName;
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:EA1A01CE829067751D1BD24D7AC819DA:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRule> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRule> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceSku.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceSku.cs
@@ -3,7 +3,7 @@
 using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
 using System;
 
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     /// <summary>
     /// Defines values for NamespaceSku.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueAuthorizationRuleImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -17,10 +17,10 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNlcnZpY2VidXMuaW1wbGVtZW50YXRpb24uUXVldWVBdXRob3JpemF0aW9uUnVsZUltcGw=
     internal partial class QueueAuthorizationRuleImpl  :
-        AuthorizationRuleBaseImpl<Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule,
-            Microsoft.Azure.Management.Servicebus.Fluent.QueueImpl,
+        AuthorizationRuleBaseImpl<Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule,
+            Microsoft.Azure.Management.ServiceBus.Fluent.QueueImpl,
             SharedAccessAuthorizationRuleInner,
-            Microsoft.Azure.Management.Servicebus.Fluent.QueueAuthorizationRuleImpl,
+            Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRuleImpl,
             IHasId,
             QueueAuthorizationRule.Update.IUpdate,
             ServiceBus.Fluent.IServiceBusManager>,
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:B2EB74D988CD2A7EFC551E57BE9B48BB:46F4637261BEB669A9232C7B41AE2D1A
-        protected async override Task<Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var inner = await this.Manager.Inner.Queues.CreateOrUpdateAuthorizationRuleAsync(this.ResourceGroupName,
                 this.namespaceName,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueAuthorizationRulesImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -16,12 +16,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNlcnZpY2VidXMuaW1wbGVtZW50YXRpb24uUXVldWVBdXRob3JpemF0aW9uUnVsZXNJbXBs
     internal partial class QueueAuthorizationRulesImpl :
-        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule,
+        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule,
             QueueAuthorizationRuleImpl,
             SharedAccessAuthorizationRuleInner,
             IQueuesOperations,
             IServiceBusManager,
-            Microsoft.Azure.Management.Servicebus.Fluent.IQueue>,
+            Microsoft.Azure.Management.ServiceBus.Fluent.IQueue>,
             IQueueAuthorizationRules
     {
         private string resourceGroupName;
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:EA1A01CE829067751D1BD24D7AC819DA:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         IDefinition,
         IUpdate
     {
-        private IList<ICreatable<Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRule>> rulesToCreate;
+        private IList<ICreatable<Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule>> rulesToCreate;
         private IList<string> rulesToDelete;
 
         ///GENMHASH:2E16A3C3DDA5707111D704BA0D4871AD:E384D1DC0323D2359E002A2334C75FD1
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:396C89E2447B0E70C3C95439926DFC1A:E32C091119D6FB6D73E1D3322965866B
         public QueueImpl WithNewManageRule(string name)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRules rules = this.AuthorizationRules();
+            Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRules rules = this.AuthorizationRules();
             this.rulesToCreate.Add(rules.Define(name).WithManagementEnabled());
             return this;
         }
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:41482A7907F5C3C16FDB1A8E3CEB3B9F:B5BA3212E181BC7B599A722AEFAC04B4
         public QueueImpl WithNewSendRule(string name)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRules rules = this.AuthorizationRules();
+            Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRules rules = this.AuthorizationRules();
             this.rulesToCreate.Add(rules.Define(name).WithSendingEnabled());
             return this;
         }
@@ -413,7 +413,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:B2EB74D988CD2A7EFC551E57BE9B48BB:92202640FA5E86BA9A0B8B1004BEF8C7
-        protected async override Task<Microsoft.Azure.Management.Servicebus.Fluent.IQueue> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<Microsoft.Azure.Management.ServiceBus.Fluent.IQueue> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             try
             {
@@ -455,7 +455,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:CF2CF801A7E4A9CAE7624D815E5EE4F4:E6E0C1CF73E25181AD5C0BE989C2DE15
         public QueueImpl WithNewListenRule(string name)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.IQueueAuthorizationRules rules = this.AuthorizationRules();
+            Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRules rules = this.AuthorizationRules();
             this.rulesToCreate.Add(rules.Define(name).WithListeningEnabled());
             return this;
         }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueuesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueuesImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -16,12 +16,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNlcnZpY2VidXMuaW1wbGVtZW50YXRpb24uUXVldWVzSW1wbA==
     internal partial class QueuesImpl :
-        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.Servicebus.Fluent.IQueue,
-            Microsoft.Azure.Management.Servicebus.Fluent.QueueImpl,
+        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.ServiceBus.Fluent.IQueue,
+            Microsoft.Azure.Management.ServiceBus.Fluent.QueueImpl,
             QueueInner,
             IQueuesOperations,
             IServiceBusManager,
-            Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,
+            Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace>,
         IQueues
     {
         private string resourceGroupName;
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:EA1A01CE829067751D1BD24D7AC819DA:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<Microsoft.Azure.Management.Servicebus.Fluent.IQueue> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<Microsoft.Azure.Management.ServiceBus.Fluent.IQueue> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusChildResourcesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusChildResourcesImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusManager.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusManager.cs
@@ -4,7 +4,7 @@
 using Microsoft.Azure.Management.Fluent.ServiceBus;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-using Microsoft.Azure.Management.Servicebus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent;
 using System;
 using System.Linq;
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespaceImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespaceImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:396C89E2447B0E70C3C95439926DFC1A:E32C091119D6FB6D73E1D3322965866B
         public ServiceBusNamespaceImpl WithNewManageRule(string name)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRules rules = this.AuthorizationRules();
+            Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRules rules = this.AuthorizationRules();
             this.rulesToCreate.Add(rules.Define(name).WithManagementEnabled());
             return this;
         }
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:41482A7907F5C3C16FDB1A8E3CEB3B9F:B5BA3212E181BC7B599A722AEFAC04B4
         public ServiceBusNamespaceImpl WithNewSendRule(string name)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRules rules = this.AuthorizationRules();
+            Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRules rules = this.AuthorizationRules();
             this.rulesToCreate.Add(rules.Define(name).WithSendingEnabled());
             return this;
         }
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:0056597C3B557D2380B446CF23AF2A7B:3ED10B976FB7009877FF91F8B760BA3E
         public ServiceBusNamespaceImpl WithNewQueue(string name, int maxSizeInMB)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.IQueues queues = this.Queues();
+            Microsoft.Azure.Management.ServiceBus.Fluent.IQueues queues = this.Queues();
             this.queuesToCreate.Add(queues.Define(name).WithSizeInMB(maxSizeInMB));
             return this;
         }
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:CF2CF801A7E4A9CAE7624D815E5EE4F4:E6E0C1CF73E25181AD5C0BE989C2DE15
         public ServiceBusNamespaceImpl WithNewListenRule(string name)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.INamespaceAuthorizationRules rules = this.AuthorizationRules();
+            Microsoft.Azure.Management.ServiceBus.Fluent.INamespaceAuthorizationRules rules = this.AuthorizationRules();
             this.rulesToCreate.Add(rules.Define(name).WithListeningEnabled());
             return this;
         }
@@ -199,13 +199,13 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:98A63A985E9B6B6F14188D0E5238F102:8647FDD47A835E6860B5FD34AEAF4704
         public ServiceBusNamespaceImpl WithNewTopic(string name, int maxSizeInMB)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.ITopics topics = this.Topics();
+            Microsoft.Azure.Management.ServiceBus.Fluent.ITopics topics = this.Topics();
             this.topicsToCreate.Add(topics.Define(name).WithSizeInMB(maxSizeInMB));
             return this;
         }
 
         ///GENMHASH:0202A00A1DCF248D2647DBDBEF2CA865:BBFCE2924F9633469A6BC7350F5D2F05
-        public async override Task<Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace> CreateResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public async override Task<Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace> CreateResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             try
             {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespacesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespacesImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Management.Fluent.ServiceBus;
     using Management.Fluent.ServiceBus.Models;
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:42E0B61F5AA4A1130D7B90CCBAAE3A5D:9F33885F608914F714E6FA1E746CFA88
-        public async Task<Microsoft.Azure.Management.Servicebus.Fluent.ICheckNameAvailabilityResult> CheckNameAvailabilityAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.ServiceBus.Fluent.ICheckNameAvailabilityResult> CheckNameAvailabilityAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             var resultInner = await this.Inner.CheckNameAvailabilityMethodAsync(name, cancellationToken);
             return new CheckNameAvailabilityResultImpl(resultInner);

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -241,7 +241,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:B2EB74D988CD2A7EFC551E57BE9B48BB:250033B2F34291DBD013248656522902
-        protected async override Task<Microsoft.Azure.Management.Servicebus.Fluent.ISubscription> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var inner = await this.Manager.Inner.Subscriptions.CreateOrUpdateAsync(this.ResourceGroupName,
                 this.namespaceName,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionsImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionsImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -15,12 +15,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNlcnZpY2VidXMuaW1wbGVtZW50YXRpb24uU3Vic2NyaXB0aW9uc0ltcGw=
     internal partial class SubscriptionsImpl :
-        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.Servicebus.Fluent.ISubscription,
-            Microsoft.Azure.Management.Servicebus.Fluent.SubscriptionImpl,
+        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription,
+            Microsoft.Azure.Management.ServiceBus.Fluent.SubscriptionImpl,
             Management.Fluent.ServiceBus.Models.SubscriptionInner,
             ISubscriptionsOperations,
             IServiceBusManager,
-            Microsoft.Azure.Management.Servicebus.Fluent.ITopic>,
+            Microsoft.Azure.Management.ServiceBus.Fluent.ITopic>,
         ISubscriptions
     {
         private string resourceGroupName;
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:EA1A01CE829067751D1BD24D7AC819DA:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<Microsoft.Azure.Management.Servicebus.Fluent.ISubscription> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicAuthorizationRuleImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -17,10 +17,10 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNlcnZpY2VidXMuaW1wbGVtZW50YXRpb24uVG9waWNBdXRob3JpemF0aW9uUnVsZUltcGw=
     internal partial class TopicAuthorizationRuleImpl  :
-            AuthorizationRuleBaseImpl<Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule,
-            Microsoft.Azure.Management.Servicebus.Fluent.TopicImpl,
+            AuthorizationRuleBaseImpl<Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRule,
+            Microsoft.Azure.Management.ServiceBus.Fluent.TopicImpl,
             SharedAccessAuthorizationRuleInner,
-            Microsoft.Azure.Management.Servicebus.Fluent.TopicAuthorizationRuleImpl,
+            Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRuleImpl,
             IHasId,
             TopicAuthorizationRule.Update.IUpdate,
             ServiceBus.Fluent.IServiceBusManager>,
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:B2EB74D988CD2A7EFC551E57BE9B48BB:4187094DEEE3C6A3870BD8806AF85CA6
-        protected async override Task<Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRule> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var inner = await this.Manager.Inner.Topics.CreateOrUpdateAuthorizationRuleAsync(this.ResourceGroupName,
                 this.namespaceName,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicAuthorizationRulesImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Management.Fluent.ServiceBus;
     using Management.Fluent.ServiceBus.Models;
@@ -16,12 +16,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNlcnZpY2VidXMuaW1wbGVtZW50YXRpb24uVG9waWNBdXRob3JpemF0aW9uUnVsZXNJbXBs
     internal partial class TopicAuthorizationRulesImpl :
-        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule,
+        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRule,
             TopicAuthorizationRuleImpl,
             SharedAccessAuthorizationRuleInner,
             ITopicsOperations,
             IServiceBusManager,
-            Microsoft.Azure.Management.Servicebus.Fluent.ITopic>,
+            Microsoft.Azure.Management.ServiceBus.Fluent.ITopic>,
             ITopicAuthorizationRules
     {
         private string resourceGroupName;
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:EA1A01CE829067751D1BD24D7AC819DA:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRule> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -31,8 +31,8 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         IDefinition,
         IUpdate
     {
-        private IList<ICreatable<Microsoft.Azure.Management.Servicebus.Fluent.ISubscription>> subscriptionsToCreate;
-        private IList<ICreatable<Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRule>> rulesToCreate;
+        private IList<ICreatable<Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription>> subscriptionsToCreate;
+        private IList<ICreatable<Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRule>> rulesToCreate;
         private IList<string> subscriptionsToDelete;
         private IList<string> rulesToDelete;
 
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:396C89E2447B0E70C3C95439926DFC1A:E32C091119D6FB6D73E1D3322965866B
         public TopicImpl WithNewManageRule(string name)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRules rules = this.AuthorizationRules();
+            Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRules rules = this.AuthorizationRules();
             this.rulesToCreate.Add(rules.Define(name).WithManagementEnabled());
             return this;
         }
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:41482A7907F5C3C16FDB1A8E3CEB3B9F:B5BA3212E181BC7B599A722AEFAC04B4
         public TopicImpl WithNewSendRule(string name)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRules rules = this.AuthorizationRules();
+            Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRules rules = this.AuthorizationRules();
             this.rulesToCreate.Add(rules.Define(name).WithSendingEnabled());
             return this;
         }
@@ -234,7 +234,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:C9DAE4BC5B8D28759976D191CF3F2F49:132DDA9E524ED4559BBB94874F4BABA8
         public TopicImpl WithNewSubscription(string name)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.ISubscriptions subscriptions = this.Subscriptions();
+            Microsoft.Azure.Management.ServiceBus.Fluent.ISubscriptions subscriptions = this.Subscriptions();
             this.subscriptionsToCreate.Add(subscriptions.Define(name));
             return this;
         }
@@ -274,7 +274,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:B2EB74D988CD2A7EFC551E57BE9B48BB:645BAB1C541C407A2777CECFAAF22EBC
-        protected async override Task<Microsoft.Azure.Management.Servicebus.Fluent.ITopic> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<Microsoft.Azure.Management.ServiceBus.Fluent.ITopic> CreateChildResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             try
             {
@@ -385,7 +385,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         ///GENMHASH:CF2CF801A7E4A9CAE7624D815E5EE4F4:E6E0C1CF73E25181AD5C0BE989C2DE15
         public TopicImpl WithNewListenRule(string name)
         {
-            Microsoft.Azure.Management.Servicebus.Fluent.ITopicAuthorizationRules rules = this.AuthorizationRules();
+            Microsoft.Azure.Management.ServiceBus.Fluent.ITopicAuthorizationRules rules = this.AuthorizationRules();
             this.rulesToCreate.Add(rules.Define(name).WithListeningEnabled());
             return this;
         }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicsImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicsImpl.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-namespace Microsoft.Azure.Management.Servicebus.Fluent
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -16,12 +16,12 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
     /// </summary>
     ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnNlcnZpY2VidXMuaW1wbGVtZW50YXRpb24uVG9waWNzSW1wbA==
     internal partial class TopicsImpl :
-        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.Servicebus.Fluent.ITopic,
-            Microsoft.Azure.Management.Servicebus.Fluent.TopicImpl,
+        ServiceBusChildResourcesImpl<Microsoft.Azure.Management.ServiceBus.Fluent.ITopic,
+            Microsoft.Azure.Management.ServiceBus.Fluent.TopicImpl,
             TopicInner,
             ITopicsOperations,
             IServiceBusManager,
-            Microsoft.Azure.Management.Servicebus.Fluent.IServiceBusNamespace>,
+            Microsoft.Azure.Management.ServiceBus.Fluent.IServiceBusNamespace>,
         ITopics
     {
         private string resourceGroupName;
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Management.Servicebus.Fluent
         }
 
         ///GENMHASH:EA1A01CE829067751D1BD24D7AC819DA:DBE309666B1D8BDFE15651BA9A0DD4A1
-        public override Task<Microsoft.Azure.Management.Servicebus.Fluent.ITopic> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<Microsoft.Azure.Management.ServiceBus.Fluent.ITopic> GetByParentAsync(string resourceGroup, string parentName, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             // 'IndependentChildResourcesImpl' will be refactoring to remove all 'ByParent' methods
             // This method is not exposed to end user from any of the derived types of IndependentChildResourcesImpl


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.