### PR TITLE
Publishing Test related packages.

### DIFF
--- a/src/SDKs/Monitor/Monitor.Tests/Monitor.Tests.csproj
+++ b/src/SDKs/Monitor/Monitor.Tests/Monitor.Tests.csproj
@@ -5,7 +5,7 @@
     <Description>Monitor.Tests Class library</Description>
     <PackageId>Monitor.Tests</PackageId>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Management.Monitor\Microsoft.Azure.Management.Monitor.csproj" />

--- a/src/SdkCommon/ClientRuntime.Azure.Authentication/Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj
+++ b/src/SdkCommon/ClientRuntime.Azure.Authentication/Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj
@@ -5,7 +5,7 @@
     <Description>Provides ADAL based authentication for Azure management client libraries</Description>
     <AssemblyName>Microsoft.Rest.ClientRuntime.Azure.Authentication</AssemblyName>
     <AssemblyTitle>Authentication for Azure Management Clients</AssemblyTitle>
-    <VersionPrefix>2.2.13</VersionPrefix>    
+    <VersionPrefix>2.3.0</VersionPrefix>    
     <PackageTags>Microsoft AutoRest ClientRuntime Authentication $(NugetCommonTags) $(NugetCommonProfileTags)</PackageTags>
   </PropertyGroup>
   <PropertyGroup>
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[2.28.3]" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[3.13.5]" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[3.13.9]" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="[5.1.2]" />
   </ItemGroup>
 </Project>

--- a/src/SdkCommon/ClientRuntime.Azure.Authentication/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/ClientRuntime.Azure.Authentication/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Rest Azure Client Runtime Authentication")]
 [assembly: AssemblyDescription("Client authentication infrastructure for Azure client libraries.")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.2.13.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]

--- a/src/SdkCommon/TestFramework/ClientRuntime.Azure.TestFramework/ConnectionString.cs
+++ b/src/SdkCommon/TestFramework/ClientRuntime.Azure.TestFramework/ConnectionString.cs
@@ -230,7 +230,6 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         /// <param name="connString">Semicolon delimented KeyValue pair(e.g. KeyName1=value1;KeyName2=value2;KeyName3=value3)</param>
         public void Parse(string connString)
         {
-            //string keyName;
             string parseRegEx = @"(?<KeyName>[^=]+)=(?<KeyValue>.+)";
 
             if (_parseErrorSb != null) _parseErrorSb.Clear();

--- a/src/SdkCommon/TestFramework/ClientRuntime.Azure.TestFramework/ConnectionString.cs
+++ b/src/SdkCommon/TestFramework/ClientRuntime.Azure.TestFramework/ConnectionString.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         /// <param name="connString">Semicolon delimented KeyValue pair(e.g. KeyName1=value1;KeyName2=value2;KeyName3=value3)</param>
         public void Parse(string connString)
         {
-            string keyName;
+            //string keyName;
             string parseRegEx = @"(?<KeyName>[^=]+)=(?<KeyValue>.+)";
 
             if (_parseErrorSb != null) _parseErrorSb.Clear();
@@ -257,14 +257,22 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
 
                     if (m.Groups.Count > 2)
                     {
-                        keyName = m.Groups["KeyName"].Value.ToLower();
+                        string keyName = m.Groups["KeyName"].Value;
+                        string newValue = m.Groups["KeyValue"].Value;
+
                         if (KeyValuePairs.ContainsKey(keyName))
                         {
-                            KeyValuePairs[keyName] = m.Groups["KeyValue"].Value;
+                            string existingValue = KeyValuePairs[keyName];
+                            // Replace if the existing value do not match.
+                            // We allow existing key values to be overwritten (this is especially true for endpoints)
+                            if (!existingValue.Equals(newValue, StringComparison.OrdinalIgnoreCase))
+                            {
+                                KeyValuePairs[keyName] = newValue;
+                            }
                         }
                         else
                         {
-                            ParseErrors = string.Format("'{0}' invalid keyname", keyName);
+                            KeyValuePairs[keyName] = newValue;
                         }
                     }
                     else

--- a/src/SdkCommon/TestFramework/ClientRuntime.Azure.TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework.csproj
+++ b/src/SdkCommon/TestFramework/ClientRuntime.Azure.TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Microsoft.Rest.ClientRuntime.Azure.TestFramework</Description>
     <AssemblyTitle>Test framework for Microsoft AutoRest Generated Clients</AssemblyTitle>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <AssemblyName>Microsoft.Rest.ClientRuntime.Azure.TestFramework</AssemblyName>
     <PackageId>Microsoft.Rest.ClientRuntime.Azure.TestFramework</PackageId>
     <PackageTags>Microsoft AutoRest ClientRuntime REST TestFramework</PackageTags>

--- a/src/SdkCommon/TestFramework/ClientRuntime.Azure.TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework.csproj
+++ b/src/SdkCommon/TestFramework/ClientRuntime.Azure.TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <!--<Import Project="$([MSBuild]::GetPathOfFileAbove('test.props'))" />-->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('clientruntime.reference.props'))" />  
   <PropertyGroup>
     <Description>Microsoft.Rest.ClientRuntime.Azure.TestFramework</Description>
     <AssemblyTitle>Test framework for Microsoft AutoRest Generated Clients</AssemblyTitle>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <AssemblyName>Microsoft.Rest.ClientRuntime.Azure.TestFramework</AssemblyName>
     <PackageId>Microsoft.Rest.ClientRuntime.Azure.TestFramework</PackageId>
     <PackageTags>Microsoft AutoRest ClientRuntime REST TestFramework</PackageTags>
@@ -15,9 +14,14 @@
   </PropertyGroup>
   
   <ItemGroup>        
-    <!--<ProjectReference Include="..\..\ClientRuntime\ClientRuntime\Microsoft.Rest.ClientRuntime.csproj" />--> 
+    <!--
+    <ProjectReference Include="..\..\ClientRuntime\ClientRuntime\Microsoft.Rest.ClientRuntime.csproj" />
     <ProjectReference Include="..\..\ClientRuntime.Azure.Authentication\Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.Test.HttpRecorder\Microsoft.Azure.Test.HttpRecorder.csproj" />
+    -->
+    
+    <PackageReference Include="Microsoft.Azure.Test.HttpRecorder" Version="[1.7.0,2.0.0)" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="[2.2.12,3.0.0)" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">

--- a/src/SdkCommon/TestFramework/ClientRuntime.Azure.TestFramework/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/TestFramework/ClientRuntime.Azure.TestFramework/Properties/AssemblyInfo.cs
@@ -3,12 +3,12 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
-/*
+
 [assembly: AssemblyTitle("Microsoft.Rest.ClientRuntime.Azure.TestFramework.Framework")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft.Rest.ClientRuntime.Azure.TestFramework.Framework")]
 [assembly: AssemblyCopyright("Microsoft (c) 2015")]
-*/
+
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -16,7 +16,6 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6eb355e3-e1e1-4f46-bcfa-737812ccff87")]
-/*
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.3.0")]
-*/
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.6.0.0")]

--- a/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/Microsoft.Azure.Test.HttpRecorder.csproj
+++ b/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/Microsoft.Azure.Test.HttpRecorder.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Microsoft.Azure.Test.HttpRecorder</Description>
     <AssemblyTitle>HttpRecorder Library for recording Clinet/Server communication in Azure</AssemblyTitle>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.8.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.Test.HttpRecorder</AssemblyName>
     <PackageId>Microsoft.Azure.Test.HttpRecorder</PackageId>
     <PackageTags>Microsoft AutoRest ClientRuntime HttpRecorder REST;$(CommonNugetPackageTags)</PackageTags>

--- a/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/Properties/AssemblyInfo.cs
@@ -11,7 +11,6 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("c77934b2-fc7c-4f23-b2e1-12da90bfe716")]
 
-/*
 [assembly: AssemblyTitle("HttpRecorder")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
@@ -23,5 +22,4 @@ using System.Runtime.InteropServices;
 
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.6.9.0")]
-*/
+[assembly: AssemblyFileVersion("1.8.0.0")]

--- a/src/SdkCommon/TestFramework/TestFramework.Tests/TestEnvironment/ConnectionStringParseTests.cs
+++ b/src/SdkCommon/TestFramework/TestFramework.Tests/TestEnvironment/ConnectionStringParseTests.cs
@@ -60,16 +60,7 @@ namespace TestFramework.Tests.TestEnvironment
             connStr.Parse(missingKeyValue);            
             Assert.True(string.IsNullOrEmpty(connStr.ParseErrors));
         }
-
-        [Fact]
-        public void InvalidKeyValuePairString()
-        {
-            // invalid KeyValue Connection string
-            string legalConnStrWithInvalidKeyNames = @"foo=bar;hello=world";
-            connStr.Parse(legalConnStrWithInvalidKeyNames);
-            Assert.False(string.IsNullOrEmpty(connStr.ParseErrors));
-        }
-                
+        
         [Fact]
         public void MalformedString()
         {
@@ -119,6 +110,29 @@ namespace TestFramework.Tests.TestEnvironment
 
             //As userId is non-empty, we cannot assume password is ServicePrincipalSecretKey and so will not be updated
             Assert.Equal(string.Empty, connStr.KeyValuePairs["ServicePrincipalSecret".ToLower()]);
+        }
+
+        [Fact]
+        public void CustomKeyValuesInConnStr()
+        {
+            // This test will test if custome Key-Value pairs are honored.
+            // Also if there are duplicate keys, it will pick the last occurance of the key, 
+            // and will overwrite earlier instances of the same key
+
+            string clientIdButNoSPN = @"MyKey=MyValue;MyKey=NewValue;CustomKey=CustomValue;AADClientId=alsdkfjalakdsjflasdj;UserId=Hello@world.com";
+            connStr.Parse(clientIdButNoSPN);
+            Assert.Equal(string.Empty, connStr.ParseErrors);
+
+            //ServicePrincipal will be updated with AADClientId
+            Assert.NotEqual(string.Empty, connStr.KeyValuePairs["ServicePrincipal"]);
+
+            // Earlier instance of the same key will be overwritten
+            Assert.NotEqual("MyValue", connStr.KeyValuePairs["MyKey"]);
+
+            // last instance of the same key is retained
+            Assert.Equal("NewValue", connStr.KeyValuePairs["MyKey"]);
+            
+            Assert.Equal("CustomValue", connStr.KeyValuePairs["CustomKey"]);
         }
 
         private string CreateConnStrWithAllPossibleValues()

--- a/src/SdkCommon/TestFramework/TestFramework.Tests/TestFramework.Tests.csproj
+++ b/src/SdkCommon/TestFramework/TestFramework.Tests/TestFramework.Tests.csproj
@@ -11,31 +11,24 @@
     <TestProjectType>true</TestProjectType>
   </PropertyGroup>
   <ItemGroup>
-    <!-- <ProjectReference Include="..\..\ClientRuntime.Azure.Authentication\Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj" /> -->
-    <!-- <ProjectReference Include="..\..\ClientRuntime.Azure\ClientRuntime.Azure\Microsoft.Rest.ClientRuntime.Azure.csproj" /> -->
-    <!-- <ProjectReference Include="..\..\ClientRuntime\ClientRuntime\Microsoft.Rest.ClientRuntime.csproj" /> -->
-    <!-- <ProjectReference Include="..\ClientRuntime.Azure.TestFramework\Microsoft.Rest.ClientRuntime.Azure.TestFramework.csproj" /> -->
-    <!-- <ProjectReference Include="..\Microsoft.Azure.Test.HttpRecorder\Microsoft.Azure.Test.HttpRecorder.csproj" /> -->
+    <!-- 
+    <ProjectReference Include="..\..\ClientRuntime\ClientRuntime\Microsoft.Rest.ClientRuntime.csproj" />
+    <ProjectReference Include="..\Microsoft.Azure.Test.HttpRecorder\Microsoft.Azure.Test.HttpRecorder.csproj" />
+    <ProjectReference Include="..\..\ClientRuntime.Azure\ClientRuntime.Azure\Microsoft.Rest.ClientRuntime.Azure.csproj" />
+    -->
+    <ProjectReference Include="..\..\ClientRuntime.Azure.Authentication\Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj" />    
+    <ProjectReference Include="..\ClientRuntime.Azure.TestFramework\Microsoft.Rest.ClientRuntime.Azure.TestFramework.csproj" />
   </ItemGroup>
   
-  <ItemGroup>
-    <!--<PackageReference Include="Microsoft.Rest.ClientRuntime" Version="[2.3.5,3.0)" />-->
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="[3.3.5,4.0.0)" />
+  <ItemGroup>    
+    <!--
+      <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="[1.6.0,2.0.0)" />
+      <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="[2.2.12,3.0.0)" />    
+    -->
     <PackageReference Include="Microsoft.Azure.Test.HttpRecorder" Version="[1.7.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="[1.6.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="[2.2.12,3.0.0)" />    
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="[3.3.5,4.0.0)" />
   </ItemGroup>
   
-  
-  <!--<ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System" />
-    <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.Serialization" />
-  </ItemGroup>-->
- 
   <ItemGroup>
     <None Update="SessionRecords\**\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
- Enables TestFramework to accept custom key/value pairs. This helps in injecting information needed during running test so that it does not need to be hard coded in tests.
- Adding new tests to test framework
- Updating versions for HttpRecorder, Azure.Authentication and Test Framework.
This PR will enable to publish HttpRecorder and Azure.Authentication.
Which will be followed by publishing TestFramework later. (PR 2 will be followed)
And finally updating the entire repo to use the latest Test related packages. (PR 3 will be followed)