### PR TITLE
Fix head formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ src\SDKs\Compute
 
 ### To build:
 
-####Full Build
+#### Full Build
 
  1. Open VS 2017 command prompt
  2. Navigate to repository root directory
@@ -33,12 +33,12 @@ src\SDKs\Compute
  TestResult can be found under < root >\TestResults
 ##### *Full Build* without any scope will build all SDK's run all tests.
 
-####Build one nuget package
+#### Build one nuget package
 In order to build one package and run it's test
 
  > msbuild build.proj /t:FullBuild /p:scope=SDKs\Compute /p:NugetPackageName=Microsoft.Azure.Management.Compute
 
-####Using Visual Studio:
+#### Using Visual Studio:
  1. Open any solution, say, "SDKs\Compute\Compute.sln"
  2. Invoke "build" command.
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.