### PR TITLE
Fix compatibility issue with Newtonsoft.Json 10

### DIFF
--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/JsonSerializerExtensions.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/JsonSerializerExtensions.cs
@@ -25,7 +25,10 @@ namespace Microsoft.Rest.Azure
             }
             JsonSerializer newSerializer = new JsonSerializer();
             var properties = typeof(JsonSerializer).GetTypeInfo().DeclaredProperties;
-            foreach (var property in properties.Where(p => p.SetMethod != null && !p.SetMethod.IsPrivate))
+            foreach (var property in properties.Where(p => 
+                     p.SetMethod != null && 
+                     !p.SetMethod.IsPrivate &&
+                     p.GetCustomAttribute(typeof(ObsoleteAttribute)) == null))
             {
                 property.SetValue(newSerializer, property.GetValue(serializer, null), null);
             }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Microsoft.Rest.ClientRuntime.Azure.csproj
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Microsoft.Rest.ClientRuntime.Azure.csproj
@@ -4,7 +4,7 @@
     <PackageId>Microsoft.Rest.ClientRuntime.Azure</PackageId>
     <Description>Provides common error handling, tracing, and HTTP/REST-based pipeline manipulation.</Description>
     <AssemblyTitle>Client Runtime for Microsoft Azure Libraries</AssemblyTitle>
-    <VersionPrefix>3.3.7</VersionPrefix>
+    <VersionPrefix>3.3.8</VersionPrefix>
     <AssemblyName>Microsoft.Rest.ClientRuntime.Azure</AssemblyName>
     <PackageTags>Microsoft Azure AutoRest ClientRuntime REST  $(NugetCommonTags) $(NugetCommonProfileTags)</PackageTags>
   </PropertyGroup>

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Rest Azure Client Runtime")]
 [assembly: AssemblyDescription("Client infrastructure for Azure client libraries.")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.3.7.0")]
+[assembly: AssemblyFileVersion("3.3.8.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/ResourceJsonConverter.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/ResourceJsonConverter.cs
@@ -188,7 +188,10 @@ namespace Microsoft.Rest.Azure
             }
             JsonSerializer newSerializer = new JsonSerializer();
             var properties = typeof(JsonSerializer).GetTypeInfo().DeclaredProperties;
-            foreach (var property in properties.Where(p => p.SetMethod != null && !p.SetMethod.IsPrivate))
+            foreach (var property in properties.Where(p => 
+                     p.SetMethod != null && 
+                     !p.SetMethod.IsPrivate &&
+                     p.GetCustomAttribute(typeof(ObsoleteAttribute)) == null))
             {
                 property.SetValue(newSerializer, property.GetValue(serializer, null), null);
             }


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-sdk-for-net/issues/2552
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
