### PR TITLE
Restoring all projects prior to build

### DIFF
--- a/tools/buildTargets/common.targets
+++ b/tools/buildTargets/common.targets
@@ -73,7 +73,7 @@
     </PropertyGroup>
     <Message Text="Cleaning Initiated....." />
     <MSBuild Targets="$(LatestProjectDefaultCleanTarget)"
-        Projects="@(SDKProject);@(SDKTestProject)"
+        Projects="@(SDKProject);@(SDKTestProject);@(unsupportedProj)"
         Properties="PackageOutputPath=$(PackageOutputPath)"
         BuildInParallel="$(BuildInParallel)"
         ContinueOnError="ErrorAndStop" />
@@ -92,12 +92,18 @@
     <PropertyGroup>
       <LatestProjectDefaultRestoreTarget Condition=" '$(LatestProjectDefaultRestoreTarget)' == '' ">Restore</LatestProjectDefaultRestoreTarget>
     </PropertyGroup>
-    <Message Text="Now Restoring @(SDKProject);@(SDKTestProject)" />
+    <Message Text="Now Restoring @(SDKProject);@(SDKTestProject);@(unsupportedProj)" />
 
     <MSBuild Targets="$(LatestProjectDefaultRestoreTarget)"
             Projects="@(SDKProject);@(SDKTestProject)"
             BuildInParallel="$(BuildInParallel)"
             ContinueOnError="ErrorAndStop" />
+	
+	<MSBuild Targets="$(LatestProjectDefaultRestoreTarget)"
+            Projects="@(unsupportedProj)"
+            BuildInParallel="$(BuildInParallel)"
+            ContinueOnError="ErrorAndStop" />
+			
   </Target>
 
   <Target Name="BuildLatestProjects" Condition=" '$(SkipBuild)' != 'true' ">


### PR DESCRIPTION
Enabling restoring all projects prior to build.
Fix https://github.com/Azure/azure-sdk-for-net/issues/3322
