### PR TITLE
ARM: Removed hardcoded passwords from Network SDK's tests

### DIFF
--- a/src/SDKs/Network/Network.Tests/Helpers/Deployment.cs
+++ b/src/SDKs/Network/Network.Tests/Helpers/Deployment.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Azure.Management.Resources;
 using Microsoft.Azure.Management.Resources.Models;
+using Networks.Tests.Helpers;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -9,6 +10,8 @@ using System.Threading.Tasks;
 
 namespace Network.Tests.Helpers
 {
+    using Networks.Tests.Helpers;
+
     public static class Deployments
     {
         public static void CreateVm(
@@ -33,7 +36,7 @@ namespace Network.Tests.Helpers
                 @"'virtualNetworkName': { 'value': '" + resourceGroupName + "-vnet'}," +
                 @"'networkInterfaceName': { 'value': '" + networkInterfaceName + "'}," +
                 @"'networkSecurityGroupName': { 'value': '" + networkSecurityGroupName + "'}," +
-                @"'adminPassword': { 'value': 'netanalytics-32!'}," +
+                @"'adminPassword': { 'value': '" + NetworkManagementTestUtilities.GetRandomPassword() + "'}," +
                 @"'storageAccountType': { 'value': 'Premium_LRS'}," +
                 @"'diagnosticsStorageAccountName': { 'value': '" + diagnosticsStorageAccountName + "'}," +
                 @"'diagnosticsStorageAccountId': { 'value': 'Microsoft.Storage/storageAccounts/" + diagnosticsStorageAccountName + "'}," +

--- a/src/SDKs/Network/Network.Tests/Helpers/DeploymentUpdate.cs
+++ b/src/SDKs/Network/Network.Tests/Helpers/DeploymentUpdate.cs
@@ -9,6 +9,8 @@ using System.Threading.Tasks;
 
 namespace Network.Tests.Helpers
 {
+    using Networks.Tests.Helpers;
+
     public static class DeploymentUpdate
     {
         public static void CreateVm(
@@ -33,7 +35,7 @@ namespace Network.Tests.Helpers
                 @"'virtualNetworkName': { 'value': '" + resourceGroupName + "-vnet'}," +
                 @"'networkInterfaceName': { 'value': '" + networkInterfaceName + "'}," +
                 @"'networkSecurityGroupName': { 'value': '" + networkSecurityGroupName + "'}," +
-                @"'adminPassword': { 'value': 'netanalytics-32!'}," +
+                @"'adminPassword': { 'value': '" + NetworkManagementTestUtilities.GetRandomPassword() + "'}," +
                 @"'storageAccountType': { 'value': 'Premium_LRS'}," +
                 @"'diagnosticsStorageAccountName': { 'value': '" + diagnosticsStorageAccountName + "'}," +
                 @"'diagnosticsStorageAccountId': { 'value': 'Microsoft.Storage/storageAccounts/" + diagnosticsStorageAccountName + "'}," +

--- a/src/SDKs/Network/Network.Tests/Helpers/NetworkManagementTestUtilities.cs
+++ b/src/SDKs/Network/Network.Tests/Helpers/NetworkManagementTestUtilities.cs
@@ -142,5 +142,14 @@ namespace Networks.Tests.Helpers
 
             return null;
         }
+
+        /// <summary>
+        /// Get randomly generated password
+        /// </summary>
+        /// <returns>Randomly generated password string</returns>
+        public static string GetRandomPassword()
+        {
+            return "AzureSDKNetworkTest#" + Guid.NewGuid().ToString().Replace("-", "@");
+        }
     }
 }


### PR DESCRIPTION
## Description

Removed hardcoded passwords from ARM's Network SDK's tests (CredScanner issue)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.