### PR TITLE
Adding Azure Sql related test case and recorded json.

### DIFF
--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/AzureSqlTests.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/AzureSqlTests.cs
@@ -9,26 +9,18 @@ using Xunit;
 
 namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
 {
+
 	/// <summary>
-	/// In order to run the tests in Record mode, some test artifacts need to be created manually. Here are the details:
-	/// 1. Resource Group - Any permissible name is allowed.
-	/// 2. Azure VM: any size, version, created in the above resource group.
-	/// 3. Resource Group for Storage Account - Any permissible name is allowed.
-	/// 4. Storage Account: any configuration, but should be of the same version of the above VM, created in the resource group specified for the storage account. 
-	///    This will be used for the restore operation.
-	/// NOTE: Region should preferably be West US. Otherwise, it should be in the same region as the test vault being created.
-	/// 
-	/// These details need to be updated in the TestSettings.json file. A sample is given here:
-	/// 
-	/// {
-	/// "VirtualMachineName": "pstestv2vm1",
-	/// "VirtualMachineResourceGroupName": "pstestrg",
-	/// "VirtualMachineType": "Compute",
-	/// "RestoreStorageAccountName": "pstestrg4762",
-	/// "RestoreStorageAccountResourceGroupName": "pstestrg"
-	/// }
-	/// 
-	/// Here, if the VM is a Classic Compute VM, set VirtualMachineType as "Classic" and if it is a Compute VM, set VirtualMachineType as "Compute"
+	/// To run this test case in record mode, we will have to do following presetup.
+	/// 1.	Create resource and resource group and replace the value accordingly in following lines of the code.
+	/// 			private const string azureSqlVaultName = "sqlpaasrn";
+	/// 			private const string azureSqlResourceGroupName = "sqlpaasrg";
+	///
+	///	2.	Create a policy , Sql Server and and protect the database from Azure Sql Portal.
+	///	3.	Replace the values accordingly in TestSetting.json
+	///				"AzureSqlItemName": "dsName;satyay-sea-d1-fc1-catalog-2016-11-11-17-20;661f0942-d5b7-486a-b3cb-68f97d325a3c",
+	///				"AzureSqlPolicyName": "sqlpaaspolicy",
+	///				"AzureSqlContainerName": "AzureSqlContainer;Sql;sqlpaasrg;sqlpaasserver"
 	/// </summary>
 	public class AzureSqlScenarioTests : TestBase, IDisposable
 	{

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/AzureSqlTests.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/AzureSqlTests.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Azure.Management.RecoveryServices.Backup.Models;
+using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
+using Xunit;
+
+namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
+{
+	/// <summary>
+	/// In order to run the tests in Record mode, some test artifacts need to be created manually. Here are the details:
+	/// 1. Resource Group - Any permissible name is allowed.
+	/// 2. Azure VM: any size, version, created in the above resource group.
+	/// 3. Resource Group for Storage Account - Any permissible name is allowed.
+	/// 4. Storage Account: any configuration, but should be of the same version of the above VM, created in the resource group specified for the storage account. 
+	///    This will be used for the restore operation.
+	/// NOTE: Region should preferably be West US. Otherwise, it should be in the same region as the test vault being created.
+	/// 
+	/// These details need to be updated in the TestSettings.json file. A sample is given here:
+	/// 
+	/// {
+	/// "VirtualMachineName": "pstestv2vm1",
+	/// "VirtualMachineResourceGroupName": "pstestrg",
+	/// "VirtualMachineType": "Compute",
+	/// "RestoreStorageAccountName": "pstestrg4762",
+	/// "RestoreStorageAccountResourceGroupName": "pstestrg"
+	/// }
+	/// 
+	/// Here, if the VM is a Classic Compute VM, set VirtualMachineType as "Classic" and if it is a Compute VM, set VirtualMachineType as "Compute"
+	/// </summary>
+	public class AzureSqlScenarioTests : TestBase, IDisposable
+	{
+		private const string azureSqlVaultName = "sqlpaasrn";
+		private const string azureSqlResourceGroupName = "sqlpaasrg";
+
+		[Fact]
+		public void AzureSqlItemContainerPolicyGetTest()
+		{
+			var testHelper = new TestHelper() { VaultName = azureSqlVaultName, ResourceGroup = azureSqlResourceGroupName };
+
+			using (var context = MockContext.Start(this.GetType().FullName))
+			{
+				testHelper.Initialize(context);
+				var containerUniqueName = TestSettings.Instance.AzureSqlContainerName;
+				var itemName = TestSettings.Instance.AzureSqlItemName;
+				var policyName = TestSettings.Instance.AzureSqlPolicyName;
+				string azureSqlItemType = "AzureSqlDb";
+				string itemUniqueName = string.Join(";", azureSqlItemType, itemName);
+
+				// 1. List protected items
+				var items = testHelper.ListProtectedItems();
+				Assert.NotNull(items);
+				Assert.True(items.Any(item => itemName.Contains(item.Name.ToLower())));
+
+				// 2. Get ProtectedItem
+				var protectedItem = testHelper.GetProtectedItem(containerUniqueName, itemUniqueName);
+				Assert.NotNull(protectedItem);
+				Assert.True(itemName == protectedItem.Name);
+
+				// 3. Get policy
+				var policy = testHelper.GetPolicyWithRetries(policyName);
+				Assert.NotNull(policy);
+				Assert.True(policyName == policy.Name);
+
+				// 4. Get container
+				Microsoft.Rest.Azure.OData.ODataQuery<BMSContainerQueryObject> odataQuery = new Rest.Azure.OData.ODataQuery<BMSContainerQueryObject>();
+				odataQuery.Filter = "backupManagementType eq 'AzureSql'";
+				var containers = testHelper.ListContainers(odataQuery);
+				Assert.NotNull(containers);
+				Assert.True(containers.Any(container => containerUniqueName.Contains(container.Name)));
+			}
+		}
+
+		public void Dispose()
+		{
+
+		}
+	}
+}

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/SessionRecords/Microsoft.Azure.Management.RecoveryServices.Backup.Tests.AzureSqlScenarioTests/AzureSqlItemContainerPolicyGetTest.json
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/SessionRecords/Microsoft.Azure.Management.RecoveryServices.Backup.Tests.AzureSqlScenarioTests/AzureSqlItemContainerPolicyGetTest.json
@@ -1,0 +1,405 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourcegroups/sqlpaasrg?api-version=2015-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjc0MjQ0MzAtMTAzYi00YmEzLWJkOWUtYjZmMDk4NmY4NDhhL3Jlc291cmNlZ3JvdXBzL3NxbHBhYXNyZz9hcGktdmVyc2lvbj0yMDE1LTExLTAx",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"westus\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "28"
+        ],
+        "x-ms-client-request-id": [
+          "4884395d-b5f4-4cb9-81d7-b7d1eed13c06"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25009.03",
+          "Microsoft.Azure.Management.Resources.ResourceManagementClient/1.1.0-preview"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"ResourceGroupBeingDeleted\",\r\n    \"message\": \"The resource group 'sqlpaasrg' is in deprovisioning state and cannot perform this operation.\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "151"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 28 Apr 2017 12:20:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-failure-cause": [
+          "gateway"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1194"
+        ],
+        "x-ms-request-id": [
+          "fe771e36-166c-43c7-be19-2e9cd86a1b39"
+        ],
+        "x-ms-correlation-request-id": [
+          "fe771e36-166c-43c7-be19-2e9cd86a1b39"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALINDIA:20170428T122047Z:fe771e36-166c-43c7-be19-2e9cd86a1b39"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 409
+    },
+    {
+      "RequestUri": "/subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn?api-version=2016-06-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjc0MjQ0MzAtMTAzYi00YmEzLWJkOWUtYjZmMDk4NmY4NDhhL3Jlc291cmNlR3JvdXBzL3NxbHBhYXNyZy9wcm92aWRlcnMvTWljcm9zb2Z0LlJlY292ZXJ5U2VydmljZXMvdmF1bHRzL3NxbHBhYXNybj9hcGktdmVyc2lvbj0yMDE2LTA2LTAx",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {},\r\n  \"sku\": {\r\n    \"name\": \"Standard\"\r\n  },\r\n  \"location\": \"westus\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "91"
+        ],
+        "x-ms-client-request-id": [
+          "6cdb9fb8-7e10-4bb5-816d-e2a9d819b317"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25009.03",
+          "Microsoft.Azure.Management.RecoveryServices.RecoveryServicesClient/4.2.0-preview"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"ResourceGroupBeingDeleted\",\r\n    \"message\": \"The resource group 'sqlpaasrg' is in deprovisioning state and cannot perform this operation.\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "151"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 28 Apr 2017 12:20:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-failure-cause": [
+          "gateway"
+        ],
+        "x-ms-request-id": [
+          "1a76138b-fe7e-4867-b45b-865e517a5c99"
+        ],
+        "x-ms-correlation-request-id": [
+          "1a76138b-fe7e-4867-b45b-865e517a5c99"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALINDIA:20170428T122047Z:1a76138b-fe7e-4867-b45b-865e517a5c99"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 409
+    },
+    {
+      "RequestUri": "/Subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn/backupProtectedItems?api-version=2016-12-01",
+      "EncodedRequestUri": "L1N1YnNjcmlwdGlvbnMvZjc0MjQ0MzAtMTAzYi00YmEzLWJkOWUtYjZmMDk4NmY4NDhhL3Jlc291cmNlR3JvdXBzL3NxbHBhYXNyZy9wcm92aWRlcnMvTWljcm9zb2Z0LlJlY292ZXJ5U2VydmljZXMvdmF1bHRzL3NxbHBhYXNybi9iYWNrdXBQcm90ZWN0ZWRJdGVtcz9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "5b15bf1d-d253-4305-8a12-24c0a250efa0"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25009.03",
+          "Microsoft.Azure.Management.RecoveryServices.Backup.RecoveryServicesBackupClient/1.3.0-preview"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"id\": \"/Subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn/backupFabrics/ActiveDirectory/protectionContainers/Windows;Sql;sqlpaasrg;sqlpaasserver/protectedItems/AzureSqlDb;661f0942-d5b7-486a-b3cb-68f97d325a3c\",\r\n      \"name\": \"661f0942-d5b7-486a-b3cb-68f97d325a3c\",\r\n      \"type\": \"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems\",\r\n      \"properties\": {\r\n        \"friendlyName\": \"661f0942-d5b7-486a-b3cb-68f97d325a3c\",\r\n        \"computerName\": \"Sql;sqlpaasrg;sqlpaasserver\",\r\n        \"lastBackupStatus\": \"\",\r\n        \"protectionState\": \"Protected\",\r\n        \"protectedItemType\": \"MabFileFolderProtectedItem\",\r\n        \"backupManagementType\": \"MAB\",\r\n        \"workloadType\": \"AzureSqlDb\",\r\n        \"containerName\": \"Sql;sqlpaasrg;sqlpaasserver\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/Subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn/backupFabrics/Azure/protectionContainers/AzureSqlContainer;Sql;sqlpaasrg;sqlpaasserver/protectedItems/AzureSqlDb;dsName;satyay-sea-d1-fc1-catalog-2016-11-11-17-20;661f0942-d5b7-486a-b3cb-68f97d325a3c\",\r\n      \"name\": \"dsName;satyay-sea-d1-fc1-catalog-2016-11-11-17-20;661f0942-d5b7-486a-b3cb-68f97d325a3c\",\r\n      \"type\": \"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems\",\r\n      \"properties\": {\r\n        \"protectedItemDataId\": \"211106587505007\",\r\n        \"protectionState\": \"Protected\",\r\n        \"protectedItemType\": \"Microsoft.Sql/servers/databases\",\r\n        \"backupManagementType\": \"AzureSql\",\r\n        \"workloadType\": \"AzureSqlDb\",\r\n        \"containerName\": \"Sql;sqlpaasrg;sqlpaasserver\",\r\n        \"policyId\": \"/Subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn/backupPolicies/sqlpaaspolicy\",\r\n        \"policyName\": \"sqlpaaspolicy\"\r\n      }\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 28 Apr 2017 12:20:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "e5935232-2f76-428f-b5fb-1755151b5897"
+        ],
+        "x-ms-client-request-id": [
+          "5b15bf1d-d253-4305-8a12-24c0a250efa0",
+          "5b15bf1d-d253-4305-8a12-24c0a250efa0"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14918"
+        ],
+        "x-ms-correlation-request-id": [
+          "e5935232-2f76-428f-b5fb-1755151b5897"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALINDIA:20170428T122050Z:e5935232-2f76-428f-b5fb-1755151b5897"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/Subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn/backupFabrics/Azure/protectionContainers/AzureSqlContainer%3BSql%3Bsqlpaasrg%3Bsqlpaasserver/protectedItems/AzureSqlDb%3BdsName%3Bsatyay-sea-d1-fc1-catalog-2016-11-11-17-20%3B661f0942-d5b7-486a-b3cb-68f97d325a3c?api-version=2016-12-01",
+      "EncodedRequestUri": "L1N1YnNjcmlwdGlvbnMvZjc0MjQ0MzAtMTAzYi00YmEzLWJkOWUtYjZmMDk4NmY4NDhhL3Jlc291cmNlR3JvdXBzL3NxbHBhYXNyZy9wcm92aWRlcnMvTWljcm9zb2Z0LlJlY292ZXJ5U2VydmljZXMvdmF1bHRzL3NxbHBhYXNybi9iYWNrdXBGYWJyaWNzL0F6dXJlL3Byb3RlY3Rpb25Db250YWluZXJzL0F6dXJlU3FsQ29udGFpbmVyJTNCU3FsJTNCc3FscGFhc3JnJTNCc3FscGFhc3NlcnZlci9wcm90ZWN0ZWRJdGVtcy9BenVyZVNxbERiJTNCZHNOYW1lJTNCc2F0eWF5LXNlYS1kMS1mYzEtY2F0YWxvZy0yMDE2LTExLTExLTE3LTIwJTNCNjYxZjA5NDItZDViNy00ODZhLWIzY2ItNjhmOTdkMzI1YTNjP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "63e42d40-f3b9-43d3-9b46-7ccfb66b2828"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25009.03",
+          "Microsoft.Azure.Management.RecoveryServices.Backup.RecoveryServicesBackupClient/1.3.0-preview"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/Subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn/backupFabrics/Azure/protectionContainers/AzureSqlContainer;Sql;sqlpaasrg;sqlpaasserver/protectedItems/AzureSqlDb;dsName;satyay-sea-d1-fc1-catalog-2016-11-11-17-20;661f0942-d5b7-486a-b3cb-68f97d325a3c\",\r\n  \"name\": \"dsName;satyay-sea-d1-fc1-catalog-2016-11-11-17-20;661f0942-d5b7-486a-b3cb-68f97d325a3c\",\r\n  \"type\": \"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems\",\r\n  \"properties\": {\r\n    \"protectedItemDataId\": \"211106587505007\",\r\n    \"protectionState\": \"Protected\",\r\n    \"protectedItemType\": \"Microsoft.Sql/servers/databases\",\r\n    \"backupManagementType\": \"AzureSql\",\r\n    \"workloadType\": \"AzureSqlDb\",\r\n    \"containerName\": \"Sql;sqlpaasrg;sqlpaasserver\",\r\n    \"policyId\": \"/Subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn/backupPolicies/sqlpaaspolicy\",\r\n    \"policyName\": \"sqlpaaspolicy\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 28 Apr 2017 12:20:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "58d91f9c-3c9c-4d6b-9ae6-d6ff79a2e1ab"
+        ],
+        "x-ms-client-request-id": [
+          "63e42d40-f3b9-43d3-9b46-7ccfb66b2828",
+          "63e42d40-f3b9-43d3-9b46-7ccfb66b2828"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14917"
+        ],
+        "x-ms-correlation-request-id": [
+          "58d91f9c-3c9c-4d6b-9ae6-d6ff79a2e1ab"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALINDIA:20170428T122051Z:58d91f9c-3c9c-4d6b-9ae6-d6ff79a2e1ab"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/Subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn/backupPolicies/sqlpaaspolicy?api-version=2016-12-01",
+      "EncodedRequestUri": "L1N1YnNjcmlwdGlvbnMvZjc0MjQ0MzAtMTAzYi00YmEzLWJkOWUtYjZmMDk4NmY4NDhhL3Jlc291cmNlR3JvdXBzL3NxbHBhYXNyZy9wcm92aWRlcnMvTWljcm9zb2Z0LlJlY292ZXJ5U2VydmljZXMvdmF1bHRzL3NxbHBhYXNybi9iYWNrdXBQb2xpY2llcy9zcWxwYWFzcG9saWN5P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "9abff963-725a-4efd-bcbd-7bb6fd48e848"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25009.03",
+          "Microsoft.Azure.Management.RecoveryServices.Backup.RecoveryServicesBackupClient/1.3.0-preview"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/Subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn/backupPolicies/sqlpaaspolicy\",\r\n  \"name\": \"sqlpaaspolicy\",\r\n  \"type\": \"Microsoft.RecoveryServices/vaults/backupPolicies\",\r\n  \"properties\": {\r\n    \"backupManagementType\": \"AzureSql\",\r\n    \"retentionPolicy\": {\r\n      \"retentionPolicyType\": \"SimpleRetentionPolicy\",\r\n      \"retentionDuration\": {\r\n        \"count\": 3,\r\n        \"durationType\": \"Months\"\r\n      }\r\n    },\r\n    \"protectedItemsCount\": 1\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 28 Apr 2017 12:20:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "2996cdda-f7bb-4778-8f41-5ec0cec699e8"
+        ],
+        "x-ms-client-request-id": [
+          "9abff963-725a-4efd-bcbd-7bb6fd48e848",
+          "9abff963-725a-4efd-bcbd-7bb6fd48e848"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14916"
+        ],
+        "x-ms-correlation-request-id": [
+          "2996cdda-f7bb-4778-8f41-5ec0cec699e8"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALINDIA:20170428T122053Z:2996cdda-f7bb-4778-8f41-5ec0cec699e8"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/Subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn/backupProtectionContainers?$filter=backupManagementType%20eq%20'AzureSql'&api-version=2016-12-01",
+      "EncodedRequestUri": "L1N1YnNjcmlwdGlvbnMvZjc0MjQ0MzAtMTAzYi00YmEzLWJkOWUtYjZmMDk4NmY4NDhhL3Jlc291cmNlR3JvdXBzL3NxbHBhYXNyZy9wcm92aWRlcnMvTWljcm9zb2Z0LlJlY292ZXJ5U2VydmljZXMvdmF1bHRzL3NxbHBhYXNybi9iYWNrdXBQcm90ZWN0aW9uQ29udGFpbmVycz8kZmlsdGVyPWJhY2t1cE1hbmFnZW1lbnRUeXBlJTIwZXElMjAnQXp1cmVTcWwnJmFwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "42377d4d-8600-4902-9f21-ec2d500ca5e1"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25009.03",
+          "Microsoft.Azure.Management.RecoveryServices.Backup.RecoveryServicesBackupClient/1.3.0-preview"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"id\": \"/Subscriptions/f7424430-103b-4ba3-bd9e-b6f0986f848a/resourceGroups/sqlpaasrg/providers/Microsoft.RecoveryServices/vaults/sqlpaasrn/backupFabrics/Azure/protectionContainers/AzureSqlContainer;Sql;sqlpaasrg;sqlpaasserver\",\r\n      \"name\": \"AzureSqlContainer;Sql;sqlpaasrg;sqlpaasserver\",\r\n      \"type\": \"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers\",\r\n      \"properties\": {\r\n        \"friendlyName\": \"\",\r\n        \"backupManagementType\": \"AzureSql\",\r\n        \"registrationStatus\": \"Registered\",\r\n        \"healthStatus\": \"\",\r\n        \"containerType\": \"AzureSqlContainer\",\r\n        \"protectableObjectType\": \"AzureSqlContainer\"\r\n      }\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 28 Apr 2017 12:20:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "d0ca587e-84d8-40c4-9301-c2dd3c5eba55"
+        ],
+        "x-ms-client-request-id": [
+          "42377d4d-8600-4902-9f21-ec2d500ca5e1",
+          "42377d4d-8600-4902-9f21-ec2d500ca5e1"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14915"
+        ],
+        "x-ms-correlation-request-id": [
+          "d0ca587e-84d8-40c4-9301-c2dd3c5eba55"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALINDIA:20170428T122054Z:d0ca587e-84d8-40c4-9301-c2dd3c5eba55"
+        ]
+      },
+      "StatusCode": 200
+    }
+  ],
+  "Names": {},
+  "Variables": {
+    "SubscriptionId": "f7424430-103b-4ba3-bd9e-b6f0986f848a"
+  }
+}

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestHelper.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestHelper.cs
@@ -15,379 +15,397 @@ using HttpStatusCode = System.Net.HttpStatusCode;
 
 namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
 {
-    public class TestHelper : IDisposable
-    {
-        public string ResourceGroup = "SwaggerTestRg";
-        public string VaultName = "SDKTestRsVault";
-        public string Location = "westus";
-        public string FabricName = "Azure";
-
-        public RecoveryServicesClient VaultClient { get; private set; }
-
-        public RecoveryServicesBackupClient BackupClient { get; private set; }
-
-        public void Initialize(MockContext context)
-        {
-            VaultClient = this.GetVaultClient(context);
-            BackupClient = this.GetBackupClient(context);
-
-            CreateResourceGroup(context);
-
-            CreateVault(VaultName);
-        }
-
-        private void CreateResourceGroup(MockContext context)
-        {
-            ResourceManagementClient resourcesClient = this.GetResourcesClient(context);
-
-            try
-            {
-                resourcesClient.ResourceGroups.CreateOrUpdate(ResourceGroup,
-                new ResourceGroup
-                {
-                    Location = Location
-                });
-
-            }
-            catch (CloudException ex)
-            {
-                if (ex.Response.StatusCode != System.Net.HttpStatusCode.Conflict) throw;
-            }
-        }
-
-        private void CreateVault(string vaultName)
-        {
-            Vault vault = new Vault()
-            {
-                Location = Location,
-                Sku = new Sku()
-                {
-                    Name = SkuName.Standard
-                },
-                Properties = new VaultProperties()
-            };
-
-            try
-            {
-                VaultClient.Vaults.CreateOrUpdate(ResourceGroup, vaultName, vault);
-            }
-            catch (CloudException ex)
-            {
-                if (ex.Response.StatusCode != System.Net.HttpStatusCode.Conflict) throw;
-            }
-        }
-
-        public void DisposeVaults()
-        {
-            var vaults = VaultClient.Vaults.ListByResourceGroup(ResourceGroup);
-            foreach (var vault in vaults)
-            {
-                VaultClient.Vaults.Delete(ResourceGroup, vault.Name);
-            }
-        }
-
-        public List<ProtectionPolicyResource> ListAllPoliciesWithRetries()
-        {
-            List<ProtectionPolicyResource> policies = new List<ProtectionPolicyResource>();
-
-            RetryActionWithTimeout(
-                () => policies = GetPagedList(() => BackupClient.BackupPolicies.List(VaultName, ResourceGroup),
-                        nextLink => BackupClient.BackupPolicies.ListNext(nextLink)),
-                () => policies.Count > 0,
-                TimeSpan.FromMinutes(5),
-                ResourceNotSyncedRetryLogic);
-
-            return policies;
-        }
-
-        public ProtectionPolicyResource GetPolicyWithRetries(string policyName)
-        {
-            ProtectionPolicyResource policy = null;
-            RetryActionWithTimeout(
-                () => policy = BackupClient.ProtectionPolicies.Get(VaultName, ResourceGroup, policyName),
-                () => policy != null,
-                TimeSpan.FromMinutes(5),
-                ResourceNotSyncedRetryLogic);
-
-            return policy;
-        }
-
-        public string EnableProtection(string containerName, string protectedItemName, string policyName)
-        {
-            ProtectionPolicyResource policy = GetPolicyWithRetries(policyName);
-
-            BackupClient.ProtectionContainers.Refresh(VaultName, ResourceGroup, FabricName);
-
-            IPage<WorkloadProtectableItemResource> protectableItems = BackupClient.BackupProtectableItems.List(VaultName, ResourceGroup);
-
-            var desiredProtectedItem = (AzureIaaSComputeVMProtectableItem) protectableItems.First(
-                protectableItem => containerName.ToLower().Contains(protectableItem.Name.ToLower())
-                ).Properties;
-
-            Assert.NotNull(desiredProtectedItem);
-
-            var item = new ProtectedItemResource()
-            {
-                Properties = new AzureIaaSComputeVMProtectedItem()
-                {
-                    PolicyId = policy.Id,
-                    SourceResourceId = desiredProtectedItem.VirtualMachineId,
-                }
-            };
-            
-            var response = BackupClient.ProtectedItems.CreateOrUpdateWithHttpMessagesAsync(
-                VaultName, ResourceGroup, FabricName, containerName, protectedItemName, item).Result;
-            ValidateOperationResponse(response);
-
-            var jobResponse = GetOperationResponse<ProtectedItemResource, OperationStatusJobExtendedInfo>(
-                containerName, protectedItemName, response,
-                operationId => BackupClient.ProtectedItemOperationResults.GetWithHttpMessagesAsync(
-                    VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result,
-                operationId => BackupClient.ProtectedItemOperationStatuses.GetWithHttpMessagesAsync(
-                    VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result);
-
-            Assert.NotNull(jobResponse.JobId);
-
-            return jobResponse.JobId;
-        }
-
-        public string Backup(string containerName, string protectedItemName)
-        {
-            BackupRequestResource request = new BackupRequestResource()
-            {
-                Properties = new IaasVMBackupRequest()
-                {
-                    RecoveryPointExpiryTimeInUTC = DateTime.UtcNow.AddDays(2),
-                },
-            };
-
-            var response = BackupClient.Backups.TriggerWithHttpMessagesAsync(
-                VaultName, ResourceGroup, FabricName, containerName, protectedItemName, request).Result;
-            ValidateOperationResponse(response);
-
-            var jobResponse = GetOperationResponse<ProtectedItemResource, OperationStatusJobExtendedInfo>(
-                containerName, protectedItemName, response,
-                operationId => BackupClient.ProtectedItemOperationResults.GetWithHttpMessagesAsync(
-                    VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result,
-                operationId => BackupClient.ProtectedItemOperationStatuses.GetWithHttpMessagesAsync(
-                    VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result);
-
-            Assert.NotNull(jobResponse.JobId);
-
-            return jobResponse.JobId;
-        }
-
-        public void WaitForJobCompletion(string jobId)
-        {
-            string jobStatus = string.Empty;
-
-            RetryActionWithTimeout(
-                () => jobStatus = GetJobStatus(jobId),
-                () => !IsJobInProgress(jobStatus),
-                TimeSpan.FromHours(3),
-                statusCode =>
-                {
-                    TestUtilities.Wait(5000);
-                    return true;
-                });
-        }
-
-        public string GetJobStatus(string jobId)
-        {
-            var result = BackupClient.JobDetails.GetWithHttpMessagesAsync(VaultName, ResourceGroup, jobId).Result;
-            Assert.NotNull(result);
-            Assert.Equal(result.Response.StatusCode, System.Net.HttpStatusCode.OK);
-            return ((AzureIaaSVMJob)result.Body.Properties).Status;
-        }
-
-        public bool IsJobInProgress(string jobStatus)
-        {
-            return jobStatus.CompareTo("InProgress") == 0 || jobStatus.CompareTo("Cancelling") == 0;
-        }
-
-        public void RetryActionWithTimeout(Action action, Func<bool> validator, TimeSpan timeout, Func<HttpStatusCode, bool> shouldRetry)
-        {
-            DateTime timedOut = DateTime.Now + timeout;
-
-            do
-            {
-                try
-                {
-                    action();
-                }
-                catch (CloudException exception)
-                {
-                    if (!shouldRetry(exception.Response.StatusCode))
-                    {
-                        throw;
-                    }
-                }
-            }
-            while (DateTime.Now < timedOut && !validator());
-        }
-
-        private void ValidateOperationResponse(AzureOperationResponse response)
-        {
-            Assert.NotNull(response);
-            Assert.Equal(System.Net.HttpStatusCode.Accepted, response.Response.StatusCode);
-            Assert.True(response.Response.Headers.Contains("Location"));
-            Assert.True(response.Response.Headers.Contains("Azure-AsyncOperation"));
-            Assert.True(response.Response.Headers.Contains("Retry-After"));
-        }
-        
-        public List<ProtectedItemResource> ListProtectedItems()
-        {
-            return GetPagedList(
-                () => BackupClient.BackupProtectedItems.List(VaultName, ResourceGroup),
-                nextLink => BackupClient.BackupProtectedItems.ListNext(nextLink));
-        }
-
-        public List<T> GetPagedList<T>(Func<IPage<T>> listResources, Func<string, IPage<T>> listNext)
-            where T : Models.Resource
-        {
-            var resources = new List<T>();
-            string nextLink = null;
-
-            var pagedResources = listResources();
-
-            foreach (var pagedResource in pagedResources)
-            {
-                resources.Add(pagedResource);
-            }
-
-            while (!string.IsNullOrEmpty(nextLink))
-            {
-                nextLink = pagedResources.NextPageLink;
-
-                foreach (var pagedResource in listNext(nextLink))
-                {
-                    resources.Add(pagedResource);
-                }
-            }
-
-            return resources;
-        }
-
-        public List<RecoveryPointResource> ListRecoveryPoints(string containerName, string protectedItemName)
-        {
-            return GetPagedList(
-                () => BackupClient.RecoveryPoints.List(VaultName, ResourceGroup, FabricName, containerName, protectedItemName),
-                nextLink => BackupClient.RecoveryPoints.ListNext(nextLink));
-        }
-
-        public string Restore(string containerName, string protectedItemName, string recoveryPointName, string sourceResourceId, string storageAccountId)
-        {
-            RestoreRequestResource request = new RestoreRequestResource()
-            {
-                Properties = new IaasVMRestoreRequest()
-                {
-                    CreateNewCloudService = false,
-                    RecoveryPointId = recoveryPointName,
-                    RecoveryType = RecoveryType.RestoreDisks,
-                    Region = Location,
-                    SourceResourceId = sourceResourceId,
-                    StorageAccountId = storageAccountId,
-                }
-            };
-            var response = BackupClient.Restores.TriggerWithHttpMessagesAsync(
-                VaultName, ResourceGroup, FabricName, containerName, protectedItemName, recoveryPointName, request).Result;
-            ValidateOperationResponse(response);
-
-            var jobResponse = GetOperationResponse<ProtectedItemResource, OperationStatusJobExtendedInfo>(
-                containerName, protectedItemName, response,
-                operationId => BackupClient.ProtectedItemOperationResults.GetWithHttpMessagesAsync(
-                    VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result,
-                operationId => BackupClient.ProtectedItemOperationStatuses.GetWithHttpMessagesAsync(
-                    VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result);
-
-            Assert.NotNull(jobResponse.JobId);
-
-            return jobResponse.JobId;
-        }
-
-        public string DisableProtection(string containerName, string itemName)
-        {
-            var response = BackupClient.ProtectedItems.DeleteWithHttpMessagesAsync(
-                VaultName, ResourceGroup, FabricName, containerName, itemName).Result;
-            ValidateOperationResponse(response);
-
-            var jobResponse = GetOperationStatus<OperationStatusJobExtendedInfo>(
-                containerName, itemName, response,
-                operationId => BackupClient.BackupOperationStatuses.GetWithHttpMessagesAsync(
-                    VaultName, ResourceGroup, operationId).Result);
-
-            Assert.NotNull(jobResponse.JobId);
-
-            return jobResponse.JobId;
-        }
-
-        public TokenInformation GetBackupSecurityPin()
-        {
-            return BackupClient.SecurityPINs.Get(VaultName, ResourceGroup);
-        }
-
-        #region Private Method
-
-        private T GetOperationStatus<T>(string containerName, string itemName, AzureOperationResponse response,
-            Func<string, AzureOperationResponse<OperationStatus>> getOpStatus)
-            where T : OperationStatusExtendedInfo
-        {
-            var operationId = response.Response.Headers.GetAzureAsyncOperationId();
-
-            var opStatusResponse = getOpStatus(operationId);
-
-            while (opStatusResponse.Body.Status == OperationStatusValues.InProgress)
-            {
-                TestUtilities.Wait(5000);
-
-                opStatusResponse = getOpStatus(operationId);
-            }
-
-            opStatusResponse = getOpStatus(operationId);
-            Assert.Equal(OperationStatusValues.Succeeded, opStatusResponse.Body.Status);
-
-            return (T)(opStatusResponse.Body.Properties);
-        }
-
-        private S GetOperationResponse<T, S>(string containerName, string protectedItemName, AzureOperationResponse response,
-            Func<string, AzureOperationResponse<T>> getOpResult,
-            Func<string, AzureOperationResponse<OperationStatus>> getOpStatus)
-            where T : class
-            where S : OperationStatusExtendedInfo
-        {
-            var operationId = response.Response.Headers.Location.Segments.Last();
-
-            var opResponse = getOpResult(operationId);
-
-            while (opResponse.Response.StatusCode == System.Net.HttpStatusCode.Accepted)
-            {
-                TestUtilities.Wait(5000);
-
-                opResponse = getOpResult(opResponse.Response.Headers.Location.Segments.Last());
-            }
-
-            var opStatusResponse = getOpStatus(operationId);
-
-            return (S)(opStatusResponse.Body.Properties);
-        }
-
-        private bool ResourceNotSyncedRetryLogic(HttpStatusCode statusCode)
-        {
-            bool shouldRetry = statusCode == (HttpStatusCode)429 || statusCode == HttpStatusCode.NotFound;
-            if (shouldRetry)
-            {
-                TestUtilities.Wait(TimeSpan.FromSeconds(30));
-            }
-            return shouldRetry;
-        }
-
-
-        #endregion
-        public void Dispose()
-        {
-            DisposeVaults();
-            BackupClient.Dispose();
-            VaultClient.Dispose();
-        }
-    }
+	public class TestHelper : IDisposable
+	{
+		public string ResourceGroup = "SwaggerTestRg";
+		public string VaultName = "SDKTestRsVault";
+		public string Location = "westus";
+		public string FabricName = "Azure";
+
+		public RecoveryServicesClient VaultClient { get; private set; }
+
+		public RecoveryServicesBackupClient BackupClient { get; private set; }
+
+		public void Initialize(MockContext context)
+		{
+			VaultClient = this.GetVaultClient(context);
+			BackupClient = this.GetBackupClient(context);
+
+			CreateResourceGroup(context);
+
+			CreateVault(VaultName);
+		}
+
+		private void CreateResourceGroup(MockContext context)
+		{
+			ResourceManagementClient resourcesClient = this.GetResourcesClient(context);
+
+			try
+			{
+				resourcesClient.ResourceGroups.CreateOrUpdate(ResourceGroup,
+				new ResourceGroup
+				{
+					Location = Location
+				});
+
+			}
+			catch (CloudException ex)
+			{
+				if (ex.Response.StatusCode != System.Net.HttpStatusCode.Conflict) throw;
+			}
+		}
+
+		private void CreateVault(string vaultName)
+		{
+			Vault vault = new Vault()
+			{
+				Location = Location,
+				Sku = new Sku()
+				{
+					Name = SkuName.Standard
+				},
+				Properties = new VaultProperties()
+			};
+
+			try
+			{
+				VaultClient.Vaults.CreateOrUpdate(ResourceGroup, vaultName, vault);
+			}
+			catch (CloudException ex)
+			{
+				if (ex.Response.StatusCode != System.Net.HttpStatusCode.Conflict) throw;
+			}
+		}
+
+		public void DisposeVaults()
+		{
+			var vaults = VaultClient.Vaults.ListByResourceGroup(ResourceGroup);
+			foreach (var vault in vaults)
+			{
+				VaultClient.Vaults.Delete(ResourceGroup, vault.Name);
+			}
+		}
+
+		public List<ProtectionPolicyResource> ListAllPoliciesWithRetries()
+		{
+			List<ProtectionPolicyResource> policies = new List<ProtectionPolicyResource>();
+
+			RetryActionWithTimeout(
+				() => policies = GetPagedList(() => BackupClient.BackupPolicies.List(VaultName, ResourceGroup),
+						nextLink => BackupClient.BackupPolicies.ListNext(nextLink)),
+				() => policies.Count > 0,
+				TimeSpan.FromMinutes(5),
+				ResourceNotSyncedRetryLogic);
+
+			return policies;
+		}
+
+		public ProtectionPolicyResource GetPolicyWithRetries(string policyName)
+		{
+			ProtectionPolicyResource policy = null;
+			RetryActionWithTimeout(
+				() => policy = BackupClient.ProtectionPolicies.Get(VaultName, ResourceGroup, policyName),
+				() => policy != null,
+				TimeSpan.FromMinutes(5),
+				ResourceNotSyncedRetryLogic);
+
+			return policy;
+		}
+
+		public string EnableProtection(string containerName, string protectedItemName, string policyName)
+		{
+			ProtectionPolicyResource policy = GetPolicyWithRetries(policyName);
+
+			BackupClient.ProtectionContainers.Refresh(VaultName, ResourceGroup, FabricName);
+
+			IPage<WorkloadProtectableItemResource> protectableItems = BackupClient.BackupProtectableItems.List(VaultName, ResourceGroup);
+
+			var desiredProtectedItem = (AzureIaaSComputeVMProtectableItem)protectableItems.First(
+				protectableItem => containerName.ToLower().Contains(protectableItem.Name.ToLower())
+				).Properties;
+
+			Assert.NotNull(desiredProtectedItem);
+
+			var item = new ProtectedItemResource()
+			{
+				Properties = new AzureIaaSComputeVMProtectedItem()
+				{
+					PolicyId = policy.Id,
+					SourceResourceId = desiredProtectedItem.VirtualMachineId,
+				}
+			};
+
+			var response = BackupClient.ProtectedItems.CreateOrUpdateWithHttpMessagesAsync(
+				VaultName, ResourceGroup, FabricName, containerName, protectedItemName, item).Result;
+			ValidateOperationResponse(response);
+
+			var jobResponse = GetOperationResponse<ProtectedItemResource, OperationStatusJobExtendedInfo>(
+				containerName, protectedItemName, response,
+				operationId => BackupClient.ProtectedItemOperationResults.GetWithHttpMessagesAsync(
+					VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result,
+				operationId => BackupClient.ProtectedItemOperationStatuses.GetWithHttpMessagesAsync(
+					VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result);
+
+			Assert.NotNull(jobResponse.JobId);
+
+			return jobResponse.JobId;
+		}
+
+		public string Backup(string containerName, string protectedItemName)
+		{
+			BackupRequestResource request = new BackupRequestResource()
+			{
+				Properties = new IaasVMBackupRequest()
+				{
+					RecoveryPointExpiryTimeInUTC = DateTime.UtcNow.AddDays(2),
+				},
+			};
+
+			var response = BackupClient.Backups.TriggerWithHttpMessagesAsync(
+				VaultName, ResourceGroup, FabricName, containerName, protectedItemName, request).Result;
+			ValidateOperationResponse(response);
+
+			var jobResponse = GetOperationResponse<ProtectedItemResource, OperationStatusJobExtendedInfo>(
+				containerName, protectedItemName, response,
+				operationId => BackupClient.ProtectedItemOperationResults.GetWithHttpMessagesAsync(
+					VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result,
+				operationId => BackupClient.ProtectedItemOperationStatuses.GetWithHttpMessagesAsync(
+					VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result);
+
+			Assert.NotNull(jobResponse.JobId);
+
+			return jobResponse.JobId;
+		}
+
+		public void WaitForJobCompletion(string jobId)
+		{
+			string jobStatus = string.Empty;
+
+			RetryActionWithTimeout(
+				() => jobStatus = GetJobStatus(jobId),
+				() => !IsJobInProgress(jobStatus),
+				TimeSpan.FromHours(3),
+				statusCode =>
+				{
+					TestUtilities.Wait(5000);
+					return true;
+				});
+		}
+
+		public string GetJobStatus(string jobId)
+		{
+			var result = BackupClient.JobDetails.GetWithHttpMessagesAsync(VaultName, ResourceGroup, jobId).Result;
+			Assert.NotNull(result);
+			Assert.Equal(result.Response.StatusCode, System.Net.HttpStatusCode.OK);
+			return ((AzureIaaSVMJob)result.Body.Properties).Status;
+		}
+
+		public bool IsJobInProgress(string jobStatus)
+		{
+			return jobStatus.CompareTo("InProgress") == 0 || jobStatus.CompareTo("Cancelling") == 0;
+		}
+
+		public void RetryActionWithTimeout(Action action, Func<bool> validator, TimeSpan timeout, Func<HttpStatusCode, bool> shouldRetry)
+		{
+			DateTime timedOut = DateTime.Now + timeout;
+
+			do
+			{
+				try
+				{
+					action();
+				}
+				catch (CloudException exception)
+				{
+					if (!shouldRetry(exception.Response.StatusCode))
+					{
+						throw;
+					}
+				}
+			}
+			while (DateTime.Now < timedOut && !validator());
+		}
+
+		private void ValidateOperationResponse(AzureOperationResponse response)
+		{
+			Assert.NotNull(response);
+			Assert.Equal(System.Net.HttpStatusCode.Accepted, response.Response.StatusCode);
+			Assert.True(response.Response.Headers.Contains("Location"));
+			Assert.True(response.Response.Headers.Contains("Azure-AsyncOperation"));
+			Assert.True(response.Response.Headers.Contains("Retry-After"));
+		}
+
+		public List<ProtectedItemResource> ListProtectedItems()
+		{
+			return GetPagedList(
+				() => BackupClient.BackupProtectedItems.List(VaultName, ResourceGroup),
+				nextLink => BackupClient.BackupProtectedItems.ListNext(nextLink));
+		}
+
+		public List<T> GetPagedList<T>(Func<IPage<T>> listResources, Func<string, IPage<T>> listNext)
+			where T : Models.Resource
+		{
+			var resources = new List<T>();
+			string nextLink = null;
+
+			var pagedResources = listResources();
+
+			foreach (var pagedResource in pagedResources)
+			{
+				resources.Add(pagedResource);
+			}
+
+			while (!string.IsNullOrEmpty(nextLink))
+			{
+				nextLink = pagedResources.NextPageLink;
+
+				foreach (var pagedResource in listNext(nextLink))
+				{
+					resources.Add(pagedResource);
+				}
+			}
+
+			return resources;
+		}
+
+		public List<RecoveryPointResource> ListRecoveryPoints(string containerName, string protectedItemName)
+		{
+			return GetPagedList(
+				() => BackupClient.RecoveryPoints.List(VaultName, ResourceGroup, FabricName, containerName, protectedItemName),
+				nextLink => BackupClient.RecoveryPoints.ListNext(nextLink));
+		}
+
+		public string Restore(string containerName, string protectedItemName, string recoveryPointName, string sourceResourceId, string storageAccountId)
+		{
+			RestoreRequestResource request = new RestoreRequestResource()
+			{
+				Properties = new IaasVMRestoreRequest()
+				{
+					CreateNewCloudService = false,
+					RecoveryPointId = recoveryPointName,
+					RecoveryType = RecoveryType.RestoreDisks,
+					Region = Location,
+					SourceResourceId = sourceResourceId,
+					StorageAccountId = storageAccountId,
+				}
+			};
+			var response = BackupClient.Restores.TriggerWithHttpMessagesAsync(
+				VaultName, ResourceGroup, FabricName, containerName, protectedItemName, recoveryPointName, request).Result;
+			ValidateOperationResponse(response);
+
+			var jobResponse = GetOperationResponse<ProtectedItemResource, OperationStatusJobExtendedInfo>(
+				containerName, protectedItemName, response,
+				operationId => BackupClient.ProtectedItemOperationResults.GetWithHttpMessagesAsync(
+					VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result,
+				operationId => BackupClient.ProtectedItemOperationStatuses.GetWithHttpMessagesAsync(
+					VaultName, ResourceGroup, FabricName, containerName, protectedItemName, operationId).Result);
+
+			Assert.NotNull(jobResponse.JobId);
+
+			return jobResponse.JobId;
+		}
+
+		public string DisableProtection(string containerName, string itemName)
+		{
+			var response = BackupClient.ProtectedItems.DeleteWithHttpMessagesAsync(
+				VaultName, ResourceGroup, FabricName, containerName, itemName).Result;
+			ValidateOperationResponse(response);
+
+			var jobResponse = GetOperationStatus<OperationStatusJobExtendedInfo>(
+				containerName, itemName, response,
+				operationId => BackupClient.BackupOperationStatuses.GetWithHttpMessagesAsync(
+					VaultName, ResourceGroup, operationId).Result);
+
+			Assert.NotNull(jobResponse.JobId);
+
+			return jobResponse.JobId;
+		}
+
+		public ProtectedItemResource GetProtectedItem(string containerName, string itemName)
+		{
+			return BackupClient.ProtectedItems.Get(VaultName, ResourceGroup, FabricName, containerName, itemName);
+		}
+
+		public ProtectionContainerResource GetContainer(string containerName)
+		{
+			return BackupClient.ProtectionContainers.Get(VaultName, ResourceGroup, FabricName, containerName);
+		}
+
+		public List<ProtectionContainerResource> ListContainers(Microsoft.Rest.Azure.OData.ODataQuery<BMSContainerQueryObject> odataQuery)
+		{
+			return GetPagedList(
+				() => BackupClient.BackupProtectionContainers.List(VaultName, ResourceGroup, odataQuery),
+				nextLink => BackupClient.BackupProtectionContainers.ListNext(nextLink));
+		}
+
+		public TokenInformation GetBackupSecurityPin()
+		{
+			return BackupClient.SecurityPINs.Get(VaultName, ResourceGroup);
+		}
+
+		#region Private Method
+
+		private T GetOperationStatus<T>(string containerName, string itemName, AzureOperationResponse response,
+			Func<string, AzureOperationResponse<OperationStatus>> getOpStatus)
+			where T : OperationStatusExtendedInfo
+		{
+			var operationId = response.Response.Headers.GetAzureAsyncOperationId();
+
+			var opStatusResponse = getOpStatus(operationId);
+
+			while (opStatusResponse.Body.Status == OperationStatusValues.InProgress)
+			{
+				TestUtilities.Wait(5000);
+
+				opStatusResponse = getOpStatus(operationId);
+			}
+
+			opStatusResponse = getOpStatus(operationId);
+			Assert.Equal(OperationStatusValues.Succeeded, opStatusResponse.Body.Status);
+
+			return (T)(opStatusResponse.Body.Properties);
+		}
+
+		private S GetOperationResponse<T, S>(string containerName, string protectedItemName, AzureOperationResponse response,
+			Func<string, AzureOperationResponse<T>> getOpResult,
+			Func<string, AzureOperationResponse<OperationStatus>> getOpStatus)
+			where T : class
+			where S : OperationStatusExtendedInfo
+		{
+			var operationId = response.Response.Headers.Location.Segments.Last();
+
+			var opResponse = getOpResult(operationId);
+
+			while (opResponse.Response.StatusCode == System.Net.HttpStatusCode.Accepted)
+			{
+				TestUtilities.Wait(5000);
+
+				opResponse = getOpResult(opResponse.Response.Headers.Location.Segments.Last());
+			}
+
+			var opStatusResponse = getOpStatus(operationId);
+
+			return (S)(opStatusResponse.Body.Properties);
+		}
+
+		private bool ResourceNotSyncedRetryLogic(HttpStatusCode statusCode)
+		{
+			bool shouldRetry = statusCode == (HttpStatusCode)429 || statusCode == HttpStatusCode.NotFound;
+			if (shouldRetry)
+			{
+				TestUtilities.Wait(TimeSpan.FromSeconds(30));
+			}
+			return shouldRetry;
+		}
+
+
+		#endregion
+		public void Dispose()
+		{
+			DisposeVaults();
+			BackupClient.Dispose();
+			VaultClient.Dispose();
+		}
+
+	}
 }

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestHelper.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestHelper.cs
@@ -406,6 +406,5 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
 			BackupClient.Dispose();
 			VaultClient.Dispose();
 		}
-
 	}
 }

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestSettings.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestSettings.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
 
 		public string AzureSqlItemName { get; set; }
 
-
 		public string AzureSqlPolicyName { get; set; }
 
 

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestSettings.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestSettings.cs
@@ -21,7 +21,15 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
 
         public string RestoreStorageAccountResourceGroupName { get; set; }
 
-        public TestSettings Initialize()
+		public string AzureSqlContainerName { get; set; }
+
+		public string AzureSqlItemName { get; set; }
+
+
+		public string AzureSqlPolicyName { get; set; }
+
+
+		public TestSettings Initialize()
         {
             string content = File.ReadAllText(@"TestSettings.json");
             JObject jObject = JObject.Parse(content);
@@ -33,7 +41,10 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
             VirtualMachineType = testSettings.VirtualMachineType;
             RestoreStorageAccountName = testSettings.RestoreStorageAccountName;
             RestoreStorageAccountResourceGroupName = testSettings.RestoreStorageAccountResourceGroupName;
-            return this;
+			AzureSqlContainerName = testSettings.AzureSqlContainerName;
+			AzureSqlItemName = testSettings.AzureSqlItemName;
+			AzureSqlPolicyName = testSettings.AzureSqlPolicyName;
+			return this;
         }
 
         public static TestSettings Instance = new TestSettings().Initialize();

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestSettings.json
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestSettings.json
@@ -3,5 +3,8 @@
   "VirtualMachineResourceGroupName": "sdktestrg",
   "VirtualMachineType": "Compute",
   "RestoreStorageAccountName": "sdktestrg",
-  "RestoreStorageAccountResourceGroupName": "sdktestrg"
+  "RestoreStorageAccountResourceGroupName": "sdktestrg",
+  "AzureSqlItemName": "dsName;satyay-sea-d1-fc1-catalog-2016-11-11-17-20;661f0942-d5b7-486a-b3cb-68f97d325a3c",
+  "AzureSqlPolicyName": "sqlpaaspolicy",
+  "AzureSqlContainerName": "AzureSqlContainer;Sql;sqlpaasrg;sqlpaasserver"
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as a link to the swagger spec, used to generate the code.
- [ ] The `project.json` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.