### PR TITLE
Fixed SubscriptionCleaner project.

### DIFF
--- a/Samples/Tests/AppService.cs
+++ b/Samples/Tests/AppService.cs
@@ -114,7 +114,7 @@ namespace Samples.Tests
                Path.Combine("..", "Common"));
         }
 
-        [Fact]
+        [Fact(Skip ="Manual only test: Requires user interaction.")]
         [Trait("Samples", "AppService")]
         public void ManageLinuxWebAppSqlConnectionTest()
         {

--- a/tools/SubscriptionCleaner/Program.cs
+++ b/tools/SubscriptionCleaner/Program.cs
@@ -37,7 +37,7 @@ namespace SubscriptionCleaner
 
                 var azure = Azure
                     .Configure()
-                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.BASIC)
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
                     .Authenticate(credentials)
                     .WithDefaultSubscription();
 

--- a/tools/SubscriptionCleaner/SubscriptionCleaner.sln
+++ b/tools/SubscriptionCleaner/SubscriptionCleaner.sln
@@ -33,6 +33,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.TrafficManager.Fluent", "..\..\src\ResourceManagement\TrafficManager\Microsoft.Azure.Management.TrafficManager.Fluent\Microsoft.Azure.Management.TrafficManager.Fluent.xproj", "{BC0F91B9-FEA6-4CDA-A44C-2291D157991D}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.ServiceBus.Fluent", "..\..\src\ResourceManagement\ServiceBus\Microsoft.Azure.Management.ServiceBus.Fluent\Microsoft.Azure.Management.ServiceBus.Fluent.xproj", "{9C9553CE-5BD4-4E9B-8B2D-4D04AB8D11EA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -99,6 +101,10 @@ Global
 		{BC0F91B9-FEA6-4CDA-A44C-2291D157991D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BC0F91B9-FEA6-4CDA-A44C-2291D157991D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BC0F91B9-FEA6-4CDA-A44C-2291D157991D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C9553CE-5BD4-4E9B-8B2D-4D04AB8D11EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C9553CE-5BD4-4E9B-8B2D-4D04AB8D11EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C9553CE-5BD4-4E9B-8B2D-4D04AB8D11EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C9553CE-5BD4-4E9B-8B2D-4D04AB8D11EA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.