### PR TITLE
Added ContainerRegistry.sln and DocumentDB.sln

### DIFF
--- a/src/ResourceManagement/ContainerRegistry/ContainerRegistry.sln
+++ b/src/ResourceManagement/ContainerRegistry/ContainerRegistry.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.ContainerRegistry.Fluent", "Microsoft.Azure.Management.ContainerRegistry.Fluent\Microsoft.Azure.Management.ContainerRegistry.Fluent.xproj", "{B3749CA4-706F-4D61-9B4F-05DD2ECBF1A8}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.ResourceManager.Fluent", "..\ResourceManager\Microsoft.Azure.Management.ResourceManager.Fluent\Microsoft.Azure.Management.ResourceManager.Fluent.xproj", "{A5986BDB-0D0D-48AA-9E49-ECE96BAC8AEE}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.Storage.Fluent", "..\Storage\Microsoft.Azure.Management.Storage.Fluent\Microsoft.Azure.Management.Storage.Fluent.xproj", "{A9B44E1B-C26F-44AB-B13F-F22742371135}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B3749CA4-706F-4D61-9B4F-05DD2ECBF1A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3749CA4-706F-4D61-9B4F-05DD2ECBF1A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3749CA4-706F-4D61-9B4F-05DD2ECBF1A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3749CA4-706F-4D61-9B4F-05DD2ECBF1A8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8AEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8AEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8AEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8AEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9B44E1B-C26F-44AB-B13F-F22742371135}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9B44E1B-C26F-44AB-B13F-F22742371135}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9B44E1B-C26F-44AB-B13F-F22742371135}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9B44E1B-C26F-44AB-B13F-F22742371135}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/ResourceManagement/DocumentDB/DocumentDB.sln
+++ b/src/ResourceManagement/DocumentDB/DocumentDB.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.DocumentDB.Fluent", "Microsoft.Azure.Management.DocumentDB.Fluent\Microsoft.Azure.Management.DocumentDB.Fluent.xproj", "{4EF5ECA2-495E-428E-ACEF-EB6C031242C5}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Azure.Management.ResourceManager.Fluent", "..\ResourceManager\Microsoft.Azure.Management.ResourceManager.Fluent\Microsoft.Azure.Management.ResourceManager.Fluent.xproj", "{A5986BDB-0D0D-48AA-9E49-ECE96BAC8AEE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4EF5ECA2-495E-428E-ACEF-EB6C031242C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EF5ECA2-495E-428E-ACEF-EB6C031242C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EF5ECA2-495E-428E-ACEF-EB6C031242C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EF5ECA2-495E-428E-ACEF-EB6C031242C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8AEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8AEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8AEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5986BDB-0D0D-48AA-9E49-ECE96BAC8AEE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
