### PR TITLE
Fixed and re-recorded failing Async Sample test

### DIFF
--- a/Samples/ResourceManagement/Compute/ManageVirtualMachineScaleSetAsync/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachineScaleSetAsync/Program.cs
@@ -83,7 +83,7 @@ namespace ManageVirtualMachineScaleSetAsync
                         }),
                         azure.PublicIPAddresses.Define(publicIpName)
                         .WithRegion(region)
-                        .WithExistingResourceGroup(rgName)
+                        .WithNewResourceGroup(rgName)
                         .WithLeafDomainLabel(publicIpName)
                         .CreateAsync()
                         .ContinueWith(pip =>

--- a/Samples/Tests/SessionRecords/Samples.Tests.Compute/ManageVirtualMachineScaleSetTestAsync.json
+++ b/Samples/Tests/SessionRecords/Samples.Tests.Compute/ManageVirtualMachineScaleSetTestAsync.json
@@ -1,8 +1,8 @@
 {
   "Entries": [
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rgcovsf4045222?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL3JnY292c2Y0MDQ1MjIyP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rgcovs40c84343?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL3JnY292czQwYzg0MzQzP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"location\": \"westcentralus\"\r\n}",
       "RequestHeaders": {
@@ -13,7 +13,7 @@
           "35"
         ],
         "x-ms-client-request-id": [
-          "857a517f-9086-4e49-bd6a-4cceb4e2b8b1"
+          "d3b47a1b-aa77-4263-beef-e0703e86a4ab"
         ],
         "accept-language": [
           "en-US"
@@ -23,7 +23,7 @@
           "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222\",\r\n  \"name\": \"rgcovsf4045222\",\r\n  \"location\": \"westcentralus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343\",\r\n  \"name\": \"rgcovs40c84343\",\r\n  \"location\": \"westcentralus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "188"
@@ -38,22 +38,22 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:43:07 GMT"
+          "Fri, 14 Apr 2017 18:06:34 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1199"
+          "1194"
         ],
         "x-ms-request-id": [
-          "88bca5d5-8dce-451b-8545-fbfdc944edd2"
+          "0a37334a-b328-48d2-8b1a-9eb868c972ae"
         ],
         "x-ms-correlation-request-id": [
-          "88bca5d5-8dce-451b-8545-fbfdc944edd2"
+          "0a37334a-b328-48d2-8b1a-9eb868c972ae"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214308Z:88bca5d5-8dce-451b-8545-fbfdc944edd2"
+          "WESTUS2:20170414T180634Z:0a37334a-b328-48d2-8b1a-9eb868c972ae"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -62,8 +62,69 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay92aXJ0dWFsTmV0d29ya3Mvdm5ldGNkYjU5NjY1YjU2NTE1P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rgcovs40c84343?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL3JnY292czQwYzg0MzQzP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"westcentralus\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "35"
+        ],
+        "x-ms-client-request-id": [
+          "a377f8ec-edeb-4642-8834-ef2690205430"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343\",\r\n  \"name\": \"rgcovs40c84343\",\r\n  \"location\": \"westcentralus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "188"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:06:34 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1192"
+        ],
+        "x-ms-request-id": [
+          "79292963-3054-4752-8e2c-4405075b376e"
+        ],
+        "x-ms-correlation-request-id": [
+          "79292963-3054-4752-8e2c-4405075b376e"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T180635Z:79292963-3054-4752-8e2c-4405075b376e"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay92aXJ0dWFsTmV0d29ya3Mvdm5ldGM5ZTQ1MzYxY2M2NmE2P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"properties\": {\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"172.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"properties\": {\r\n          \"addressPrefix\": \"172.16.1.0/24\"\r\n        },\r\n        \"name\": \"Front-end\"\r\n      }\r\n    ]\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
@@ -74,7 +135,7 @@
           "375"
         ],
         "x-ms-client-request-id": [
-          "242367ed-ed15-4b8c-a02c-071627d7005d"
+          "48eea5d1-bbe9-42e9-bb94-8840307ccd3f"
         ],
         "accept-language": [
           "en-US"
@@ -84,7 +145,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"vnetcdb59665b56515\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515\",\r\n  \"etag\": \"W/\\\"b6bf64f0-0997-435d-9db0-11f4f871fd82\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"1ad212a3-ff4e-46de-8c3a-a8f93aaaed35\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"172.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"Front-end\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\",\r\n        \"etag\": \"W/\\\"b6bf64f0-0997-435d-9db0-11f4f871fd82\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"addressPrefix\": \"172.16.1.0/24\"\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"vnetc9e45361cc66a6\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6\",\r\n  \"etag\": \"W/\\\"23def6cd-aba2-4188-a7c5-d6c8c95e6ac9\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"e471521f-3612-407d-a9bc-0f9816eb719c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"172.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"Front-end\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\",\r\n        \"etag\": \"W/\\\"23def6cd-aba2-4188-a7c5-d6c8c95e6ac9\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"addressPrefix\": \"172.16.1.0/24\"\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "1092"
@@ -99,7 +160,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:43:08 GMT"
+          "Fri, 14 Apr 2017 18:06:35 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -112,31 +173,31 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "8b84cd1c-861d-4d9d-beed-e42b6762ec82"
+          "7f0f9d2e-fc1a-4030-a5fa-8b1ace16c349"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/8b84cd1c-861d-4d9d-beed-e42b6762ec82?api-version=2016-12-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/7f0f9d2e-fc1a-4030-a5fa-8b1ace16c349?api-version=2016-12-01"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1198"
+          "1193"
         ],
         "x-ms-correlation-request-id": [
-          "33ff219a-5696-4285-bb4a-0d7cdd582861"
+          "142ef567-c1a8-41ea-8063-e71ba688151b"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214309Z:33ff219a-5696-4285-bb4a-0d7cdd582861"
+          "WESTUS2:20170414T180635Z:142ef567-c1a8-41ea-8063-e71ba688151b"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9waXAtaW50bGItOTJlMDg2ODdmND9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9waXAtaW50bGItOGM0NzUxODgzZj9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"pip-intlb-92e08687f4\"\r\n    }\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"pip-intlb-8c4751883f\"\r\n    }\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -145,7 +206,7 @@
           "153"
         ],
         "x-ms-client-request-id": [
-          "7a11f572-7502-4988-b397-5261de322a5c"
+          "f1ad1775-0d68-445f-bac0-e5b392c74dd0"
         ],
         "accept-language": [
           "en-US"
@@ -155,7 +216,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"pip-intlb-92e08687f4\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4\",\r\n  \"etag\": \"W/\\\"f9bb4488-2aaa-462e-bff5-623ffcee91da\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"421a7e8d-0203-4564-aef1-2072928d4440\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"pip-intlb-92e08687f4\",\r\n      \"fqdn\": \"pip-intlb-92e08687f4.westcentralus.cloudapp.azure.com\"\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"pip-intlb-8c4751883f\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f\",\r\n  \"etag\": \"W/\\\"6b90a556-a5aa-4ba7-8228-27cc2c27be97\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"a47790b2-5e2b-4f2f-b6f5-6afcbf6bd128\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"pip-intlb-8c4751883f\",\r\n      \"fqdn\": \"pip-intlb-8c4751883f.westcentralus.cloudapp.azure.com\"\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "742"
@@ -170,7 +231,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:43:08 GMT"
+          "Fri, 14 Apr 2017 18:06:35 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -183,29 +244,29 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "103578b4-5499-4c0f-a624-d7d1fee3ce1c"
+          "5c5d69c7-0647-4660-8fa1-0ef2fb814d4b"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/103578b4-5499-4c0f-a624-d7d1fee3ce1c?api-version=2016-12-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/5c5d69c7-0647-4660-8fa1-0ef2fb814d4b?api-version=2016-12-01"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1199"
+          "1191"
         ],
         "x-ms-correlation-request-id": [
-          "bdc8bad1-4837-4f83-9871-6990019f6666"
+          "e8fb53dc-b734-4ac9-8914-fc5ada322c4d"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214309Z:bdc8bad1-4837-4f83-9871-6990019f6666"
+          "WESTUS2:20170414T180636Z:e8fb53dc-b734-4ac9-8914-fc5ada322c4d"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/8b84cd1c-861d-4d9d-beed-e42b6762ec82?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzhiODRjZDFjLTg2MWQtNGQ5ZC1iZWVkLWU0MmI2NzYyZWM4Mj9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/7f0f9d2e-fc1a-4030-a5fa-8b1ace16c349?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzdmMGY5ZDJlLWZjMWEtNDAzMC1hNWZhLThiMWFjZTE2YzM0OT9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -226,7 +287,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:43:38 GMT"
+          "Fri, 14 Apr 2017 18:07:05 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -242,26 +303,26 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "18553df1-8450-47eb-86e4-e6872ef10228"
+          "6a4cef75-2191-49ed-8636-43bbd4d1a946"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14993"
+          "14956"
         ],
         "x-ms-correlation-request-id": [
-          "74991d40-42ab-41f7-902e-b03476ea9556"
+          "eddd9275-00f3-432b-b635-56936a924c9b"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214339Z:74991d40-42ab-41f7-902e-b03476ea9556"
+          "WESTUS2:20170414T180706Z:eddd9275-00f3-432b-b635-56936a924c9b"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay92aXJ0dWFsTmV0d29ya3Mvdm5ldGNkYjU5NjY1YjU2NTE1P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay92aXJ0dWFsTmV0d29ya3Mvdm5ldGM5ZTQ1MzYxY2M2NmE2P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -270,7 +331,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"vnetcdb59665b56515\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515\",\r\n  \"etag\": \"W/\\\"3202147e-db13-4ecc-b49b-a2bb76aa2527\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1ad212a3-ff4e-46de-8c3a-a8f93aaaed35\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"172.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"Front-end\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\",\r\n        \"etag\": \"W/\\\"3202147e-db13-4ecc-b49b-a2bb76aa2527\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"addressPrefix\": \"172.16.1.0/24\"\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"vnetc9e45361cc66a6\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6\",\r\n  \"etag\": \"W/\\\"953f0603-1de8-470d-b071-c91fa672884d\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e471521f-3612-407d-a9bc-0f9816eb719c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"172.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"Front-end\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\",\r\n        \"etag\": \"W/\\\"953f0603-1de8-470d-b071-c91fa672884d\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"addressPrefix\": \"172.16.1.0/24\"\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -282,7 +343,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:43:38 GMT"
+          "Fri, 14 Apr 2017 18:07:05 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -291,7 +352,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"3202147e-db13-4ecc-b49b-a2bb76aa2527\""
+          "W/\"953f0603-1de8-470d-b071-c91fa672884d\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -301,26 +362,26 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "56a286ab-f81e-4488-8774-bb293cad97a6"
+          "07f32232-bd49-41a0-8d46-92ea4b371c05"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14992"
+          "14958"
         ],
         "x-ms-correlation-request-id": [
-          "489f2a24-5c55-40ba-9dc5-2b2774153fa0"
+          "5cfa9b87-1981-4215-a440-9bbfedc5ed9c"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214339Z:489f2a24-5c55-40ba-9dc5-2b2774153fa0"
+          "WESTUS2:20170414T180706Z:5cfa9b87-1981-4215-a440-9bbfedc5ed9c"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/103578b4-5499-4c0f-a624-d7d1fee3ce1c?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzEwMzU3OGI0LTU0OTktNGMwZi1hNjI0LWQ3ZDFmZWUzY2UxYz9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/5c5d69c7-0647-4660-8fa1-0ef2fb814d4b?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzVjNWQ2OWM3LTA2NDctNDY2MC04ZmExLTBlZjJmYjgxNGQ0Yj9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -341,7 +402,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:43:39 GMT"
+          "Fri, 14 Apr 2017 18:07:05 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -357,26 +418,26 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "08b32cee-876d-4829-bd24-094d700acb81"
+          "d3b55e3f-e082-414d-924e-60916b2e6bbf"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14996"
+          "14955"
         ],
         "x-ms-correlation-request-id": [
-          "3eaf473c-2d56-49c2-a465-76d6fe9b239a"
+          "e885a2d0-5a6f-46c4-be72-326737f9ffa0"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214339Z:3eaf473c-2d56-49c2-a465-76d6fe9b239a"
+          "WESTUS2:20170414T180706Z:e885a2d0-5a6f-46c4-be72-326737f9ffa0"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9waXAtaW50bGItOTJlMDg2ODdmND9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9waXAtaW50bGItOGM0NzUxODgzZj9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -385,7 +446,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"pip-intlb-92e08687f4\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4\",\r\n  \"etag\": \"W/\\\"394cb801-acff-40d0-a7bd-ac2c3c0a8379\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"421a7e8d-0203-4564-aef1-2072928d4440\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"pip-intlb-92e08687f4\",\r\n      \"fqdn\": \"pip-intlb-92e08687f4.westcentralus.cloudapp.azure.com\"\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"pip-intlb-8c4751883f\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f\",\r\n  \"etag\": \"W/\\\"b6484502-46aa-48e6-83b7-e0a833fd1252\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"a47790b2-5e2b-4f2f-b6f5-6afcbf6bd128\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"pip-intlb-8c4751883f\",\r\n      \"fqdn\": \"pip-intlb-8c4751883f.westcentralus.cloudapp.azure.com\"\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -397,7 +458,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:43:39 GMT"
+          "Fri, 14 Apr 2017 18:07:06 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -406,7 +467,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"394cb801-acff-40d0-a7bd-ac2c3c0a8379\""
+          "W/\"b6484502-46aa-48e6-83b7-e0a833fd1252\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -416,28 +477,28 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "64ed75ac-9fad-4d5a-b6e4-310c4d276378"
+          "6ac1bd5e-6231-4b4c-b527-abdffb843a8a"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14995"
+          "14957"
         ],
         "x-ms-correlation-request-id": [
-          "92c5f10d-a576-4313-8f5d-ff34bbd66960"
+          "917a15ba-7336-4ee8-8db2-73f201998601"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214339Z:92c5f10d-a576-4313-8f5d-ff34bbd66960"
+          "WESTUS2:20170414T180706Z:917a15ba-7336-4ee8-8db2-73f201998601"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLTkyZTA4Njg3ZjQ/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLThjNDc1MTg4M2Y/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"properties\": {\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4\"\r\n          }\r\n        },\r\n        \"name\": \"intlb-92e08687f4-FE1\"\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP1\"\r\n      },\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP2\"\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"properties\": {\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\"\r\n          },\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80\r\n        },\r\n        \"name\": \"httpRule\"\r\n      },\r\n      {\r\n        \"properties\": {\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\"\r\n          },\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443\r\n        },\r\n        \"name\": \"httpsRule\"\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"properties\": {\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\"\r\n        },\r\n        \"name\": \"httpProbe\"\r\n      },\r\n      {\r\n        \"properties\": {\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\"\r\n        },\r\n        \"name\": \"httpsProbe\"\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"properties\": {\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22\r\n        },\r\n        \"name\": \"natPool50XXto22\"\r\n      },\r\n      {\r\n        \"properties\": {\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23\r\n        },\r\n        \"name\": \"natPool60XXto23\"\r\n      }\r\n    ]\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"properties\": {\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f\"\r\n          }\r\n        },\r\n        \"name\": \"intlb-8c4751883f-FE1\"\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP1\"\r\n      },\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP2\"\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"properties\": {\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\"\r\n          },\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80\r\n        },\r\n        \"name\": \"httpRule\"\r\n      },\r\n      {\r\n        \"properties\": {\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\"\r\n          },\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443\r\n        },\r\n        \"name\": \"httpsRule\"\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"properties\": {\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\"\r\n        },\r\n        \"name\": \"httpProbe\"\r\n      },\r\n      {\r\n        \"properties\": {\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\"\r\n        },\r\n        \"name\": \"httpsProbe\"\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"properties\": {\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22\r\n        },\r\n        \"name\": \"natPool50XXto22\"\r\n      },\r\n      {\r\n        \"properties\": {\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23\r\n        },\r\n        \"name\": \"natPool60XXto23\"\r\n      }\r\n    ]\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -446,7 +507,7 @@
           "3849"
         ],
         "x-ms-client-request-id": [
-          "1375001f-760f-48e2-a556-39715529deba"
+          "05cd942c-5fb9-4762-a3ec-1aed1c00b1d2"
         ],
         "accept-language": [
           "en-US"
@@ -456,7 +517,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"intlb-92e08687f4\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4\",\r\n  \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1282da60-197f-4f05-b996-7ff7283cd308\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"intlb-8c4751883f\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f\",\r\n  \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"db309f34-c70d-4490-94eb-6279b00f145f\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "9529"
@@ -471,7 +532,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:43:40 GMT"
+          "Fri, 14 Apr 2017 18:07:06 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -481,29 +542,29 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "fc3235df-7393-4cd0-ac99-ba6453d4a06b"
+          "a1a9a9fb-55f9-47e9-92cc-cbc378a920c6"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/fc3235df-7393-4cd0-ac99-ba6453d4a06b?api-version=2016-12-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/a1a9a9fb-55f9-47e9-92cc-cbc378a920c6?api-version=2016-12-01"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1197"
+          "1192"
         ],
         "x-ms-correlation-request-id": [
-          "19686364-84e1-471a-a788-c43f56060c04"
+          "3a9e1f41-2c3e-43e7-8669-e63c56df2505"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214340Z:19686364-84e1-471a-a788-c43f56060c04"
+          "WESTUS2:20170414T180707Z:3a9e1f41-2c3e-43e7-8669-e63c56df2505"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLTkyZTA4Njg3ZjQ/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLThjNDc1MTg4M2Y/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -512,7 +573,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"intlb-92e08687f4\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4\",\r\n  \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1282da60-197f-4f05-b996-7ff7283cd308\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"intlb-8c4751883f\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f\",\r\n  \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"db309f34-c70d-4490-94eb-6279b00f145f\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -524,7 +585,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:43:40 GMT"
+          "Fri, 14 Apr 2017 18:07:07 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -533,7 +594,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"5a885cd2-a2f4-4779-b223-b90f897fd870\""
+          "W/\"14bba839-1a42-4b55-bb7f-6eae26d34192\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -543,31 +604,31 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "49d94506-74fc-4300-8cf1-1e34ee31f0be"
+          "93da5dce-0b88-48e0-b18f-828514eb544a"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14994"
+          "14956"
         ],
         "x-ms-correlation-request-id": [
-          "2114066e-3af8-4c41-a0ab-e6263ba1e6aa"
+          "9229e1c9-05e3-48a5-a89e-0dd0845bedb6"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214341Z:2114066e-3af8-4c41-a0ab-e6263ba1e6aa"
+          "WESTUS2:20170414T180707Z:9229e1c9-05e3-48a5-a89e-0dd0845bedb6"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLTkyZTA4Njg3ZjQ/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLThjNDc1MTg4M2Y/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "8ca8c95d-e834-4cdf-9e99-cdd0ed5ec141"
+          "523d0822-1bf2-49bf-abd2-a8fa0ae71d80"
         ],
         "accept-language": [
           "en-US"
@@ -577,7 +638,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"intlb-92e08687f4\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4\",\r\n  \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1282da60-197f-4f05-b996-7ff7283cd308\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"5a885cd2-a2f4-4779-b223-b90f897fd870\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"intlb-8c4751883f\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f\",\r\n  \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"db309f34-c70d-4490-94eb-6279b00f145f\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"14bba839-1a42-4b55-bb7f-6eae26d34192\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -589,7 +650,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:43:41 GMT"
+          "Fri, 14 Apr 2017 18:07:06 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -598,7 +659,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"5a885cd2-a2f4-4779-b223-b90f897fd870\""
+          "W/\"14bba839-1a42-4b55-bb7f-6eae26d34192\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -608,31 +669,31 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "c149f995-a0f9-418b-b00f-c4d8e721bb38"
+          "93f403fe-b2c2-4886-87bc-7914d6089f06"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14993"
+          "14954"
         ],
         "x-ms-correlation-request-id": [
-          "db79979a-1c96-4ad1-ad16-53869eb5e8c2"
+          "8d219d32-85dc-46fe-8465-82db370943b4"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214341Z:db79979a-1c96-4ad1-ad16-53869eb5e8c2"
+          "WESTUS2:20170414T180707Z:8d219d32-85dc-46fe-8465-82db370943b4"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLTkyZTA4Njg3ZjQ/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLThjNDc1MTg4M2Y/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "8adcf0c6-1f65-4b78-a662-6c78552f7e4b"
+          "51ff1091-0d72-4ed5-a699-5044459c66c2"
         ],
         "accept-language": [
           "en-US"
@@ -642,7 +703,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"intlb-92e08687f4\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4\",\r\n  \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1282da60-197f-4f05-b996-7ff7283cd308\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.6\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.6\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [\r\n      {\r\n        \"name\": \"natPool50XXto22.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.0\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5000,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.0\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6000,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5001,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6001,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.2\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5002,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.2\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6002,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.3\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5003,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.3\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6003,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.4\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5004,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.4\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6004,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.5\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5005,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.5\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6005,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.6\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5006,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.6\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6006,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"intlb-8c4751883f\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f\",\r\n  \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"db309f34-c70d-4490-94eb-6279b00f145f\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.6\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.6\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [\r\n      {\r\n        \"name\": \"natPool50XXto22.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.0\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5000,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.0\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6000,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5001,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6001,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.2\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5002,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.2\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6002,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.3\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5003,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.3\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6003,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.4\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5004,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.4\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6004,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.5\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5005,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.5\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6005,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.6\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5006,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.6\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6006,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -654,7 +715,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:47:14 GMT"
+          "Fri, 14 Apr 2017 18:10:39 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -663,7 +724,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"ef5071e3-f086-41cd-871c-152cc1a6317e\""
+          "W/\"99d0f658-262f-4686-ba66-1329098f9f15\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -673,31 +734,31 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "cbf9f310-29c5-4e0b-b8e6-67ee2cbdc3d8"
+          "80faf803-25c0-460c-9ec0-9e792feb498f"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14982"
+          "14943"
         ],
         "x-ms-correlation-request-id": [
-          "eeeb24ee-9a9c-4c3b-a48b-fe51aa0146e3"
+          "69729c64-680e-48b4-ae20-dbbaa0866e2b"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214714Z:eeeb24ee-9a9c-4c3b-a48b-fe51aa0146e3"
+          "WESTUS2:20170414T181040Z:69729c64-680e-48b4-ae20-dbbaa0866e2b"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLTkyZTA4Njg3ZjQ/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLThjNDc1MTg4M2Y/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "5fa172c4-9f50-4d64-b936-521d5d121d4a"
+          "4f82a496-c74d-422d-99af-ebe5cd948579"
         ],
         "accept-language": [
           "en-US"
@@ -707,7 +768,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"intlb-92e08687f4\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4\",\r\n  \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1282da60-197f-4f05-b996-7ff7283cd308\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.6\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.6\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [\r\n      {\r\n        \"name\": \"natPool50XXto22.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.0\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5000,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.0\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6000,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5001,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6001,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.2\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5002,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.2\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6002,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.3\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5003,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.3\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6003,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.4\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5004,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.4\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6004,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.5\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5005,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.5\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6005,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.6\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5006,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.6\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6006,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"intlb-8c4751883f\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f\",\r\n  \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"db309f34-c70d-4490-94eb-6279b00f145f\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.6\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.6\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [\r\n      {\r\n        \"name\": \"natPool50XXto22.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.0\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5000,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.0\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6000,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5001,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6001,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.2\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5002,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.2\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6002,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.3\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5003,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.3\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6003,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.4\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5004,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.4\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6004,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.5\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5005,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.5\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6005,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.6\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5006,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.6\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6006,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -719,7 +780,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:47:14 GMT"
+          "Fri, 14 Apr 2017 18:10:39 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -728,7 +789,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"ef5071e3-f086-41cd-871c-152cc1a6317e\""
+          "W/\"99d0f658-262f-4686-ba66-1329098f9f15\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -738,31 +799,31 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "138086b8-d122-4731-8cd7-df8ecd35f07f"
+          "5a66ec3d-923d-4c3c-9144-9bdec14db0b5"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14980"
+          "14941"
         ],
         "x-ms-correlation-request-id": [
-          "477a1d1f-a4f2-4aa6-885d-184dfab51a5a"
+          "926a5a99-b4cb-4a01-82fa-e37a50171fbf"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214714Z:477a1d1f-a4f2-4aa6-885d-184dfab51a5a"
+          "WESTUS2:20170414T181040Z:926a5a99-b4cb-4a01-82fa-e37a50171fbf"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLTkyZTA4Njg3ZjQ/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLThjNDc1MTg4M2Y/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "59bc3be7-1834-4a0d-9f7d-9a18fffb18e7"
+          "32889e0f-7247-4ce6-8284-680cbd3e9d54"
         ],
         "accept-language": [
           "en-US"
@@ -772,7 +833,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"intlb-92e08687f4\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4\",\r\n  \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1282da60-197f-4f05-b996-7ff7283cd308\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.6\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.6\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [\r\n      {\r\n        \"name\": \"natPool50XXto22.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.0\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5000,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.0\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6000,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5001,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.1\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6001,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.2\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5002,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.2\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6002,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.3\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5003,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.3\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6003,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.4\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5004,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.4\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6004,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.5\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5005,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.5\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6005,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.6\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5006,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.6\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6006,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"ef5071e3-f086-41cd-871c-152cc1a6317e\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"intlb-8c4751883f\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f\",\r\n  \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"db309f34-c70d-4490-94eb-6279b00f145f\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.3\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.5\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.6\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.6\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [\r\n      {\r\n        \"name\": \"natPool50XXto22.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.0\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5000,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.0\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6000,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5001,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.1\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6001,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.2\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5002,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.2\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6002,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.3\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5003,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.3\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.3\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6003,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/3/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.4\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5004,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.4\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6004,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.5\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5005,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.5\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.5\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6005,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/5/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.6\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5006,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.6\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.6\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6006,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/6/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"99d0f658-262f-4686-ba66-1329098f9f15\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -784,7 +845,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:47:14 GMT"
+          "Fri, 14 Apr 2017 18:10:39 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -793,7 +854,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"ef5071e3-f086-41cd-871c-152cc1a6317e\""
+          "W/\"99d0f658-262f-4686-ba66-1329098f9f15\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -803,31 +864,31 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "88209a98-84eb-4867-9ba8-56a75e7df447"
+          "81dc4687-848c-4c4c-b8c5-0699b8666969"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14978"
+          "14939"
         ],
         "x-ms-correlation-request-id": [
-          "8e293393-339d-41f7-95e8-7d539754e3f1"
+          "fc5624e3-1de8-4146-9752-fefe93631b16"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214715Z:8e293393-339d-41f7-95e8-7d539754e3f1"
+          "WESTUS2:20170414T181040Z:fc5624e3-1de8-4146-9752-fefe93631b16"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4?api-version=2016-12-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLTkyZTA4Njg3ZjQ/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2ludGxiLThjNDc1MTg4M2Y/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "25625ea3-e7a9-43e7-82d5-a1705b819f5a"
+          "aeb512c4-8ca4-41fb-b974-e8fd4d914506"
         ],
         "accept-language": [
           "en-US"
@@ -837,7 +898,7 @@
           "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"intlb-92e08687f4\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4\",\r\n  \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"1282da60-197f-4f05-b996-7ff7283cd308\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/publicIPAddresses/pip-intlb-92e08687f4\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.4\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.4\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-92e08687f4-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [\r\n      {\r\n        \"name\": \"natPool50XXto22.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.1\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5001,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.1\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6001,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.2\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5002,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.2\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6002,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.4\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 5004,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.4\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.4\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          },\r\n          \"frontendPort\": 6004,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/frontendIPConfigurations/intlb-92e08687f4-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"intlb-8c4751883f\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f\",\r\n  \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n  \"type\": \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"db309f34-c70d-4490-94eb-6279b00f145f\",\r\n    \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-FE1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/publicIPAddresses/pip-intlb-8c4751883f\"\r\n          },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.0\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.1\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.2\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.2\"\r\n            }\r\n          ],\r\n          \"inboundNatPools\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\": [\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"intlb-8c4751883f-BAP2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"backendIPConfigurations\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            },\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n            }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [\r\n      {\r\n        \"name\": \"httpRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\": 80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsRule\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 443,\r\n          \"backendPort\": 443,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n          },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n        \"name\": \"httpProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpProbe\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpRule\"\r\n            }\r\n          ]\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"httpsProbe\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/probes/httpsProbe\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"Http\",\r\n          \"port\": 443,\r\n          \"requestPath\": \"/\",\r\n          \"intervalInSeconds\": 15,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/loadBalancingRules/httpsRule\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [\r\n      {\r\n        \"name\": \"natPool50XXto22.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.0\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5000,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.0\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.0\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6000,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.1\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5001,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.1\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6001,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool50XXto22.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.2\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 5002,\r\n          \"backendPort\": 22,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23.2\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.2\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          },\r\n          \"frontendPort\": 6002,\r\n          \"backendPort\": 23,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\": 4,\r\n          \"protocol\": \"Tcp\",\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\": [],\r\n    \"inboundNatPools\": [\r\n      {\r\n        \"name\": \"natPool50XXto22\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 5000,\r\n          \"frontendPortRangeEnd\": 5099,\r\n          \"backendPort\": 22,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"natPool60XXto23\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\",\r\n        \"etag\": \"W/\\\"c64bd044-39fb-4702-a1e2-45f3d466c86b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"frontendPortRangeStart\": 6000,\r\n          \"frontendPortRangeEnd\": 6099,\r\n          \"backendPort\": 23,\r\n          \"protocol\": \"Tcp\",\r\n          \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/frontendIPConfigurations/intlb-8c4751883f-FE1\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"slbService\": {\r\n      \"version\": 0,\r\n      \"macs\": {},\r\n      \"vips\": {}\r\n    }\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -849,7 +910,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:54:16 GMT"
+          "Fri, 14 Apr 2017 18:16:12 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -858,7 +919,7 @@
           "chunked"
         ],
         "ETag": [
-          "W/\"8634a08a-c1ec-4f01-a1c4-aa9a752c44d8\""
+          "W/\"c64bd044-39fb-4702-a1e2-45f3d466c86b\""
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
@@ -868,28 +929,28 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "16f6725f-8be2-41f4-a718-84c4676c0285"
+          "b672846e-d6d8-4fe6-8956-e97d53a79c38"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14958"
+          "14926"
         ],
         "x-ms-correlation-request-id": [
-          "bf32f95b-c448-4133-b218-26a80421fba6"
+          "e583e567-036b-4ed8-bd82-115790e07548"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215417Z:bf32f95b-c448-4133-b218-26a80421fba6"
+          "WESTUS2:20170414T181612Z:e583e567-036b-4ed8-bd82-115790e07548"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjY/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTI/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 3\r\n  },\r\n  \"properties\": {\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm98055\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        }\r\n      },\r\n      \"storageProfile\": {\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"osDisk\": {\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"fromImage\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 0,\r\n            \"caching\": \"ReadWrite\",\r\n            \"createOption\": \"empty\",\r\n            \"diskSizeGB\": 100,\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            }\r\n          },\r\n          {\r\n            \"lun\": 1,\r\n            \"caching\": \"ReadWrite\",\r\n            \"createOption\": \"empty\",\r\n            \"diskSizeGB\": 100,\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            }\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"caching\": \"ReadWrite\",\r\n            \"createOption\": \"empty\",\r\n            \"diskSizeGB\": 100,\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"name\": \"CustomScriptForLinux\",\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            }\r\n          }\r\n        ]\r\n      }\r\n    }\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 3\r\n  },\r\n  \"properties\": {\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm28467\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        }\r\n      },\r\n      \"storageProfile\": {\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"osDisk\": {\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"fromImage\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 0,\r\n            \"caching\": \"ReadWrite\",\r\n            \"createOption\": \"empty\",\r\n            \"diskSizeGB\": 100,\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            }\r\n          },\r\n          {\r\n            \"lun\": 1,\r\n            \"caching\": \"ReadWrite\",\r\n            \"createOption\": \"empty\",\r\n            \"diskSizeGB\": 100,\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            }\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"caching\": \"ReadWrite\",\r\n            \"createOption\": \"empty\",\r\n            \"diskSizeGB\": 100,\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"name\": \"CustomScriptForLinux\",\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            }\r\n          }\r\n        ]\r\n      }\r\n    }\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -898,7 +959,7 @@
           "4865"
         ],
         "x-ms-client-request-id": [
-          "5bfa4bc8-0c9c-4e7c-bdbd-8bfcc95f4f6b"
+          "258a21d3-fd77-495a-b830-7cae8d1deb20"
         ],
         "accept-language": [
           "en-US"
@@ -908,7 +969,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 3\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm98055\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 0,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 1,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            },\r\n            \"name\": \"CustomScriptForLinux\"\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Creating\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f1a873a9-a329-403a-b9d6-02f94cab8133\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26\",\r\n  \"name\": \"vmss0918303254dd26\"\r\n}",
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 3\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm28467\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 0,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 1,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            },\r\n            \"name\": \"CustomScriptForLinux\"\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Creating\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"e884da2e-58dc-489e-b5b4-ba3c37674668\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2\",\r\n  \"name\": \"vmss51984024ddf6a2\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "4504"
@@ -923,7 +984,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:43:42 GMT"
+          "Fri, 14 Apr 2017 18:07:08 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -933,7 +994,7 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c4b92751-efff-4014-98b9-e539066c161e?api-version=2016-04-30-preview"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/a2ab784f-ac44-4b5d-8007-c5db9473053f?api-version=2016-04-30-preview"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -942,25 +1003,25 @@
           "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
         ],
         "x-ms-request-id": [
-          "c4b92751-efff-4014-98b9-e539066c161e"
+          "a2ab784f-ac44-4b5d-8007-c5db9473053f"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1196"
+          "1189"
         ],
         "x-ms-correlation-request-id": [
-          "c434fe4d-3a37-415c-873f-9ce985c51d22"
+          "6da60760-244b-4e07-adc6-55b65b66f5de"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214343Z:c434fe4d-3a37-415c-873f-9ce985c51d22"
+          "WESTUS2:20170414T180708Z:6da60760-244b-4e07-adc6-55b65b66f5de"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjY/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTI/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 6\r\n  },\r\n  \"properties\": {\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm98055\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"osDisk\": {\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"fromImage\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 1,\r\n            \"caching\": \"ReadWrite\",\r\n            \"createOption\": \"empty\",\r\n            \"diskSizeGB\": 100,\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            }\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"caching\": \"ReadWrite\",\r\n            \"createOption\": \"empty\",\r\n            \"diskSizeGB\": 100,\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"name\": \"CustomScriptForLinux\",\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              },\r\n              \"protectedSettings\": {}\r\n            }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"overprovision\": true,\r\n    \"singlePlacementGroup\": true\r\n  },\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 6\r\n  },\r\n  \"properties\": {\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm28467\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"osDisk\": {\r\n          \"caching\": \"ReadWrite\",\r\n          \"createOption\": \"fromImage\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 1,\r\n            \"caching\": \"ReadWrite\",\r\n            \"createOption\": \"empty\",\r\n            \"diskSizeGB\": 100,\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            }\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"caching\": \"ReadWrite\",\r\n            \"createOption\": \"empty\",\r\n            \"diskSizeGB\": 100,\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"name\": \"CustomScriptForLinux\",\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              },\r\n              \"protectedSettings\": {}\r\n            }\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"overprovision\": true,\r\n    \"singlePlacementGroup\": true\r\n  },\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -969,7 +1030,7 @@
           "4903"
         ],
         "x-ms-client-request-id": [
-          "729dde3f-6460-4bdc-af28-8fb9311b9ba4"
+          "c38f193f-3a81-46a5-8005-21ced0895f1a"
         ],
         "accept-language": [
           "en-US"
@@ -979,7 +1040,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 6\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm98055\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 1,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            },\r\n            \"name\": \"CustomScriptForLinux\"\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f1a873a9-a329-403a-b9d6-02f94cab8133\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26\",\r\n  \"name\": \"vmss0918303254dd26\"\r\n}",
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 6\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm28467\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 1,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            },\r\n            \"name\": \"CustomScriptForLinux\"\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Updating\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"e884da2e-58dc-489e-b5b4-ba3c37674668\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2\",\r\n  \"name\": \"vmss51984024ddf6a2\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -991,7 +1052,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:54:17 GMT"
+          "Fri, 14 Apr 2017 18:16:13 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1007,7 +1068,7 @@
           "Accept-Encoding"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/267e9284-0c67-41e4-a54c-1375ef1601bb?api-version=2016-04-30-preview"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25fca7cf-f6a0-4c20-aed0-92b62f8f45be?api-version=2016-04-30-preview"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1016,23 +1077,23 @@
           "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
         ],
         "x-ms-request-id": [
-          "267e9284-0c67-41e4-a54c-1375ef1601bb"
+          "25fca7cf-f6a0-4c20-aed0-92b62f8f45be"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1192"
+          "1188"
         ],
         "x-ms-correlation-request-id": [
-          "e8b59151-a57e-4594-b77a-feea5893bbc9"
+          "479f07b9-c7b4-45ce-b4e1-c52e092882ef"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215417Z:e8b59151-a57e-4594-b77a-feea5893bbc9"
+          "WESTUS2:20170414T181613Z:479f07b9-c7b4-45ce-b4e1-c52e092882ef"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c4b92751-efff-4014-98b9-e539066c161e?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2M0YjkyNzUxLWVmZmYtNDAxNC05OGI5LWU1MzkwNjZjMTYxZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/a2ab784f-ac44-4b5d-8007-c5db9473053f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2EyYWI3ODRmLWFjNDQtNGI1ZC04MDA3LWM1ZGI5NDczMDUzZj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -1041,7 +1102,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:43:42.6455839-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"c4b92751-efff-4014-98b9-e539066c161e\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:07:08.6214209-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"a2ab784f-ac44-4b5d-8007-c5db9473053f\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1053,7 +1114,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:44:12 GMT"
+          "Fri, 14 Apr 2017 18:07:38 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1075,2127 +1136,23 @@
           "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
         ],
         "x-ms-request-id": [
-          "3195bf59-0806-47b7-90f1-99acd4526e22"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14992"
-        ],
-        "x-ms-correlation-request-id": [
-          "c436423a-673c-4c59-80d1-d72e3126bb64"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214413Z:c436423a-673c-4c59-80d1-d72e3126bb64"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c4b92751-efff-4014-98b9-e539066c161e?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2M0YjkyNzUxLWVmZmYtNDAxNC05OGI5LWU1MzkwNjZjMTYxZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:43:42.6455839-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"c4b92751-efff-4014-98b9-e539066c161e\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:44:42 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "4ed2c27b-6de8-460d-8cd3-a90a094b1482"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14991"
-        ],
-        "x-ms-correlation-request-id": [
-          "0a42dd61-2ca0-418f-8187-a57824add9d9"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214443Z:0a42dd61-2ca0-418f-8187-a57824add9d9"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c4b92751-efff-4014-98b9-e539066c161e?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2M0YjkyNzUxLWVmZmYtNDAxNC05OGI5LWU1MzkwNjZjMTYxZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:43:42.6455839-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"c4b92751-efff-4014-98b9-e539066c161e\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:45:13 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "2a1ef02f-674b-43d1-8e29-1e29d90ea0d1"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14990"
-        ],
-        "x-ms-correlation-request-id": [
-          "e98e7f70-0559-4a86-a207-9dab2108d56e"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214513Z:e98e7f70-0559-4a86-a207-9dab2108d56e"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c4b92751-efff-4014-98b9-e539066c161e?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2M0YjkyNzUxLWVmZmYtNDAxNC05OGI5LWU1MzkwNjZjMTYxZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:43:42.6455839-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"c4b92751-efff-4014-98b9-e539066c161e\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:45:42 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "3726e992-d952-426a-8153-2ee2570601a9"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14989"
-        ],
-        "x-ms-correlation-request-id": [
-          "114ffb26-6466-48e1-b1a5-f9f8f029d076"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214543Z:114ffb26-6466-48e1-b1a5-f9f8f029d076"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c4b92751-efff-4014-98b9-e539066c161e?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2M0YjkyNzUxLWVmZmYtNDAxNC05OGI5LWU1MzkwNjZjMTYxZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:43:42.6455839-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"c4b92751-efff-4014-98b9-e539066c161e\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:46:13 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "8a8ab16e-ab18-4384-848e-8a63d1d2476b"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14988"
-        ],
-        "x-ms-correlation-request-id": [
-          "e56c8f92-b824-43b6-b521-01c82ca22924"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214613Z:e56c8f92-b824-43b6-b521-01c82ca22924"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c4b92751-efff-4014-98b9-e539066c161e?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2M0YjkyNzUxLWVmZmYtNDAxNC05OGI5LWU1MzkwNjZjMTYxZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:43:42.6455839-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"c4b92751-efff-4014-98b9-e539066c161e\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:46:42 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "ce5ca5ca-45bc-40af-bfa6-cac6e760e7c6"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14987"
-        ],
-        "x-ms-correlation-request-id": [
-          "06fd3553-5063-461b-9272-90b6cd1a25ca"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214643Z:06fd3553-5063-461b-9272-90b6cd1a25ca"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c4b92751-efff-4014-98b9-e539066c161e?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2M0YjkyNzUxLWVmZmYtNDAxNC05OGI5LWU1MzkwNjZjMTYxZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:43:42.6455839-07:00\",\r\n  \"endTime\": \"2017-04-10T14:46:47.2227508-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"c4b92751-efff-4014-98b9-e539066c161e\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:47:13 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "3c1fae80-8594-41f0-a9c3-9590e9b6c1b8"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14986"
-        ],
-        "x-ms-correlation-request-id": [
-          "3bc5b9d9-e61c-4e34-ab8a-fedb55931e0a"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214713Z:3bc5b9d9-e61c-4e34-ab8a-fedb55931e0a"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjY/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 3\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm98055\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 0,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 1,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            },\r\n            \"name\": \"CustomScriptForLinux\"\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f1a873a9-a329-403a-b9d6-02f94cab8133\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26\",\r\n  \"name\": \"vmss0918303254dd26\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:47:13 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "27007e8a-f183-4c93-a3da-17200d23d771"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14985"
-        ],
-        "x-ms-correlation-request-id": [
-          "fea80b59-092f-42c5-91ec-a9843f9aac32"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214713Z:fea80b59-092f-42c5-91ec-a9843f9aac32"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjY/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "aad7fa88-4a57-46a3-bc84-7fe88753d8b5"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 3\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm98055\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 0,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 1,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            },\r\n            \"name\": \"CustomScriptForLinux\"\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f1a873a9-a329-403a-b9d6-02f94cab8133\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26\",\r\n  \"name\": \"vmss0918303254dd26\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:52:46 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "afe836ba-28c6-4a30-a3b6-be88e352def1"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14963"
-        ],
-        "x-ms-correlation-request-id": [
-          "093c2353-e45c-4798-a628-85b73effc578"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215246Z:093c2353-e45c-4798-a628-85b73effc578"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjY/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 6\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm98055\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 1,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            },\r\n            \"name\": \"CustomScriptForLinux\"\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"f1a873a9-a329-403a-b9d6-02f94cab8133\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26\",\r\n  \"name\": \"vmss0918303254dd26\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:57:17 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "ad81cac8-0f2e-4660-ba76-188cf2c9a776"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14950"
-        ],
-        "x-ms-correlation-request-id": [
-          "e2374855-9820-484b-aef8-09d16b9e4b40"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215718Z:e2374855-9820-484b-aef8-09d16b9e4b40"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjYvdmlydHVhbE1hY2hpbmVzP2FwaS12ZXJzaW9uPTIwMTYtMDQtMzAtcHJldmlldw==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "4d3a14ed-5c98-49c0-978c-fcba280b3a12"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"instanceId\": \"1\",\r\n      \"sku\": {\r\n        \"name\": \"Standard_D3_v2\",\r\n        \"tier\": \"Standard\"\r\n      },\r\n      \"properties\": {\r\n        \"latestModelApplied\": true,\r\n        \"vmId\": \"0bd21ad3-ccff-4ee6-a987-13856b48c5da\",\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"16.04.0-LTS\",\r\n            \"version\": \"16.04.201611150\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"vmss0918303254dd26_vmss0918303254dd26_1_OsDisk_1_1a49d7cfdea34cfdadd87e31847a292b\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_1_OsDisk_1_1a49d7cfdea34cfdadd87e31847a292b\"\r\n            },\r\n            \"diskSizeGB\": 30\r\n          },\r\n          \"dataDisks\": [\r\n            {\r\n              \"lun\": 0,\r\n              \"name\": \"vmss0918303254dd26_vmss0918303254dd26_1_disk2_4748e5531ee5480fa83f47c745d915aa\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_1_disk2_4748e5531ee5480fa83f47c745d915aa\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 1,\r\n              \"name\": \"vmss0918303254dd26_vmss0918303254dd26_1_disk3_b1c3247214694891857bc260d2c59cd4\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_1_disk3_b1c3247214694891857bc260d2c59cd4\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 2,\r\n              \"name\": \"vmss0918303254dd26_vmss0918303254dd26_1_disk4_828249218b6e44348252cebc2e7c3b6a\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_1_disk4_828249218b6e44348252cebc2e7c3b6a\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            }\r\n          ]\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss-vm98055000001\",\r\n          \"adminUsername\": \"tirekicker\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\": {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\r\n          \"networkInterfaces\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg\"\r\n            }\r\n          ]\r\n        },\r\n        \"provisioningState\": \"Updating\"\r\n      },\r\n      \"resources\": [\r\n        {\r\n          \"properties\": {\r\n            \"publisher\": \"Microsoft.OSTCExtensions\",\r\n            \"type\": \"CustomScriptForLinux\",\r\n            \"typeHandlerVersion\": \"1.4\",\r\n            \"autoUpgradeMinorVersion\": true,\r\n            \"settings\": {\r\n              \"fileUris\": [\r\n                \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n              ],\r\n              \"commandToExecute\": \"bash install_apache.sh\"\r\n            },\r\n            \"provisioningState\": \"Updating\"\r\n          },\r\n          \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n          \"location\": \"westcentralus\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVSF4045222/providers/Microsoft.Compute/virtualMachines/vmss0918303254dd26_1/extensions/CustomScriptForLinux\",\r\n          \"name\": \"CustomScriptForLinux\"\r\n        }\r\n      ],\r\n      \"type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVSF4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1\",\r\n      \"name\": \"vmss0918303254dd26_1\"\r\n    },\r\n    {\r\n      \"instanceId\": \"2\",\r\n      \"sku\": {\r\n        \"name\": \"Standard_D3_v2\",\r\n        \"tier\": \"Standard\"\r\n      },\r\n      \"properties\": {\r\n        \"latestModelApplied\": true,\r\n        \"vmId\": \"f1645931-8522-4e02-af6f-3351f6cf1f09\",\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"16.04.0-LTS\",\r\n            \"version\": \"16.04.201611150\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"vmss0918303254dd26_vmss0918303254dd26_2_OsDisk_1_8d36be6ab315448cabc3bf529cd2cb05\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_2_OsDisk_1_8d36be6ab315448cabc3bf529cd2cb05\"\r\n            },\r\n            \"diskSizeGB\": 30\r\n          },\r\n          \"dataDisks\": [\r\n            {\r\n              \"lun\": 0,\r\n              \"name\": \"vmss0918303254dd26_vmss0918303254dd26_2_disk2_3ba582f46a9e40049077a926ae74e233\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_2_disk2_3ba582f46a9e40049077a926ae74e233\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 1,\r\n              \"name\": \"vmss0918303254dd26_vmss0918303254dd26_2_disk3_7234dce5ac1744fe92a5d0de4cf8ae77\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_2_disk3_7234dce5ac1744fe92a5d0de4cf8ae77\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 2,\r\n              \"name\": \"vmss0918303254dd26_vmss0918303254dd26_2_disk4_da4ec84d264b415ca5fb529f7e083538\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_2_disk4_da4ec84d264b415ca5fb529f7e083538\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            }\r\n          ]\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss-vm98055000002\",\r\n          \"adminUsername\": \"tirekicker\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\": {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\r\n          \"networkInterfaces\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg\"\r\n            }\r\n          ]\r\n        },\r\n        \"provisioningState\": \"Updating\"\r\n      },\r\n      \"resources\": [\r\n        {\r\n          \"properties\": {\r\n            \"publisher\": \"Microsoft.OSTCExtensions\",\r\n            \"type\": \"CustomScriptForLinux\",\r\n            \"typeHandlerVersion\": \"1.4\",\r\n            \"autoUpgradeMinorVersion\": true,\r\n            \"settings\": {\r\n              \"fileUris\": [\r\n                \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n              ],\r\n              \"commandToExecute\": \"bash install_apache.sh\"\r\n            },\r\n            \"provisioningState\": \"Updating\"\r\n          },\r\n          \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n          \"location\": \"westcentralus\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVSF4045222/providers/Microsoft.Compute/virtualMachines/vmss0918303254dd26_2/extensions/CustomScriptForLinux\",\r\n          \"name\": \"CustomScriptForLinux\"\r\n        }\r\n      ],\r\n      \"type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVSF4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2\",\r\n      \"name\": \"vmss0918303254dd26_2\"\r\n    },\r\n    {\r\n      \"instanceId\": \"4\",\r\n      \"sku\": {\r\n        \"name\": \"Standard_D3_v2\",\r\n        \"tier\": \"Standard\"\r\n      },\r\n      \"properties\": {\r\n        \"latestModelApplied\": true,\r\n        \"vmId\": \"017d2050-0310-48f4-a2c8-8031ad5f6164\",\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"16.04.0-LTS\",\r\n            \"version\": \"16.04.201611150\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"vmss0918303254dd26_vmss0918303254dd26_4_OsDisk_1_e4aa5d5813a840889fa433147bb9f9a2\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_4_OsDisk_1_e4aa5d5813a840889fa433147bb9f9a2\"\r\n            },\r\n            \"diskSizeGB\": 30\r\n          },\r\n          \"dataDisks\": [\r\n            {\r\n              \"lun\": 0,\r\n              \"name\": \"vmss0918303254dd26_vmss0918303254dd26_4_disk2_ce8dba2db9dd4f4dab77bd2e0b777aad\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_4_disk2_ce8dba2db9dd4f4dab77bd2e0b777aad\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 1,\r\n              \"name\": \"vmss0918303254dd26_vmss0918303254dd26_4_disk3_cfb9a0e3444e4e9cb6f6d957c5686d72\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_4_disk3_cfb9a0e3444e4e9cb6f6d957c5686d72\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 2,\r\n              \"name\": \"vmss0918303254dd26_vmss0918303254dd26_4_disk4_189afed1de13402cabb3d83f885997b6\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/disks/vmss0918303254dd26_vmss0918303254dd26_4_disk4_189afed1de13402cabb3d83f885997b6\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            }\r\n          ]\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss-vm98055000004\",\r\n          \"adminUsername\": \"tirekicker\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\": {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\r\n          \"networkInterfaces\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg\"\r\n            }\r\n          ]\r\n        },\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"resources\": [\r\n        {\r\n          \"properties\": {\r\n            \"publisher\": \"Microsoft.OSTCExtensions\",\r\n            \"type\": \"CustomScriptForLinux\",\r\n            \"typeHandlerVersion\": \"1.4\",\r\n            \"autoUpgradeMinorVersion\": true,\r\n            \"settings\": {\r\n              \"fileUris\": [\r\n                \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n              ],\r\n              \"commandToExecute\": \"bash install_apache.sh\"\r\n            },\r\n            \"provisioningState\": \"Succeeded\"\r\n          },\r\n          \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n          \"location\": \"westcentralus\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVSF4045222/providers/Microsoft.Compute/virtualMachines/vmss0918303254dd26_4/extensions/CustomScriptForLinux\",\r\n          \"name\": \"CustomScriptForLinux\"\r\n        }\r\n      ],\r\n      \"type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVSF4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4\",\r\n      \"name\": \"vmss0918303254dd26_4\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:47:13 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "d0f6ce9a-2b56-482e-9c98-5fecfeb81347"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14984"
-        ],
-        "x-ms-correlation-request-id": [
-          "b7034f07-82c8-49d9-b3b8-3bf8909d7992"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214714Z:b7034f07-82c8-49d9-b3b8-3bf8909d7992"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces?api-version=2016-09-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9taWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjYvdmlydHVhbE1hY2hpbmVzLzEvbmV0d29ya0ludGVyZmFjZXM/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "4b43564f-5e34-4285-b7c2-4fa21d0fb18c"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"primary-nic-cfg\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg\",\r\n      \"etag\": \"W/\\\"258c8b20-8590-46aa-8eff-6d461971912b\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"a86c710e-1db0-4238-8e51-a1515f3e16d1\",\r\n        \"ipConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-ip-cfg\",\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\",\r\n            \"etag\": \"W/\\\"258c8b20-8590-46aa-8eff-6d461971912b\\\"\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"privateIPAddress\": \"172.16.1.5\",\r\n              \"privateIPAllocationMethod\": \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\"\r\n              },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\": \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n                }\r\n              ],\r\n              \"loadBalancerInboundNatRules\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.1\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.1\"\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n          \"internalDomainNameSuffix\": \"umjnegso55pendb0vd2tvkxngf.yx.internal.cloudapp.net\"\r\n        },\r\n        \"macAddress\": \"00-0D-3A-F8-3E-4E\",\r\n        \"enableAcceleratedNetworking\": false,\r\n        \"enableIPForwarding\": false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/1\"\r\n        }\r\n      }\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:47:14 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "6e21ba52-d44a-4701-a9e4-9b329010f737"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14983"
-        ],
-        "x-ms-correlation-request-id": [
-          "4ddc286b-e64a-41a2-b1f7-77e2026fda57"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214714Z:4ddc286b-e64a-41a2-b1f7-77e2026fda57"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces?api-version=2016-09-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9taWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjYvdmlydHVhbE1hY2hpbmVzLzIvbmV0d29ya0ludGVyZmFjZXM/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "57ea259a-72a5-4373-ac32-5ba55159fec3"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"primary-nic-cfg\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg\",\r\n      \"etag\": \"W/\\\"097d3fd3-ec81-461b-90a2-98c7f0c88eda\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"35670a7f-db49-4d26-9d0b-aa477b5e68a7\",\r\n        \"ipConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-ip-cfg\",\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\",\r\n            \"etag\": \"W/\\\"097d3fd3-ec81-461b-90a2-98c7f0c88eda\\\"\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"privateIPAddress\": \"172.16.1.6\",\r\n              \"privateIPAllocationMethod\": \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\"\r\n              },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\": \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n                }\r\n              ],\r\n              \"loadBalancerInboundNatRules\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.2\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.2\"\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n          \"internalDomainNameSuffix\": \"umjnegso55pendb0vd2tvkxngf.yx.internal.cloudapp.net\"\r\n        },\r\n        \"macAddress\": \"00-0D-3A-F8-35-50\",\r\n        \"enableAcceleratedNetworking\": false,\r\n        \"enableIPForwarding\": false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/2\"\r\n        }\r\n      }\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:47:14 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "ff793d1e-f6dd-48c6-8e73-a0dc4dfa0e88"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14981"
-        ],
-        "x-ms-correlation-request-id": [
-          "959fb610-4446-47dc-a848-2d256436cb0f"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214714Z:959fb610-4446-47dc-a848-2d256436cb0f"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces?api-version=2016-09-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9taWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjYvdmlydHVhbE1hY2hpbmVzLzQvbmV0d29ya0ludGVyZmFjZXM/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "8912bf1d-34a2-4a61-b53c-5541691006c2"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"primary-nic-cfg\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg\",\r\n      \"etag\": \"W/\\\"92437194-59ee-4c71-adca-9ac704673018\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"2cd5ef12-61d2-422b-9560-a54bc7b7be7f\",\r\n        \"ipConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-ip-cfg\",\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\",\r\n            \"etag\": \"W/\\\"92437194-59ee-4c71-adca-9ac704673018\\\"\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"privateIPAddress\": \"172.16.1.8\",\r\n              \"privateIPAllocationMethod\": \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/virtualNetworks/vnetcdb59665b56515/subnets/Front-end\"\r\n              },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\": \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP1\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/backendAddressPools/intlb-92e08687f4-BAP2\"\r\n                }\r\n              ],\r\n              \"loadBalancerInboundNatRules\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool50XXto22.4\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Network/loadBalancers/intlb-92e08687f4/inboundNatRules/natPool60XXto23.4\"\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n          \"internalDomainNameSuffix\": \"umjnegso55pendb0vd2tvkxngf.yx.internal.cloudapp.net\"\r\n        },\r\n        \"macAddress\": \"00-0D-3A-F8-37-08\",\r\n        \"enableAcceleratedNetworking\": false,\r\n        \"enableIPForwarding\": false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/virtualMachines/4\"\r\n        }\r\n      }\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:47:14 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "4372f669-e868-47c6-8063-cbdb5c0d42e9"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14979"
-        ],
-        "x-ms-correlation-request-id": [
-          "5e725c35-4a9a-4d07-933d-99faf391ac11"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214714Z:5e725c35-4a9a-4d07-933d-99faf391ac11"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/poweroff?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjYvcG93ZXJvZmY/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
-      "RequestMethod": "POST",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "52cba7c0-35c1-4cf1-a6dd-e3b36d59f3dc"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "0"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:47:15 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/8030514e-eb3b-42f3-b8cd-8907fb8fe355?monitor=true&api-version=2016-04-30-preview"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/8030514e-eb3b-42f3-b8cd-8907fb8fe355?api-version=2016-04-30-preview"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "8030514e-eb3b-42f3-b8cd-8907fb8fe355"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1195"
-        ],
-        "x-ms-correlation-request-id": [
-          "413049ed-d448-48c8-8288-11b6a0091e3a"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214715Z:413049ed-d448-48c8-8288-11b6a0091e3a"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/8030514e-eb3b-42f3-b8cd-8907fb8fe355?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzgwMzA1MTRlLWViM2ItNDJmMy1iOGNkLTg5MDdmYjhmZTM1NT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:47:15.9570154-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"8030514e-eb3b-42f3-b8cd-8907fb8fe355\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:47:44 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "c302de04-7bad-4216-adee-16614bc2eb21"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14977"
-        ],
-        "x-ms-correlation-request-id": [
-          "e4e11d8a-9605-40aa-a1a1-f17b7841c0e1"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214745Z:e4e11d8a-9605-40aa-a1a1-f17b7841c0e1"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/8030514e-eb3b-42f3-b8cd-8907fb8fe355?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzgwMzA1MTRlLWViM2ItNDJmMy1iOGNkLTg5MDdmYjhmZTM1NT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:47:15.9570154-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"8030514e-eb3b-42f3-b8cd-8907fb8fe355\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:48:14 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "957d4bfa-34ea-4c32-ae69-562cad31bbd2"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14976"
-        ],
-        "x-ms-correlation-request-id": [
-          "2351e96d-be57-4665-8c81-cd071b9c96a4"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214815Z:2351e96d-be57-4665-8c81-cd071b9c96a4"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/8030514e-eb3b-42f3-b8cd-8907fb8fe355?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzgwMzA1MTRlLWViM2ItNDJmMy1iOGNkLTg5MDdmYjhmZTM1NT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:47:15.9570154-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"8030514e-eb3b-42f3-b8cd-8907fb8fe355\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:48:45 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "44798a54-93f8-4112-bd84-7ab94ca00101"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14975"
-        ],
-        "x-ms-correlation-request-id": [
-          "5a51ecce-5a9b-47de-9dd1-01cb7a92aa81"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214845Z:5a51ecce-5a9b-47de-9dd1-01cb7a92aa81"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/8030514e-eb3b-42f3-b8cd-8907fb8fe355?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzgwMzA1MTRlLWViM2ItNDJmMy1iOGNkLTg5MDdmYjhmZTM1NT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:47:15.9570154-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"8030514e-eb3b-42f3-b8cd-8907fb8fe355\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:49:15 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "07d483f2-4c06-46ab-91b2-a5cf82bae49a"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14973"
-        ],
-        "x-ms-correlation-request-id": [
-          "88febb6f-f999-4996-b9c0-32cbd1808395"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214915Z:88febb6f-f999-4996-b9c0-32cbd1808395"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/8030514e-eb3b-42f3-b8cd-8907fb8fe355?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzgwMzA1MTRlLWViM2ItNDJmMy1iOGNkLTg5MDdmYjhmZTM1NT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:47:15.9570154-07:00\",\r\n  \"endTime\": \"2017-04-10T14:49:18.0969691-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"8030514e-eb3b-42f3-b8cd-8907fb8fe355\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:49:44 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "50b77f9f-5e34-4a49-952e-a94a8b22d176"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14972"
-        ],
-        "x-ms-correlation-request-id": [
-          "67ff2e86-bebe-4aff-9eb4-95062163f0c6"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214945Z:67ff2e86-bebe-4aff-9eb4-95062163f0c6"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/deallocate?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjYvZGVhbGxvY2F0ZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "POST",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "d077dd63-fedf-444f-8741-3f6a40f1e7f1"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "0"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:49:46 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/86dca183-48ca-4fbd-8f15-b925c53cfd55?monitor=true&api-version=2016-04-30-preview"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/86dca183-48ca-4fbd-8f15-b925c53cfd55?api-version=2016-04-30-preview"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "86dca183-48ca-4fbd-8f15-b925c53cfd55"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1194"
-        ],
-        "x-ms-correlation-request-id": [
-          "83f70842-179a-4191-86d5-4dd6893e082f"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T214946Z:83f70842-179a-4191-86d5-4dd6893e082f"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/86dca183-48ca-4fbd-8f15-b925c53cfd55?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzg2ZGNhMTgzLTQ4Y2EtNGZiZC04ZjE1LWI5MjVjNTNjZmQ1NT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:49:46.7843061-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"86dca183-48ca-4fbd-8f15-b925c53cfd55\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:50:15 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "e8d74b46-f69c-440c-8406-4272d00ef706"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14971"
-        ],
-        "x-ms-correlation-request-id": [
-          "1c920033-ae5b-4b33-924b-ef1be2e02054"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215016Z:1c920033-ae5b-4b33-924b-ef1be2e02054"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/86dca183-48ca-4fbd-8f15-b925c53cfd55?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzg2ZGNhMTgzLTQ4Y2EtNGZiZC04ZjE1LWI5MjVjNTNjZmQ1NT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:49:46.7843061-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"86dca183-48ca-4fbd-8f15-b925c53cfd55\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:50:45 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "bb86e52b-cdd7-4b34-ab12-a09b984e6c77"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14968"
-        ],
-        "x-ms-correlation-request-id": [
-          "f3a4d1c3-6819-4ea4-b10d-cac17547e32d"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215046Z:f3a4d1c3-6819-4ea4-b10d-cac17547e32d"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/86dca183-48ca-4fbd-8f15-b925c53cfd55?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzg2ZGNhMTgzLTQ4Y2EtNGZiZC04ZjE1LWI5MjVjNTNjZmQ1NT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:49:46.7843061-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"86dca183-48ca-4fbd-8f15-b925c53cfd55\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:51:16 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "7b585a90-3252-45c0-b908-1798bb0dab0e"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14967"
-        ],
-        "x-ms-correlation-request-id": [
-          "0cd8121f-272b-49ff-b110-a8f1c9f897fd"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215116Z:0cd8121f-272b-49ff-b110-a8f1c9f897fd"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/86dca183-48ca-4fbd-8f15-b925c53cfd55?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzg2ZGNhMTgzLTQ4Y2EtNGZiZC04ZjE1LWI5MjVjNTNjZmQ1NT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:49:46.7843061-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"86dca183-48ca-4fbd-8f15-b925c53cfd55\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:51:45 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "6637bd46-3c8f-4e18-8cf8-5117047d4394"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14966"
-        ],
-        "x-ms-correlation-request-id": [
-          "ac50f9c5-a338-492e-bd2c-b70aea495d67"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215146Z:ac50f9c5-a338-492e-bd2c-b70aea495d67"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/86dca183-48ca-4fbd-8f15-b925c53cfd55?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzg2ZGNhMTgzLTQ4Y2EtNGZiZC04ZjE1LWI5MjVjNTNjZmQ1NT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:49:46.7843061-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"86dca183-48ca-4fbd-8f15-b925c53cfd55\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:52:15 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "50c6f3ca-cea5-4878-a049-9775a415e083"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14965"
-        ],
-        "x-ms-correlation-request-id": [
-          "9969166a-f210-4241-a4e1-f0c144ff6685"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215216Z:9969166a-f210-4241-a4e1-f0c144ff6685"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/86dca183-48ca-4fbd-8f15-b925c53cfd55?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzg2ZGNhMTgzLTQ4Y2EtNGZiZC04ZjE1LWI5MjVjNTNjZmQ1NT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:49:46.7843061-07:00\",\r\n  \"endTime\": \"2017-04-10T14:52:19.5023728-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"86dca183-48ca-4fbd-8f15-b925c53cfd55\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:52:46 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "6bdb0e69-b4a7-4972-97c9-5794064bac5e"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14964"
-        ],
-        "x-ms-correlation-request-id": [
-          "e566163d-1fac-4a90-9ae3-332208a0f7fb"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215246Z:e566163d-1fac-4a90-9ae3-332208a0f7fb"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/start?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjYvc3RhcnQ/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
-      "RequestMethod": "POST",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "48f89474-3da7-4192-96d3-e0602d138bb7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "0"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:52:46 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/06b59cee-adba-4891-9e9f-0b891f79194b?monitor=true&api-version=2016-04-30-preview"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/06b59cee-adba-4891-9e9f-0b891f79194b?api-version=2016-04-30-preview"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "06b59cee-adba-4891-9e9f-0b891f79194b"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1193"
-        ],
-        "x-ms-correlation-request-id": [
-          "9d88b074-45d2-4427-b68f-8033026284ea"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215246Z:9d88b074-45d2-4427-b68f-8033026284ea"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/06b59cee-adba-4891-9e9f-0b891f79194b?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzA2YjU5Y2VlLWFkYmEtNDg5MS05ZTlmLTBiODkxZjc5MTk0Yj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:52:47.4554397-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"06b59cee-adba-4891-9e9f-0b891f79194b\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:53:16 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "2b79b029-c725-4253-8842-a94d894c8586"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14962"
-        ],
-        "x-ms-correlation-request-id": [
-          "6643aabd-80c5-401a-b531-d688720c012d"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215316Z:6643aabd-80c5-401a-b531-d688720c012d"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/06b59cee-adba-4891-9e9f-0b891f79194b?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzA2YjU5Y2VlLWFkYmEtNDg5MS05ZTlmLTBiODkxZjc5MTk0Yj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:52:47.4554397-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"06b59cee-adba-4891-9e9f-0b891f79194b\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:53:46 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "3b9ba4dc-b858-4922-add3-995314de554c"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14960"
-        ],
-        "x-ms-correlation-request-id": [
-          "09711bc8-594c-4a04-a9e3-34ebf5ef6046"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215346Z:09711bc8-594c-4a04-a9e3-34ebf5ef6046"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/06b59cee-adba-4891-9e9f-0b891f79194b?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzA2YjU5Y2VlLWFkYmEtNDg5MS05ZTlmLTBiODkxZjc5MTk0Yj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:52:47.4554397-07:00\",\r\n  \"endTime\": \"2017-04-10T14:54:04.8457983-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"06b59cee-adba-4891-9e9f-0b891f79194b\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:54:16 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "bed78fca-09ff-4d0c-9a3f-c905266fb18d"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14959"
-        ],
-        "x-ms-correlation-request-id": [
-          "04e652be-2385-499b-bd5b-7d69a46714f8"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215416Z:04e652be-2385-499b-bd5b-7d69a46714f8"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/267e9284-0c67-41e4-a54c-1375ef1601bb?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI2N2U5Mjg0LTBjNjctNDFlNC1hNTRjLTEzNzVlZjE2MDFiYj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:54:18.2207866-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"267e9284-0c67-41e4-a54c-1375ef1601bb\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:54:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "302a1a6b-9ae0-4c40-9f9c-65dc42e2aeb4"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14957"
-        ],
-        "x-ms-correlation-request-id": [
-          "2bb0e1b5-1d87-4ef4-ac08-a172eb8a99f5"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215448Z:2bb0e1b5-1d87-4ef4-ac08-a172eb8a99f5"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/267e9284-0c67-41e4-a54c-1375ef1601bb?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI2N2U5Mjg0LTBjNjctNDFlNC1hNTRjLTEzNzVlZjE2MDFiYj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:54:18.2207866-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"267e9284-0c67-41e4-a54c-1375ef1601bb\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:55:17 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "00551454-fc31-4184-a65c-f695087f8dde"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14956"
-        ],
-        "x-ms-correlation-request-id": [
-          "669536c6-4cab-439c-b148-63366785ac86"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215518Z:669536c6-4cab-439c-b148-63366785ac86"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/267e9284-0c67-41e4-a54c-1375ef1601bb?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI2N2U5Mjg0LTBjNjctNDFlNC1hNTRjLTEzNzVlZjE2MDFiYj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:54:18.2207866-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"267e9284-0c67-41e4-a54c-1375ef1601bb\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:55:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "cc3d57df-41cd-40eb-bb38-795988c568c5"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14955"
-        ],
-        "x-ms-correlation-request-id": [
-          "34907377-4e9c-4b84-956a-27b3562270ea"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215548Z:34907377-4e9c-4b84-956a-27b3562270ea"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/267e9284-0c67-41e4-a54c-1375ef1601bb?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI2N2U5Mjg0LTBjNjctNDFlNC1hNTRjLTEzNzVlZjE2MDFiYj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:54:18.2207866-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"267e9284-0c67-41e4-a54c-1375ef1601bb\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:56:18 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "e070f90f-75ba-4144-aa86-9c6a376a37a9"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14954"
-        ],
-        "x-ms-correlation-request-id": [
-          "198914fb-e9a3-48d6-8a47-77aec40d2de6"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215618Z:198914fb-e9a3-48d6-8a47-77aec40d2de6"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/267e9284-0c67-41e4-a54c-1375ef1601bb?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI2N2U5Mjg0LTBjNjctNDFlNC1hNTRjLTEzNzVlZjE2MDFiYj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:54:18.2207866-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"267e9284-0c67-41e4-a54c-1375ef1601bb\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 21:56:47 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0",
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-served-by": [
-          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
-        ],
-        "x-ms-request-id": [
-          "091a13cc-f753-4227-9e8f-06258651b352"
+          "c10a9212-fd4a-47fc-8585-2017b4a4d985"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14953"
         ],
         "x-ms-correlation-request-id": [
-          "8e9d1c87-87ac-4706-8144-b1c92962a858"
+          "5d925b5c-9bd1-49e5-aede-295f673de795"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215648Z:8e9d1c87-87ac-4706-8144-b1c92962a858"
+          "WESTUS2:20170414T180738Z:5d925b5c-9bd1-49e5-aede-295f673de795"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/267e9284-0c67-41e4-a54c-1375ef1601bb?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI2N2U5Mjg0LTBjNjctNDFlNC1hNTRjLTEzNzVlZjE2MDFiYj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/a2ab784f-ac44-4b5d-8007-c5db9473053f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2EyYWI3ODRmLWFjNDQtNGI1ZC04MDA3LWM1ZGI5NDczMDUzZj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3204,7 +1161,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:54:18.2207866-07:00\",\r\n  \"endTime\": \"2017-04-10T14:57:19.1415875-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"267e9284-0c67-41e4-a54c-1375ef1601bb\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:07:08.6214209-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"a2ab784f-ac44-4b5d-8007-c5db9473053f\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -3216,7 +1173,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:57:17 GMT"
+          "Fri, 14 Apr 2017 18:08:08 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -3238,28 +1195,757 @@
           "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
         ],
         "x-ms-request-id": [
-          "b2e88e11-e7b4-47fd-8631-cdd857bcd0aa"
+          "0cd61687-27ce-4077-83c5-443dec47841b"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14951"
+          "14952"
         ],
         "x-ms-correlation-request-id": [
-          "9ef9e442-b66c-4687-8e62-4dd43d29d7fd"
+          "8ce1d751-d28e-4aac-943f-be9e7b67f046"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215718Z:9ef9e442-b66c-4687-8e62-4dd43d29d7fd"
+          "WESTUS2:20170414T180809Z:8ce1d751-d28e-4aac-943f-be9e7b67f046"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovsf4045222/providers/Microsoft.Compute/virtualMachineScaleSets/vmss0918303254dd26/restart?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292c2Y0MDQ1MjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzMDkxODMwMzI1NGRkMjYvcmVzdGFydD9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/a2ab784f-ac44-4b5d-8007-c5db9473053f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2EyYWI3ODRmLWFjNDQtNGI1ZC04MDA3LWM1ZGI5NDczMDUzZj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:07:08.6214209-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"a2ab784f-ac44-4b5d-8007-c5db9473053f\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:08:38 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "0773fead-032c-4f7e-94e0-01e3c999706f"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14951"
+        ],
+        "x-ms-correlation-request-id": [
+          "8e6f44e1-949a-48a1-b85b-64eafb145f61"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T180839Z:8e6f44e1-949a-48a1-b85b-64eafb145f61"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/a2ab784f-ac44-4b5d-8007-c5db9473053f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2EyYWI3ODRmLWFjNDQtNGI1ZC04MDA3LWM1ZGI5NDczMDUzZj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:07:08.6214209-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"a2ab784f-ac44-4b5d-8007-c5db9473053f\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:09:09 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "06c499bf-3c09-4b5a-81d5-98565a58f5ed"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14950"
+        ],
+        "x-ms-correlation-request-id": [
+          "100bf302-76a3-4955-a67a-92b538928129"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T180909Z:100bf302-76a3-4955-a67a-92b538928129"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/a2ab784f-ac44-4b5d-8007-c5db9473053f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2EyYWI3ODRmLWFjNDQtNGI1ZC04MDA3LWM1ZGI5NDczMDUzZj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:07:08.6214209-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"a2ab784f-ac44-4b5d-8007-c5db9473053f\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:09:38 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "cf302b8e-5ccf-4c60-87e5-fd61d4874c18"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14949"
+        ],
+        "x-ms-correlation-request-id": [
+          "b1553295-6f12-4cc7-8cee-c4d70301f5b2"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T180939Z:b1553295-6f12-4cc7-8cee-c4d70301f5b2"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/a2ab784f-ac44-4b5d-8007-c5db9473053f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2EyYWI3ODRmLWFjNDQtNGI1ZC04MDA3LWM1ZGI5NDczMDUzZj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:07:08.6214209-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"a2ab784f-ac44-4b5d-8007-c5db9473053f\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:10:08 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "f25938c8-8808-4a1c-ba2d-c67ed6774f16"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14948"
+        ],
+        "x-ms-correlation-request-id": [
+          "04659f94-90d7-4fe1-ba44-7192863a0636"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181009Z:04659f94-90d7-4fe1-ba44-7192863a0636"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/a2ab784f-ac44-4b5d-8007-c5db9473053f?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2EyYWI3ODRmLWFjNDQtNGI1ZC04MDA3LWM1ZGI5NDczMDUzZj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:07:08.6214209-07:00\",\r\n  \"endTime\": \"2017-04-14T11:10:33.4893494-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"a2ab784f-ac44-4b5d-8007-c5db9473053f\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:10:38 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "fb982747-75fd-4fc2-a34d-bb3a27f747c8"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14947"
+        ],
+        "x-ms-correlation-request-id": [
+          "c17fdf41-6310-4ae9-b500-7f8fb7aaa02e"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181039Z:c17fdf41-6310-4ae9-b500-7f8fb7aaa02e"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTI/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 3\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm28467\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 0,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 1,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            },\r\n            \"name\": \"CustomScriptForLinux\"\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"e884da2e-58dc-489e-b5b4-ba3c37674668\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2\",\r\n  \"name\": \"vmss51984024ddf6a2\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:10:38 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "00a32feb-f029-4661-bb2e-c65de07aacd7"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14946"
+        ],
+        "x-ms-correlation-request-id": [
+          "7c346a8d-732f-4dd1-833e-93a9359be9a1"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181039Z:7c346a8d-732f-4dd1-833e-93a9359be9a1"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTI/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "5871559a-3802-4460-89ec-285c1872ef0e"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 3\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm28467\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 0,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 1,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            },\r\n            \"name\": \"CustomScriptForLinux\"\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"e884da2e-58dc-489e-b5b4-ba3c37674668\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2\",\r\n  \"name\": \"vmss51984024ddf6a2\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:14:41 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "992bc448-7f36-4cf2-88d5-9c119ede8c99"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14930"
+        ],
+        "x-ms-correlation-request-id": [
+          "185cb407-7a2a-4af2-a97e-056a3996ccbf"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181441Z:185cb407-7a2a-4af2-a97e-056a3996ccbf"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTI/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_D3_v2\",\r\n    \"tier\": \"Standard\",\r\n    \"capacity\": 6\r\n  },\r\n  \"properties\": {\r\n    \"singlePlacementGroup\": true,\r\n    \"upgradePolicy\": {\r\n      \"mode\": \"Automatic\"\r\n    },\r\n    \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\": \"vmss-vm28467\",\r\n        \"adminUsername\": \"tirekicker\",\r\n        \"linuxConfiguration\": {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\": {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n              }\r\n            ]\r\n          }\r\n        },\r\n        \"secrets\": []\r\n      },\r\n      \"storageProfile\": {\r\n        \"osDisk\": {\r\n          \"createOption\": \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\": {\r\n            \"storageAccountType\": \"Standard_LRS\"\r\n          }\r\n        },\r\n        \"imageReference\": {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n          \"sku\": \"16.04.0-LTS\",\r\n          \"version\": \"latest\"\r\n        },\r\n        \"dataDisks\": [\r\n          {\r\n            \"lun\": 1,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          },\r\n          {\r\n            \"lun\": 2,\r\n            \"createOption\": \"Empty\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\"\r\n            },\r\n            \"diskSizeGB\": 100\r\n          }\r\n        ]\r\n      },\r\n      \"networkProfile\": {\r\n        \"networkInterfaceConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-cfg\",\r\n            \"properties\": {\r\n              \"primary\": true,\r\n              \"ipConfigurations\": [\r\n                {\r\n                  \"name\": \"primary-nic-ip-cfg\",\r\n                  \"properties\": {\r\n                    \"subnet\": {\r\n                      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\"\r\n                    },\r\n                    \"loadBalancerBackendAddressPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n                      }\r\n                    ],\r\n                    \"loadBalancerInboundNatPools\": [\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool50XXto22\"\r\n                      },\r\n                      {\r\n                        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatPools/natPool60XXto23\"\r\n                      }\r\n                    ]\r\n                  }\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ]\r\n      },\r\n      \"extensionProfile\": {\r\n        \"extensions\": [\r\n          {\r\n            \"properties\": {\r\n              \"publisher\": \"Microsoft.OSTCExtensions\",\r\n              \"type\": \"CustomScriptForLinux\",\r\n              \"typeHandlerVersion\": \"1.4\",\r\n              \"autoUpgradeMinorVersion\": true,\r\n              \"settings\": {\r\n                \"fileUris\": [\r\n                  \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n                ],\r\n                \"commandToExecute\": \"bash install_apache.sh\"\r\n              }\r\n            },\r\n            \"name\": \"CustomScriptForLinux\"\r\n          }\r\n        ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"overprovision\": true,\r\n    \"uniqueId\": \"e884da2e-58dc-489e-b5b4-ba3c37674668\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2\",\r\n  \"name\": \"vmss51984024ddf6a2\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:20:14 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "0b5f01c9-c5c6-4902-ba20-c3c74ae648eb"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14917"
+        ],
+        "x-ms-correlation-request-id": [
+          "35c84366-7f05-4e7e-b9f9-678dc51612bd"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T182014Z:35c84366-7f05-4e7e-b9f9-678dc51612bd"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTIvdmlydHVhbE1hY2hpbmVzP2FwaS12ZXJzaW9uPTIwMTYtMDQtMzAtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "f726b029-9c79-4ca0-82ce-db0adc7382ab"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"instanceId\": \"0\",\r\n      \"sku\": {\r\n        \"name\": \"Standard_D3_v2\",\r\n        \"tier\": \"Standard\"\r\n      },\r\n      \"properties\": {\r\n        \"latestModelApplied\": true,\r\n        \"vmId\": \"46c13322-d7dd-46ac-b383-daa513561fa7\",\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"16.04.0-LTS\",\r\n            \"version\": \"16.04.201611150\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_0_OsDisk_1_c1ae3b79d38f4eaa82d50d61be8d750a\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_0_OsDisk_1_c1ae3b79d38f4eaa82d50d61be8d750a\"\r\n            },\r\n            \"diskSizeGB\": 30\r\n          },\r\n          \"dataDisks\": [\r\n            {\r\n              \"lun\": 0,\r\n              \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_0_disk2_27a852b153404c99a6aa0cc2458c86bc\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_0_disk2_27a852b153404c99a6aa0cc2458c86bc\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 1,\r\n              \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_0_disk3_bfd8b8bc62a442b49d3db9f9a40774c6\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_0_disk3_bfd8b8bc62a442b49d3db9f9a40774c6\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 2,\r\n              \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_0_disk4_4d029928809c4624b708299be1c88b12\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_0_disk4_4d029928809c4624b708299be1c88b12\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            }\r\n          ]\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss-vm28467000000\",\r\n          \"adminUsername\": \"tirekicker\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\": {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\r\n          \"networkInterfaces\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg\"\r\n            }\r\n          ]\r\n        },\r\n        \"provisioningState\": \"Updating\"\r\n      },\r\n      \"resources\": [\r\n        {\r\n          \"properties\": {\r\n            \"publisher\": \"Microsoft.OSTCExtensions\",\r\n            \"type\": \"CustomScriptForLinux\",\r\n            \"typeHandlerVersion\": \"1.4\",\r\n            \"autoUpgradeMinorVersion\": true,\r\n            \"settings\": {\r\n              \"fileUris\": [\r\n                \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n              ],\r\n              \"commandToExecute\": \"bash install_apache.sh\"\r\n            },\r\n            \"provisioningState\": \"Updating\"\r\n          },\r\n          \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n          \"location\": \"westcentralus\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVS40C84343/providers/Microsoft.Compute/virtualMachines/vmss51984024ddf6a2_0/extensions/CustomScriptForLinux\",\r\n          \"name\": \"CustomScriptForLinux\"\r\n        }\r\n      ],\r\n      \"type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVS40C84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0\",\r\n      \"name\": \"vmss51984024ddf6a2_0\"\r\n    },\r\n    {\r\n      \"instanceId\": \"1\",\r\n      \"sku\": {\r\n        \"name\": \"Standard_D3_v2\",\r\n        \"tier\": \"Standard\"\r\n      },\r\n      \"properties\": {\r\n        \"latestModelApplied\": true,\r\n        \"vmId\": \"cc719009-fc6c-47b1-93b6-817528f04b5d\",\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"16.04.0-LTS\",\r\n            \"version\": \"16.04.201611150\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_1_OsDisk_1_abe72aeab11b4180b7872e9247e0c635\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_1_OsDisk_1_abe72aeab11b4180b7872e9247e0c635\"\r\n            },\r\n            \"diskSizeGB\": 30\r\n          },\r\n          \"dataDisks\": [\r\n            {\r\n              \"lun\": 0,\r\n              \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_1_disk2_e2e381e95173406887ecf044cac6078a\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_1_disk2_e2e381e95173406887ecf044cac6078a\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 1,\r\n              \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_1_disk3_cbb0fa3230a7491fad91b42d49623a19\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_1_disk3_cbb0fa3230a7491fad91b42d49623a19\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 2,\r\n              \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_1_disk4_daba00f6b64e4e5fa59ce6efae520d1c\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_1_disk4_daba00f6b64e4e5fa59ce6efae520d1c\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            }\r\n          ]\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss-vm28467000001\",\r\n          \"adminUsername\": \"tirekicker\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\": {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\r\n          \"networkInterfaces\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg\"\r\n            }\r\n          ]\r\n        },\r\n        \"provisioningState\": \"Updating\"\r\n      },\r\n      \"resources\": [\r\n        {\r\n          \"properties\": {\r\n            \"publisher\": \"Microsoft.OSTCExtensions\",\r\n            \"type\": \"CustomScriptForLinux\",\r\n            \"typeHandlerVersion\": \"1.4\",\r\n            \"autoUpgradeMinorVersion\": true,\r\n            \"settings\": {\r\n              \"fileUris\": [\r\n                \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n              ],\r\n              \"commandToExecute\": \"bash install_apache.sh\"\r\n            },\r\n            \"provisioningState\": \"Updating\"\r\n          },\r\n          \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n          \"location\": \"westcentralus\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVS40C84343/providers/Microsoft.Compute/virtualMachines/vmss51984024ddf6a2_1/extensions/CustomScriptForLinux\",\r\n          \"name\": \"CustomScriptForLinux\"\r\n        }\r\n      ],\r\n      \"type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVS40C84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1\",\r\n      \"name\": \"vmss51984024ddf6a2_1\"\r\n    },\r\n    {\r\n      \"instanceId\": \"2\",\r\n      \"sku\": {\r\n        \"name\": \"Standard_D3_v2\",\r\n        \"tier\": \"Standard\"\r\n      },\r\n      \"properties\": {\r\n        \"latestModelApplied\": true,\r\n        \"vmId\": \"7b169653-aa40-443f-a8b8-92b9c0acffa9\",\r\n        \"storageProfile\": {\r\n          \"imageReference\": {\r\n            \"publisher\": \"Canonical\",\r\n            \"offer\": \"UbuntuServer\",\r\n            \"sku\": \"16.04.0-LTS\",\r\n            \"version\": \"16.04.201611150\"\r\n          },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\",\r\n            \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_2_OsDisk_1_b0d7ed8c1ee7429d9e0402b7658e4e78\",\r\n            \"createOption\": \"FromImage\",\r\n            \"caching\": \"ReadWrite\",\r\n            \"managedDisk\": {\r\n              \"storageAccountType\": \"Standard_LRS\",\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_2_OsDisk_1_b0d7ed8c1ee7429d9e0402b7658e4e78\"\r\n            },\r\n            \"diskSizeGB\": 30\r\n          },\r\n          \"dataDisks\": [\r\n            {\r\n              \"lun\": 0,\r\n              \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_2_disk2_794f4fcdf60e42a98d416e439974c73c\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_2_disk2_794f4fcdf60e42a98d416e439974c73c\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 1,\r\n              \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_2_disk3_4356e52e736f4112adddd70ed54c8097\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_2_disk3_4356e52e736f4112adddd70ed54c8097\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            },\r\n            {\r\n              \"lun\": 2,\r\n              \"name\": \"vmss51984024ddf6a2_vmss51984024ddf6a2_2_disk4_59660b75e7cb49369d16a8b8d98624f4\",\r\n              \"createOption\": \"Empty\",\r\n              \"caching\": \"None\",\r\n              \"managedDisk\": {\r\n                \"storageAccountType\": \"Standard_LRS\",\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/disks/vmss51984024ddf6a2_vmss51984024ddf6a2_2_disk4_59660b75e7cb49369d16a8b8d98624f4\"\r\n              },\r\n              \"diskSizeGB\": 100\r\n            }\r\n          ]\r\n        },\r\n        \"osProfile\": {\r\n          \"computerName\": \"vmss-vm28467000002\",\r\n          \"adminUsername\": \"tirekicker\",\r\n          \"linuxConfiguration\": {\r\n            \"disablePasswordAuthentication\": true,\r\n            \"ssh\": {\r\n              \"publicKeys\": [\r\n                {\r\n                  \"path\": \"/home/tirekicker/.ssh/authorized_keys\",\r\n                  \"keyData\": \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCfSPC2K7LZcFKEO+/t3dzmQYtrJFZNxOsbVgOVKietqHyvmYGHEC0J2wPdAqQ/63g/hhAEFRoyehM+rbeDri4txB3YFfnOK58jqdkyXzupWqXzOrlKY4Wz9SKjjN765+dqUITjKRIaAip1Ri137szRg71WnrmdP3SphTRlCx1Bk2nXqWPsclbRDCiZeF8QOTi4JqbmJyK5+0UqhqYRduun8ylAwKKQJ1NJt85sYIHn9f1Rfr6Tq2zS0wZ7DHbZL+zB5rSlAr8QyUdg/GQD+cmSs6LvPJKL78d6hMGk84ARtFo4A79ovwX/Fj01znDQkU6nJildfkaolH2rWFG/qttD azjava@javalib.Com\"\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\r\n          \"networkInterfaces\": [\r\n            {\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg\"\r\n            }\r\n          ]\r\n        },\r\n        \"provisioningState\": \"Updating\"\r\n      },\r\n      \"resources\": [\r\n        {\r\n          \"properties\": {\r\n            \"publisher\": \"Microsoft.OSTCExtensions\",\r\n            \"type\": \"CustomScriptForLinux\",\r\n            \"typeHandlerVersion\": \"1.4\",\r\n            \"autoUpgradeMinorVersion\": true,\r\n            \"settings\": {\r\n              \"fileUris\": [\r\n                \"https://raw.githubusercontent.com/Azure/azure-sdk-for-java/master/azure-samples/src/main/resources/install_apache.sh\"\r\n              ],\r\n              \"commandToExecute\": \"bash install_apache.sh\"\r\n            },\r\n            \"provisioningState\": \"Updating\"\r\n          },\r\n          \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n          \"location\": \"westcentralus\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVS40C84343/providers/Microsoft.Compute/virtualMachines/vmss51984024ddf6a2_2/extensions/CustomScriptForLinux\",\r\n          \"name\": \"CustomScriptForLinux\"\r\n        }\r\n      ],\r\n      \"type\": \"Microsoft.Compute/virtualMachineScaleSets/virtualMachines\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/RGCOVS40C84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2\",\r\n      \"name\": \"vmss51984024ddf6a2_2\"\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:10:38 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "147b1af2-a508-448e-8a1e-9e4e2a5e0d25"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14945"
+        ],
+        "x-ms-correlation-request-id": [
+          "a09b242c-34da-4891-a282-6d39c05d8c49"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181039Z:a09b242c-34da-4891-a282-6d39c05d8c49"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces?api-version=2016-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9taWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTIvdmlydHVhbE1hY2hpbmVzLzAvbmV0d29ya0ludGVyZmFjZXM/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "9f509f91-0a57-4a61-ab67-dd67ac3befd0"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"primary-nic-cfg\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg\",\r\n      \"etag\": \"W/\\\"019647bd-ed38-4415-b7fa-e3b286c0e8b5\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"5fddd090-1637-4ae5-a037-c574295288cb\",\r\n        \"ipConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-ip-cfg\",\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\",\r\n            \"etag\": \"W/\\\"019647bd-ed38-4415-b7fa-e3b286c0e8b5\\\"\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"privateIPAddress\": \"172.16.1.4\",\r\n              \"privateIPAllocationMethod\": \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\"\r\n              },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\": \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n                }\r\n              ],\r\n              \"loadBalancerInboundNatRules\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.0\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.0\"\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n          \"internalDomainNameSuffix\": \"d3jhdzasgz4ubkn2b4mbn01rte.yx.internal.cloudapp.net\"\r\n        },\r\n        \"macAddress\": \"00-0D-3A-F8-A5-E5\",\r\n        \"enableAcceleratedNetworking\": false,\r\n        \"enableIPForwarding\": false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/0\"\r\n        }\r\n      }\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:10:39 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "7e66f148-425b-4df9-b16d-d38c2c24d74e"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14944"
+        ],
+        "x-ms-correlation-request-id": [
+          "ad8d65eb-e630-4cb1-9d49-d418238e7c16"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181040Z:ad8d65eb-e630-4cb1-9d49-d418238e7c16"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces?api-version=2016-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9taWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTIvdmlydHVhbE1hY2hpbmVzLzEvbmV0d29ya0ludGVyZmFjZXM/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "7f2f8fb1-697e-4669-b691-6d2aaa289560"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"primary-nic-cfg\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg\",\r\n      \"etag\": \"W/\\\"0ec38be8-4f76-4a91-b34a-e4aa5e605afd\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"5b2de8ae-89bd-4b3d-9929-ff02bf78963f\",\r\n        \"ipConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-ip-cfg\",\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\",\r\n            \"etag\": \"W/\\\"0ec38be8-4f76-4a91-b34a-e4aa5e605afd\\\"\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"privateIPAddress\": \"172.16.1.5\",\r\n              \"privateIPAllocationMethod\": \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\"\r\n              },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\": \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n                }\r\n              ],\r\n              \"loadBalancerInboundNatRules\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.1\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.1\"\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n          \"internalDomainNameSuffix\": \"d3jhdzasgz4ubkn2b4mbn01rte.yx.internal.cloudapp.net\"\r\n        },\r\n        \"macAddress\": \"00-0D-3A-F8-B9-4B\",\r\n        \"enableAcceleratedNetworking\": false,\r\n        \"enableIPForwarding\": false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/1\"\r\n        }\r\n      }\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:10:39 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "b8a5a707-291e-4782-833e-820f3a5231a4"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14942"
+        ],
+        "x-ms-correlation-request-id": [
+          "b0abe333-45c0-4891-b38a-defa7ffce8d3"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181040Z:b0abe333-45c0-4891-b38a-defa7ffce8d3"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces?api-version=2016-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9taWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTIvdmlydHVhbE1hY2hpbmVzLzIvbmV0d29ya0ludGVyZmFjZXM/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "a0ab0b2f-8ad6-4fb5-b5c1-aa2537b6d880"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"primary-nic-cfg\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg\",\r\n      \"etag\": \"W/\\\"b717dfd5-8b69-4dd5-aed9-8a20de8773f6\\\"\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\": \"ca2c39c9-3b6c-43ea-9458-d5161675811c\",\r\n        \"ipConfigurations\": [\r\n          {\r\n            \"name\": \"primary-nic-ip-cfg\",\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2/networkInterfaces/primary-nic-cfg/ipConfigurations/primary-nic-ip-cfg\",\r\n            \"etag\": \"W/\\\"b717dfd5-8b69-4dd5-aed9-8a20de8773f6\\\"\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"privateIPAddress\": \"172.16.1.6\",\r\n              \"privateIPAllocationMethod\": \"Dynamic\",\r\n              \"subnet\": {\r\n                \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/virtualNetworks/vnetc9e45361cc66a6/subnets/Front-end\"\r\n              },\r\n              \"primary\": true,\r\n              \"privateIPAddressVersion\": \"IPv4\",\r\n              \"loadBalancerBackendAddressPools\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP1\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/backendAddressPools/intlb-8c4751883f-BAP2\"\r\n                }\r\n              ],\r\n              \"loadBalancerInboundNatRules\": [\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool50XXto22.2\"\r\n                },\r\n                {\r\n                  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Network/loadBalancers/intlb-8c4751883f/inboundNatRules/natPool60XXto23.2\"\r\n                }\r\n              ]\r\n            }\r\n          }\r\n        ],\r\n        \"dnsSettings\": {\r\n          \"dnsServers\": [],\r\n          \"appliedDnsServers\": [],\r\n          \"internalDomainNameSuffix\": \"d3jhdzasgz4ubkn2b4mbn01rte.yx.internal.cloudapp.net\"\r\n        },\r\n        \"macAddress\": \"00-0D-3A-F8-BE-39\",\r\n        \"enableAcceleratedNetworking\": false,\r\n        \"enableIPForwarding\": false,\r\n        \"primary\": true,\r\n        \"virtualMachine\": {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/virtualMachines/2\"\r\n        }\r\n      }\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:10:39 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "1ce7c5c5-5ece-4adf-825f-23fbaa692ffb"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14940"
+        ],
+        "x-ms-correlation-request-id": [
+          "75251cc0-fd21-4c91-b442-3bf5bf1aecdb"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181040Z:75251cc0-fd21-4c91-b442-3bf5bf1aecdb"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/poweroff?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTIvcG93ZXJvZmY/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
       "RequestMethod": "POST",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "f201e320-7910-4046-a996-3e73a4fcd7ad"
+          "9e9fdbd8-1383-4e82-b782-d1e232de2af1"
         ],
         "accept-language": [
           "en-US"
@@ -3281,20 +1967,20 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:57:18 GMT"
+          "Fri, 14 Apr 2017 18:10:40 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/886312f5-5eb8-4745-b02d-2a3bbcbc81b3?monitor=true&api-version=2016-04-30-preview"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25885a2d-6b8d-47a3-983a-e00038fdea77?monitor=true&api-version=2016-04-30-preview"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/886312f5-5eb8-4745-b02d-2a3bbcbc81b3?api-version=2016-04-30-preview"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25885a2d-6b8d-47a3-983a-e00038fdea77?api-version=2016-04-30-preview"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3303,23 +1989,23 @@
           "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
         ],
         "x-ms-request-id": [
-          "886312f5-5eb8-4745-b02d-2a3bbcbc81b3"
+          "25885a2d-6b8d-47a3-983a-e00038fdea77"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1191"
         ],
         "x-ms-correlation-request-id": [
-          "836f7045-ff98-473c-8ff5-48b2ca2e9451"
+          "a7cb1576-c6e5-4357-8ef2-84b67845ef5f"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215718Z:836f7045-ff98-473c-8ff5-48b2ca2e9451"
+          "WESTUS2:20170414T181040Z:a7cb1576-c6e5-4357-8ef2-84b67845ef5f"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/886312f5-5eb8-4745-b02d-2a3bbcbc81b3?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzg4NjMxMmY1LTVlYjgtNDc0NS1iMDJkLTJhM2JiY2JjODFiMz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25885a2d-6b8d-47a3-983a-e00038fdea77?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ODg1YTJkLTZiOGQtNDdhMy05ODNhLWUwMDAzOGZkZWE3Nz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3328,7 +2014,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:57:19.5634581-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"886312f5-5eb8-4745-b02d-2a3bbcbc81b3\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:10:41.1175125-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"25885a2d-6b8d-47a3-983a-e00038fdea77\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -3340,7 +2026,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:57:48 GMT"
+          "Fri, 14 Apr 2017 18:11:10 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -3362,23 +2048,23 @@
           "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
         ],
         "x-ms-request-id": [
-          "0adca985-20ad-45f3-96e1-492e9df160a8"
+          "c259c9d0-cf25-4fb8-8c61-6744ca6784fc"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14949"
+          "14938"
         ],
         "x-ms-correlation-request-id": [
-          "8ade619e-2988-4794-8255-fc18e8f4e746"
+          "aad9390d-15aa-4a35-bdb2-3a3158977802"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215748Z:8ade619e-2988-4794-8255-fc18e8f4e746"
+          "WESTUS2:20170414T181110Z:aad9390d-15aa-4a35-bdb2-3a3158977802"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/886312f5-5eb8-4745-b02d-2a3bbcbc81b3?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzg4NjMxMmY1LTVlYjgtNDc0NS1iMDJkLTJhM2JiY2JjODFiMz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25885a2d-6b8d-47a3-983a-e00038fdea77?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ODg1YTJkLTZiOGQtNDdhMy05ODNhLWUwMDAzOGZkZWE3Nz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3387,7 +2073,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:57:19.5634581-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"886312f5-5eb8-4745-b02d-2a3bbcbc81b3\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:10:41.1175125-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"25885a2d-6b8d-47a3-983a-e00038fdea77\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -3399,7 +2085,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:58:18 GMT"
+          "Fri, 14 Apr 2017 18:11:40 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -3421,23 +2107,23 @@
           "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
         ],
         "x-ms-request-id": [
-          "faa58db0-9fed-417d-88b6-9d9d3d984cb6"
+          "a6da23d2-f5a3-468b-aba2-8c5a412979b9"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14948"
+          "14937"
         ],
         "x-ms-correlation-request-id": [
-          "9baea024-c35c-4ef7-b72f-ae41b73fc32d"
+          "e2acf559-6b30-410b-b75f-75c9e5eec629"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215818Z:9baea024-c35c-4ef7-b72f-ae41b73fc32d"
+          "WESTUS2:20170414T181141Z:e2acf559-6b30-410b-b75f-75c9e5eec629"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/886312f5-5eb8-4745-b02d-2a3bbcbc81b3?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzg4NjMxMmY1LTVlYjgtNDc0NS1iMDJkLTJhM2JiY2JjODFiMz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25885a2d-6b8d-47a3-983a-e00038fdea77?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ODg1YTJkLTZiOGQtNDdhMy05ODNhLWUwMDAzOGZkZWE3Nz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3446,7 +2132,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:57:19.5634581-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"886312f5-5eb8-4745-b02d-2a3bbcbc81b3\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:10:41.1175125-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"25885a2d-6b8d-47a3-983a-e00038fdea77\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -3458,7 +2144,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:58:48 GMT"
+          "Fri, 14 Apr 2017 18:12:10 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -3480,23 +2166,23 @@
           "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
         ],
         "x-ms-request-id": [
-          "60effffb-d9a1-4f07-a219-4b64fef712f8"
+          "a49b9800-fb94-4687-a161-10393c758a15"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14947"
+          "14936"
         ],
         "x-ms-correlation-request-id": [
-          "63d6d8c4-79db-4a10-b5cc-5a99e321088e"
+          "3d7e0973-aa38-4639-ae48-cb174a49f2bd"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215848Z:63d6d8c4-79db-4a10-b5cc-5a99e321088e"
+          "WESTUS2:20170414T181211Z:3d7e0973-aa38-4639-ae48-cb174a49f2bd"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/886312f5-5eb8-4745-b02d-2a3bbcbc81b3?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzg4NjMxMmY1LTVlYjgtNDc0NS1iMDJkLTJhM2JiY2JjODFiMz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25885a2d-6b8d-47a3-983a-e00038fdea77?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ODg1YTJkLTZiOGQtNDdhMy05ODNhLWUwMDAzOGZkZWE3Nz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3505,7 +2191,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:57:19.5634581-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"886312f5-5eb8-4745-b02d-2a3bbcbc81b3\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:10:41.1175125-07:00\",\r\n  \"endTime\": \"2017-04-14T11:12:34.8359377-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"25885a2d-6b8d-47a3-983a-e00038fdea77\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -3517,7 +2203,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:59:18 GMT"
+          "Fri, 14 Apr 2017 18:12:40 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -3539,23 +2225,88 @@
           "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
         ],
         "x-ms-request-id": [
-          "2601ad6e-4004-4c43-b5db-6c112771ef7a"
+          "a5b2a6b5-2203-4afa-be4d-853f12c65423"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14946"
+          "14935"
         ],
         "x-ms-correlation-request-id": [
-          "cc4406a5-b3c2-4215-8aee-f06ae51d4815"
+          "f66a5a85-aab4-441b-8564-aed4640184b0"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215918Z:cc4406a5-b3c2-4215-8aee-f06ae51d4815"
+          "WESTUS2:20170414T181241Z:f66a5a85-aab4-441b-8564-aed4640184b0"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/886312f5-5eb8-4745-b02d-2a3bbcbc81b3?api-version=2016-04-30-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzg4NjMxMmY1LTVlYjgtNDc0NS1iMDJkLTJhM2JiY2JjODFiMz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/deallocate?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTIvZGVhbGxvY2F0ZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "a97e3247-6083-46df-aa35-e52ad9282b62"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:12:40 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/830b9e71-51fc-4fd7-926b-dec433bb9b66?monitor=true&api-version=2016-04-30-preview"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/830b9e71-51fc-4fd7-926b-dec433bb9b66?api-version=2016-04-30-preview"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "830b9e71-51fc-4fd7-926b-dec433bb9b66"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1190"
+        ],
+        "x-ms-correlation-request-id": [
+          "4732e969-5292-434b-ab85-0d9c13178459"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181241Z:4732e969-5292-434b-ab85-0d9c13178459"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/830b9e71-51fc-4fd7-926b-dec433bb9b66?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzgzMGI5ZTcxLTUxZmMtNGZkNy05MjZiLWRlYzQzM2JiOWI2Nj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3564,7 +2315,7 @@
           "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-10T14:57:19.5634581-07:00\",\r\n  \"endTime\": \"2017-04-10T14:59:27.172017-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"886312f5-5eb8-4745-b02d-2a3bbcbc81b3\"\r\n}",
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:12:41.854399-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"830b9e71-51fc-4fd7-926b-dec433bb9b66\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -3576,7 +2327,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:59:48 GMT"
+          "Fri, 14 Apr 2017 18:13:10 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -3598,28 +2349,1102 @@
           "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
         ],
         "x-ms-request-id": [
-          "73a8b84a-9470-41d5-a509-afa2dbfaa5e4"
+          "07d187c8-cb15-450e-bcc5-9bb86bb487c8"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14945"
+          "14934"
         ],
         "x-ms-correlation-request-id": [
-          "719a82b6-4089-4d81-bbbf-7a5e4e5a0ef4"
+          "286185a7-3b1d-40c2-891d-4aa29729d10c"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215949Z:719a82b6-4089-4d81-bbbf-7a5e4e5a0ef4"
+          "WESTUS2:20170414T181311Z:286185a7-3b1d-40c2-891d-4aa29729d10c"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rgcovsf4045222?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL3JnY292c2Y0MDQ1MjIyP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/830b9e71-51fc-4fd7-926b-dec433bb9b66?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzgzMGI5ZTcxLTUxZmMtNGZkNy05MjZiLWRlYzQzM2JiOWI2Nj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:12:41.854399-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"830b9e71-51fc-4fd7-926b-dec433bb9b66\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:13:41 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "7829ce35-55f1-49ca-91c3-a5cca45cabb1"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14933"
+        ],
+        "x-ms-correlation-request-id": [
+          "397fffae-8899-47cd-b84d-42d76b6e0794"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181341Z:397fffae-8899-47cd-b84d-42d76b6e0794"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/830b9e71-51fc-4fd7-926b-dec433bb9b66?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzgzMGI5ZTcxLTUxZmMtNGZkNy05MjZiLWRlYzQzM2JiOWI2Nj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:12:41.854399-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"830b9e71-51fc-4fd7-926b-dec433bb9b66\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:14:11 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "872817b7-281a-43a6-82d0-255fb252e59f"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14932"
+        ],
+        "x-ms-correlation-request-id": [
+          "deb80e30-8845-432e-b91b-f5390127a247"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181411Z:deb80e30-8845-432e-b91b-f5390127a247"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/830b9e71-51fc-4fd7-926b-dec433bb9b66?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzgzMGI5ZTcxLTUxZmMtNGZkNy05MjZiLWRlYzQzM2JiOWI2Nj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:12:41.854399-07:00\",\r\n  \"endTime\": \"2017-04-14T11:14:23.6452023-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"830b9e71-51fc-4fd7-926b-dec433bb9b66\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:14:41 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "405639e7-b162-4587-be0b-02ae195aa7ca"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14931"
+        ],
+        "x-ms-correlation-request-id": [
+          "26f4d3ba-790c-46a0-84c7-e2c43b81ae9d"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181441Z:26f4d3ba-790c-46a0-84c7-e2c43b81ae9d"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/start?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTIvc3RhcnQ/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "3cb16c39-c50e-443b-b3bc-8e8d711ee991"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:14:41 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/51a45d63-55d5-4912-b1fc-ca9235622f0c?monitor=true&api-version=2016-04-30-preview"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/51a45d63-55d5-4912-b1fc-ca9235622f0c?api-version=2016-04-30-preview"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "51a45d63-55d5-4912-b1fc-ca9235622f0c"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1189"
+        ],
+        "x-ms-correlation-request-id": [
+          "9518f763-a6a0-42bd-ac49-6d055fced0a4"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181442Z:9518f763-a6a0-42bd-ac49-6d055fced0a4"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/51a45d63-55d5-4912-b1fc-ca9235622f0c?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzUxYTQ1ZDYzLTU1ZDUtNDkxMi1iMWZjLWNhOTIzNTYyMmYwYz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:14:42.5277352-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"51a45d63-55d5-4912-b1fc-ca9235622f0c\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:15:11 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "cd7b3612-87ac-4ecc-b08f-1b456986f65e"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14929"
+        ],
+        "x-ms-correlation-request-id": [
+          "2a84c823-d284-44e9-abc4-72a6f1111818"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181512Z:2a84c823-d284-44e9-abc4-72a6f1111818"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/51a45d63-55d5-4912-b1fc-ca9235622f0c?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzUxYTQ1ZDYzLTU1ZDUtNDkxMi1iMWZjLWNhOTIzNTYyMmYwYz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:14:42.5277352-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"51a45d63-55d5-4912-b1fc-ca9235622f0c\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:15:41 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "049d6f85-41a7-410d-b2d4-0f4175695143"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14928"
+        ],
+        "x-ms-correlation-request-id": [
+          "c429674c-f4af-4c83-80ce-bd911ec2d67e"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181542Z:c429674c-f4af-4c83-80ce-bd911ec2d67e"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/51a45d63-55d5-4912-b1fc-ca9235622f0c?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzUxYTQ1ZDYzLTU1ZDUtNDkxMi1iMWZjLWNhOTIzNTYyMmYwYz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:14:42.5277352-07:00\",\r\n  \"endTime\": \"2017-04-14T11:16:06.4046095-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"51a45d63-55d5-4912-b1fc-ca9235622f0c\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:16:11 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "d1f747fd-4ba0-4df3-a8fa-5cc5efd16e6a"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14927"
+        ],
+        "x-ms-correlation-request-id": [
+          "0dbbb40e-e04b-409f-8533-79a5407968eb"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181612Z:0dbbb40e-e04b-409f-8533-79a5407968eb"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25fca7cf-f6a0-4c20-aed0-92b62f8f45be?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ZmNhN2NmLWY2YTAtNGMyMC1hZWQwLTkyYjYyZjhmNDViZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:16:13.8450264-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"25fca7cf-f6a0-4c20-aed0-92b62f8f45be\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:16:43 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "fc843e52-5d5b-47c2-ba72-b75993c751e7"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14925"
+        ],
+        "x-ms-correlation-request-id": [
+          "93a97daf-1617-4a56-ad4d-45d850e4cf23"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181643Z:93a97daf-1617-4a56-ad4d-45d850e4cf23"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25fca7cf-f6a0-4c20-aed0-92b62f8f45be?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ZmNhN2NmLWY2YTAtNGMyMC1hZWQwLTkyYjYyZjhmNDViZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:16:13.8450264-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"25fca7cf-f6a0-4c20-aed0-92b62f8f45be\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:17:13 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "83b061e4-76cd-43cb-adba-d9b02e51af31"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14924"
+        ],
+        "x-ms-correlation-request-id": [
+          "74fda6b8-4fc4-4c5f-adce-f13653b594b5"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181713Z:74fda6b8-4fc4-4c5f-adce-f13653b594b5"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25fca7cf-f6a0-4c20-aed0-92b62f8f45be?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ZmNhN2NmLWY2YTAtNGMyMC1hZWQwLTkyYjYyZjhmNDViZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:16:13.8450264-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"25fca7cf-f6a0-4c20-aed0-92b62f8f45be\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:17:43 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "8791e652-3de4-4ccf-9a74-e446679ed673"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14923"
+        ],
+        "x-ms-correlation-request-id": [
+          "c81ae82a-b364-4fe9-8ffd-957ec0ca69db"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181743Z:c81ae82a-b364-4fe9-8ffd-957ec0ca69db"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25fca7cf-f6a0-4c20-aed0-92b62f8f45be?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ZmNhN2NmLWY2YTAtNGMyMC1hZWQwLTkyYjYyZjhmNDViZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:16:13.8450264-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"25fca7cf-f6a0-4c20-aed0-92b62f8f45be\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:18:13 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "68382952-40d5-4095-9f3f-743062de649c"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14922"
+        ],
+        "x-ms-correlation-request-id": [
+          "326c31b9-e0e2-4f27-a640-0455a8211d98"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181813Z:326c31b9-e0e2-4f27-a640-0455a8211d98"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25fca7cf-f6a0-4c20-aed0-92b62f8f45be?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ZmNhN2NmLWY2YTAtNGMyMC1hZWQwLTkyYjYyZjhmNDViZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:16:13.8450264-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"25fca7cf-f6a0-4c20-aed0-92b62f8f45be\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:18:43 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "39c73e6c-4372-45b9-bcf3-b4f23f16e0a1"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14921"
+        ],
+        "x-ms-correlation-request-id": [
+          "bbffa3a1-1136-4560-a600-06af872e5d3c"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181844Z:bbffa3a1-1136-4560-a600-06af872e5d3c"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25fca7cf-f6a0-4c20-aed0-92b62f8f45be?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ZmNhN2NmLWY2YTAtNGMyMC1hZWQwLTkyYjYyZjhmNDViZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:16:13.8450264-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"25fca7cf-f6a0-4c20-aed0-92b62f8f45be\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:19:13 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "5c1ba1ad-53de-43d6-9d0c-db8c2b6cd91a"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14920"
+        ],
+        "x-ms-correlation-request-id": [
+          "9857d6c6-5a49-4da5-a9bf-2268a0ef343d"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181914Z:9857d6c6-5a49-4da5-a9bf-2268a0ef343d"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25fca7cf-f6a0-4c20-aed0-92b62f8f45be?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ZmNhN2NmLWY2YTAtNGMyMC1hZWQwLTkyYjYyZjhmNDViZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:16:13.8450264-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"25fca7cf-f6a0-4c20-aed0-92b62f8f45be\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:19:44 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "e5869c27-31ed-4df9-a3b4-111aaf531332"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14919"
+        ],
+        "x-ms-correlation-request-id": [
+          "6541db78-5429-4a56-b8df-3639c6a44bd6"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T181944Z:6541db78-5429-4a56-b8df-3639c6a44bd6"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/25fca7cf-f6a0-4c20-aed0-92b62f8f45be?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzI1ZmNhN2NmLWY2YTAtNGMyMC1hZWQwLTkyYjYyZjhmNDViZT9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:16:13.8450264-07:00\",\r\n  \"endTime\": \"2017-04-14T11:20:11.6389923-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"25fca7cf-f6a0-4c20-aed0-92b62f8f45be\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:20:14 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "a49a7236-6e89-4793-bb0f-b4246980581a"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14918"
+        ],
+        "x-ms-correlation-request-id": [
+          "a1535f89-44ac-475a-acec-832aca6b365d"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T182014Z:a1535f89-44ac-475a-acec-832aca6b365d"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rgcovs40c84343/providers/Microsoft.Compute/virtualMachineScaleSets/vmss51984024ddf6a2/restart?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnY292czQwYzg0MzQzL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZVNjYWxlU2V0cy92bXNzNTE5ODQwMjRkZGY2YTIvcmVzdGFydD9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "ed502824-f989-42b7-a884-585182c911de"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:20:14 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c5735255-2bf4-46d9-9ce8-dfa887b9158b?monitor=true&api-version=2016-04-30-preview"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c5735255-2bf4-46d9-9ce8-dfa887b9158b?api-version=2016-04-30-preview"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "c5735255-2bf4-46d9-9ce8-dfa887b9158b"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1187"
+        ],
+        "x-ms-correlation-request-id": [
+          "0d21a0d5-8e11-457f-919b-08c5ee5ca204"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T182014Z:0d21a0d5-8e11-457f-919b-08c5ee5ca204"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c5735255-2bf4-46d9-9ce8-dfa887b9158b?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2M1NzM1MjU1LTJiZjQtNDZkOS05Y2U4LWRmYTg4N2I5MTU4Yj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:20:15.2028176-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"c5735255-2bf4-46d9-9ce8-dfa887b9158b\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:20:44 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "0d204e78-607b-4ba5-844c-90eef4c59851"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14916"
+        ],
+        "x-ms-correlation-request-id": [
+          "4c263dc0-4248-4822-b09b-80b6702e14bf"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T182044Z:4c263dc0-4248-4822-b09b-80b6702e14bf"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/c5735255-2bf4-46d9-9ce8-dfa887b9158b?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2M1NzM1MjU1LTJiZjQtNDZkOS05Y2U4LWRmYTg4N2I5MTU4Yj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.24410.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-04-14T11:20:15.2028176-07:00\",\r\n  \"endTime\": \"2017-04-14T11:20:58.2813003-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"c5735255-2bf4-46d9-9ce8-dfa887b9158b\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 14 Apr 2017 18:21:14 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131239303813266421"
+        ],
+        "x-ms-request-id": [
+          "ce693d97-3052-4a83-baab-0109b78a1bb0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14915"
+        ],
+        "x-ms-correlation-request-id": [
+          "823b6024-3205-41ba-b66a-257c7a8800a1"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170414T182114Z:823b6024-3205-41ba-b66a-257c7a8800a1"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rgcovs40c84343?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL3JnY292czQwYzg0MzQzP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "cef46587-a9a9-434f-a23e-e4afe366506a"
+          "973708b2-efea-4ac7-a8c1-e7ba93eea115"
         ],
         "accept-language": [
           "en-US"
@@ -3641,28 +3466,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 21:59:49 GMT"
+          "Fri, 14 Apr 2017 18:21:14 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1190"
+          "1184"
         ],
         "x-ms-request-id": [
-          "40574041-c2c0-4c0a-9db6-fb0021e9d2ce"
+          "c45818f5-c331-4f9d-9514-18d439916f4c"
         ],
         "x-ms-correlation-request-id": [
-          "40574041-c2c0-4c0a-9db6-fb0021e9d2ce"
+          "c45818f5-c331-4f9d-9514-18d439916f4c"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T215949Z:40574041-c2c0-4c0a-9db6-fb0021e9d2ce"
+          "WESTUS2:20170414T182115Z:c45818f5-c331-4f9d-9514-18d439916f4c"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3671,8 +3496,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTTBNRU00TkRNME15MVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3693,28 +3518,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 22:00:18 GMT"
+          "Fri, 14 Apr 2017 18:21:44 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14944"
+          "14914"
         ],
         "x-ms-request-id": [
-          "5f28475c-a563-47d9-bbdd-89c72b083e38"
+          "a3abdaa0-b9ea-4f37-a9e9-643073d2b134"
         ],
         "x-ms-correlation-request-id": [
-          "5f28475c-a563-47d9-bbdd-89c72b083e38"
+          "a3abdaa0-b9ea-4f37-a9e9-643073d2b134"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220019Z:5f28475c-a563-47d9-bbdd-89c72b083e38"
+          "WESTUS2:20170414T182145Z:a3abdaa0-b9ea-4f37-a9e9-643073d2b134"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3723,8 +3548,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTTBNRU00TkRNME15MVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3745,28 +3570,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 22:00:49 GMT"
+          "Fri, 14 Apr 2017 18:22:15 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14942"
+          "14912"
         ],
         "x-ms-request-id": [
-          "e5fd9e9d-1912-45aa-9e87-71627f4a903e"
+          "f5974be7-e1b1-4675-81f8-f2adf2e141fc"
         ],
         "x-ms-correlation-request-id": [
-          "e5fd9e9d-1912-45aa-9e87-71627f4a903e"
+          "f5974be7-e1b1-4675-81f8-f2adf2e141fc"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220049Z:e5fd9e9d-1912-45aa-9e87-71627f4a903e"
+          "WESTUS2:20170414T182215Z:f5974be7-e1b1-4675-81f8-f2adf2e141fc"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3775,8 +3600,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTTBNRU00TkRNME15MVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3797,28 +3622,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 22:01:19 GMT"
+          "Fri, 14 Apr 2017 18:22:44 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14941"
+          "14911"
         ],
         "x-ms-request-id": [
-          "fdd0e8ff-78be-4f9b-82dd-be835fc2f074"
+          "7d6873d1-df1a-4aff-b613-f01b93e636a1"
         ],
         "x-ms-correlation-request-id": [
-          "fdd0e8ff-78be-4f9b-82dd-be835fc2f074"
+          "7d6873d1-df1a-4aff-b613-f01b93e636a1"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220119Z:fdd0e8ff-78be-4f9b-82dd-be835fc2f074"
+          "WESTUS2:20170414T182245Z:7d6873d1-df1a-4aff-b613-f01b93e636a1"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3827,8 +3652,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTTBNRU00TkRNME15MVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3849,28 +3674,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 22:01:48 GMT"
+          "Fri, 14 Apr 2017 18:23:15 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14940"
+          "14909"
         ],
         "x-ms-request-id": [
-          "0e64ff71-01ed-4d4d-b756-d29b628cde86"
+          "51663540-a400-402b-842b-c3e6fbf0f9d3"
         ],
         "x-ms-correlation-request-id": [
-          "0e64ff71-01ed-4d4d-b756-d29b628cde86"
+          "51663540-a400-402b-842b-c3e6fbf0f9d3"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220149Z:0e64ff71-01ed-4d4d-b756-d29b628cde86"
+          "WESTUS2:20170414T182315Z:51663540-a400-402b-842b-c3e6fbf0f9d3"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3879,8 +3704,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTTBNRU00TkRNME15MVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3901,28 +3726,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 22:02:19 GMT"
+          "Fri, 14 Apr 2017 18:23:45 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14939"
+          "14908"
         ],
         "x-ms-request-id": [
-          "09588edb-c5df-4928-857c-805a702c643e"
+          "a7918738-a94e-4b20-b57d-d2853a20d600"
         ],
         "x-ms-correlation-request-id": [
-          "09588edb-c5df-4928-857c-805a702c643e"
+          "a7918738-a94e-4b20-b57d-d2853a20d600"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220220Z:09588edb-c5df-4928-857c-805a702c643e"
+          "WESTUS2:20170414T182345Z:a7918738-a94e-4b20-b57d-d2853a20d600"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3931,8 +3756,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTTBNRU00TkRNME15MVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -3953,28 +3778,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 22:02:49 GMT"
+          "Fri, 14 Apr 2017 18:24:15 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14938"
+          "14907"
         ],
         "x-ms-request-id": [
-          "a1693da2-5672-4b1d-8705-cec2b02009b4"
+          "ec80408b-8960-42c6-b365-3abb9db4b60c"
         ],
         "x-ms-correlation-request-id": [
-          "a1693da2-5672-4b1d-8705-cec2b02009b4"
+          "ec80408b-8960-42c6-b365-3abb9db4b60c"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220250Z:a1693da2-5672-4b1d-8705-cec2b02009b4"
+          "WESTUS2:20170414T182415Z:ec80408b-8960-42c6-b365-3abb9db4b60c"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -3983,8 +3808,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTTBNRU00TkRNME15MVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -4005,28 +3830,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 22:03:20 GMT"
+          "Fri, 14 Apr 2017 18:24:45 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14937"
+          "14906"
         ],
         "x-ms-request-id": [
-          "6dbb7850-0824-4d08-8e7c-8514f3ded620"
+          "8878fd10-a002-4cbf-b0d9-bdd7539d6040"
         ],
         "x-ms-correlation-request-id": [
-          "6dbb7850-0824-4d08-8e7c-8514f3ded620"
+          "8878fd10-a002-4cbf-b0d9-bdd7539d6040"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220320Z:6dbb7850-0824-4d08-8e7c-8514f3ded620"
+          "WESTUS2:20170414T182445Z:8878fd10-a002-4cbf-b0d9-bdd7539d6040"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -4035,8 +3860,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTTBNRU00TkRNME15MVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -4057,28 +3882,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 22:03:49 GMT"
+          "Fri, 14 Apr 2017 18:25:15 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14936"
+          "14905"
         ],
         "x-ms-request-id": [
-          "ade4b4af-4960-4e6b-b464-4ebbd7be144c"
+          "fa8ac3a1-c589-47d3-95b1-c63d6cbde233"
         ],
         "x-ms-correlation-request-id": [
-          "ade4b4af-4960-4e6b-b464-4ebbd7be144c"
+          "fa8ac3a1-c589-47d3-95b1-c63d6cbde233"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220350Z:ade4b4af-4960-4e6b-b464-4ebbd7be144c"
+          "WESTUS2:20170414T182516Z:fa8ac3a1-c589-47d3-95b1-c63d6cbde233"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -4087,8 +3912,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTTBNRU00TkRNME15MVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -4109,28 +3934,28 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 22:04:19 GMT"
+          "Fri, 14 Apr 2017 18:25:45 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14935"
+          "14904"
         ],
         "x-ms-request-id": [
-          "a7b7ee5b-79cd-4ab0-93a6-e0b82a9d0d3f"
+          "e064c565-3ff6-4b73-8291-54d2401653e7"
         ],
         "x-ms-correlation-request-id": [
-          "a7b7ee5b-79cd-4ab0-93a6-e0b82a9d0d3f"
+          "e064c565-3ff6-4b73-8291-54d2401653e7"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220420Z:a7b7ee5b-79cd-4ab0-93a6-e0b82a9d0d3f"
+          "WESTUS2:20170414T182546Z:e064c565-3ff6-4b73-8291-54d2401653e7"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -4139,8 +3964,8 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlM0MEM4NDM0My1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTTBNRU00TkRNME15MVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
@@ -4161,230 +3986,22 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 10 Apr 2017 22:04:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14934"
-        ],
-        "x-ms-request-id": [
-          "9a7035c7-625f-490d-8e13-089c3cfec497"
-        ],
-        "x-ms-correlation-request-id": [
-          "9a7035c7-625f-490d-8e13-089c3cfec497"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220450Z:9a7035c7-625f-490d-8e13-089c3cfec497"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "0"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 22:05:19 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14933"
-        ],
-        "x-ms-request-id": [
-          "64f51b0f-5b87-4470-b775-7fa7cb1ae965"
-        ],
-        "x-ms-correlation-request-id": [
-          "64f51b0f-5b87-4470-b775-7fa7cb1ae965"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220520Z:64f51b0f-5b87-4470-b775-7fa7cb1ae965"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "0"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 22:05:50 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14932"
-        ],
-        "x-ms-request-id": [
-          "d68f63da-5e57-4725-81d5-808b6fcd6122"
-        ],
-        "x-ms-correlation-request-id": [
-          "d68f63da-5e57-4725-81d5-808b6fcd6122"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220550Z:d68f63da-5e57-4725-81d5-808b6fcd6122"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "0"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 22:06:20 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14931"
-        ],
-        "x-ms-request-id": [
-          "bcc69a68-0817-4e97-82c8-9da4b5e16cf9"
-        ],
-        "x-ms-correlation-request-id": [
-          "bcc69a68-0817-4e97-82c8-9da4b5e16cf9"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220620Z:bcc69a68-0817-4e97-82c8-9da4b5e16cf9"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0NPVlNGNDA0NTIyMi1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFTUjBOUFZsTkdOREEwTlRJeU1pMVhSVk5VUTBWT1ZGSkJURlZUSWl3aWFtOWlURzlqWVhScGIyNGlPaUozWlhOMFkyVnVkSEpoYkhWekluMD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.24410.01",
-          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.0.0"
-        ]
-      },
-      "ResponseBody": "",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "0"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Mon, 10 Apr 2017 22:06:49 GMT"
+          "Fri, 14 Apr 2017 18:26:15 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14930"
+          "14903"
         ],
         "x-ms-request-id": [
-          "e26bd73c-759f-4103-ab69-09a648d10925"
+          "88fafb47-0a4e-4208-8d5e-2b69417f9d5a"
         ],
         "x-ms-correlation-request-id": [
-          "e26bd73c-759f-4103-ab69-09a648d10925"
+          "88fafb47-0a4e-4208-8d5e-2b69417f9d5a"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170410T220650Z:e26bd73c-759f-4103-ab69-09a648d10925"
+          "WESTUS2:20170414T182616Z:88fafb47-0a4e-4208-8d5e-2b69417f9d5a"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -4395,11 +4012,11 @@
   ],
   "Names": {
     "ManageVirtualMachineScaleSetTestAsync": [
-      "rgcovsf4045222",
-      "vnetcdb59665b56515",
-      "intlb-92e08687f4",
-      "vmss0918303254dd26",
-      "vmss-vm98055"
+      "rgcovs40c84343",
+      "vnetc9e45361cc66a6",
+      "intlb-8c4751883f",
+      "vmss51984024ddf6a2",
+      "vmss-vm28467"
     ]
   },
   "Variables": {


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.