### PR TITLE
Initial cleanup for cast to IReadOnlyList 

### DIFF
--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceDomainImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceDomainImpl.cs
@@ -63,9 +63,8 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         }
 
         ///GENMHASH:2EBE0E253F1D6DB178F3433FF5310EA8:62D7374C9C52BDCC93D26784CA76AFA8
-        public IList<string> NameServers()
+        public IReadOnlyList<string> NameServers()
         {
-            return Inner.NameServers;
         }
 
         ///GENMHASH:0202A00A1DCF248D2647DBDBEF2CA865:90FEC55929748850F1ED324D0CB61EE7

--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceDomainImpl.cs
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent/AppServiceDomainImpl.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:2EBE0E253F1D6DB178F3433FF5310EA8:62D7374C9C52BDCC93D26784CA76AFA8
         public IReadOnlyList<string> NameServers()
         {
+            return Inner.NameServers?.ToList();
         }
 
         ///GENMHASH:0202A00A1DCF248D2647DBDBEF2CA865:90FEC55929748850F1ED324D0CB61EE7

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/ApplicationImpl.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/ApplicationImpl.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         }
 
         ///GENMHASH:EFC1A644FBCF1755C5FEB8713E37C978:7F01B6BD1881008A6F33AB93CA13267F
-        internal IDictionary<string, IApplicationPackage> ApplicationPackages()
+        internal IReadOnlyDictionary<string, IApplicationPackage> ApplicationPackages()
         {
             return applicationPackages.AsMap();
         }

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/ApplicationPackagesImpl.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/ApplicationPackagesImpl.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         }
 
         ///GENMHASH:310B2185D2F2431DF2BBDBC06E585C74:F487B2409E11AB3B3255E980C7B88B89
-        internal IDictionary<string, Microsoft.Azure.Management.Batch.Fluent.IApplicationPackage> AsMap()
+        internal IReadOnlyDictionary<string, Microsoft.Azure.Management.Batch.Fluent.IApplicationPackage> AsMap()
         {
             var result = new Dictionary<string, IApplicationPackage>();
 

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/ApplicationsImpl.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/ApplicationsImpl.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         }
 
         ///GENMHASH:310B2185D2F2431DF2BBDBC06E585C74:9EA9A37597EAD8A99691D15719026E07
-        internal IDictionary<string, IApplication> AsMap()
+        internal IReadOnlyDictionary<string, IApplication> AsMap()
         {
             var result = new Dictionary<string, IApplication>();
 

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/BatchAccountImpl.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/BatchAccountImpl.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         }
 
         ///GENMHASH:672E69F72385496EBDF873EB27A7AA15:C0743C8E69844064A4120ADE2213CA5B
-        internal IDictionary<string, IApplication> Applications()
+        internal IReadOnlyDictionary<string, IApplication> Applications()
         {
             return applicationsImpl.AsMap();
         }

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/BatchAccountsInner.cs
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent/BatchAccountsInner.cs
@@ -1,6 +1,0 @@
-﻿namespace Microsoft.Azure.Management.Batch.Fluent
-{
-    public class BatchAccountsInner
-    {
-    }
-}

--- a/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/CdnEndpointImpl.cs
+++ b/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/CdnEndpointImpl.cs
@@ -216,6 +216,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         ///GENMHASH:3BC1B56E1EA6D8692923934DD96FA69E:3E899646D6EF65C7F18D49308FB9672A
         public IReadOnlyList<Microsoft.Azure.Management.Cdn.Fluent.Models.GeoFilter> GeoFilters()
         {
+                return Inner.GeoFilters?.ToList();
         }
 
         ///GENMHASH:6F62B34CB3A912AA692DBF18C6F448CB:A04B2C5688B47A48AC0B72C698E4AFC4
@@ -394,6 +395,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         ///GENMHASH:02F4B346FD2A70C665ACC639FDB892A8:55B871B6D1B5DB1661BCCFCFAE29D39C
         public IReadOnlyList<string> ContentTypesToCompress()
         {
+			return Inner.ContentTypesToCompress?.ToList();
         }
 
         ///GENMHASH:E6BF4911DAC5A8F7935D5D2C29B496A4:5599AE7A8F08BDC419B9D9D6350D80B3

--- a/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/CdnEndpointImpl.cs
+++ b/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent/CdnEndpointImpl.cs
@@ -214,9 +214,8 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         }
 
         ///GENMHASH:3BC1B56E1EA6D8692923934DD96FA69E:3E899646D6EF65C7F18D49308FB9672A
-        public IList<Microsoft.Azure.Management.Cdn.Fluent.Models.GeoFilter> GeoFilters()
+        public IReadOnlyList<Microsoft.Azure.Management.Cdn.Fluent.Models.GeoFilter> GeoFilters()
         {
-                return Inner.GeoFilters;
         }
 
         ///GENMHASH:6F62B34CB3A912AA692DBF18C6F448CB:A04B2C5688B47A48AC0B72C698E4AFC4
@@ -393,9 +392,8 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         }
 
         ///GENMHASH:02F4B346FD2A70C665ACC639FDB892A8:55B871B6D1B5DB1661BCCFCFAE29D39C
-        public IList<string> ContentTypesToCompress()
+        public IReadOnlyList<string> ContentTypesToCompress()
         {
-			return Inner.ContentTypesToCompress;
         }
 
         ///GENMHASH:E6BF4911DAC5A8F7935D5D2C29B496A4:5599AE7A8F08BDC419B9D9D6350D80B3
@@ -420,7 +418,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         }
 
         ///GENMHASH:C245F1873A239F9C8B080F237C995994:CADA2D8BC52DA7D402455B63B068EB16
-        public IList<string> CustomDomains()
+        public IReadOnlyList<string> CustomDomains()
         {
 			return this.customDomainList.Select(cd => cd.HostName).ToList();
         }

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/AvailabilitySetImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/AvailabilitySetImpl.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:2BD1C2DEE2E7FBB6D90AB920FAD6E9EE:EA53AD3391D9207B84DE8253439698A9
-        public IList<InstanceViewStatus> Statuses()
+        public IReadOnlyList<InstanceViewStatus> Statuses()
         {
-            return Inner.Statuses;
+            return Inner.Statuses?.ToList();
         }
 
         ///GENMHASH:1FF50300531E284E780AF0F5120C9D38:294D69029925C7F021009A4279127F9F

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImageImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImageImpl.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:467A5E1DBEFF6DFFFD3FD21A958498A3:FAFE8BE8CCB0532D78869AAF9E2F5DDF
         public IReadOnlyList<DataDiskImage> DataDiskImages()
         {
+            return Inner.DataDiskImages?.ToList();
         }
 
         public ImageReference ImageReference()

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImageImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineImageImpl.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using Models;
     using ResourceManager.Fluent.Core;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// The implementation for VirtualMachineImage.
@@ -52,9 +53,8 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:467A5E1DBEFF6DFFFD3FD21A958498A3:FAFE8BE8CCB0532D78869AAF9E2F5DDF
-        public IList<DataDiskImage> DataDiskImages()
+        public IReadOnlyList<DataDiskImage> DataDiskImages()
         {
-            return Inner.DataDiskImages;
         }
 
         public ImageReference ImageReference()

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetImpl.cs
@@ -1535,13 +1535,13 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:FD4CE9D235CA642C8185D0844177DDFB:D7E2129941B29E412D9F2124F2BAE432
-        public IList<string> VhdContainers()
+        public IReadOnlyList<string> VhdContainers()
         {
             if (Inner.VirtualMachineProfile.StorageProfile != null
                 && Inner.VirtualMachineProfile.StorageProfile.OsDisk != null
                 && Inner.VirtualMachineProfile.StorageProfile.OsDisk.VhdContainers != null)
             {
-                return Inner.VirtualMachineProfile.StorageProfile.OsDisk.VhdContainers;
+                return Inner.VirtualMachineProfile.StorageProfile.OsDisk.VhdContainers?.ToList();
             }
             return new List<string>();
         }

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetVMImpl.cs
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent/VirtualMachineScaleSetVMImpl.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         ///GENMHASH:606A3D349546DF27E3A091C321476658:DE6214AA350F8F418A233CAFCB35739F
-        public IList<string> NetworkInterfaceIds()
+        public IReadOnlyList<string> NetworkInterfaceIds()
         {
             return Inner
                 .NetworkProfile

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/ARecordSetImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/ARecordSetImpl.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     {
 
         ///GENMHASH:04586DB2C8D9E7DB2F3AB47785D5A15A:F328364702E41F21DD4388BDA9FC5770
-        public IList<string> Ipv4Addresses()
+        public IReadOnlyList<string> Ipv4Addresses()
         {
             List<string> ipv4Addresses = new List<string>();
             if (Inner.ARecords != null) {

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/AaaaRecordSetImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/AaaaRecordSetImpl.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         }
 
         ///GENMHASH:4E53164CA4B37A1BF907696B7858DE65:0789FFFE5FE21310241EC5F7738AE5A4
-        public IList<string> Ipv6Addresses()
+        public IReadOnlyList<string> Ipv6Addresses()
         {
             List<string> ipv6Addresses = new List<string>();
             if (Inner.AaaaRecords != null) {

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/DnsZoneImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/DnsZoneImpl.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using System.Collections.Generic;
     using DnsZone.Definition;
     using Models;
+    using System.Linq;
 
     /// <summary>
     /// Implementation for DnsZone.
@@ -56,9 +57,9 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         }
 
         ///GENMHASH:2EBE0E253F1D6DB178F3433FF5310EA8:676B110D94D76F014EEEE150AEE3144F
-        public IList<string> NameServers()
+        public IReadOnlyList<string> NameServers()
         {
-            return Inner.NameServers;
+            return Inner.NameServers?.ToList();
         }
 
         ///GENMHASH:11F6C7A282BFB4C2631CAE48D9B23761:266B9231EBE6B8B39DE5D64A23C759BF

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/NsRecordSetImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/NsRecordSetImpl.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         }
 
         ///GENMHASH:2EBE0E253F1D6DB178F3433FF5310EA8:90C2D44162C23B74515368207322B17F
-        public IList<string> NameServers()
+        public IReadOnlyList<string> NameServers()
         {
             List<string> nameServers = new List<string>();
             if (Inner.NsRecords != null)

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/PtrRecordSetImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/PtrRecordSetImpl.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         }
 
         ///GENMHASH:0E9769D28DB5D19653E121715C77F6C8:87B8885472B9F53C36F3E59296FB7453
-        public IList<string> TargetDomainNames()
+        public IReadOnlyList<string> TargetDomainNames()
         {
             List<string> targetDomainNames = new List<string>();
             if (Inner.PtrRecords != null) {

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/SrvRecordSetImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/SrvRecordSetImpl.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using Models;
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Implementation of SrvRecordSet.
@@ -55,11 +56,11 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         }
 
         ///GENMHASH:4FC81B687476F8722014B0A4F98E1756:8E7FFCF6FB312ED092A54EB827BE698C
-        public IList<SrvRecord> Records()
+        public IReadOnlyList<SrvRecord> Records()
         {
             if (Inner.SrvRecords != null)
             {
-                return Inner.SrvRecords;
+                return Inner.SrvRecords?.ToList();
             }
             return new List<SrvRecord>();
         }

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/TxtRecordSetImpl.cs
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent/TxtRecordSetImpl.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using Models;
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Implementation of TxtRecordSet.
@@ -59,10 +60,10 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         }
 
         ///GENMHASH:4FC81B687476F8722014B0A4F98E1756:271F0595F800257FBA25E945FA53FCF5
-        public IList<TxtRecord> Records()
+        public IReadOnlyList<TxtRecord> Records()
         {
             if (Inner.TxtRecords != null) {
-                return Inner.TxtRecords;
+                return Inner.TxtRecords?.ToList();
             }
             return new List<TxtRecord>();
         }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayRequestRoutingRuleImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/ApplicationGatewayRequestRoutingRuleImpl.cs
@@ -326,9 +326,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:88B8E503CCDD1E57245F30B2FC889572:C47FFCDA6121AF8D962DEDAF0FD7135D
-        public IList<ApplicationGatewayBackendAddress> BackendAddresses()
+        public IReadOnlyList<ApplicationGatewayBackendAddress> BackendAddresses()
         {
-            IList<ApplicationGatewayBackendAddress> addresses = new List<ApplicationGatewayBackendAddress>();
+            var addresses = new List<ApplicationGatewayBackendAddress>();
             var backend = Backend();
             if (backend != null && backend.Addresses != null)
             {

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerBackendImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerBackendImpl.cs
@@ -28,11 +28,11 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:1FC649C97657147238976F3B54524F58:1DE7E24B5141F230DDAD34D53E6C0E04
-        internal IDictionary<string, string> BackendNicIPConfigurationNames()
+        internal IReadOnlyDictionary<string, string> BackendNicIPConfigurationNames()
         {
             // This assumes a NIC can only have one IP config associated with the backend of an LB,
             // which is correct at the time of this implementation and seems unlikely to ever change
-            IDictionary<string, string> ipConfigNames = new SortedDictionary<string, string>();
+            var ipConfigNames = new Dictionary<string, string>();
             if (Inner.BackendIPConfigurations != null)
             {
                 foreach (var inner in Inner.BackendIPConfigurations)
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         internal ISet<string> GetVirtualMachineIds ()
         {
             ISet<string> vmIds = new HashSet<string>();
-            IDictionary<string, string> nicConfigs = BackendNicIPConfigurationNames();
+            var nicConfigs = BackendNicIPConfigurationNames();
             if (nicConfigs != null)
             {
                 foreach (string nicId in nicConfigs.Keys)

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerFrontendImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerFrontendImpl.cs
@@ -75,9 +75,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:4EDB057B59A7F7BB0C722F8A1399C004:239049AD1BE51FBFCA5EFE2D3D90D634
-        internal IDictionary<string,Microsoft.Azure.Management.Network.Fluent.ILoadBalancingRule> LoadBalancingRules ()
+        internal IReadOnlyDictionary<string,Microsoft.Azure.Management.Network.Fluent.ILoadBalancingRule> LoadBalancingRules ()
         {
-            IDictionary<string, ILoadBalancingRule> rules = new SortedDictionary<string, ILoadBalancingRule>();
+            var rules = new Dictionary<string, ILoadBalancingRule>();
             if(Inner.LoadBalancingRules != null)
             {
                 foreach(var innerRef in Inner.LoadBalancingRules)
@@ -93,9 +93,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:8A52CACDB59192E1D0B37583E7088612:E06C6AC8649C7D094661074B1621FE5E
-        internal IDictionary<string, ILoadBalancerInboundNatPool> InboundNatPools ()
+        internal IReadOnlyDictionary<string, ILoadBalancerInboundNatPool> InboundNatPools ()
         {
-            IDictionary<string, ILoadBalancerInboundNatPool> pools = new SortedDictionary<string, ILoadBalancerInboundNatPool>();
+            var pools = new Dictionary<string, ILoadBalancerInboundNatPool>();
             if (Inner.InboundNatPools != null)
             {
                 foreach (var innerRef in Inner.InboundNatPools)
@@ -113,9 +113,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:E8B1A4CD5F6DE0F12BD4A52F19DDADA3:D324027CACD9F0F14120E933769AE69D
-        internal IDictionary<string, ILoadBalancerInboundNatRule> InboundNatRules ()
+        internal IReadOnlyDictionary<string, ILoadBalancerInboundNatRule> InboundNatRules ()
         {
-            IDictionary<string, ILoadBalancerInboundNatRule> rules = new SortedDictionary<string, ILoadBalancerInboundNatRule>();
+            var rules = new Dictionary<string, ILoadBalancerInboundNatRule>();
             if (Inner.InboundNatRules != null)
             {
                 foreach (var innerRef in Inner.InboundNatRules)

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerImpl.cs
@@ -34,13 +34,13 @@ namespace Microsoft.Azure.Management.Network.Fluent
         private IDictionary<string, string> creatablePIPKeys = new Dictionary<string, string>();
 
         // Children
-        private IDictionary<string, ILoadBalancerBackend> backends;
-        private IDictionary<string, ILoadBalancerTcpProbe> tcpProbes;
-        private IDictionary<string, ILoadBalancerHttpProbe> httpProbes;
-        private IDictionary<string, ILoadBalancingRule> loadBalancingRules;
-        private IDictionary<string, ILoadBalancerFrontend> frontends;
-        private IDictionary<string, ILoadBalancerInboundNatRule> inboundNatRules;
-        private IDictionary<string, ILoadBalancerInboundNatPool> inboundNatPools;
+        private Dictionary<string, ILoadBalancerBackend> backends;
+        private Dictionary<string, ILoadBalancerTcpProbe> tcpProbes;
+        private Dictionary<string, ILoadBalancerHttpProbe> httpProbes;
+        private Dictionary<string, ILoadBalancingRule> loadBalancingRules;
+        private Dictionary<string, ILoadBalancerFrontend> frontends;
+        private Dictionary<string, ILoadBalancerInboundNatRule> inboundNatRules;
+        private Dictionary<string, ILoadBalancerInboundNatPool> inboundNatPools;
 
         ///GENMHASH:A5942A0C76A5AF979ACC449D61F54472:55E548B15E635A8197D52049D3FAB8D3
         internal  LoadBalancerImpl (
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:38719597698E42AABAD5A9917188C155:D9C6887E0B146C62C173F2FC8A940200
         private void InitializeFrontendsFromInner ()
         {
-            frontends = new SortedDictionary<string, ILoadBalancerFrontend>();
+            frontends = new Dictionary<string, ILoadBalancerFrontend>();
             IList<FrontendIPConfigurationInner> frontendsInner = Inner.FrontendIPConfigurations;
             if (frontendsInner != null)
             {
@@ -246,7 +246,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:38BB8357245354CED812C58E4EC79068:DC3D25D8FDD465052EB41638FB17F9B2
         private void InitializeBackendsFromInner ()
         {
-            backends = new SortedDictionary<string, ILoadBalancerBackend>();
+            backends = new Dictionary<string, ILoadBalancerBackend>();
             IList<BackendAddressPoolInner> backendsInner = Inner.BackendAddressPools;
             if (backendsInner != null)
             {
@@ -261,7 +261,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:7963C76B84396C00185D8DA2B2F7C665:F1E436F5834A4C1F8A48115529DB0ACD
         private void InitializeLoadBalancingRulesFromInner()
         {
-            loadBalancingRules = new SortedDictionary<string, ILoadBalancingRule>();
+            loadBalancingRules = new Dictionary<string, ILoadBalancingRule>();
             IList<LoadBalancingRuleInner> rulesInner = Inner.LoadBalancingRules;
             if (rulesInner != null)
             {
@@ -275,8 +275,8 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:12C04D490C1E5A715E97451A0D94F9ED:EF6B6A3CB2DFC605432EDB763513E641
         private void InitializeProbesFromInner ()
         {
-            httpProbes = new SortedDictionary<string, ILoadBalancerHttpProbe>();
-            tcpProbes = new SortedDictionary<string, ILoadBalancerTcpProbe>();
+            httpProbes = new Dictionary<string, ILoadBalancerHttpProbe>();
+            tcpProbes = new Dictionary<string, ILoadBalancerTcpProbe>();
             if (Inner.Probes != null) {
                 foreach (var probeInner in Inner.Probes) {
                     var probe = new LoadBalancerProbeImpl(probeInner, this);
@@ -296,7 +296,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         private void InitializeInboundNatPoolsFromInner ()
         {
 
-            inboundNatPools = new SortedDictionary<string, ILoadBalancerInboundNatPool>();
+            inboundNatPools = new Dictionary<string, ILoadBalancerInboundNatPool>();
             if (Inner.InboundNatPools != null) {
                 foreach (var inner in Inner.InboundNatPools)
                 {
@@ -309,7 +309,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:D7F8078784461C05471F1B08FCC5E9D9:A3C76C7153C126B77AA240D3FCFB08EC
         private void InitializeInboundNatRulesFromInner ()
         {
-            inboundNatRules = new SortedDictionary<string, ILoadBalancerInboundNatRule>();
+            inboundNatRules = new Dictionary<string, ILoadBalancerInboundNatRule>();
             if (Inner.InboundNatRules != null) {
                 foreach (var inner in Inner.InboundNatRules) {
                     var rule = new LoadBalancerInboundNatRuleImpl(inner, this);
@@ -778,13 +778,13 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:A45CE73D7318CE351EAF634272B1CA21:AAFEA7A6CB469B72F235861703236767
-        internal IDictionary<string, ILoadBalancerBackend> Backends ()
+        internal IReadOnlyDictionary<string, ILoadBalancerBackend> Backends ()
         {
             return backends;
         }
 
         ///GENMHASH:8A52CACDB59192E1D0B37583E7088612:ABDF5C10B8D024D4FF2F19FCC08D545B
-        internal IDictionary<string, ILoadBalancerInboundNatPool> InboundNatPools ()
+        internal IReadOnlyDictionary<string, ILoadBalancerInboundNatPool> InboundNatPools ()
         {
             return inboundNatPools;
         }
@@ -796,31 +796,31 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:3BF87DE2E0C9BBAA60FEF8B345571B0D:78DEDBCE9849DD9B71BA61C7FBEA3261
-        internal IDictionary<string, ILoadBalancerFrontend> Frontends ()
+        internal IReadOnlyDictionary<string, ILoadBalancerFrontend> Frontends ()
         {
             return frontends;
         }
 
         ///GENMHASH:E8B1A4CD5F6DE0F12BD4A52F19DDADA3:08B702001C3E5904E4105656090C99DB
-        internal IDictionary<string, ILoadBalancerInboundNatRule> InboundNatRules ()
+        internal IReadOnlyDictionary<string, ILoadBalancerInboundNatRule> InboundNatRules ()
         {
             return inboundNatRules;
         }
 
         ///GENMHASH:24748C01B3C4E2C8AA78FF1218414773:1E910A825FD89730E12401CA3FB434B7
-        internal IDictionary<string, ILoadBalancerHttpProbe> HttpProbes ()
+        internal IReadOnlyDictionary<string, ILoadBalancerHttpProbe> HttpProbes ()
         {
             return httpProbes;
         }
 
         ///GENMHASH:4EDB057B59A7F7BB0C722F8A1399C004:AAA6E6E9080AF0A38342B9778B29320E
-        internal IDictionary<string, ILoadBalancingRule> LoadBalancingRules ()
+        internal IReadOnlyDictionary<string, ILoadBalancingRule> LoadBalancingRules ()
         {
             return loadBalancingRules;
         }
 
         ///GENMHASH:6352ECA72191EB7B29EABE1E30B18CF4:CF345546D001F32F4850EF402DE6ED22
-        internal List<string> PublicIPAddressIds()
+        internal IReadOnlyList<string> PublicIPAddressIds()
         {
             List<string> publicIPAddressIds = new List<string>();
             foreach (ILoadBalancerFrontend frontend in Frontends().Values)

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerProbeImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/LoadBalancerProbeImpl.cs
@@ -61,9 +61,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:4EDB057B59A7F7BB0C722F8A1399C004:A2F94AF9792429D630DA94FCC75CFD8B
-        internal IDictionary<string, ILoadBalancingRule> LoadBalancingRules ()
+        internal IReadOnlyDictionary<string, ILoadBalancingRule> LoadBalancingRules ()
         {
-            IDictionary<string, ILoadBalancingRule> rules = new SortedDictionary<string, ILoadBalancingRule>();
+            var rules = new Dictionary<string, ILoadBalancingRule>();
             if (Inner.LoadBalancingRules != null)
             {
                 foreach (SubResource inner in Inner.LoadBalancingRules)

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkImpl.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     using ResourceManager.Fluent.Core;
     using System.Threading.Tasks;
     using System.Threading;
+    using System.Linq;
 
     /// <summary>
     /// Implementation for Network
@@ -26,7 +27,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         Network.Definition.IDefinition,
         Network.Update.IUpdate
     {
-        private IDictionary<string, ISubnet> subnets;
+        private Dictionary<string, ISubnet> subnets;
         ///GENMHASH:3D0F0C9DA19FF797EAF5133A38664022:55E548B15E635A8197D52049D3FAB8D3
         internal NetworkImpl(string name, VirtualNetworkInner innerModel, INetworkManager networkManager)
             : base(name, innerModel, networkManager)
@@ -36,7 +37,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:6D9F740D6D73C56877B02D9F1C96F6E7:7D80D923C32722759F2DC956E9A32D71
         override protected void InitializeChildrenFromInner()
         {
-            subnets = new SortedDictionary<string, ISubnet>();
+            subnets = new Dictionary<string, ISubnet>();
             IList<SubnetInner> inners = Inner.Subnets;
             if (inners != null)
             {
@@ -124,29 +125,29 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:0A630A9A81A6D7FB1D87E339FE830A51:FD878AA481D05018C98B67E014CFC475
-        internal IList<string> AddressSpaces()
+        internal IReadOnlyList<string> AddressSpaces()
         {
             if (Inner.AddressSpace == null)
                 return new List<string>();
             else if (Inner.AddressSpace.AddressPrefixes == null)
                 return new List<string>();
             else
-                return Inner.AddressSpace.AddressPrefixes;
+                return Inner.AddressSpace.AddressPrefixes?.ToList();
         }
 
         ///GENMHASH:08B7E1E5C1AFE7A46CE9F049D5CDA430:6FEBAF2F043487BFE65A5D9D04AA1315
-        internal IList<string> DnsServerIPs()
+        internal IReadOnlyList<string> DnsServerIPs()
         {
             if (Inner.DhcpOptions == null)
                 return new List<string>();
             else if (Inner.DhcpOptions.DnsServers == null)
                 return new List<string>();
             else
-                return Inner.DhcpOptions.DnsServers;
+                return Inner.DhcpOptions.DnsServers?.ToList();
         }
 
         ///GENMHASH:690E8F594CD13FA2074316AFD9B45928:8131F4AA7A989D064C8AB8B74BFCAD25
-        internal IDictionary<string, ISubnet> Subnets()
+        internal IReadOnlyDictionary<string, ISubnet> Subnets()
         {
             return subnets;
         }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkManagerExtensions.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkManagerExtensions.cs
@@ -39,10 +39,10 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         /// Internal utility function
-        internal static IList<ISubnet> ListAssociatedSubnets(this INetworkManager manager, IList<SubnetInner> subnetRefs)
+        internal static IReadOnlyList<ISubnet> ListAssociatedSubnets(this INetworkManager manager, IList<SubnetInner> subnetRefs)
         {
             IDictionary<string, INetwork> networks = new Dictionary<string, INetwork>();
-            IList<ISubnet> subnets = new List<ISubnet>();
+            var subnets = new List<ISubnet>();
             if (subnetRefs != null)
             {
                 foreach (SubnetInner subnetRef in subnetRefs)

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkSecurityGroupImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NetworkSecurityGroupImpl.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Azure.Management.Network.Fluent
         NetworkSecurityGroup.Definition.IDefinition,
         NetworkSecurityGroup.Update.IUpdate
     {
-        private IDictionary<string, INetworkSecurityRule> rules;
-        private IDictionary<string, INetworkSecurityRule> defaultRules;
+        private Dictionary<string, INetworkSecurityRule> rules;
+        private Dictionary<string, INetworkSecurityRule> defaultRules;
         ///GENMHASH:EF8FBA50FA03F1FE4888F19050CEDBB9:55E548B15E635A8197D52049D3FAB8D3
         internal  NetworkSecurityGroupImpl(
             string name,
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:6D9F740D6D73C56877B02D9F1C96F6E7:6624452329542D5B0E4B4BE8D790304C
         override protected void InitializeChildrenFromInner ()
         {
-            rules = new SortedDictionary<string, INetworkSecurityRule>();
+            rules = new Dictionary<string, INetworkSecurityRule>();
             IList<SecurityRuleInner> inners = Inner.SecurityRules;
             if (inners != null)
             {
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            defaultRules = new SortedDictionary<string, INetworkSecurityRule>();
+            defaultRules = new Dictionary<string, INetworkSecurityRule>();
             inners = Inner.DefaultSecurityRules;
             if (inners != null)
             {
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         #region Actions
 
         ///GENMHASH:E78D7ACAEEE05A0117BC7B6E41B0D53B:062BFEFE0393BE2C1D9F8B1A963FDE23
-        internal IList<ISubnet> ListAssociatedSubnets()
+        internal IReadOnlyList<ISubnet> ListAssociatedSubnets()
         {
             return Manager.ListAssociatedSubnets(Inner.Subnets);
         }
@@ -139,13 +139,13 @@ namespace Microsoft.Azure.Management.Network.Fluent
         #region Accessors
 
         ///GENMHASH:F8F85F9267133B95FDDB0B6F1F27E816:FC8B3AE517369B64F33F8DC475426F01
-        internal IDictionary<string, INetworkSecurityRule> SecurityRules ()
+        internal IReadOnlyDictionary<string, INetworkSecurityRule> SecurityRules ()
         {
             return rules;
         }
 
         ///GENMHASH:79407FFCDB8168F82199BE25744F9808:90E13C4BC15B37167DE1F6486AFDC06C
-        internal IDictionary<string, INetworkSecurityRule> DefaultSecurityRules ()
+        internal IReadOnlyDictionary<string, INetworkSecurityRule> DefaultSecurityRules ()
         {
             return defaultRules;
         }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NicIpConfigurationBaseImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/NicIpConfigurationBaseImpl.cs
@@ -99,16 +99,16 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:744A3724C9A3248553B33B2939CE091A:47A4EFA20BF9EBE9F94B6AF74FC75F03
-        internal IList<ILoadBalancerInboundNatRule> ListAssociatedLoadBalancerInboundNatRules()
+        internal IReadOnlyList<ILoadBalancerInboundNatRule> ListAssociatedLoadBalancerInboundNatRules()
         {
-            IList<InboundNatRuleInner> inboundNatPoolRefs = Inner.LoadBalancerInboundNatRules;
+            var inboundNatPoolRefs = Inner.LoadBalancerInboundNatRules;
             if (inboundNatPoolRefs == null)
             {
                 return new List<ILoadBalancerInboundNatRule>();
             }
 
-            Dictionary<string, ILoadBalancer> loadBalancers = new Dictionary<string, ILoadBalancer>();
-            List<ILoadBalancerInboundNatRule> rules = new List<ILoadBalancerInboundNatRule>();
+            var loadBalancers = new Dictionary<string, ILoadBalancer>();
+            var rules = new List<ILoadBalancerInboundNatRule>();
             foreach (var reference in inboundNatPoolRefs)
             {
                 string loadBalancerId = ResourceUtils.ParentResourcePathFromResourceId(reference.Id);
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:D5259819D030517B66106CDFA84D3219:3471F8356719EA5868DD7F34332B58E4
-        internal IList<ILoadBalancerBackend> ListAssociatedLoadBalancerBackends()
+        internal IReadOnlyList<ILoadBalancerBackend> ListAssociatedLoadBalancerBackends()
         {
             var backendRefs = Inner.LoadBalancerBackendAddressPools;
             if (backendRefs == null)

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/RouteTableImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/RouteTableImpl.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:E78D7ACAEEE05A0117BC7B6E41B0D53B:062BFEFE0393BE2C1D9F8B1A963FDE23
-        public IList<ISubnet> ListAssociatedSubnets()
+        public IReadOnlyList<ISubnet> ListAssociatedSubnets()
         {
             return this.Manager.ListAssociatedSubnets(Inner.Subnets);
         }

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/VirtualMachineScaleSetNetworkInterfaceImpl.cs
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent/VirtualMachineScaleSetNetworkInterfaceImpl.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     using ResourceManager.Fluent.Core;
     using System.Threading.Tasks;
     using System.Threading;
+    using System.Linq;
 
     internal partial class VirtualMachineScaleSetNetworkInterfaceImpl :
         ResourceBase<IVirtualMachineScaleSetNetworkInterface,
@@ -84,22 +85,22 @@ namespace Microsoft.Azure.Management.Network.Fluent
             return Inner.DnsSettings.InternalDomainNameSuffix;
         }
 
-        internal IList<string> DnsServers()
+        internal IReadOnlyList<string> DnsServers()
         {
             if (Inner.DnsSettings == null || Inner.DnsSettings.DnsServers == null)
             {
                 return new List<string>();
             }
-            return Inner.DnsSettings.DnsServers;
+            return Inner.DnsSettings.DnsServers?.ToList();
         }
 
-        internal IList<string> AppliedDnsServers()
+        internal IReadOnlyList<string> AppliedDnsServers()
         {
             if (Inner.DnsSettings == null || Inner.DnsSettings.AppliedDnsServers == null)
             {
                 return new List<string>();
             }
-            return Inner.DnsSettings.AppliedDnsServers;
+            return Inner.DnsSettings.AppliedDnsServers?.ToList();
         }
 
         internal string PrimaryPrivateIP()

--- a/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent/RedisCacheImpl.cs
+++ b/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent/RedisCacheImpl.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
         }
 
         ///GENMHASH:CC99BC6F0FDDE008E581A6EB944FE764:0C30EC62BAFB5962817F1799BCD0FA3F
-        public IList<Models.ScheduleEntry> ListPatchSchedules()
+        public IReadOnlyList<Models.ScheduleEntry> ListPatchSchedules()
         {
             RedisPatchScheduleInner patchSchedules = null;
             try

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/RecommendedElasticPoolImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/RecommendedElasticPoolImpl.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         private ResourceId resourceId;
 
         ///GENMHASH:DF46C62E0E8998CD0340B3F8A136F135:2EE5EC6E56E27CC62928F7FDA722AB08
-        public IList<ISqlDatabase> Databases()
+        public IReadOnlyList<ISqlDatabase> Databases()
         {
             return Inner.Databases.Select(databaseInner => (ISqlDatabase)new SqlDatabaseImpl(
                 databaseInner.Name,
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:CD775E31F43CBA6304D6EEA9E01682A1:FE7D9343E169D0420CF0E1FC9A9A3736
-        public IList<Microsoft.Azure.Management.Sql.Fluent.ISqlDatabase> ListDatabases()
+        public IReadOnlyList<Microsoft.Azure.Management.Sql.Fluent.ISqlDatabase> ListDatabases()
         {
             var databases = Manager.Inner.RecommendedElasticPools.ListDatabases(
                 ResourceGroupName(),
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:77909FCEE2BCE7A1585A5D65D695B384:13846C17B14D55E5F3A4AE220EAFBEDC
-        public IList<IRecommendedElasticPoolMetric> ListMetrics()
+        public IReadOnlyList<IRecommendedElasticPoolMetric> ListMetrics()
         {
             var metricInner = Manager.Inner.RecommendedElasticPools.ListMetrics(
                 ResourceGroupName(),

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlDatabasesImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlDatabasesImpl.cs
@@ -30,13 +30,13 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:16CEA22B57032A6757D8EFC1BF423794:F46E4D0A3CDB6C5AE412BF5B7FB52B09
-        public IList<ISqlDatabase> ListBySqlServer(string resourceGroupName, string sqlServerName)
+        public IReadOnlyList<ISqlDatabase> ListBySqlServer(string resourceGroupName, string sqlServerName)
         {
             return new List<ISqlDatabase>(this.ListByParent(resourceGroupName, sqlServerName));
         }
 
         ///GENMHASH:CD989F8A79EC70D56C4F5154E2B8BE11:57462F0C7FF757AFBBFD3B3561C9F9ED
-        public IList<ISqlDatabase> ListBySqlServer(ISqlServer sqlServer)
+        public IReadOnlyList<ISqlDatabase> ListBySqlServer(ISqlServer sqlServer)
         {
             return new List<ISqlDatabase>(this.ListByParent(sqlServer));
         }

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlElasticPoolImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlElasticPoolImpl.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:C183D7089E5DF699C59758CC103308DF:9A4ADAD649EDB890CDCEB767D8708E33
-        public IList<IElasticPoolActivity> ListActivities()
+        public IReadOnlyList<IElasticPoolActivity> ListActivities()
         {
             var activities = Manager.Inner.ElasticPools.ListActivity(
                 ResourceGroupName,
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:CD775E31F43CBA6304D6EEA9E01682A1:2A3515CB32DF22200CBB032FFC4BCCFC
-        public IList<ISqlDatabase> ListDatabases()
+        public IReadOnlyList<ISqlDatabase> ListDatabases()
         {
             var databases = Manager.Inner.ElasticPools.ListDatabases(
                         ResourceGroupName,
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:DA730BE4F3BEA4D8DCD1631C079435CB:2D0DE4C2F41ED4D39BD2E654A3511EEE
-        public IList<Microsoft.Azure.Management.Sql.Fluent.IElasticPoolDatabaseActivity> ListDatabaseActivities()
+        public IReadOnlyList<Microsoft.Azure.Management.Sql.Fluent.IElasticPoolDatabaseActivity> ListDatabaseActivities()
         {
             var databaseActivities = Manager.Inner.ElasticPools.ListDatabaseActivity(
                     ResourceGroupName,

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlElasticPoolsImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlElasticPoolsImpl.cs
@@ -32,13 +32,13 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:16CEA22B57032A6757D8EFC1BF423794:F46E4D0A3CDB6C5AE412BF5B7FB52B09
-        public IList<ISqlElasticPool> ListBySqlServer(string resourceGroupName, string sqlServerName)
+        public IReadOnlyList<ISqlElasticPool> ListBySqlServer(string resourceGroupName, string sqlServerName)
         {
             return new List<ISqlElasticPool>(this.ListByParent(resourceGroupName, sqlServerName));
         }
 
         ///GENMHASH:CD989F8A79EC70D56C4F5154E2B8BE11:57462F0C7FF757AFBBFD3B3561C9F9ED
-        public IList<ISqlElasticPool> ListBySqlServer(ISqlServer sqlServer)
+        public IReadOnlyList<ISqlElasticPool> ListBySqlServer(ISqlServer sqlServer)
         {
             return new List<ISqlElasticPool>(this.ListByParent(sqlServer));
         }

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlFirewallRulesImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlFirewallRulesImpl.cs
@@ -30,13 +30,13 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:16CEA22B57032A6757D8EFC1BF423794:F46E4D0A3CDB6C5AE412BF5B7FB52B09
-        public IList<ISqlFirewallRule> ListBySqlServer(string resourceGroupName, string sqlServerName)
+        public IReadOnlyList<ISqlFirewallRule> ListBySqlServer(string resourceGroupName, string sqlServerName)
         {
             return new List<ISqlFirewallRule>(this.ListByParent(resourceGroupName, sqlServerName));
         }
 
         ///GENMHASH:CD989F8A79EC70D56C4F5154E2B8BE11:57462F0C7FF757AFBBFD3B3561C9F9ED
-        public IList<ISqlFirewallRule> ListBySqlServer(ISqlServer sqlServer)
+        public IReadOnlyList<ISqlFirewallRule> ListBySqlServer(ISqlServer sqlServer)
         {
             return new List<ISqlFirewallRule>(this.ListByParent(sqlServer));
         }

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlServerImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlServerImpl.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         }
 
         ///GENMHASH:0E666BFDFC9A666CA31FD735D7839414:2AAE577C01D4088729534C3BC39664A7
-        public IList<IServerMetric> ListUsages()
+        public IReadOnlyList<IServerMetric> ListUsages()
         {
             var usages = Manager.Inner.Servers.ListUsages(
                 ResourceGroupName,


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.