### PR TITLE
Fix Azure Batch netcore header signing

### DIFF
--- a/src/SDKs/Batch/DataPlane/Azure.Batch.IntegrationTests/App.config
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch.IntegrationTests/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/SDKs/Batch/DataPlane/Azure.Batch.IntegrationTests/Azure.Batch.IntegrationTests.csproj
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch.IntegrationTests/Azure.Batch.IntegrationTests.csproj
@@ -74,5 +74,7 @@
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="WindowsBase" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/src/SDKs/Batch/DataPlane/Azure.Batch.ProtocolTests/Azure.Batch.ProtocolTests.csproj
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch.ProtocolTests/Azure.Batch.ProtocolTests.csproj
@@ -26,6 +26,10 @@
     <!-- <PackageReference Include="Microsoft.NETCore.App" Version="1.0.2" /> -->
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <ItemGroup>
     <!-- This is needed for discovering tests in test explorer -->
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />	
   </ItemGroup>

--- a/src/SDKs/Batch/DataPlane/Azure.Batch.Unit.Tests/Azure.Batch.Unit.Tests.csproj
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch.Unit.Tests/Azure.Batch.Unit.Tests.csproj
@@ -30,6 +30,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Server.WebListener" Version="1.0.2" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170222-09" />

--- a/src/SDKs/Batch/DataPlane/Azure.Batch.Unit.Tests/Azure.Batch.Unit.Tests.csproj
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch.Unit.Tests/Azure.Batch.Unit.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <RestorePackagesPath>$(LibraryNugetPackageFolder)</RestorePackagesPath>
-    <NugetCommonProfileTags/>
+    <NugetCommonProfileTags />
     <PackageOutputPath>$(BuiltPackageOutputDir)</PackageOutputPath>
     <AddProjectReferenceForDebuggingPurpose>false</AddProjectReferenceForDebuggingPurpose>
     <AddNugetReferenceForCIandCmdlineBuild>true</AddNugetReferenceForCIandCmdlineBuild>
@@ -25,6 +25,10 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta1-build1309" />
@@ -43,7 +47,7 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
   </PropertyGroup>
 
   <!--Do not remove until VS Test Tools fixes #472-->

--- a/src/SDKs/Batch/DataPlane/Azure.Batch.Unit.Tests/HttpClientBehaviorTests.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch.Unit.Tests/HttpClientBehaviorTests.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Azure.Batch.Unit.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Net.Http.Server;
+    using Xunit;
+
+    public class HttpClientBehaviorTests
+    {
+        private const string url = "http://localhost:2055";
+
+        [Theory]
+        [MemberData(nameof(HttpMethods))]
+        public async Task HttpClient_IncludesContentLengthHeaderOnExpectedHttpVerbs(HttpMethod httpMethod)
+        {
+            BatchSharedKeyCredential creds = new BatchSharedKeyCredential(ClientUnitTestCommon.DummyAccountName, ClientUnitTestCommon.DummyAccountKey);
+
+            HttpRequestMessage message = new HttpRequestMessage(httpMethod, url);
+            message.Headers.Add("client-request-id", Guid.NewGuid().ToString());
+
+            await creds.ProcessHttpRequestAsync(message, CancellationToken.None);
+            Assert.NotNull(message.Headers.Authorization);
+
+            var settings = new WebListenerSettings()
+            {
+                Authentication = { Schemes = AuthenticationSchemes.None },
+                UrlPrefixes = { url }
+            };
+            using (WebListener listener = new WebListener(settings))
+            {
+                listener.Start();
+                Task listenTask = AcceptAndAssertAsync(httpMethod, listener, AssertRequestHasExpectedContentLength);
+
+                HttpClient client = new HttpClient();
+                await client.SendAsync(message);
+
+                await listenTask;
+            }
+        }
+
+        private static IEnumerable<object[]> HttpMethods()
+        {
+            yield return new[] { HttpMethod.Delete };
+            yield return new[] { HttpMethod.Post };
+            yield return new[] { HttpMethod.Get };
+            yield return new[] { HttpMethod.Head };
+            yield return new[] { new HttpMethod("PATCH") };
+            yield return new[] { HttpMethod.Put };
+            yield return new[] { HttpMethod.Options };
+        }
+
+        private static async Task AcceptAndAssertAsync(HttpMethod httpMethod, WebListener listener, Action<HttpMethod, RequestContext> assertLambda)
+        {
+            using (RequestContext ctx = await listener.AcceptAsync())
+            {
+                assertLambda(httpMethod, ctx);
+                ctx.Response.StatusCode = 200;
+            }
+        }
+
+        private static void AssertRequestHasExpectedContentLength(HttpMethod httpMethod, RequestContext ctx)
+        {
+            if (httpMethod == HttpMethod.Head || httpMethod == HttpMethod.Get)
+            {
+                Assert.DoesNotContain(ctx.Request.Headers.Keys, str => str == "Content-Length");
+            }
+            else if (httpMethod == HttpMethod.Delete || httpMethod == new HttpMethod("PATCH") || httpMethod == HttpMethod.Options)
+            {
+#if !FullNetFx
+                Assert.DoesNotContain(ctx.Request.Headers.Keys, str => str == "Content-Length");
+#else
+                Assert.Contains(ctx.Request.Headers.Keys, str => str == "Content-Length");
+                Assert.Equal("0", ctx.Request.Headers["Content-Length"].Single());
+#endif
+            }
+            else if (httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put)
+            {
+                Assert.Contains(ctx.Request.Headers.Keys, str => str == "Content-Length");
+                Assert.Equal("0", ctx.Request.Headers["Content-Length"].Single());
+            }
+            else
+            {
+                throw new ArgumentException($"Unexpected HTTP request type: {httpMethod}");
+            }
+        }
+    }
+}

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/AssemblyAttributes.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/AssemblyAttributes.cs
@@ -9,8 +9,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft.Azure.Batch")]
 [assembly: AssemblyDescription("Client library for interacting with the Azure Batch service.")]
 
-[assembly: AssemblyVersion("7.0.0.0")]
-[assembly: AssemblyFileVersion("7.0.0.0")]
+[assembly: AssemblyVersion("7.0.1.0")]
+[assembly: AssemblyFileVersion("7.0.1.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Azure.Batch</PackageId>
     <Description>This client library provides access to the Microsoft Azure Batch service.</Description>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>7.0.1</VersionPrefix>
     <DefineConstants>$(DefineConstants);CODESIGN</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Microsoft.Azure.Batch</AssemblyName>

--- a/src/SDKs/Batch/DataPlane/changelog.md
+++ b/src/SDKs/Batch/DataPlane/changelog.md
@@ -3,6 +3,14 @@
 ### Upcoming changes
 These changes are planned but haven't been published yet.
 
+### Changes in 7.0.1
+#### Bug fixes
+- Fixed a bug where requests using HTTP DELETE (for example, `DeletePool` and `DeleteJob`) failed with an authentication error in the netstandard package. This was due to a change made to `HttpClient` in netcore.
+  - This bug impacted the 6.1.0 release as well.
+
+#### REST API version
+This version of the Batch .NET client library targets version 2017-05-01.5.0 of the Azure Batch REST API.
+
 ### Changes in 7.0.0
 #### License
 Moved source code and NuGet package from Apache 2.0 license to MIT license. This is more consistent with the other Azure SDKs as well as other open source projects from Microsoft such as .NET.


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
