### PR TITLE
Rename logging levels to C# style enums and add mac address hash to user agent

### DIFF
--- a/Samples/ResourceManagement/AppService/ManageFunctionAppBasic/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageFunctionAppBasic/Program.cs
@@ -154,7 +154,7 @@ namespace ManageFunctionAppBasic
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageFunctionAppSourceControl/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageFunctionAppSourceControl/Program.cs
@@ -185,7 +185,7 @@ namespace ManageFunctionAppSourceControl
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageFunctionAppWithAuthentication/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageFunctionAppWithAuthentication/Program.cs
@@ -137,7 +137,7 @@ namespace ManageFunctionAppWithAuthentication
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageFunctionAppWithDomainSsl/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageFunctionAppWithDomainSsl/Program.cs
@@ -171,7 +171,7 @@ namespace ManageFunctionAppWithDomainSsl
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageLinuxWebAppBasic/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageLinuxWebAppBasic/Program.cs
@@ -166,7 +166,7 @@ namespace ManageLinuxWebAppBasic
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageLinuxWebAppSourceControl/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageLinuxWebAppSourceControl/Program.cs
@@ -193,7 +193,7 @@ namespace ManageLinuxWebAppSourceControl
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageLinuxWebAppSqlConnection/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageLinuxWebAppSqlConnection/Program.cs
@@ -132,7 +132,7 @@ namespace ManageLinuxWebAppSqlConnection
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageLinuxWebAppStorageAccountConnection/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageLinuxWebAppStorageAccountConnection/Program.cs
@@ -135,7 +135,7 @@ namespace ManageLinuxWebAppStorageAccountConnection
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageLinuxWebAppWithDomainSsl/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageLinuxWebAppWithDomainSsl/Program.cs
@@ -175,7 +175,7 @@ namespace ManageLinuxWebAppWithDomainSsl
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageLinuxWebAppWithTrafficManager/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageLinuxWebAppWithTrafficManager/Program.cs
@@ -225,7 +225,7 @@ namespace ManageLinuxWebAppWithTrafficManager
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageWebAppBasic/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageWebAppBasic/Program.cs
@@ -161,7 +161,7 @@ namespace ManageWebAppBasic
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageWebAppSlots/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageWebAppSlots/Program.cs
@@ -94,7 +94,7 @@ namespace ManageWebAppSlots
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageWebAppSourceControl/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageWebAppSourceControl/Program.cs
@@ -197,7 +197,7 @@ namespace ManageWebAppSourceControl
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageWebAppSourceControlAsync/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageWebAppSourceControlAsync/Program.cs
@@ -197,7 +197,7 @@ namespace ManageWebAppSourceControlAsync
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageWebAppSqlConnection/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageWebAppSqlConnection/Program.cs
@@ -135,7 +135,7 @@ namespace ManageWebAppSqlConnection
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageWebAppStorageAccountConnection/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageWebAppStorageAccountConnection/Program.cs
@@ -141,7 +141,7 @@ namespace ManageWebAppStorageAccountConnection
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageWebAppWithAuthentication/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageWebAppWithAuthentication/Program.cs
@@ -221,7 +221,7 @@ namespace ManageWebAppWithAuthentication
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageWebAppWithDomainSsl/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageWebAppWithDomainSsl/Program.cs
@@ -177,7 +177,7 @@ namespace ManageWebAppWithDomainSsl
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/AppService/ManageWebAppWithTrafficManager/Program.cs
+++ b/Samples/ResourceManagement/AppService/ManageWebAppWithTrafficManager/Program.cs
@@ -225,7 +225,7 @@ namespace ManageWebAppWithTrafficManager
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Batch/ManageBatchAccount/Program.cs
+++ b/Samples/ResourceManagement/Batch/ManageBatchAccount/Program.cs
@@ -238,7 +238,7 @@ namespace ManageBatchAccount
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Cdn/ManageCdn/Program.cs
+++ b/Samples/ResourceManagement/Cdn/ManageCdn/Program.cs
@@ -133,7 +133,7 @@ namespace ManageCdn
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ConvertVirtualMachineToManagedDisks/Program.cs
+++ b/Samples/ResourceManagement/Compute/ConvertVirtualMachineToManagedDisks/Program.cs
@@ -105,7 +105,7 @@ namespace ConvertVirtualMachineToManagedDisks
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/CreateVMsUsingCustomImageOrSpecializedVHD/Program.cs
+++ b/Samples/ResourceManagement/Compute/CreateVMsUsingCustomImageOrSpecializedVHD/Program.cs
@@ -180,7 +180,7 @@ namespace CreateVMsUsingCustomImageOrSpecializedVHD
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingCustomImageFromVHD/Program.cs
+++ b/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingCustomImageFromVHD/Program.cs
@@ -242,7 +242,7 @@ namespace CreateVirtualMachineUsingCustomImageFromVHD
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingCustomImageFromVM/Program.cs
+++ b/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingCustomImageFromVM/Program.cs
@@ -224,7 +224,7 @@ namespace CreateVirtualMachineUsingCustomImageFromVM
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingSpecializedDiskFromSnapshot/Program.cs
+++ b/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingSpecializedDiskFromSnapshot/Program.cs
@@ -260,7 +260,7 @@ namespace CreateVirtualMachineUsingSpecializedDiskFromSnapshot
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingSpecializedDiskFromVhd/Program.cs
+++ b/Samples/ResourceManagement/Compute/CreateVirtualMachineUsingSpecializedDiskFromVhd/Program.cs
@@ -210,7 +210,7 @@ namespace CreateVirtualMachineUsingSpecializedDiskFromVhd
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/CreateVirtualMachinesInParallel/Program.cs
+++ b/Samples/ResourceManagement/Compute/CreateVirtualMachinesInParallel/Program.cs
@@ -191,7 +191,7 @@ namespace CreateVirtualMachinesInParallel
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ListVirtualMachineExtensionImages/Program.cs
+++ b/Samples/ResourceManagement/Compute/ListVirtualMachineExtensionImages/Program.cs
@@ -71,7 +71,7 @@ namespace ListVirtualMachineExtensionImages
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ListVirtualMachineImages/Program.cs
+++ b/Samples/ResourceManagement/Compute/ListVirtualMachineImages/Program.cs
@@ -75,7 +75,7 @@ namespace ListVirtualMachineImages
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageAvailabilitySet/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageAvailabilitySet/Program.cs
@@ -175,7 +175,7 @@ namespace ManageAvailabilitySet
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageManagedDisks/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageManagedDisks/Program.cs
@@ -334,7 +334,7 @@ namespace ManageManagedDisks
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachine/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachine/Program.cs
@@ -201,7 +201,7 @@ namespace ManageVirtualMachine
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachineAsync/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachineAsync/Program.cs
@@ -176,7 +176,7 @@ namespace ManageVirtualMachineAsync
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachineExtension/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachineExtension/Program.cs
@@ -292,7 +292,7 @@ namespace ManageVirtualMachineExtension
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachineScaleSet/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachineScaleSet/Program.cs
@@ -335,7 +335,7 @@ namespace ManageVirtualMachineScaleSet
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachineScaleSetAsync/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachineScaleSetAsync/Program.cs
@@ -330,7 +330,7 @@ namespace ManageVirtualMachineScaleSetAsync
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachineScaleSetWithUnmanagedDisks/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachineScaleSetWithUnmanagedDisks/Program.cs
@@ -274,7 +274,7 @@ namespace ManageVirtualMachineScaleSetWithUnmanagedDisks
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachineWithDisk/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachineWithDisk/Program.cs
@@ -203,7 +203,7 @@ namespace ManageVirtualMachineWithDisk
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachineWithUnmanagedDisks/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachineWithUnmanagedDisks/Program.cs
@@ -218,7 +218,7 @@ namespace ManageVirtualMachineWithUnmanagedDisks
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachinesInParallel/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachinesInParallel/Program.cs
@@ -105,7 +105,7 @@ namespace ManageVirtualMachinesInParallel
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Compute/ManageVirtualMachinesInParallelWithNetwork/Program.cs
+++ b/Samples/ResourceManagement/Compute/ManageVirtualMachinesInParallelWithNetwork/Program.cs
@@ -224,7 +224,7 @@ namespace ManageVirtualMachinesInParallelWithNetwork
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Dns/ManageDns/Program.cs
+++ b/Samples/ResourceManagement/Dns/ManageDns/Program.cs
@@ -276,7 +276,7 @@ namespace ManageDns
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/KeyVault/ManageKeyVault/Program.cs
+++ b/Samples/ResourceManagement/KeyVault/ManageKeyVault/Program.cs
@@ -146,7 +146,7 @@ namespace ManageKeyVault
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Network/ManageApplicationGateway/Program.cs
+++ b/Samples/ResourceManagement/Network/ManageApplicationGateway/Program.cs
@@ -318,7 +318,7 @@ namespace ManageApplicationGateway
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Network/ManageInternalLoadBalancer/Program.cs
+++ b/Samples/ResourceManagement/Network/ManageInternalLoadBalancer/Program.cs
@@ -441,7 +441,7 @@ namespace ManageInternalLoadBalancer
                 var credentials = SdkContext.AzureCredentialsFactory.FromFile(Environment.GetEnvironmentVariable("AZURE_AUTH_LOCATION"));
 
                 var azure = Azure.Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Network/ManageInternetFacingLoadBalancer/Program.cs
+++ b/Samples/ResourceManagement/Network/ManageInternetFacingLoadBalancer/Program.cs
@@ -500,7 +500,7 @@ namespace ManageInternetFacingLoadBalancer
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Network/ManageIpAddress/Program.cs
+++ b/Samples/ResourceManagement/Network/ManageIpAddress/Program.cs
@@ -158,7 +158,7 @@ namespace ManageIPAddress
                 var credentials = SdkContext.AzureCredentialsFactory.FromFile(Environment.GetEnvironmentVariable("AZURE_AUTH_LOCATION"));
 
                 var azure = Azure.Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Network/ManageNetworkInterface/Program.cs
+++ b/Samples/ResourceManagement/Network/ManageNetworkInterface/Program.cs
@@ -196,7 +196,7 @@ namespace ManageNetworkInterface
                 var credentials = SdkContext.AzureCredentialsFactory.FromFile(Environment.GetEnvironmentVariable("AZURE_AUTH_LOCATION"));
 
                 var azure = Azure.Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Network/ManageNetworkSecurityGroup/Program.cs
+++ b/Samples/ResourceManagement/Network/ManageNetworkSecurityGroup/Program.cs
@@ -282,7 +282,7 @@ namespace ManageNetworkSecurityGroup
                 var credentials = SdkContext.AzureCredentialsFactory.FromFile(Environment.GetEnvironmentVariable("AZURE_AUTH_LOCATION"));
 
                 var azure = Azure.Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Network/ManageSimpleApplicationGateway/Program.cs
+++ b/Samples/ResourceManagement/Network/ManageSimpleApplicationGateway/Program.cs
@@ -149,7 +149,7 @@ namespace ManageSimpleApplicationGateway
                 var credentials = SdkContext.AzureCredentialsFactory.FromFile(Environment.GetEnvironmentVariable("AZURE_AUTH_LOCATION"));
 
                 var azure = Azure.Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Network/ManageVirtualNetwork/Program.cs
+++ b/Samples/ResourceManagement/Network/ManageVirtualNetwork/Program.cs
@@ -250,7 +250,7 @@ namespace ManageVirtualNetwork
                 var credentials = SdkContext.AzureCredentialsFactory.FromFile(Environment.GetEnvironmentVariable("AZURE_AUTH_LOCATION"));
 
                 var azure = Azure.Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Network/ManageVirtualNetworkAsync/Program.cs
+++ b/Samples/ResourceManagement/Network/ManageVirtualNetworkAsync/Program.cs
@@ -236,7 +236,7 @@ namespace ManageVirtualNetworkAsync
                 var credentials = SdkContext.AzureCredentialsFactory.FromFile(Environment.GetEnvironmentVariable("AZURE_AUTH_LOCATION"));
 
                 var azure = Azure.Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/RedisCache/ManageRedis/Program.cs
+++ b/Samples/ResourceManagement/RedisCache/ManageRedis/Program.cs
@@ -157,7 +157,7 @@ namespace ManageRedis
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                     .Authenticate(tokenCredentials).WithSubscription(tokenCredentials.DefaultSubscriptionId);
 
                 // Print selected subscription

--- a/Samples/ResourceManagement/ResourceManager/DeployUsingARMTemplate/Program.cs
+++ b/Samples/ResourceManagement/ResourceManager/DeployUsingARMTemplate/Program.cs
@@ -76,7 +76,7 @@ namespace DeployUsingARMTemplate
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/ResourceManager/DeployUsingARMTemplateWithProgress/Program.cs
+++ b/Samples/ResourceManagement/ResourceManager/DeployUsingARMTemplateWithProgress/Program.cs
@@ -94,7 +94,7 @@ namespace DeployUsingARMTemplateWithProgress
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/ResourceManager/DeployVirtualMachineUsingARMTemplate/Program.cs
+++ b/Samples/ResourceManagement/ResourceManager/DeployVirtualMachineUsingARMTemplate/Program.cs
@@ -93,7 +93,7 @@ namespace DeployVirtualMachineUsingARMTemplate
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/ResourceManager/ManageResource/Program.cs
+++ b/Samples/ResourceManagement/ResourceManager/ManageResource/Program.cs
@@ -123,7 +123,7 @@ namespace ManageResource
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/ResourceManager/ManageResourceGroup/Program.cs
+++ b/Samples/ResourceManagement/ResourceManager/ManageResourceGroup/Program.cs
@@ -108,7 +108,7 @@ namespace ManageResourceGroup
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeAdvanceFeatures/Program.cs
@@ -198,7 +198,7 @@ namespace ServiceBusPublishSubscribeAdvanceFeatures
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusPublishSubscribeBasic/Program.cs
@@ -185,7 +185,7 @@ namespace ServiceBusPublishSubscribeBasic
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueAdvanceFeatures/Program.cs
@@ -179,7 +179,7 @@ namespace ServiceBusQueueAdvanceFeatures
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusQueueBasic/Program.cs
@@ -181,7 +181,7 @@ namespace ServiceBusQueueBasic
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Program.cs
+++ b/Samples/ResourceManagement/ServiceBus/ServiceBusWithClaimBasedAuthorization/Program.cs
@@ -133,7 +133,7 @@ namespace ServiceBusWithClaimBasedAuthorization
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Sql/ManageSqlDatabase/Program.cs
+++ b/Samples/ResourceManagement/Sql/ManageSqlDatabase/Program.cs
@@ -123,7 +123,7 @@ namespace ManageSqlDatabase
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Sql/ManageSqlDatabaseInElasticPool/Program.cs
+++ b/Samples/ResourceManagement/Sql/ManageSqlDatabaseInElasticPool/Program.cs
@@ -213,7 +213,7 @@ namespace ManageSqlDatabaseInElasticPool
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Sql/ManageSqlDatabasesAcrossDifferentDataCenters/Program.cs
+++ b/Samples/ResourceManagement/Sql/ManageSqlDatabasesAcrossDifferentDataCenters/Program.cs
@@ -208,7 +208,7 @@ namespace ManageSqlDatabasesAcrossDifferentDataCenters
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Sql/ManageSqlFirewallRules/Program.cs
+++ b/Samples/ResourceManagement/Sql/ManageSqlFirewallRules/Program.cs
@@ -123,7 +123,7 @@ namespace ManageSqlFirewallRules
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Storage/ManageStorageAccount/Program.cs
+++ b/Samples/ResourceManagement/Storage/ManageStorageAccount/Program.cs
@@ -117,7 +117,7 @@ namespace ManageStorageAccount
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/Storage/ManageStorageAccountAsync/Program.cs
+++ b/Samples/ResourceManagement/Storage/ManageStorageAccountAsync/Program.cs
@@ -113,7 +113,7 @@ namespace ManageStorageAccountAsync
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/Samples/ResourceManagement/TrafficManager/ManageTrafficManager/Program.cs
+++ b/Samples/ResourceManagement/TrafficManager/ManageTrafficManager/Program.cs
@@ -245,7 +245,7 @@ namespace ManageTrafficManager
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/InterfaceImpl/AppServicePlanImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/Domain/InterfaceImpl/AppServicePlanImpl.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     using Microsoft.Azure.Management.AppService.Fluent.AppServicePlan.Definition;
     using Microsoft.Azure.Management.AppService.Fluent.AppServicePlan.Update;
     using Microsoft.Azure.Management.AppService.Fluent.Models;
-    using Microsoft.Azure.Management.ResourceManager.Fluent;
 
     internal partial class AppServicePlanImpl 
     {

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/TestHelper.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/TestHelper.cs
@@ -103,7 +103,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => NetworkManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c, c.DefaultSubscriptionId));
         }
 
@@ -112,7 +112,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => ComputeManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c, c.DefaultSubscriptionId));
         }
 
@@ -121,7 +121,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c)
                 .WithSubscription(c.DefaultSubscriptionId));
         }
@@ -131,7 +131,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => BatchManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c, c.DefaultSubscriptionId));
         }
 
@@ -140,7 +140,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => SqlManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c, c.DefaultSubscriptionId));
         }
 
@@ -149,7 +149,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => AppServiceManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c, c.DefaultSubscriptionId));
         }
 
@@ -159,7 +159,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => KeyVaultManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c, c.DefaultSubscriptionId));
         }
 
@@ -168,7 +168,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => CdnManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c, c.DefaultSubscriptionId));
         }
 
@@ -177,7 +177,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => RedisManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c, c.DefaultSubscriptionId));
         }
 
@@ -186,7 +186,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => StorageManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c, c.DefaultSubscriptionId));
         }
 
@@ -195,7 +195,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => ServiceBusManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c, c.DefaultSubscriptionId));
         }
 
@@ -204,7 +204,7 @@ namespace Fluent.Tests.Common
             return CreateMockedManager(c => Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManager
                 .Configure()
                 .WithDelegatingHandlers(GetHandlers())
-                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                 .Authenticate(c));
         }
 

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Miscellaneous/RestClientTests.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Miscellaneous/RestClientTests.cs
@@ -42,7 +42,7 @@ namespace Fluent.Tests.Miscellaneous
                     azure = Microsoft.Azure.Management.Fluent.Azure
                         .Configure()
                         .WithUserAgent("azure-fluent-test", "1.0.0-prelease")
-                        .WithLogLevel(HttpLoggingDelegatingHandler.Level.BODY)
+                        .WithLogLevel(HttpLoggingDelegatingHandler.Level.BodyAndHeaders)
                         .WithDelegatingHandlers(TestHelper.GetHandlers())
                         .Authenticate(credentials)
                         .WithDefaultSubscription();

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/RestClient/HttpLoggingDelegatingHandler.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/RestClient/HttpLoggingDelegatingHandler.cs
@@ -16,10 +16,11 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
     {
         public enum Level
         {
-            NONE,
-            BASIC,
-            HEADERS,
-            BODY
+            None,
+            Basic,
+            Headers,
+            Body,
+            BodyAndHeaders
         };
 
         public Level LogLevel { get; set; }
@@ -33,13 +34,13 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (LogLevel == Level.NONE)
+            if (LogLevel == Level.None)
             {
                 return await base.SendAsync(request, cancellationToken);
             }
 
             ServiceClientTracing.Information("Request: {0} {1}", request.Method, request.RequestUri);
-            if (LogLevel == Level.BODY || LogLevel == Level.HEADERS)
+            if (LogLevel == Level.BodyAndHeaders || LogLevel == Level.Headers)
             {
                 ServiceClientTracing.Information("  headers:");
                 foreach (var header in request.Headers)
@@ -48,7 +49,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                 }
             }
 
-            if (LogLevel == Level.BODY)
+            if (LogLevel == Level.Body || LogLevel == Level.BodyAndHeaders)
             {
                 if (request.Content != null)
                 {
@@ -59,7 +60,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
             }
 
             HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
-            if (LogLevel == Level.BODY || LogLevel == Level.HEADERS)
+            if (LogLevel == Level.BodyAndHeaders || LogLevel == Level.Headers)
             {
                 ServiceClientTracing.Information("Response:");
                 ServiceClientTracing.Information("  headers:");
@@ -70,7 +71,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
             }
 
 
-            if (LogLevel == Level.BODY)
+            if (LogLevel == Level.Body || LogLevel == Level.BodyAndHeaders)
             {
                 bool isEncoded = IsHeaderPresent(response.Content.Headers, "Content-Encoding");
                 if (!isEncoded && response.Content != null)

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/project.json
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/project.json
@@ -42,7 +42,8 @@
       "imports": [ "dnxcore50" ],
       "dependencies": {
         "NETStandard.Library": "1.6.1",
-        "System.Reflection.TypeExtensions": "4.3.0"
+        "System.Reflection.TypeExtensions": "4.3.0",
+        "System.Net.NetworkInformation": "4.3.0"
       }
     }
   }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.