### PR TITLE
TestFramework - More detailed exception message when HttpMockServer queue is empty

### DIFF
--- a/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/HttpMockServer.cs
+++ b/src/SdkCommon/TestFramework/Microsoft.Azure.Test.HttpRecorder/HttpMockServer.cs
@@ -134,7 +134,17 @@ namespace Microsoft.Azure.Test.HttpRecorder
                 // Will throw KeyNotFoundException if the request is not recorded
                 lock (records)
                 {
-                    var result = records[Matcher.GetMatchingKey(request)].Dequeue().GetResponse();
+                    var key = Matcher.GetMatchingKey(request);
+
+                    var queue = records[key];
+                    if (!queue.Any())
+                    {
+                        throw new InvalidOperationException(string.Format(
+                            "Queue empty for request {0}",
+                            Utilities.DecodeBase64AsUri(key)));
+                    }
+
+                    var result = queue.Dequeue().GetResponse();
                     result.RequestMessage = request;
                     return Task.FromResult(result);
                 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Specify request info when HttpMockServer queue is empty. This makes debugging easier in playback mode.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
