### PR TITLE
Fixed ServiceBus namespase to have Fluent at the end.

### DIFF
--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Program.cs
@@ -3,11 +3,11 @@
 
 
 using Microsoft.Azure.Management.Fluent;
-using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
 using Microsoft.Azure.Management.ServiceBus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent.Models;
 using System;
 using System.Linq;
 using System.Text;

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Program.cs
@@ -3,11 +3,11 @@
 
 
 using Microsoft.Azure.Management.Fluent;
-using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;
 using Microsoft.Azure.Management.ServiceBus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent.Models;
 using System;
 using System.Linq;
 using System.Text;

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Program.cs
@@ -3,7 +3,7 @@
 
 
 using Microsoft.Azure.Management.Fluent;
-using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
+using Microsoft.Azure.Management.ServiceBus.Fluent.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.Samples.Common;

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/ServiceBus/ServiceBusTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/ServiceBus/ServiceBusTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Fluent.Tests.Common;
-using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.ServiceBus.Fluent;
+using Microsoft.Azure.Management.ServiceBus.Fluent.Models;
 using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
 using System;
 using System.Collections.Generic;

--- a/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/Microsoft.Azure.Management.Cdn.Fluent.xproj
+++ b/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/Microsoft.Azure.Management.Cdn.Fluent.xproj
@@ -7,7 +7,7 @@
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>2dc40302-9436-4b65-bceb-053d9fa936b5</ProjectGuid>
-    <RootNamespace>Microsoft.Azure.Management.Fluent.Cdn</RootNamespace>
+    <RootNamespace>Microsoft.Azure.Management.Cdn.Fluent</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/AuthorizationKeysImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/AuthorizationKeysImpl.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using ResourceManager.Fluent.Core;
 
     /// <summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/AuthorizationRuleBaseImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/AuthorizationRuleBaseImpl.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using System.Collections.Generic;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using ResourceManager.Fluent.Core;
 
     /// <summary>
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
         }
 
         ///GENMHASH:AB1BA95F78B711F10D574A0046DE17B7:5297C65D2669C5460BC3173EBA6C2F1E
-        protected IReadOnlyList<Management.Fluent.ServiceBus.Models.AccessRights> Rights()
+        protected IReadOnlyList<Management.ServiceBus.Fluent.Models.AccessRights> Rights()
         {
             if (this.Inner.Rights == null)
             {
@@ -153,6 +153,6 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
         protected abstract Task<ResourceListKeysInner> GetKeysInnerAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         ///GENMHASH:1475FAC06F3CDD8B38B0B8B1586C3D7E:27E486AB74A10242FF421C0798DDC450
-        protected abstract Task<Management.Fluent.ServiceBus.Models.ResourceListKeysInner> RegenerateKeysInnerAsync(Policykey policykey, CancellationToken cancellationToken = default(CancellationToken));
+        protected abstract Task<Management.ServiceBus.Fluent.Models.ResourceListKeysInner> RegenerateKeysInnerAsync(Policykey policykey, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/CheckNameAvailabilityResultImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/CheckNameAvailabilityResultImpl.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using ResourceManager.Fluent.Core;
 
     /// <summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationKeys.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationKeys.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     /// <summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationRule.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IAuthorizationRule.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
     using System.Collections.Generic;
     using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
 
     /// <summary>
     /// Type representing authorization rule.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ICheckNameAvailabilityResult.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ICheckNameAvailabilityResult.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     /// <summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/INamespaceAuthorizationRules.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/INamespaceAuthorizationRules.cs
@@ -5,8 +5,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Definition;
-    using Management.Fluent.ServiceBus.Models;
-    using Management.Fluent.ServiceBus;
+    using Management.ServiceBus.Fluent.Models;
 
     /// <summary>
     /// Entry point to namespace authorization rules management API.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueue.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueue.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update;
     using System;
     using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
 
     /// <summary>
     /// Type representing Service Bus queue.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueueAuthorizationRules.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueueAuthorizationRules.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Definition;
-    using Management.Fluent.ServiceBus;
+    using Management.ServiceBus.Fluent;
 
     /// <summary>
     /// Entry point to queue authorization rules management API.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueues.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IQueues.cs
@@ -6,8 +6,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition;
     using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus.Models;
-    using Management.Fluent.ServiceBus;
+    using Management.ServiceBus.Fluent.Models;
 
     /// <summary>
     /// Entry point to service bus queue management API in Azure.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespace.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespace.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
     using Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Update;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespaces.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/IServiceBusNamespaces.cs
@@ -4,12 +4,6 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.ServiceBus.Fluent.ServiceBusNamespace.Definition;
-    using Microsoft.Rest;
-    using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus;
 
     /// <summary>
     /// Entry point to Service Bus namespace API in Azure.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscription.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscription.cs
@@ -2,12 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update;
+    using Management.ServiceBus.Fluent.Models;
     using System;
-    using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus.Models;
 
     /// <summary>
     /// Type representing service bus topic subscription.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscriptions.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ISubscriptions.cs
@@ -2,12 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition;
-    using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus;
-
     /// <summary>
     /// Entry point to service bus queue management API in Azure.
     /// </summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopic.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopic.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
     using Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Update;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopicAuthorizationRules.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopicAuthorizationRules.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.CollectionActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Definition;
-    using Management.Fluent.ServiceBus;
 
     /// <summary>
     /// Entry point to topic authorization rules management API.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopics.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/ITopics.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Microsoft.Azure.Management.ServiceBus.Fluent.Topic.Definition;
     using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus;
 
     /// <summary>
     /// Entry point to Service Bus topic management API in Azure.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/CheckNameAvailabilityResultImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/CheckNameAvailabilityResultImpl.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     internal partial class CheckNameAvailabilityResultImpl 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/NamespaceAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/NamespaceAuthorizationRuleImpl.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update;
     using Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Definition;
     using Microsoft.Azure.Management.ServiceBus.Fluent.NamespaceAuthorizationRule.Update;
-    using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
 
     internal partial class NamespaceAuthorizationRuleImpl 
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueueAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueueAuthorizationRuleImpl.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Microsoft.Azure.Management.ServiceBus.Fluent.AuthorizationRule.Update;
     using Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Definition;
     using Microsoft.Azure.Management.ServiceBus.Fluent.QueueAuthorizationRule.Update;
-    using Management.Fluent.ServiceBus.Models;
-    using ServiceBus.Fluent;
+    using Management.ServiceBus.Fluent.Models;
 
     internal partial class QueueAuthorizationRuleImpl 
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueueImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/QueueImpl.cs
@@ -2,16 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Definition;
-    using Microsoft.Azure.Management.ServiceBus.Fluent.Queue.Update;
-    using System.Collections.Generic;
     using System;
     using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
 
     internal partial class QueueImpl 
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/SubscriptionImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/SubscriptionImpl.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update;
     using System;
     using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
 
     internal partial class SubscriptionImpl 
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicAuthorizationRuleImpl.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Definition;
     using Microsoft.Azure.Management.ServiceBus.Fluent.TopicAuthorizationRule.Update;
     using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
 
     internal partial class TopicAuthorizationRuleImpl 
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/InterfaceImpl/TopicImpl.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using System.Collections.Generic;
     using System;
     using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
 
     internal partial class TopicImpl 
     {

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Subscription/Definition/IDefinition.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Subscription/Definition/IDefinition.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Definition
 {
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
     using Microsoft.Azure.Management.ServiceBus.Fluent;
     using System;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Subscription/Update/IUpdate.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Domain/Subscription/Update/IUpdate.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent.Subscription.Update
 {
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
     using Microsoft.Azure.Management.ServiceBus.Fluent;
     using System;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/INamespacesOperations.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/INamespacesOperations.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/IOperations.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/IOperations.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/IQueuesOperations.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/IQueuesOperations.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/IServiceBusManagementClient.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/IServiceBusManagementClient.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/ISubscriptionsOperations.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/ISubscriptionsOperations.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/ITopicsOperations.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/ITopicsOperations.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/AccessRights.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/AccessRights.cs
@@ -6,15 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
-    using Microsoft.Azure;
-    using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
-    using System.Runtime;
     using System.Runtime.Serialization;
 
     /// <summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/CheckNameAvailability.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/CheckNameAvailability.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Microsoft.Rest;
     using Newtonsoft.Json;
     using System.Linq;
@@ -32,7 +31,7 @@ namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
         /// <summary>
         /// Initializes a new instance of the CheckNameAvailability class.
         /// </summary>
-        /// <param name="name">The Name to check the namespce name availability
+        /// <param name="name">The Name to check the namespace name availability
         /// and The namespace name can contain only letters, numbers, and
         /// hyphens. The namespace must start with a letter, and it must end
         /// with a letter or number.</param>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/CheckNameAvailabilityResultInner.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/CheckNameAvailabilityResultInner.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Newtonsoft.Json;
     using System.Linq;
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/EntityStatus.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/EntityStatus.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
     using System.Runtime;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/MessageCountDetails.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/MessageCountDetails.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Newtonsoft.Json;
     using System.Linq;
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/NamespaceModelInner.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/NamespaceModelInner.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/NamespaceUpdateParametersInner.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/NamespaceUpdateParametersInner.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Newtonsoft.Json;
     using System.Collections;
     using System.Collections.Generic;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/Operation.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/Operation.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Newtonsoft.Json;
     using System.Linq;
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/OperationDisplay.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/OperationDisplay.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Newtonsoft.Json;
     using System.Linq;
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/Page.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/Page.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Newtonsoft.Json;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/Policykey.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/Policykey.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
     using System.Runtime;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/QueueInner.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/QueueInner.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Microsoft.Rest.Serialization;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/RegenerateKeysParameters.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/RegenerateKeysParameters.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Newtonsoft.Json;
     using System.Linq;
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/ResourceListKeysInner.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/ResourceListKeysInner.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Newtonsoft.Json;
     using System.Linq;
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/SharedAccessAuthorizationRuleInner.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/SharedAccessAuthorizationRuleInner.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Microsoft.Rest.Serialization;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/Sku.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/Sku.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Microsoft.Rest;
     using Newtonsoft.Json;
     using System.Linq;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/SubscriptionInner.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/SubscriptionInner.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Microsoft.Rest.Serialization;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/TopicInner.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Models/TopicInner.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Microsoft.Rest.Serialization;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/NamespacesOperations.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/NamespacesOperations.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/NamespacesOperationsExtensions.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/NamespacesOperationsExtensions.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Operations.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/Operations.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/OperationsExtensions.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/OperationsExtensions.cs
@@ -6,11 +6,9 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
-    using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/QueuesOperations.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/QueuesOperations.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/QueuesOperationsExtensions.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/QueuesOperationsExtensions.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/ServiceBusManagementClient.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/ServiceBusManagementClient.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Microsoft.Rest.Serialization;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/SubscriptionsOperations.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/SubscriptionsOperations.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/SubscriptionsOperationsExtensions.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/SubscriptionsOperationsExtensions.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/TopicsOperations.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/TopicsOperations.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/TopicsOperationsExtensions.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/Generated/TopicsOperationsExtensions.cs
@@ -6,11 +6,10 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus
+namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceAuthorizationRuleImpl.cs
@@ -7,10 +7,9 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using NamespaceAuthorizationRule.Definition;
     using NamespaceAuthorizationRule.Update;
     using ResourceManager.Fluent.Core;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using ServiceBus.Fluent;
     using System.Collections.Generic;
-    using Management.Fluent.ServiceBus;
 
     /// <summary>
     /// Implementation for NamespaceAuthorizationRule.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceAuthorizationRulesImpl.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Management.Fluent.ServiceBus;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using ResourceManager.Fluent.Core;
     using Rest.Azure;
     using ServiceBus.Fluent;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceSku.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/NamespaceSku.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-using Microsoft.Azure.Management.Fluent.ServiceBus.Models;
+using Microsoft.Azure.Management.ServiceBus.Fluent.Models;
 using System;
 
 namespace Microsoft.Azure.Management.ServiceBus.Fluent

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueAuthorizationRuleImpl.cs
@@ -7,10 +7,9 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using QueueAuthorizationRule.Definition;
     using QueueAuthorizationRule.Update;
     using ResourceManager.Fluent.Core;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using ServiceBus.Fluent;
     using System.Collections.Generic;
-    using Management.Fluent.ServiceBus;
 
     /// <summary>
     /// Implementation for QueueAuthorizationRule.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueAuthorizationRulesImpl.cs
@@ -5,8 +5,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using ResourceManager.Fluent.Core;
-    using Management.Fluent.ServiceBus.Models;
-    using Management.Fluent.ServiceBus;
+    using Management.ServiceBus.Fluent.Models;
     using ServiceBus.Fluent;
     using System;
     using Rest.Azure;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueueImpl.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using Queue.Update;
     using System.Collections.Generic;
     using System;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using ServiceBus.Fluent;
     using ResourceManager.Fluent.Core;
     using ResourceManager.Fluent.Core.ResourceActions;
-    using Management.Fluent.ServiceBus;
+    using Management.ServiceBus.Fluent;
     using System.Linq;
 
     /// <summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueuesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/QueuesImpl.cs
@@ -4,8 +4,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Management.Fluent.ServiceBus.Models;
-    using Management.Fluent.ServiceBus;
+    using Management.ServiceBus.Fluent.Models;
     using ServiceBus.Fluent;
     using ResourceManager.Fluent.Core;
     using System;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusManager.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusManager.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.Management.Fluent.ServiceBus;
+using Microsoft.Azure.Management.ServiceBus.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using Microsoft.Azure.Management.ServiceBus.Fluent;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespaceImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespaceImpl.cs
@@ -11,8 +11,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using ResourceManager.Fluent.Core.ResourceActions;
     using ResourceManager.Fluent;
     using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus.Models;
-    using Management.Fluent.ServiceBus;
+    using Management.ServiceBus.Fluent.Models;
     using System.Linq;
 
     /// <summary>

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespacesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/ServiceBusNamespacesImpl.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Management.Fluent.ServiceBus;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using ResourceManager.Fluent.Core;
     using Rest.Azure;
     using ServiceBus.Fluent;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SkuName.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SkuName.cs
@@ -6,7 +6,7 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using ResourceManager.Fluent.Core;
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SkuTier.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SkuTier.cs
@@ -6,7 +6,7 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using ResourceManager.Fluent.Core;
 

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionImpl.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using System;
     using ResourceManager.Fluent.Core;
     using ServiceBus.Fluent;
-    using Management.Fluent.ServiceBus.Models;
-    using Management.Fluent.ServiceBus;
+    using Management.ServiceBus.Fluent.Models;
 
     /// <summary>
     /// Implementation for Subscription.
@@ -33,7 +32,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
 
 
         ///GENMHASH:D34AFBD0F174F19A653AA4494C6644CF:FAF1EE7AC452C290A5530A75FBBD6949
-        internal SubscriptionImpl(string resourceGroupName, string namespaceName, string topicName, string name, Region region, Management.Fluent.ServiceBus.Models.SubscriptionInner inner, IServiceBusManager manager) : base(name, inner, manager)
+        internal SubscriptionImpl(string resourceGroupName, string namespaceName, string topicName, string name, Region region, Management.ServiceBus.Fluent.Models.SubscriptionInner inner, IServiceBusManager manager) : base(name, inner, manager)
         {
             this.namespaceName = namespaceName;
             this.region = region;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionsImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/SubscriptionsImpl.cs
@@ -4,7 +4,6 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Management.Fluent.ServiceBus;
     using ServiceBus.Fluent;
     using Rest.Azure;
     using ResourceManager.Fluent.Core;
@@ -17,7 +16,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     internal partial class SubscriptionsImpl :
         ServiceBusChildResourcesImpl<Microsoft.Azure.Management.ServiceBus.Fluent.ISubscription,
             Microsoft.Azure.Management.ServiceBus.Fluent.SubscriptionImpl,
-            Management.Fluent.ServiceBus.Models.SubscriptionInner,
+            Management.ServiceBus.Fluent.Models.SubscriptionInner,
             ISubscriptionsOperations,
             IServiceBusManager,
             Microsoft.Azure.Management.ServiceBus.Fluent.ITopic>,
@@ -47,14 +46,14 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
             return WrapModel(name);
         }
 
-        protected async override Task<IPage<Management.Fluent.ServiceBus.Models.SubscriptionInner>> ListInnerFirstPageAsync(CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<IPage<Management.ServiceBus.Fluent.Models.SubscriptionInner>> ListInnerFirstPageAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return await this.Inner.ListByTopicAsync(this.resourceGroupName, 
                 this.namespaceName, 
                 this.topicName, 
                 cancellationToken);
         }
-        protected async override Task<IPage<Management.Fluent.ServiceBus.Models.SubscriptionInner>> ListInnerNextPageAsync(string nextLink, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<IPage<Management.ServiceBus.Fluent.Models.SubscriptionInner>> ListInnerNextPageAsync(string nextLink, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await this.Inner.ListByTopicNextAsync(nextLink, 
                 cancellationToken);
@@ -62,7 +61,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
         }
 
         ///GENMHASH:AD2F63EB9B7A81CCDA7E3A349748EDF7:AC7DA12A153C81BA0050657D342ADB13
-        protected async override Task<Management.Fluent.ServiceBus.Models.SubscriptionInner> GetInnerByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        protected async override Task<Management.ServiceBus.Fluent.Models.SubscriptionInner> GetInnerByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await this.Inner.GetAsync(this.resourceGroupName, 
                 this.namespaceName, 
@@ -79,12 +78,12 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 this.topicName,
                 name,
                 this.region,
-                new Management.Fluent.ServiceBus.Models.SubscriptionInner(),
+                new Management.ServiceBus.Fluent.Models.SubscriptionInner(),
                 this.Manager);
         }
 
         ///GENMHASH:74B2091B6489CB9BB077D200206A9817:B9A9842A672E25F235D522F599D8F9FE
-        protected override ISubscription WrapModel(Management.Fluent.ServiceBus.Models.SubscriptionInner inner)
+        protected override ISubscription WrapModel(Management.ServiceBus.Fluent.Models.SubscriptionInner inner)
         {
             return new SubscriptionImpl(this.resourceGroupName,
                 this.namespaceName,

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicAuthorizationRuleImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicAuthorizationRuleImpl.cs
@@ -7,10 +7,9 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using TopicAuthorizationRule.Definition;
     using TopicAuthorizationRule.Update;
     using ResourceManager.Fluent.Core;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using ServiceBus.Fluent;
     using System.Collections.Generic;
-    using Management.Fluent.ServiceBus;
 
     /// <summary>
     /// Implementation for TopicAuthorizationRule.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicAuthorizationRulesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicAuthorizationRulesImpl.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
-    using Management.Fluent.ServiceBus;
-    using Management.Fluent.ServiceBus.Models;
+    using Management.ServiceBus.Fluent.Models;
     using ResourceManager.Fluent.Core;
     using Rest.Azure;
     using ServiceBus.Fluent;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicImpl.cs
@@ -2,18 +2,15 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
+    using Management.ServiceBus.Fluent.Models;
+    using ResourceManager.Fluent.Core;
+    using ResourceManager.Fluent.Core.ResourceActions;
+    using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Topic.Definition;
     using Topic.Update;
-    using System.Collections.Generic;
-    using System;
-    using ResourceManager.Fluent.Core;
-    using Management.Fluent.ServiceBus.Models;
-    using ServiceBus.Fluent;
-    using ResourceManager.Fluent.Core.ResourceActions;
-    using Management.Fluent.ServiceBus;
-    using System.Linq;
 
     /// <summary>
     /// Implementation for Topic.

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicsImpl.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/TopicsImpl.cs
@@ -4,8 +4,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Management.Fluent.ServiceBus.Models;
-    using Management.Fluent.ServiceBus;
+    using Management.ServiceBus.Fluent.Models;
     using ServiceBus.Fluent;
     using ResourceManager.Fluent.Core;
     using Rest.Azure;

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/UnavailableReason.cs
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent/UnavailableReason.cs
@@ -6,12 +6,11 @@
 // Changes may cause incorrect behavior and will be lost if the code is
 // regenerated.
 
-namespace Microsoft.Azure.Management.Fluent.ServiceBus.Models
+namespace Microsoft.Azure.Management.ServiceBus.Fluent.Models
 {
     using Microsoft.Azure;
     using Microsoft.Azure.Management;
-    using Microsoft.Azure.Management.Fluent;
-    using Microsoft.Azure.Management.Fluent.ServiceBus;
+    using Microsoft.Azure.Management.ServiceBus.Fluent;
     using ResourceManager.Fluent.Core;
 
     /// <summary>

--- a/src/ResourceManagement/gulpfile.js
+++ b/src/ResourceManagement/gulpfile.js
@@ -95,7 +95,7 @@ var mappings = {
         'args': '-FT 1'
     },
     'servicebus': {
-        'dir': 'ServiceBus/Microsoft.Azure.Management.Fluent.ServiceBus',
+        'dir': 'ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent',
         'source': 'arm-servicebus\2015-08-01\swagger\servicebus.json',
         'package': 'Microsoft.Azure.Management.Fluent.ServiceBus',
         'args': '-FT 1'


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.