### PR TITLE
Constant declarations for Spark configurations to be used by powershell

### DIFF
--- a/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/CustomizationModels/ConfigurationKey.cs
+++ b/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/CustomizationModels/ConfigurationKey.cs
@@ -92,5 +92,25 @@ namespace Microsoft.Azure.Management.HDInsight
         /// The constant for cluster identity configs.
         /// </summary>
         public const string ClusterIdentity = "clusterIdentity";
+		
+		/// <summary>
+        /// The constant for Spark-Defaults configs.
+        /// </summary>
+        public const string SparkDefaults = "spark-defaults";
+
+        /// <summary>
+        /// The constant for Spark-Thrift-SparkConf configs.
+        /// </summary>
+        public const string SparkThriftConf = "spark-thrift-sparkconf";
+
+        /// <summary>
+        /// The constant for Spark2-Defaults configs.
+        /// </summary>
+        public const string Spark2Defaults = "spark2-defaults";
+
+        /// <summary>
+        /// The constant for Spark2-Thrift-SparkConf configs.
+        /// </summary>
+        public const string Spark2ThriftConf = "spark2-thrift-sparkconf";
     }
 }

--- a/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Generated/ClusterOperations.cs
+++ b/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Generated/ClusterOperations.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Management.HDInsight
     /// </summary>
     internal partial class ClusterOperations : IServiceOperations<HDInsightManagementClient>, IClusterOperations
     {
-        private const string _userAgentString = "ARM SDK v2.0.6";
+        private const string _userAgentString = "ARM SDK v2.0.7";
         
         /// <summary>
         /// Initializes a new instance of the ClusterOperations class.

--- a/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.6.0")]
+[assembly: AssemblyFileVersion("2.0.7.0")]
 
 [assembly:InternalsVisibleTo("HDInsight.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/project.json
+++ b/src/ResourceManagement/HDInsight/Microsoft.Azure.Management.HDInsight/project.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.6",
+    "version": "2.0.7",
     "title": "Microsoft Azure HDInsight Management Library",
     "description": "The generally available HDInsight Management NuGet package. This NuGet package allows you to create and manage Azure HDInsight clusters using Azure Resource Manager (ARM).",
     "authors": [ "Microsoft" ],


### PR DESCRIPTION

## Description
Adding new constant declarations which will be used by Azure HDInsight powershell

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x ] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes. - Not necessar

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines) - Not required
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
