### PR TITLE
ASM: Removed hardcoded passwords from Network SDK's tests

### DIFF
--- a/src/ServiceManagement/Network/Network.Tests/NetworkTestBase.cs
+++ b/src/ServiceManagement/Network/Network.Tests/NetworkTestBase.cs
@@ -228,7 +228,7 @@ namespace Network.Tests
                             new ConfigurationSet()
                             {
                                 AdminUserName = "testuser",
-                                AdminPassword = "@zur3R0ck5",
+                                AdminPassword = Utilities.GetRandomPassword(),
                                 ConfigurationSetType = ConfigurationSetTypes.WindowsProvisioningConfiguration,
                                 ComputerName = serviceName,
                                 HostName = string.Format("{0}.cloudapp.net", serviceName),

--- a/src/ServiceManagement/Network/Network.Tests/Utilities.cs
+++ b/src/ServiceManagement/Network/Network.Tests/Utilities.cs
@@ -92,7 +92,7 @@ namespace Network.Tests
             parameters.Roles[0].ConfigurationSets.Add(new ConfigurationSet
             {
                 AdminUserName = "testuser",
-                AdminPassword = "@zur3R0ck5",
+                AdminPassword = GetRandomPassword(),
                 ConfigurationSetType = ConfigurationSetTypes.WindowsProvisioningConfiguration,
                 ComputerName = serviceName,
                 HostName = string.Format("{0}.cloudapp.net", serviceName),
@@ -248,6 +248,11 @@ namespace Network.Tests
                 var containerClient = blobClient.GetContainerReference(container);
                 containerClient.DeleteIfExists();
             }
+        }
+
+        public static string GetRandomPassword()
+        {
+            return "AzureSDKNetworkTest#" + Guid.NewGuid().ToString().Replace("-", "@");
         }
     }
 }


### PR DESCRIPTION
## Description

Removed hardcoded passwords from ASM's Network SDK's tests (CredScanner issue)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
