### PR TITLE
Fixed SQL server impl to use correct version.

### DIFF
--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/RestClient/RestClient.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Core/RestClient/RestClient.cs
@@ -88,23 +88,37 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
             private string GetMACAddress()
             {
-                NetworkInterface[] nics = NetworkInterface.GetAllNetworkInterfaces();
-                String sMacAddress = string.Empty;
-                foreach (NetworkInterface adapter in nics)
+                try
                 {
-                    if (sMacAddress == String.Empty) // only return MAC Address from first card
+                    NetworkInterface[] nics = NetworkInterface.GetAllNetworkInterfaces();
+                    String sMacAddress = string.Empty;
+                    foreach (NetworkInterface adapter in nics)
                     {
-                        IPInterfaceProperties properties = adapter.GetIPProperties();
-                        sMacAddress = adapter.GetPhysicalAddress().ToString();
+                        if (sMacAddress == String.Empty) // only return MAC Address from first card
+                        {
+                            IPInterfaceProperties properties = adapter.GetIPProperties();
+                            sMacAddress = adapter.GetPhysicalAddress().ToString();
+                        }
                     }
+                    return sMacAddress;
                 }
-                return sMacAddress;
+                catch
+                {
+                }
+                return null;
             }
 
             private string HashMACAddress(string macAddress)
             {
-                var hashInput = Encoding.UTF8.GetBytes(macAddress);
-                return BitConverter.ToString(SHA256.Create().ComputeHash(hashInput)).Replace("-", string.Empty).ToLowerInvariant();
+                try
+                {
+                    var hashInput = Encoding.UTF8.GetBytes(macAddress);
+                    return BitConverter.ToString(SHA256.Create().ComputeHash(hashInput)).Replace("-", string.Empty).ToLowerInvariant();
+                }
+                catch
+                {
+                }
+                return "[Unavailable]";
             }
 
             #region Fluent builder interfaces

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlServersImpl.cs
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent/SqlServersImpl.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         protected override SqlServerImpl WrapModel(string name)
         {
             ServerInner inner = new ServerInner();
-            inner.Version = ServerVersion.TwoFullStopZero;
+            inner.Version = ServerVersion.OneTwoFullStopZero;
             return new SqlServerImpl(
                 name,
                 inner,


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.