### PR TITLE
Expose new fields for bgp and community object and point apis to a new api version 

### DIFF
--- a/src/SDKs/Network/Management.Network/Generated/BgpServiceCommunitiesOperations.cs
+++ b/src/SDKs/Network/Management.Network/Generated/BgpServiceCommunitiesOperations.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;

--- a/src/SDKs/Network/Management.Network/Generated/ExpressRouteCircuitAuthorizationsOperations.cs
+++ b/src/SDKs/Network/Management.Network/Generated/ExpressRouteCircuitAuthorizationsOperations.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -551,7 +551,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -736,7 +736,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;

--- a/src/SDKs/Network/Management.Network/Generated/ExpressRouteCircuitPeeringsOperations.cs
+++ b/src/SDKs/Network/Management.Network/Generated/ExpressRouteCircuitPeeringsOperations.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -351,7 +351,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -549,7 +549,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -734,7 +734,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;

--- a/src/SDKs/Network/Management.Network/Generated/ExpressRouteCircuitsOperations.cs
+++ b/src/SDKs/Network/Management.Network/Generated/ExpressRouteCircuitsOperations.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -624,7 +624,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -813,7 +813,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -991,7 +991,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -1178,7 +1178,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -1354,7 +1354,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -1588,7 +1588,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -1801,7 +1801,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -2014,7 +2014,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;

--- a/src/SDKs/Network/Management.Network/Generated/ExpressRouteServiceProvidersOperations.cs
+++ b/src/SDKs/Network/Management.Network/Generated/ExpressRouteServiceProvidersOperations.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;

--- a/src/SDKs/Network/Management.Network/Generated/Models/BGPCommunity.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/BGPCommunity.cs
@@ -39,12 +39,18 @@ namespace Microsoft.Azure.Management.Network.Models
         /// https://docs.microsoft.com/en-us/azure/expressroute/expressroute-routing.</param>
         /// <param name="communityPrefixes">The prefixes that the bgp community
         /// contains.</param>
-        public BGPCommunity(string serviceSupportedRegion = default(string), string communityName = default(string), string communityValue = default(string), IList<string> communityPrefixes = default(IList<string>))
+        /// <param name="isAuthorizedToUse">Customer is authorized to use bgp
+        /// community or not.</param>
+        /// <param name="serviceGroup">The service group of the bgp community
+        /// contains.</param>
+        public BGPCommunity(string serviceSupportedRegion = default(string), string communityName = default(string), string communityValue = default(string), IList<string> communityPrefixes = default(IList<string>), bool? isAuthorizedToUse = default(bool?), string serviceGroup = default(string))
         {
             ServiceSupportedRegion = serviceSupportedRegion;
             CommunityName = communityName;
             CommunityValue = communityValue;
             CommunityPrefixes = communityPrefixes;
+            IsAuthorizedToUse = isAuthorizedToUse;
+            ServiceGroup = serviceGroup;
         }
 
         /// <summary>
@@ -72,6 +78,18 @@ namespace Microsoft.Azure.Management.Network.Models
         /// </summary>
         [JsonProperty(PropertyName = "communityPrefixes")]
         public IList<string> CommunityPrefixes { get; set; }
+
+        /// <summary>
+        /// Gets or sets customer is authorized to use bgp community or not.
+        /// </summary>
+        [JsonProperty(PropertyName = "isAuthorizedToUse")]
+        public bool? IsAuthorizedToUse { get; set; }
+
+        /// <summary>
+        /// Gets or sets the service group of the bgp community contains.
+        /// </summary>
+        [JsonProperty(PropertyName = "serviceGroup")]
+        public string ServiceGroup { get; set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/ExpressRouteCircuitPeeringConfig.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/ExpressRouteCircuitPeeringConfig.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Azure.Management.Network.Models
         /// </summary>
         /// <param name="advertisedPublicPrefixes">The reference of
         /// AdvertisedPublicPrefixes.</param>
+        /// <param name="advertisedCommunities">The communities of bgp peering.
+        /// Spepcified for microsoft peering</param>
         /// <param
         /// name="advertisedPublicPrefixesState">AdvertisedPublicPrefixState of
         /// the Peering resource. Possible values are 'NotConfigured',
@@ -40,13 +42,16 @@ namespace Microsoft.Azure.Management.Network.Models
         /// values include: 'NotConfigured', 'Configuring', 'Configured',
         /// 'ValidationNeeded'</param>
         /// <param name="customerASN">The CustomerASN of the peering.</param>
+        /// <param name="legacyMode">The legacy mode of the peering.</param>
         /// <param name="routingRegistryName">The RoutingRegistryName of the
         /// configuration.</param>
-        public ExpressRouteCircuitPeeringConfig(IList<string> advertisedPublicPrefixes = default(IList<string>), string advertisedPublicPrefixesState = default(string), int? customerASN = default(int?), string routingRegistryName = default(string))
+        public ExpressRouteCircuitPeeringConfig(IList<string> advertisedPublicPrefixes = default(IList<string>), IList<string> advertisedCommunities = default(IList<string>), string advertisedPublicPrefixesState = default(string), int? customerASN = default(int?), int? legacyMode = default(int?), string routingRegistryName = default(string))
         {
             AdvertisedPublicPrefixes = advertisedPublicPrefixes;
+            AdvertisedCommunities = advertisedCommunities;
             AdvertisedPublicPrefixesState = advertisedPublicPrefixesState;
             CustomerASN = customerASN;
+            LegacyMode = legacyMode;
             RoutingRegistryName = routingRegistryName;
         }
 
@@ -55,6 +60,13 @@ namespace Microsoft.Azure.Management.Network.Models
         /// </summary>
         [JsonProperty(PropertyName = "advertisedPublicPrefixes")]
         public IList<string> AdvertisedPublicPrefixes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the communities of bgp peering. Spepcified for
+        /// microsoft peering
+        /// </summary>
+        [JsonProperty(PropertyName = "advertisedCommunities")]
+        public IList<string> AdvertisedCommunities { get; set; }
 
         /// <summary>
         /// Gets or sets advertisedPublicPrefixState of the Peering resource.
@@ -70,6 +82,12 @@ namespace Microsoft.Azure.Management.Network.Models
         /// </summary>
         [JsonProperty(PropertyName = "customerASN")]
         public int? CustomerASN { get; set; }
+
+        /// <summary>
+        /// Gets or sets the legacy mode of the peering.
+        /// </summary>
+        [JsonProperty(PropertyName = "legacyMode")]
+        public int? LegacyMode { get; set; }
 
         /// <summary>
         /// Gets or sets the RoutingRegistryName of the configuration.

--- a/src/SDKs/Network/Management.Network/Generated/RouteFilterRulesOperations.cs
+++ b/src/SDKs/Network/Management.Network/Generated/RouteFilterRulesOperations.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -576,7 +576,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -768,7 +768,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 routeFilterRuleParameters = new RouteFilterRule();
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -1007,7 +1007,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 routeFilterRuleParameters = new PatchRouteFilterRule();
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;

--- a/src/SDKs/Network/Management.Network/Generated/RouteFiltersOperations.cs
+++ b/src/SDKs/Network/Management.Network/Generated/RouteFiltersOperations.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -361,7 +361,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -539,7 +539,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -726,7 +726,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -901,7 +901,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -1127,7 +1127,7 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2017-03-01";
+            string apiVersion = "2017-04-01";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;

--- a/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
+++ b/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
@@ -4,7 +4,7 @@
     <PackageId>Microsoft.Azure.Management.Network</PackageId>
     <Description>Provides management capabilities for Network services.</Description>
     <AssemblyName>Microsoft.Azure.Management.Network</AssemblyName>
-    <VersionPrefix>10.1.1-preview</VersionPrefix>
+    <VersionPrefix>10.2.1-preview</VersionPrefix>
     <PackageTags>Microsoft Azure Network management;Network;Network management;windowsazureofficial</PackageTags>    
   </PropertyGroup>
   <PropertyGroup>

--- a/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Network Management Library")]
 [assembly: AssemblyDescription("Provides Microsoft Azure Network management functions for managing the Microsoft Azure Network service.")]
 
-[assembly: AssemblyVersion("10.1.1.0")]
-[assembly: AssemblyFileVersion("10.1.1.0")]
+[assembly: AssemblyVersion("10.2.1.0")]
+[assembly: AssemblyFileVersion("10.2.1.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
