### PR TITLE
Fixed a place where Batch VM size support info had not been updated

### DIFF
--- a/src/SDKs/Batch/DataPlane/Azure.Batch/Generated/PoolUsageMetrics.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/Generated/PoolUsageMetrics.cs
@@ -96,9 +96,17 @@ namespace Microsoft.Azure.Batch
         }
 
         /// <summary>
-        /// Gets the size of virtual machine in the pool. All virtual machines in a pool are the same size. Azure Batch supports 
-        /// all Azure virtual machine sizes except ExtraSmall.
+        /// Gets the size of the virtual machines in the pool.  All virtual machines in a pool are the same size.
         /// </summary>
+        /// <remarks>
+        /// <para>For information about available sizes of virtual machines for Cloud Services pools (pools created with 
+        /// a <see cref="CloudServiceConfiguration"/>), see https://azure.microsoft.com/documentation/articles/cloud-services-sizes-specs/. 
+        /// Batch supports all Cloud Services VM sizes except ExtraSmall.</para><para>For information about available VM 
+        /// sizes for pools using images from the Virtual Machines Marketplace (pools created with a <see cref="VirtualMachineConfiguration"/>) 
+        /// see https://azure.microsoft.com/documentation/articles/virtual-machines-linux-sizes/ or https://azure.microsoft.com/documentation/articles/virtual-machines-windows-sizes/. 
+        /// Batch supports all Azure VM sizes except STANDARD_A0 and those with premium storage (for example STANDARD_GS, 
+        /// STANDARD_DS, and STANDARD_DSV2 series).</para>
+        /// </remarks>
         public string VirtualMachineSize
         {
             get { return this.virtualMachineSize; }

--- a/src/SDKs/Batch/DataPlane/Tools/ObjectModelCodeGeneration/ObjectModelCodeGenerator/Spec/PoolUsageMetrics.json
+++ b/src/SDKs/Batch/DataPlane/Tools/ObjectModelCodeGeneration/ObjectModelCodeGenerator/Spec/PoolUsageMetrics.json
@@ -89,8 +89,8 @@
           "Key": {
             "Type": "string",
             "Name": "VirtualMachineSize",
-            "SummaryComment": "The size of virtual machine in the pool. All virtual machines in a pool are the same size. Azure Batch supports all Azure virtual machine sizes except ExtraSmall.",
-            "RemarksComment": null,
+            "SummaryComment": "The size of the virtual machines in the pool.  All virtual machines in a pool are the same size.",
+            "RemarksComment": "<para>For information about available sizes of virtual machines for Cloud Services pools (pools created with a <see cref=\"CloudServiceConfiguration\"/>), see https://azure.microsoft.com/documentation/articles/cloud-services-sizes-specs/. Batch supports all Cloud Services VM sizes except ExtraSmall.</para><para>For information about available VM sizes for pools using images from the Virtual Machines Marketplace (pools created with a <see cref=\"VirtualMachineConfiguration\"/>) see https://azure.microsoft.com/documentation/articles/virtual-machines-linux-sizes/ or https://azure.microsoft.com/documentation/articles/virtual-machines-windows-sizes/. Batch supports all Azure VM sizes except STANDARD_A0 and those with premium storage (for example STANDARD_GS, STANDARD_DS, and STANDARD_DSV2 series).</para>",
             "BoundAccess": "read",
             "UnboundAccess": "none"
           },


### PR DESCRIPTION
The information about supported Azure Batch VM sizes had been updated in most places but there was one place where it still linked to an incorrect article.  This PR updates that place with consistent wording and links.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
