### PR TITLE
Service Principal sample

### DIFF
--- a/Samples/Common/Asset/createCert1.ps1
+++ b/Samples/Common/Asset/createCert1.ps1
@@ -1,0 +1,17 @@
+param (
+    [Parameter(Mandatory=$true)][string]$pfxFileName,
+	[Parameter(Mandatory=$true)][string]$cerFileName,
+    [Parameter(Mandatory=$true)][string]$pfxPassword,
+    [Parameter(Mandatory=$true)][string]$domainName
+)
+
+. ./New-SelfSignedCertificateEx.ps1
+
+#[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine")]
+New-SelfsignedCertificateEx -Subject "CN=*.$($domainName)" -EKU "1.3.6.1.5.5.7.3.1" -Path ".\$($pfxFileName)" -Password (ConvertTo-SecureString $pfxPassword -AsPlainText -Force) -Exportable
+$pfxPath = Join-Path $pwd.Path $pfxFileName
+Write-Host "pfxPath: $pfxPath"
+$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+$cert.Import($pfxPath, $pfxPassword,'DefaultKeySet')
+Write-Host "exporting to CERT"
+Export-Certificate -Cert $cert -FilePath $cerFileName -Type CERT

--- a/Samples/Common/Utilities.cs
+++ b/Samples/Common/Utilities.cs
@@ -1564,6 +1564,30 @@ namespace Microsoft.Azure.Management.Samples.Common
             }
         }
 
+        public static void CreateCertificate(string domainName, string pfxName, string cerName, string password)
+        {
+            if (!IsRunningMocked)
+            {
+                string args = string.Format(
+                    @".\createCert1.ps1 -pfxFileName {0} -cerFileName {1} -pfxPassword ""{2}"" -domainName ""{3}""",
+                    pfxName,
+                    cerName,
+                    password,
+                    domainName);
+                ProcessStartInfo info = new ProcessStartInfo("powershell", args);
+                string assetPath = Path.Combine(ProjectPath, "Asset");
+                info.WorkingDirectory = assetPath;
+                Process.Start(info).WaitForExit();
+            }
+            else
+            {
+                File.Copy(
+                    Path.Combine(Utilities.ProjectPath, "Asset", "SampleTestCertificate.pfx"),
+                    Path.Combine(Utilities.ProjectPath, "Asset", pfxName),
+                    overwrite: true);
+            }
+        }
+
         public static void UploadFileToWebApp(IPublishingProfile profile, string filePath, string fileName = null)
         {
             if (!IsRunningMocked)

--- a/Samples/ResourceManagement/GraphRbac/ManageServicePrincipal/ManageServicePrincipal.xproj
+++ b/Samples/ResourceManagement/GraphRbac/ManageServicePrincipal/ManageServicePrincipal.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>f76272c0-d42b-462e-8bbb-499e94a0a55b</ProjectGuid>
+    <RootNamespace>ManageServicePrincipal</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/Samples/ResourceManagement/GraphRbac/ManageServicePrincipal/Program.cs
+++ b/Samples/ResourceManagement/GraphRbac/ManageServicePrincipal/Program.cs
@@ -79,7 +79,7 @@ namespace ManageServicePrincipal
             //create a self-sighed certificate
             var domainName = name + ".com";
             var certPassword = "StrongPass!12";
-            Certificate certificate = Certificate.createSelfSigned(domainName, certPassword);
+            Certificate certificate = Certificate.CreateSelfSigned(domainName, certPassword);
 
             // create Active Directory application
             var activeDirectoryApplication = authenticated.ActiveDirectoryApplications
@@ -113,7 +113,7 @@ namespace ManageServicePrincipal
             //create a self-sighed certificate
             string domainName = name + ".com";
             string certPassword = "StrongPass!12";
-            Certificate certificate = Certificate.createSelfSigned(domainName, certPassword);
+            Certificate certificate = Certificate.CreateSelfSigned(domainName, certPassword);
 
             // create  a Service Principal and assign it to a subscription with the role Contributor
             return authenticated.ServicePrincipals
@@ -180,7 +180,7 @@ namespace ManageServicePrincipal
                 private set;
             }
 
-            public static Certificate createSelfSigned(string domainName, string password)
+            public static Certificate CreateSelfSigned(string domainName, string password)
             {
                 return new Certificate(domainName, password);
             }

--- a/Samples/ResourceManagement/GraphRbac/ManageServicePrincipal/Program.cs
+++ b/Samples/ResourceManagement/GraphRbac/ManageServicePrincipal/Program.cs
@@ -1,0 +1,201 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Management.Fluent;
+using Microsoft.Azure.Management.Graph.RBAC.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+using Microsoft.Azure.Management.Samples.Common;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace ManageServicePrincipal
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            try
+            {
+                //=================================================================
+                // Authenticate
+                AzureCredentials credentials = SdkContext.AzureCredentialsFactory.FromFile(Environment.GetEnvironmentVariable("AZURE_AUTH_LOCATION"));
+
+                var authenticated = Azure
+                    .Configure()
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
+                    .Authenticate(credentials);
+
+                RunSample(authenticated);
+                Console.ReadLine();
+            }
+            catch (Exception ex)
+            {
+                Utilities.Log(ex);
+            }
+        }
+
+        /**
+         * Azure Service Principal sample for managing Service Principal -
+         *  - Create an Active Directory application
+         *  - Create a Service Principal for the application and assign a role
+         *  - Export the Service Principal to an authentication file
+         *  - Use the file to list subcription virtual machines
+         *  - Update the application 
+         *  - Delete the application and Service Principal.
+         */
+        public static void RunSample(Azure.IAuthenticated authenticated)
+        {
+            string subscriptionId = authenticated.Subscriptions.List().First<ISubscription>().SubscriptionId;
+            Utilities.Log("Selected subscription: " + subscriptionId);
+            IActiveDirectoryApplication activeDirectoryApplication = null;
+            string authFilePath = Path.Combine(Utilities.ProjectPath, "Asset", "mySamplAuthdFile.azureauth").ToString();
+            try
+            {
+                activeDirectoryApplication = CreateActiveDirectoryApplication(authenticated);
+                CreateServicePrincipalWithRoleForApplicationAndExportToFile(authenticated, activeDirectoryApplication, BuiltInRole.Contributor, subscriptionId, authFilePath);
+                // Wait until Service Principal is ready
+                SdkContext.DelayProvider.Delay(15);
+                UseAuthFile(authFilePath);
+                UpdateApplication(authenticated, activeDirectoryApplication);
+            }
+            finally
+            {
+                Utilities.Log("Deleting Active Directory application and Service Principal...");
+                if (activeDirectoryApplication != null)
+                {
+                    // this will delete Service Principal as well
+                    authenticated.ActiveDirectoryApplications.DeleteById(activeDirectoryApplication.Id);
+                }
+            }
+        }
+
+        private static IActiveDirectoryApplication CreateActiveDirectoryApplication(Azure.IAuthenticated authenticated)
+        {
+            Utilities.Log("Creating Active Directory application...");
+            var name = SdkContext.RandomResourceName("adapp-sample", 20);
+            //create a self-sighed certificate
+            var domainName = name + ".com";
+            var certPassword = "StrongPass!12";
+            Certificate certificate = Certificate.createSelfSigned(domainName, certPassword);
+
+            // create Active Directory application
+            var activeDirectoryApplication = authenticated.ActiveDirectoryApplications
+                .Define(name)
+                    .WithSignOnUrl("https://github.com/Azure/azure-sdk-for-java/" + name)
+                    // password credentials definition
+                    .DefinePasswordCredential("password")
+                        .WithPasswordValue("P@ssw0rd")
+                        .WithDuration(TimeSpan.FromDays(700))
+                        .Attach()
+                    // certificate credentials definition
+                    .DefineCertificateCredential("cert")
+                        .WithAsymmetricX509Certificate()
+                        .WithPublicKey(File.ReadAllBytes(certificate.CerPath))
+                        .WithDuration(TimeSpan.FromDays(100))
+                        .Attach()
+                    .Create();
+            Utilities.Log(activeDirectoryApplication.Id + " - " + activeDirectoryApplication.ApplicationId);
+            return activeDirectoryApplication;
+        }
+
+        private static IServicePrincipal CreateServicePrincipalWithRoleForApplicationAndExportToFile (
+            Azure.IAuthenticated authenticated,
+            IActiveDirectoryApplication activeDirectoryApplication,
+            BuiltInRole role,
+            string subscriptionId,
+            string authFilePath)
+        {
+            Utilities.Log("Creating Service Principal...");
+            string name = SdkContext.RandomResourceName("sp-sample", 20);
+            //create a self-sighed certificate
+            string domainName = name + ".com";
+            string certPassword = "StrongPass!12";
+            Certificate certificate = Certificate.createSelfSigned(domainName, certPassword);
+
+            // create  a Service Principal and assign it to a subscription with the role Contributor
+            return authenticated.ServicePrincipals
+                    .Define("name")
+                        .WithExistingApplication(activeDirectoryApplication)
+                        // password credentials definition
+                        .DefinePasswordCredential("ServicePrincipalAzureSample")
+                            .WithPasswordValue("StrongPass!12")
+                            .Attach()
+                        // certificate credentials definition
+                        .DefineCertificateCredential("spcert")
+                            .WithAsymmetricX509Certificate()
+                            .WithPublicKey(File.ReadAllBytes(certificate.CerPath))
+                            .WithDuration(TimeSpan.FromDays(7))
+                            // export the credentials to the file
+                            .WithAuthFileToExport(new StreamWriter(new FileStream(authFilePath, FileMode.OpenOrCreate)))
+                            .WithPrivateKeyFile(certificate.PfxPath)
+                            .WithPrivateKeyPassword(certPassword)
+                            .Attach()
+                    .WithNewRoleInSubscription(role, subscriptionId)
+                    .Create();
+        }
+
+        private static void UseAuthFile(string authFilePath)
+        {
+            Utilities.Log("Using auth file to list virtual machines...");
+            // use just created auth file to sign in.
+            var azure = Azure.Configure()
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
+                .Authenticate(SdkContext.AzureCredentialsFactory.FromFile(authFilePath))
+                .WithDefaultSubscription();
+            // list virtualMachines, if any.
+            var vmList = azure.VirtualMachines.List();
+            foreach (var vm in vmList)
+            {
+                Utilities.PrintVirtualMachine(vm);
+            }
+        }
+
+        private static void UpdateApplication(Azure.IAuthenticated authenticated, IActiveDirectoryApplication activeDirectoryApplication)
+        {
+            Utilities.Log("Updating Active Directory application...");
+            activeDirectoryApplication.Update()
+                    // add another password credentials
+                    .DefinePasswordCredential("password-1")
+                        .WithPasswordValue("P@ssw0rd-1")
+                        .WithDuration(TimeSpan.FromDays(700))
+                        .Attach()
+                    // add a reply url
+                    .WithReplyUrl("http://localhost:8080")
+                    .Apply();
+        }
+
+        private class Certificate
+        {
+            public string PfxPath
+            {
+                get;
+                private set;
+            }
+            public string CerPath
+            {
+                get;
+                private set;
+            }
+
+            public static Certificate createSelfSigned(string domainName, string password)
+            {
+                return new Certificate(domainName, password);
+            }
+
+            private Certificate(string domainName, string password)
+            {
+                string pfxName = domainName + ".pfx";
+                string cerName = domainName + ".cer";
+
+                PfxPath = Path.Combine(Utilities.ProjectPath, "Asset", pfxName);
+                CerPath = Path.Combine(Utilities.ProjectPath, "Asset", cerName);
+
+                Utilities.Log("Creating a self-signed certificate " + pfxName + " ...");
+                Utilities.CreateCertificate(domainName, pfxName, cerName, password);
+            }
+        }
+    }
+}

--- a/Samples/ResourceManagement/GraphRbac/ManageServicePrincipal/Properties/AssemblyInfo.cs
+++ b/Samples/ResourceManagement/GraphRbac/ManageServicePrincipal/Properties/AssemblyInfo.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ManageServicePrincipal")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("71B8ED3E-1C4E-4A24-960B-6A907A914D3F")]

--- a/Samples/ResourceManagement/GraphRbac/ManageServicePrincipal/project.json
+++ b/Samples/ResourceManagement/GraphRbac/ManageServicePrincipal/project.json
@@ -1,0 +1,27 @@
+﻿{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+
+  "dependencies": {
+    "Common": "1.0.0-*", 
+    "Microsoft.Azure.Management.Fluent": {
+      "target": "project",
+      "type": "build"
+    },
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.0"
+    }
+  },
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net451+win8"
+      ]
+    }
+  }
+}

--- a/Samples/Samples.sln
+++ b/Samples/Samples.sln
@@ -216,6 +216,9 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "ManageLinuxWebAppWithTraffi
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "ManageWebAppWithAuthentication", "ResourceManagement\AppService\ManageWebAppWithAuthentication\ManageWebAppWithAuthentication.xproj", "{F409AF61-1B4E-4A79-B7EA-11762BD27F5B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GraphRbac", "GraphRbac", "{4EF685D3-5CA1-4AC2-8E81-FC395E4C9048}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "ManageServicePrincipal", "ResourceManagement\GraphRbac\ManageServicePrincipal\ManageServicePrincipal.xproj", "{F76272C0-D42B-462E-8BBB-499E94A0A55B}"
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.ContainerRegistry.Fluent", "..\src\ResourceManagement\ContainerRegistry\Microsoft.Azure.Management.ContainerRegistry.Fluent\Microsoft.Azure.Management.ContainerRegistry.Fluent.xproj", "{B3749CA4-706F-4D61-9B4F-05DD2ECBF1A8}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.DocumentDB.Fluent", "..\src\ResourceManagement\DocumentDB\Microsoft.Azure.Management.DocumentDB.Fluent\Microsoft.Azure.Management.DocumentDB.Fluent.xproj", "{4EF5ECA2-495E-428E-ACEF-EB6C031242C5}"
@@ -596,6 +599,10 @@ Global
 		{F409AF61-1B4E-4A79-B7EA-11762BD27F5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F409AF61-1B4E-4A79-B7EA-11762BD27F5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F409AF61-1B4E-4A79-B7EA-11762BD27F5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F76272C0-D42B-462E-8BBB-499E94A0A55B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F76272C0-D42B-462E-8BBB-499E94A0A55B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F76272C0-D42B-462E-8BBB-499E94A0A55B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F76272C0-D42B-462E-8BBB-499E94A0A55B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B3749CA4-706F-4D61-9B4F-05DD2ECBF1A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B3749CA4-706F-4D61-9B4F-05DD2ECBF1A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B3749CA4-706F-4D61-9B4F-05DD2ECBF1A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -714,6 +721,7 @@ Global
 		{72AF59AF-83B9-481E-AB94-104EE85233ED} = {3A47CE2D-1D30-419E-B3A1-EB44ACF1DE77}
 		{52C40F51-22ED-4306-B23A-6CE4164794E3} = {3A47CE2D-1D30-419E-B3A1-EB44ACF1DE77}
 		{F409AF61-1B4E-4A79-B7EA-11762BD27F5B} = {3A47CE2D-1D30-419E-B3A1-EB44ACF1DE77}
+		{F76272C0-D42B-462E-8BBB-499E94A0A55B} = {4EF685D3-5CA1-4AC2-8E81-FC395E4C9048}
 		{B3749CA4-706F-4D61-9B4F-05DD2ECBF1A8} = {6CE497E2-B5F8-44C3-99F4-F19EC0097B90}
 		{4EF5ECA2-495E-428E-ACEF-EB6C031242C5} = {6CE497E2-B5F8-44C3-99F4-F19EC0097B90}
 		{AD18F398-E2F1-48BE-94FA-71F31393BA12} = {05B043C3-9691-489D-B963-5329885829F8}

--- a/Samples/Tests/GraphRbac.cs
+++ b/Samples/Tests/GraphRbac.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Azure.Tests;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Samples.Tests
+{
+    public class GraphRbac : Samples.Tests.TestBase
+    {
+        public GraphRbac(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact(Skip = "Do not record - Can contain sensitive auth info")]
+        [Trait("Samples", "GraphRbac")]
+        public void ManageServicePrincipalTest()
+        {
+
+            using (var context = FluentMockContext.Start(this.GetType().FullName))
+            {
+                RunSampleAsTest(
+                    this.GetType().FullName,
+                    ManageServicePrincipal.Program.RunSample,
+                    Path.Combine("..", "Common"));
+            }
+        }
+    }
+}

--- a/Samples/Tests/TestBase.cs
+++ b/Samples/Tests/TestBase.cs
@@ -37,5 +37,24 @@ namespace Samples.Tests
                 runSampleDelegate(rollUpClient);
             }
         }
+
+        protected void RunSampleAsTest(
+            string testTypeName,
+            Action<Microsoft.Azure.Management.Fluent.Azure.IAuthenticated> runSampleDelegate,
+            string assetFolderLocation = null,
+            [CallerMemberName] string methodName = "testframework_failed")
+        {
+            using (var context = FluentMockContext.Start(testTypeName, methodName))
+            {
+                Microsoft.Azure.Management.Samples.Common.Utilities.IsRunningMocked = HttpMockServer.Mode == HttpRecorderMode.Playback;
+                if (assetFolderLocation != null)
+                {
+                    Microsoft.Azure.Management.Samples.Common.Utilities.ProjectPath = assetFolderLocation;
+                }
+
+                var createAuthenticatedClient = TestHelper.CreateAuthenticatedClient();
+                runSampleDelegate(createAuthenticatedClient);
+            }
+        }
     }
 }

--- a/Samples/Tests/project.json
+++ b/Samples/Tests/project.json
@@ -148,6 +148,7 @@
     "ManageLinuxWebAppStorageAccountConnection": "1.0.0-*",
     "ManageLinuxWebAppWithDomainSsl": "1.0.0-*",
     "ManageLinuxWebAppWithTrafficManager": "1.0.0-*",
-    "ManageWebAppWithAuthentication": "1.0.0-*"
+    "ManageWebAppWithAuthentication": "1.0.0-*",
+    "ManageServicePrincipal": "1.0.0-*"
   }
 }

--- a/global.json
+++ b/global.json
@@ -23,6 +23,7 @@
     "Samples/ResourceManagement/Cdn",
     "Samples/ResourceManagement/Compute",
     "Samples/ResourceManagement/Dns",
+    "Samples/ResourceManagement/GraphRbac",
     "Samples/ResourceManagement/KeyVault",
     "Samples/ResourceManagement/Network",
     "Samples/ResourceManagement/RedisCache",

--- a/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/TestHelper.cs
+++ b/src/ResourceManagement/Azure.Fluent/Fluent.Tests/Common/TestHelper.cs
@@ -101,6 +101,14 @@ namespace Fluent.Tests.Common
                 .WithSubscription(c.DefaultSubscriptionId));
         }
 
+        public static Microsoft.Azure.Management.Fluent.Azure.IAuthenticated CreateAuthenticatedClient()
+        {
+            return CreateMockedManager(c => Microsoft.Azure.Management.Fluent.Azure.Configure()
+                .WithDelegatingHandlers(GetHandlers())
+                .Authenticate(c));
+        }
+
+
         public static INetworkManager CreateNetworkManager()
         {
             return CreateMockedManager(c => NetworkManager


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.

