### PR TITLE
Adding Legacy constraint for backward compatibility

### DIFF
--- a/src/SDKs/AzSdk.reference.props
+++ b/src/SDKs/AzSdk.reference.props
@@ -4,10 +4,4 @@
 	 <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="[3.3.5,4.0.0)" /> 
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="[2.3.6,3.0.0)" />
   </ItemGroup>
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-    <DelaySign>true</DelaySign>
-    <AssemblyOriginatorKeyFile>$(LibraryToolsFolder)\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
-    <NoWarn>1591;1701;1573</NoWarn>
-  </PropertyGroup>
 </Project>

--- a/src/SDKs/AzSdk.test.reference.props
+++ b/src/SDKs/AzSdk.test.reference.props
@@ -4,16 +4,9 @@
     <PackageReference Include="Microsoft.Azure.Test.HttpRecorder" Version="[1.7.0,2.0.0)" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="[1.6.0,2.0.0)" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="[3.3.5,4.0.0)" />
-    <!--<PackageReference Include="Microsoft.Rest.ClientRuntime" Version="[2.3.6,3.0)" />-->
     <PackageReference Include="Microsoft.Azure.ResourceManager" Version="1.1.0-preview" />
-	
+    
     <!-- This is needed for discovering tests in test explorer -->
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />	
   </ItemGroup>
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-    <DelaySign>true</DelaySign>
-    <AssemblyOriginatorKeyFile>$(LibraryToolsFolder)\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
-    <NoWarn>1591;1701;1573</NoWarn>
-  </PropertyGroup>
 </Project>

--- a/src/SdkCommon/TestFramework/testframework.common.props
+++ b/src/SdkCommon/TestFramework/testframework.common.props
@@ -1,28 +1,25 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>
-		<TestProjectType>true</TestProjectType>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TestProjectType>true</TestProjectType>
+  </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-		<!-- <PackageReference Update="Mirosoft.NETCore.App" Version="1.0.4" /> -->
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <!-- <PackageReference Update="Mirosoft.NETCore.App" Version="1.0.4" /> -->
   </ItemGroup>
-  
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-	<Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
-  
-      <PropertyGroup Condition=" '$(TargetFramework)'=='net452' ">
+
+  <PropertyGroup Condition=" '$(TargetFramework)'=='net452' ">
     <DefineConstants>FullNetFx</DefineConstants>
   </PropertyGroup>
-  
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <DefineConstants>netcoreapp11</DefineConstants>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
-
-
-
 </Project>

--- a/src/SdkCommon/clientruntime.reference.props
+++ b/src/SdkCommon/clientruntime.reference.props
@@ -1,6 +1,5 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.props'))" />
-	
+	<Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.props'))" />	
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Rest.ClientRuntime" Version="[2.3.6,3.0.0)" />
 	</ItemGroup>

--- a/test.props
+++ b/test.props
@@ -11,25 +11,11 @@
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(LibraryToolsFolder)\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)'=='net452' ">
-    <DefineConstants>FullNetFx</DefineConstants>
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <DefineConstants>netcoreapp11</DefineConstants>
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-  </PropertyGroup>
-  
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">  
 		<PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />		
-	</ItemGroup>  
-	
+	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)'=='net452' ">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
 		<PackageReference Include="xunit" Version="2.2.0" />
@@ -37,6 +23,5 @@
 	</ItemGroup>
    <ItemGroup> 
 	   <Compile Include="$(LibraryToolsFolder)\DisableTestRunParallel.cs" Link="DisableTestRunParallel.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" /> 
-   </ItemGroup>   
-  
+   </ItemGroup>
 </Project>

--- a/tools/buildTargets/common.Build.props
+++ b/tools/buildTargets/common.Build.props
@@ -1,52 +1,40 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>    
-		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <!--<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>-->
     <RestorePackagesPath>$(LibraryNugetPackageFolder)</RestorePackagesPath>
-	  <NugetCommonProfileTags></NugetCommonProfileTags>
-	  <PackageOutputPath>$(BuiltPackageOutputDir)</PackageOutputPath>
+    <NugetCommonProfileTags></NugetCommonProfileTags>
+    <PackageOutputPath>$(BuiltPackageOutputDir)</PackageOutputPath>
     <AddProjectReferenceForDebuggingPurpose>false</AddProjectReferenceForDebuggingPurpose>
     <AddNugetReferenceForCIandCmdlineBuild>true</AddNugetReferenceForCIandCmdlineBuild>
     <SkipBuildingTestProject>false</SkipBuildingTestProject>
-	<!-- <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences> -->
-	  <SignAssembly>true</SignAssembly>
+    <!-- <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences> -->
+    <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(LibraryToolsFolder)\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
-	  <NoWarn>1591;1701;1573</NoWarn>
+    <NoWarn>1591;1701;1573</NoWarn>
+  </PropertyGroup>
 
 
-
-    <!--
-    <PostBuildEvent>
-      
-    </PostBuildEvent>
-
-    <PreBuildEvent>
-      <CallTarget Targets="PrintStuff"/>
-    </PreBuildEvent>
-    -->
-	</PropertyGroup>
-	
-	
-	  <PropertyGroup Condition=" '$(TargetFramework)'=='net452' ">
-    <DefineConstants>FullNetFx</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)'=='net452' ">
+    <DefineConstants>FullNetFx;LEGACY</DefineConstants>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
     <DefineConstants>netstandard14</DefineConstants>
-	 <OutputPath>bin\$(Configuration)\</OutputPath>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <DefineConstants>netcoreapp11</DefineConstants>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
-  
+
   <Choose>
     <When Condition=" '$(BuildingInsideVisualStudio)' == 'true' ">
       <PropertyGroup>
@@ -56,7 +44,15 @@
     <Otherwise>
       <PropertyGroup>
         <AddNugetReferenceForCIandCmdlineBuild>true</AddNugetReferenceForCIandCmdlineBuild>
-    </PropertyGroup>
+      </PropertyGroup>
     </Otherwise>
   </Choose>
 </Project>
+
+<!--
+    <PostBuildEvent>      
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <CallTarget Targets="PrintStuff"/>
+    </PreBuildEvent>
+    -->

--- a/tools/buildTargets/common.NugetPackage.props
+++ b/tools/buildTargets/common.NugetPackage.props
@@ -1,15 +1,15 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="PackageMetaData">
     <Copyright>Copyright (c) Microsoft Corporation</Copyright>
-    <Authors>Microsoft</Authors>    
+    <Authors>Microsoft</Authors>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Azure/AutoRest</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/Azure/azure-sdk-for-net</RepositoryUrl>    
+    <RepositoryUrl>https://github.com/Azure/azure-sdk-for-net</RepositoryUrl>
     <PackageTags>$(PackageTags) $(NugetCommonTags) $(NugetCommonProfileTags)</PackageTags>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-	<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
@@ -18,8 +18,8 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
-	<PackageTargetFallback Condition=" '$(TargetFramework)' == 'net452' ">$(PackageTargetFallback);net452;dnxcore50</PackageTargetFallback>    
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'net452' ">$(PackageTargetFallback);net452;dnxcore50</PackageTargetFallback>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.4' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.4' ">1.6.1</NetStandardImplicitPackageVersion>    
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.4' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Adding Legacy constant for backward compatibility, as Autorest is still generating this in the generated code.
- Adding task that will take this constant out of generated code
https://github.com/Azure/autorest/issues/2218
- Once this is removed from AutoRest, this constant can be removed out of our build system.
