### PR TITLE
Search SDK: Fixing unit tests that were broken by VS2017 migration

### DIFF
--- a/src/SDKs/Search/DataPlane/Search.Tests/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Search/DataPlane/Search.Tests/Properties/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 // license information.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -38,3 +38,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/SDKs/Search/DataPlane/Search.Tests/Tests/SearchIndexClientTests.cs
+++ b/src/SDKs/Search/DataPlane/Search.Tests/Tests/SearchIndexClientTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Search.Tests
             Assert.Equal(ExpectedUrl, client.BaseUri.AbsoluteUri);
         }
 
-        [Fact(Skip = "Investigate, started failing after migrating to VS2017")]
+        [Fact]
         public void ConstructorThrowsForBadParameters()
         {
             var creds = new SearchCredentials("abc");
@@ -131,7 +131,6 @@ namespace Microsoft.Azure.Search.Tests
             Assert.Throws<ArgumentNullException>(
                 "credentials",
                 () => new SearchIndexClient(credentials: null, rootHandler: handler));
-            Assert.Throws<ArgumentNullException>(() => new SearchIndexClient(credentials: creds, rootHandler: null));
             Assert.Throws<ArgumentNullException>(
                 "baseUri",
                 () => new SearchIndexClient(baseUri: null, credentials: creds));
@@ -155,14 +154,11 @@ namespace Microsoft.Azure.Search.Tests
                 "credentials",
                 () => new SearchIndexClient(searchServiceName, indexName, credentials: null, rootHandler: handler));
             Assert.Throws<ArgumentNullException>(
-                () => new SearchIndexClient(searchServiceName, indexName, creds, rootHandler: null));
-            Assert.Throws<ArgumentNullException>(
                 "baseUri",
                 () => new SearchIndexClient(baseUri: null, credentials: creds, rootHandler: handler));
             Assert.Throws<ArgumentNullException>(
                 "credentials",
                 () => new SearchIndexClient(uri, credentials: null, rootHandler: handler));
-            Assert.Throws<ArgumentNullException>(() => new SearchIndexClient(uri, creds, rootHandler: null));
         }
     }
 }

--- a/src/SDKs/Search/DataPlane/Search.Tests/Tests/SearchServiceClientTests.cs
+++ b/src/SDKs/Search/DataPlane/Search.Tests/Tests/SearchServiceClientTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Search.Tests
             });
         }
 
-        [Fact(Skip = "Investigate, started failing after migrating to VS2017")]
+        [Fact]
         public void ConstructorThrowsForBadParameters()
         {
             var creds = new SearchCredentials("abc");
@@ -97,7 +97,6 @@ namespace Microsoft.Azure.Search.Tests
             Assert.Throws<ArgumentNullException>(
                 "credentials",
                 () => new SearchServiceClient(credentials: null, rootHandler: handler));
-            Assert.Throws<ArgumentNullException>(() => new SearchServiceClient(credentials: creds, rootHandler: null));
             Assert.Throws<ArgumentNullException>(
                 "baseUri",
                 () => new SearchServiceClient(baseUri: null, credentials: creds));
@@ -115,14 +114,11 @@ namespace Microsoft.Azure.Search.Tests
                 "credentials",
                 () => new SearchServiceClient(searchServiceName, credentials: null, rootHandler: handler));
             Assert.Throws<ArgumentNullException>(
-                () => new SearchServiceClient(searchServiceName, creds, rootHandler: null));
-            Assert.Throws<ArgumentNullException>(
                 "baseUri",
                 () => new SearchServiceClient(baseUri: null, credentials: creds, rootHandler: handler));
             Assert.Throws<ArgumentNullException>(
                 "credentials",
                 () => new SearchServiceClient(uri, credentials: null, rootHandler: handler));
-            Assert.Throws<ArgumentNullException>(() => new SearchServiceClient(uri, creds, rootHandler: null));
         }
     }
 }

--- a/src/SDKs/Search/Management/Search.Management.Tests/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Search/Management/Search.Management.Tests/Properties/AssemblyInfo.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -36,3 +37,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/SDKs/dirs.proj
+++ b/src/SDKs/dirs.proj
@@ -87,6 +87,7 @@
 		<ProjectToBuild Include="$(MSBuildThisFileDirectory)Resource\**\*Tests.csproj" ProjectType="Test"/>
 		<ProjectToBuild Include="$(MSBuildThisFileDirectory)Scheduler\**\*Tests.csproj" ProjectType="Test"/>
 		<ProjectToBuild Include="$(MSBuildThisFileDirectory)Search\Management\**\*Tests.csproj" ProjectType="Test"/>
+    	<ProjectToBuild Include="$(MSBuildThisFileDirectory)Search\DataPlane\**\*Tests.csproj" ProjectType="Test"/>
 		
 		<ProjectToBuild Include="$(MSBuildThisFileDirectory)ServerManagement\**\*Tests.csproj" ProjectType="Test"/>
 		<ProjectToBuild Include="$(MSBuildThisFileDirectory)ServiceBus\**\*Tests.csproj" ProjectType="Test"/>
@@ -101,7 +102,6 @@
 	<ProjectToBuild Include="$(MSBuildThisFileDirectory)DataLake.Store\**\*Tests.csproj" ProjectType="Test"/>
   	<ProjectToBuild Include="$(MSBuildThisFileDirectory)Monitor\**\*Tests.csproj" ProjectType="Test"/>
     <ProjectToBuild Include="$(MSBuildThisFileDirectory)RecoveryServices\**\*Tests.csproj" ProjectType="Test"/>
-    <ProjectToBuild Include="$(MSBuildThisFileDirectory)Search\DataPlane\**\*Tests.csproj" ProjectType="Test"/>
   -->
 
   <ItemGroup>


### PR DESCRIPTION
As part of moving to VS2017, the Search SDK is using a newer version of the ClientRuntime. Two of the unit tests were pinning constructor validation behavior of `ServiceClient`, which seems to have changed.

Also, the move to VS2017 brought back the default behavior of xunit running all tests in parallel. This won't work, since the `HttpMockServer` is apparently not thread-safe. I disabled parallel test execution to avoid this problem. All tests now pass in playback mode when run from VS2017.

FYI @shahabhijeet

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [X] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [X] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [X] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [X] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.