### PR TITLE
Add certificate based service princpial login

### DIFF
--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/AzureCredentials.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/AzureCredentials.cs
@@ -96,8 +96,16 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
             {
                 if (servicePrincipalLoginInformation != null)
                 {
-                    credentialsCache[adSettings.TokenAudience] = await ApplicationTokenProvider.LoginSilentAsync(
-                        TenantId, servicePrincipalLoginInformation.ClientId, servicePrincipalLoginInformation.ClientSecret, adSettings, TokenCache.DefaultShared);
+                    if (servicePrincipalLoginInformation.ClientSecret != null)
+                    {
+                        credentialsCache[adSettings.TokenAudience] = await ApplicationTokenProvider.LoginSilentAsync(
+                            TenantId, servicePrincipalLoginInformation.ClientId, servicePrincipalLoginInformation.ClientSecret, adSettings, TokenCache.DefaultShared);
+                    }
+                    else
+                    {
+                        credentialsCache[adSettings.TokenAudience] = await ApplicationTokenProvider.LoginSilentWithCertificateAsync(
+                            TenantId, new ClientAssertionCertificate(servicePrincipalLoginInformation.ClientId, servicePrincipalLoginInformation.Certifcate));
+                    }
                 }
 #if !PORTABLE
                 else if (userLoginInformation != null)

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/AzureCredentials.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/AzureCredentials.cs
@@ -103,8 +103,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
                     }
                     else
                     {
-                        credentialsCache[adSettings.TokenAudience] = await ApplicationTokenProvider.LoginSilentWithCertificateAsync(
-                            TenantId, new ClientAssertionCertificate(servicePrincipalLoginInformation.ClientId, servicePrincipalLoginInformation.Certifcate));
+                        credentialsCache[adSettings.TokenAudience] = await ApplicationTokenProvider.LoginSilentAsync(
+                            TenantId, servicePrincipalLoginInformation.ClientId, servicePrincipalLoginInformation.Certifcate, servicePrincipalLoginInformation.CertifcatePassword, TokenCache.DefaultShared);
                     }
                 }
 #if !PORTABLE

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/AzureCredentialsFactory.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/AzureCredentialsFactory.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Rest;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
 {
@@ -67,6 +69,24 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
         }
 
         /// <summary>
+        /// Creates a credentials object from a service principal.
+        /// </summary>
+        /// <param name="clientId">the client ID of the application the service principal is associated with</param>
+        /// <param name="clientSecret">the secret for the client ID</param>
+        /// <param name="tenantId">the tenant ID or domain the application is in</param>
+        /// <param name="environment">the environment to authenticate to</param>
+        /// <returns>an authenticated credentials object</returns>
+        public AzureCredentials FromServicePrincipal(string clientId, string certificate, string certificatePassword, string tenantId, AzureEnvironment environment)
+        {
+            var certBytes = File.ReadAllBytes(certificate);
+            return new AzureCredentials(new ServicePrincipalLoginInformation
+            {
+                ClientId = clientId,
+                Certifcate = new X509Certificate2(certBytes, certificatePassword)
+            }, tenantId, environment);
+        }
+
+        /// <summary>
         /// Creates a credentials object from a file in the following format:
         ///
         ///     subscription=&lt;subscription-id&gt;
@@ -109,7 +129,25 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
                 GraphEndpoint = config["graphurl"].Replace("\\", "")
             };
 
-            AzureCredentials credentials = FromServicePrincipal(config["client"], config["key"], config["tenant"], env);
+            AzureCredentials credentials;
+            if (config.ContainsKey("key"))
+            {
+                credentials = FromServicePrincipal(config["client"], config["key"], config["tenant"], env);
+            }
+            else if (config.ContainsKey("certificate"))
+            {
+                string certificatePath = config["certificate"].Replace("\\:", ":").Replace("\\\\", "\\");
+                if (!File.Exists(certificatePath))
+                {
+                    certificatePath = Path.Combine(Path.GetDirectoryName(authFile), certificatePath);
+                }
+                credentials = FromServicePrincipal(config["client"], certificatePath,
+                    config.ContainsKey("certificatePassword") ? config["certificatePassword"] : "", config["tenant"], env);
+            }
+            else
+            {
+                throw new ValidationException("Please specify either a client key or a client certificate.");
+            }
             credentials.WithDefaultSubscription(config["subscription"]);
             return credentials;
         }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/AzureCredentialsFactory.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/AzureCredentialsFactory.cs
@@ -72,17 +72,19 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
         /// Creates a credentials object from a service principal.
         /// </summary>
         /// <param name="clientId">the client ID of the application the service principal is associated with</param>
-        /// <param name="clientSecret">the secret for the client ID</param>
+        /// <param name="certificatePath">the certificate file for the client ID</param>]
+        /// <param name="certificatePassword">the password for the certificate</param>
         /// <param name="tenantId">the tenant ID or domain the application is in</param>
         /// <param name="environment">the environment to authenticate to</param>
         /// <returns>an authenticated credentials object</returns>
-        public AzureCredentials FromServicePrincipal(string clientId, string certificate, string certificatePassword, string tenantId, AzureEnvironment environment)
+        public AzureCredentials FromServicePrincipal(string clientId, string certificatePath, string certificatePassword, string tenantId, AzureEnvironment environment)
         {
-            var certBytes = File.ReadAllBytes(certificate);
+            var certBytes = File.ReadAllBytes(certificatePath);
             return new AzureCredentials(new ServicePrincipalLoginInformation
             {
                 ClientId = clientId,
-                Certifcate = new X509Certificate2(certBytes, certificatePassword)
+                Certifcate = certBytes,
+                CertifcatePassword = certificatePassword
             }, tenantId, environment);
         }
 
@@ -142,7 +144,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
                     certificatePath = Path.Combine(Path.GetDirectoryName(authFile), certificatePath);
                 }
                 credentials = FromServicePrincipal(config["client"], certificatePath,
-                    config.ContainsKey("certificatePassword") ? config["certificatePassword"] : "", config["tenant"], env);
+                    config.ContainsKey("certificatepassword") ? config["certificatepassword"] : "", config["tenant"], env);
             }
             else
             {

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/ServicePrincipalLoginInformation.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/ServicePrincipalLoginInformation.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
 {
     public class ServicePrincipalLoginInformation
@@ -8,5 +11,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
         public string ClientId { get; set; }
 
         public string ClientSecret { get; set; }
+
+        public X509Certificate2 Certifcate { get; set; }
     }
 }

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/ServicePrincipalLoginInformation.cs
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent/Authentication/ServicePrincipalLoginInformation.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
 
         public string ClientSecret { get; set; }
 
-        public X509Certificate2 Certifcate { get; set; }
+        public byte[] Certifcate { get; set; }
+
+        public string CertifcatePassword { get; set; }
     }
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
