### PR TITLE
Fixed System.AppDomain dependency in HttpRecorder

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,6 +3,7 @@
   <packageSources>
      <!-- To enable LocalFeed for testing uncomment the following line -->
      <add key="NugetOfficialV3" value="https://api.nuget.org/v3/index.json" />
+     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
      <add key="Local" value="tools/LocalNugetFeed" />
    </packageSources>
 </configuration>

--- a/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/HttpMockServer.cs
+++ b/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/HttpMockServer.cs
@@ -10,7 +10,6 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Reflection;
-using Microsoft.Extensions.DependencyModel;
 
 namespace Microsoft.Azure.Test.HttpRecorder
 {
@@ -65,7 +64,7 @@ namespace Microsoft.Azure.Test.HttpRecorder
             records = new Records(Matcher);
             Variables = new Dictionary<string, string>();
 
-            var asmCollection = GetAssemblies();
+            var asmCollection = AppDomain.CurrentDomain.GetAssemblies();
 
             foreach(Assembly asm in asmCollection)
             {
@@ -115,18 +114,6 @@ namespace Microsoft.Azure.Test.HttpRecorder
             initialized = true;
         }
 
-        private static Assembly[] GetAssemblies()
-        {
-            var assemblies = new List<Assembly>();
-            var dependencies = DependencyContext.Default.RuntimeLibraries;
-            foreach (var library in dependencies)
-            {
-                var assembly = Assembly.Load(new AssemblyName(library.Name));
-                assemblies.Add(assembly);
-            }
-            return assemblies.ToArray();
-        }
-        
         public static HttpMockServer CreateInstance()
         {
             if (!initialized)

--- a/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/HttpMockServer.cs
+++ b/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/HttpMockServer.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Reflection;
+using Microsoft.Extensions.DependencyModel;
 
 namespace Microsoft.Azure.Test.HttpRecorder
 {
@@ -64,7 +65,7 @@ namespace Microsoft.Azure.Test.HttpRecorder
             records = new Records(Matcher);
             Variables = new Dictionary<string, string>();
 
-            var asmCollection = AppDomain.CurrentDomain.GetAssemblies();
+            var asmCollection = GetAssemblies();
 
             foreach(Assembly asm in asmCollection)
             {
@@ -114,6 +115,18 @@ namespace Microsoft.Azure.Test.HttpRecorder
             initialized = true;
         }
 
+        private static Assembly[] GetAssemblies()
+        {
+            var assemblies = new List<Assembly>();
+            var dependencies = DependencyContext.Default.RuntimeLibraries;
+            foreach (var library in dependencies)
+            {
+                var assembly = Assembly.Load(new AssemblyName(library.Name));
+                assemblies.Add(assembly);
+            }
+            return assemblies.ToArray();
+        }
+        
         public static HttpMockServer CreateInstance()
         {
             if (!initialized)

--- a/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/Microsoft.Azure.Test.HttpRecorder.csproj
+++ b/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/Microsoft.Azure.Test.HttpRecorder.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Microsoft.Azure.Test.HttpRecorder</Description>
     <AssemblyTitle>HttpRecorder Library for recording Clinet/Server communication in Azure</AssemblyTitle>
-    <VersionPrefix>1.8.0</VersionPrefix>
+    <VersionPrefix>1.8.1</VersionPrefix>
     <AssemblyName>Microsoft.Azure.Test.HttpRecorder</AssemblyName>
     <PackageId>Microsoft.Azure.Test.HttpRecorder</PackageId>
     <PackageTags>Microsoft AutoRest ClientRuntime HttpRecorder REST;$(CommonNugetPackageTags)</PackageTags>
@@ -13,6 +13,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   
@@ -22,7 +23,4 @@
     <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <PackageReference Include="System.AppDomain" Version="2.0.11" />
-  </ItemGroup>
 </Project>

--- a/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/Microsoft.Azure.Test.HttpRecorder.csproj
+++ b/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/Microsoft.Azure.Test.HttpRecorder.csproj
@@ -9,11 +9,10 @@
     <PackageTags>Microsoft AutoRest ClientRuntime HttpRecorder REST;$(CommonNugetPackageTags)</PackageTags>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   
@@ -23,4 +22,7 @@
     <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
   
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+    <PackageReference Include="System.AppDomain" Version="2.0.11" />
+  </ItemGroup>
 </Project>

--- a/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/Properties/AssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.8.0.0")]
+[assembly: AssemblyFileVersion("1.8.1.0")]


### PR DESCRIPTION
blocks Azure PS Core CLR conversion due to hard dependency on System.AppDomain nuget package.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
