### PR TITLE
Release to remove JSON.NET ver cap imposed by Key Vault

### DIFF
--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Base64UrlJsonConverter.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Base64UrlJsonConverter.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
-// 
+//
 
 using System;
 using Newtonsoft.Json;
@@ -32,7 +32,9 @@ namespace Microsoft.Azure.KeyVault.WebKey
         private static byte[] FromBase64UrlString(string input)
         {
             if (string.IsNullOrEmpty(input))
+            {
                 throw new ArgumentNullException("input");
+            }
 
             return Convert.FromBase64String(Pad(input.Replace('-', '+').Replace('_', '/')));
         }

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Microsoft.Azure.KeyVault.WebKey.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Microsoft.Azure.KeyVault.WebKey.csproj
@@ -5,7 +5,7 @@
     <Description>Microsoft Azure Key Vault WebKey Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault WebKey</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.WebKey</AssemblyName>
-    <VersionPrefix>2.0.4</VersionPrefix>
+    <VersionPrefix>2.0.5</VersionPrefix>
     <PackageTags>Microsoft Azure key vault WebKey</PackageTags>    
   </PropertyGroup>
   <PropertyGroup>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 [assembly: AssemblyDescription("Microsoft Azure Key Vault WebKey Class Library.")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.4.0")]
+[assembly: AssemblyFileVersion("2.0.5.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Microsoft.Azure.KeyVault.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Microsoft.Azure.KeyVault.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-<Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.reference.props'))" />  
+<Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.reference.props'))" />
   <PropertyGroup>
     <PackageId>Microsoft.Azure.KeyVault</PackageId>
     <Description>Azure Key Vault enables users to store and use cryptographic keys within the Microsoft Azure environment. Azure Key Vault supports multiple key types and algorithms and enables the use of Hardware Security Modules (HSM) for high value customer keys. In addition, Azure Key Vault allows users to securely store secrets in a Key Vault; secrets are limited size octet objects and Azure Key Vault applies no specific semantics to these objects. A Key Vault may contain a mix of keys and secrets at the same time, and access control for the two types of object is independently controlled. Users, subject to appropriate authorization, may: 1) Manage cryptographic keys using Create, Import, Update, Delete and other operations 2) Manage secrets using Get, Set, Delete and other operations 3) Use cryptographic keys with Sign/Verify, WrapKey/UnwrapKey and Encrypt/Decrypt operations. Operations against Key Vaults are authenticated and authorized using Azure Active Directory. Key Vault now supports certificates, a complex type that makes use of existing key and secret infrastructure for certificate operations. KV certificates also support notification and auto-renewal as well as other management features.</Description>
     <AssemblyTitle>Microsoft Azure key vault</AssemblyTitle>
-    <VersionPrefix>2.2.0-preview</VersionPrefix>
+    <VersionPrefix>2.2.1-preview</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault</AssemblyName>
     <PackageTags>Microsoft Azure key vault;Key Vault;REST HTTP client;azureofficial;windowsazureofficial</PackageTags>
-    <PackageReleaseNotes>This is a preview release of the Azure Key Vault .NET SDK, based on version 2016-10-01 of the Azure Key Vault REST API. For migration guide from version 1.0, please visit https://azure.microsoft.com/en-us/documentation/articles/key-vault-dotnet2api-release-notes/.</PackageReleaseNotes>    
+    <PackageReleaseNotes>This is a preview release of the Azure Key Vault .NET SDK, based on version 2016-10-01 of the Azure Key Vault REST API. For migration guide from version 1.0, please visit https://azure.microsoft.com/en-us/documentation/articles/key-vault-dotnet2api-release-notes/.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.KeyVault.WebKey\Microsoft.Azure.KeyVault.WebKey.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
-// 
+//
 
 using System.Reflection;
 using System.Resources;
@@ -10,7 +10,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Azure Key Vault enables users to store and use cryptographic keys within the Microsoft Azure environment. Azure Key Vault supports multiple key types and algorithms and enables the use of Hardware Security Modules (HSM) for high value customer keys. In addition, Azure Key Vault allows users to securely store secrets in a Key Vault; secrets are limited size octet objects and Azure Key Vault applies no specific semantics to these objects. A Key Vault may contain a mix of keys and secrets at the same time, and access control for the two types of object is independently controlled. Users, subject to appropriate authorization, may: 1) Manage cryptographic keys using Create, Import, Update, Delete and other operations 2) Manage secrets using Get, Set, Delete and other operations 3) Use cryptographic keys with Sign/Verify, WrapKey/UnwrapKey and Encrypt/Decrypt operations. Operations against Key Vaults are authenticated and authorized using Azure Active Directory.")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
ASP.NET requires a version of JSON.NET greater than the one allowed by the nuget dependency declaration for the Microsoft.Azure.KeyVault.WebKey assembly.  It appears that the port to VS2017 has already removed that restriction.  The change in this PR is simply to up the version of that assembly and the root Key Vault assembly, Microsoft.Azure.KeyVault.WebKey, in order to release new versions of these assemblies and nuget packages that do not have a cap on the version of the JSON.NET dependency.

fixes #3003 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x ] Title of the pull request is clear and informative.
- [ x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ x] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.