### PR TITLE
Modify ImportExport tests so that they create all dependencies.

### DIFF
--- a/src/SDKs/SqlManagement/Sql.Tests/ImportExportScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/ImportExportScenarioTests.cs
@@ -2,12 +2,19 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.Management.ResourceManager;
+using Microsoft.Azure.Management.ResourceManager.Models;
 using Microsoft.Azure.Management.Sql;
 using Microsoft.Azure.Management.Sql.Models;
+using Microsoft.Azure.Management.Storage;
+using Microsoft.Azure.Management.Storage.Models;
 using Microsoft.Azure.Test.HttpRecorder;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Globalization;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Sql.Tests
@@ -27,12 +34,22 @@ namespace Sql.Tests
             string testPrefix = "sqlcrudtest-";
             TestImportExport(false, testPrefix, "TestImportNewDatabase");
         }
-        
+
         public void TestImportExport(bool preexistingDatabase, string testPrefix, string testName)
         {
             string suiteName = this.GetType().FullName;
-            SqlManagementTestUtilities.RunTestInNewV12Server(suiteName, testName, testPrefix, (resClient, sqlClient, resourceGroup, server) =>
+            using (SqlManagementTestContext context = new SqlManagementTestContext(this, testName = testName))
             {
+                SqlManagementClient sqlClient = context.GetClient<SqlManagementClient>();
+
+                ResourceGroup resourceGroup = context.CreateResourceGroup();
+
+                // Begin creating storage account and container
+                Task<StorageContainerInfo> storageContainerTask = CreateStorageContainer(context, resourceGroup);
+
+                // Create server and database
+                Server server = context.CreateServer(resourceGroup);
+
                 string login = SqlManagementTestUtilities.DefaultLogin;
                 string password = SqlManagementTestUtilities.DefaultPassword;
                 string dbName = SqlManagementTestUtilities.GenerateName(testPrefix);
@@ -68,19 +85,11 @@ namespace Sql.Tests
                 }
 
                 // Get Storage container credentials
-                HttpRecorderMode testMode = HttpMockServer.GetCurrentMode();
-                string storageKey = "StorageKey";
-                string exportBacpacLink = string.Format(CultureInfo.InvariantCulture, "http://test.blob.core.windows.net/databases/{0}.bacpac", dbName);
-
-                if (testMode == HttpRecorderMode.Record)
-                {
-                    string importBacpacContainer = Environment.GetEnvironmentVariable("TEST_IMPORT_CONTAINER");
-                    storageKey = Environment.GetEnvironmentVariable("TEST_STORAGE_KEY");
-                    exportBacpacLink = string.Format(CultureInfo.InvariantCulture, "{0}/{1}.bacpac", importBacpacContainer, dbName);
-
-                    Assert.False(string.IsNullOrWhiteSpace(storageKey), "Environment variable TEST_STORAGE_KEY has not been set.  Set it to storage account key.");
-                    Assert.False(string.IsNullOrWhiteSpace(importBacpacContainer), "Environment variable TEST_IMPORT_CONTAINER has not been set.  Set it to a valid storage container URL.");
-                }
+                StorageContainerInfo storageContainerInfo = storageContainerTask.Result;
+                string exportBacpacLink = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0}/{1}.bacpac",
+                    storageContainerInfo.StorageContainerUri, dbName);
 
                 // Export database to bacpac
                 sqlClient.Databases.Export(resourceGroup.Name, server.Name, dbName, new ExportRequest()
@@ -88,7 +97,7 @@ namespace Sql.Tests
                     AdministratorLogin = login,
                     AdministratorLoginPassword = password,
                     AuthenticationType = AuthenticationType.SQL,
-                    StorageKey = storageKey,
+                    StorageKey = storageContainerInfo.StorageAccountKey,
                     StorageKeyType = StorageKeyType.StorageAccessKey,
                     StorageUri = exportBacpacLink
                 });
@@ -102,7 +111,7 @@ namespace Sql.Tests
                         AdministratorLogin = login,
                         AdministratorLoginPassword = password,
                         AuthenticationType = AuthenticationType.SQL,
-                        StorageKey = storageKey,
+                        StorageKey = storageContainerInfo.StorageAccountKey,
                         StorageKeyType = StorageKeyType.StorageAccessKey,
                         StorageUri = exportBacpacLink
                     });
@@ -114,7 +123,7 @@ namespace Sql.Tests
                         AdministratorLogin = login,
                         AdministratorLoginPassword = password,
                         AuthenticationType = AuthenticationType.SQL,
-                        StorageKey = storageKey,
+                        StorageKey = storageContainerInfo.StorageAccountKey,
                         StorageKeyType = StorageKeyType.StorageAccessKey,
                         StorageUri = exportBacpacLink,
                         DatabaseName = dbName2,
@@ -123,7 +132,54 @@ namespace Sql.Tests
                         MaxSizeBytes = (2 * 1024L * 1024L * 1024L).ToString(),
                     });
                 }
-            });
+            }
+        }
+
+        private struct StorageContainerInfo
+        {
+            public string StorageAccountKey;
+            public Uri StorageContainerUri;
+        }
+
+        private async Task<StorageContainerInfo> CreateStorageContainer(SqlManagementTestContext context, ResourceGroup resourceGroup)
+        {
+            StorageManagementClient storageClient = context.GetClient<StorageManagementClient>();
+            StorageAccount storageAccount = await storageClient.StorageAccounts.CreateAsync(
+                resourceGroup.Name,
+                accountName: SqlManagementTestUtilities.GenerateName(prefix: "sqlcrudtest"), // '-' is not allowed
+                parameters: new StorageAccountCreateParameters(
+                    new Microsoft.Azure.Management.Storage.Models.Sku(SkuName.StandardLRS, SkuTier.Standard),
+                    Kind.BlobStorage,
+                    resourceGroup.Location,
+                    accessTier: AccessTier.Cool));
+
+            StorageAccountListKeysResult keys =
+                storageClient.StorageAccounts.ListKeys(resourceGroup.Name, storageAccount.Name);
+            string key = keys.Keys.First().Value;
+
+            string containerName = "container";
+
+            // Create container
+            // Since this is a data-plane client and not an ARM client it's harder to inject
+            // HttpMockServer into it to record/playback, but that's fine because we don't need
+            // any of the response data to continue with the test.
+            if (HttpMockServer.Mode == HttpRecorderMode.Record)
+            {
+                CloudStorageAccount storageAccountClient = new CloudStorageAccount(
+                    new Microsoft.WindowsAzure.Storage.Auth.StorageCredentials(
+                        storageAccount.Name,
+                        key),
+                    useHttps: true);
+                CloudBlobClient blobClient = storageAccountClient.CreateCloudBlobClient();
+                CloudBlobContainer containerReference = blobClient.GetContainerReference(containerName);
+                await containerReference.CreateIfNotExistsAsync();
+            }
+
+            return new StorageContainerInfo
+            {
+                StorageAccountKey = key,
+                StorageContainerUri = new Uri(storageAccount.PrimaryEndpoints.Blob + containerName)
+            };
         }
     }
 }

--- a/src/SDKs/SqlManagement/Sql.Tests/SessionRecords/Sql.Tests.ImportExportScenarioTests/TestImportExistingDatabase.json
+++ b/src/SDKs/SqlManagement/Sql.Tests/SessionRecords/Sql.Tests.ImportExportScenarioTests/TestImportExistingDatabase.json
@@ -1,10 +1,10 @@
 {
   "Entries": [
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourcegroups/sqlcrudtest-8152?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTgxNTI/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourcegroups/sqlcrudtest-5987?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTU5ODc/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"location\": \"Japan East\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-8152\": \"2017-06-01 18:25:33Z\"\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"location\": \"Japan East\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-5987\": \"2017-06-22 05:37:36Z\"\r\n  }\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -13,7 +13,7 @@
           "99"
         ],
         "x-ms-client-request-id": [
-          "58531677-b44f-40a8-983c-273627ab936e"
+          "2f52f114-6293-43cb-aa5e-7bcc7eeba105"
         ],
         "accept-language": [
           "en-US"
@@ -23,7 +23,7 @@
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152\",\r\n  \"name\": \"sqlcrudtest-8152\",\r\n  \"location\": \"japaneast\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-8152\": \"2017-06-01 18:25:33Z\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987\",\r\n  \"name\": \"sqlcrudtest-5987\",\r\n  \"location\": \"japaneast\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-5987\": \"2017-06-22 05:37:36Z\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "239"
@@ -38,22 +38,22 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:25:34 GMT"
+          "Thu, 22 Jun 2017 05:37:38 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1195"
+          "1199"
         ],
         "x-ms-request-id": [
-          "af4e1b9e-70e2-42e1-a09e-b2fdaaa5a731"
+          "0fa29b76-5e92-4576-b8e3-51f4b120fa85"
         ],
         "x-ms-correlation-request-id": [
-          "af4e1b9e-70e2-42e1-a09e-b2fdaaa5a731"
+          "0fa29b76-5e92-4576-b8e3-51f4b120fa85"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182534Z:af4e1b9e-70e2-42e1-a09e-b2fdaaa5a731"
+          "WESTUS2:20170622T053738Z:0fa29b76-5e92-4576-b8e3-51f4b120fa85"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -62,8 +62,76 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490?api-version=2015-05-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwP2FwaS12ZXJzaW9uPTIwMTUtMDUtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Storage/storageAccounts/sqlcrudtest3491?api-version=2017-06-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TdG9yYWdlL3N0b3JhZ2VBY2NvdW50cy9zcWxjcnVkdGVzdDM0OTE/YXBpLXZlcnNpb249MjAxNy0wNi0wMQ==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\"\r\n  },\r\n  \"kind\": \"BlobStorage\",\r\n  \"location\": \"japaneast\",\r\n  \"properties\": {\r\n    \"accessTier\": \"Cool\"\r\n  }\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "154"
+        ],
+        "x-ms-client-request-id": [
+          "71440889-40b7-4f74-b6af-0689ee6f4334"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Storage.StorageManagementClient/6.5.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:37:41 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/providers/Microsoft.Storage/operations/063e219c-7fac-4ce0-a49d-af4ed82dd6f4?monitor=true&api-version=2017-06-01"
+        ],
+        "Retry-After": [
+          "17"
+        ],
+        "Server": [
+          "Microsoft-Azure-Storage-Resource-Provider/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1198"
+        ],
+        "x-ms-request-id": [
+          "4b982d05-5313-4346-95cf-e1eec377080f"
+        ],
+        "x-ms-correlation-request-id": [
+          "4b982d05-5313-4346-95cf-e1eec377080f"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170622T053742Z:4b982d05-5313-4346-95cf-e1eec377080f"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955?api-version=2015-05-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1P2FwaS12ZXJzaW9uPTIwMTUtMDUtMDEtcHJldmlldw==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"administratorLoginPassword\": \"Un53cuRE!\",\r\n    \"version\": \"12.0\"\r\n  },\r\n  \"tags\": {},\r\n  \"location\": \"japaneast\"\r\n}",
       "RequestHeaders": {
@@ -74,20 +142,20 @@
           "183"
         ],
         "x-ms-client-request-id": [
-          "1ca5c6d6-ce75-409b-bf60-cdddde5c9d50"
+          "02acd010-46a0-4ebb-8733-0ca1a6d57d87"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"UpsertLogicalServer\",\r\n  \"startTime\": \"2017-06-01T18:25:37.003Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"UpsertLogicalServer\",\r\n  \"startTime\": \"2017-06-22T05:37:43.54Z\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "74"
+          "73"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -99,13 +167,13 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:25:36 GMT"
+          "Thu, 22 Jun 2017 05:37:42 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/providers/Microsoft.Sql/locations/japaneast/serverOperationResults/d8a8dbd3-6032-4e7e-9545-939107cd8a4f?api-version=2015-05-01-preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/providers/Microsoft.Sql/locations/japaneast/serverOperationResults/ad797c82-a3da-4330-88de-1877a42d6c9e?api-version=2015-05-01-preview"
         ],
         "Retry-After": [
           "60"
@@ -114,19 +182,19 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/providers/Microsoft.Sql/locations/japaneast/serverAzureAsyncOperation/d8a8dbd3-6032-4e7e-9545-939107cd8a4f?api-version=2015-05-01-preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/providers/Microsoft.Sql/locations/japaneast/serverAzureAsyncOperation/ad797c82-a3da-4330-88de-1877a42d6c9e?api-version=2015-05-01-preview"
         ],
         "x-ms-request-id": [
-          "d8a8dbd3-6032-4e7e-9545-939107cd8a4f"
+          "ad797c82-a3da-4330-88de-1877a42d6c9e"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1194"
+          "1199"
         ],
         "x-ms-correlation-request-id": [
-          "adc9b726-8781-410c-b7ad-9ac53570d2b3"
+          "c0d8e2b5-6be4-44c5-a5b2-d6e9b8140aa5"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182536Z:adc9b726-8781-410c-b7ad-9ac53570d2b3"
+          "WESTUS2:20170622T053742Z:c0d8e2b5-6be4-44c5-a5b2-d6e9b8140aa5"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -135,17 +203,73 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/providers/Microsoft.Sql/locations/japaneast/serverAzureAsyncOperation/d8a8dbd3-6032-4e7e-9545-939107cd8a4f?api-version=2015-05-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9qYXBhbmVhc3Qvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi9kOGE4ZGJkMy02MDMyLTRlN2UtOTU0NS05MzkxMDdjZDhhNGY/YXBpLXZlcnNpb249MjAxNS0wNS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/providers/Microsoft.Storage/operations/063e219c-7fac-4ce0-a49d-af4ed82dd6f4?monitor=true&api-version=2017-06-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3RvcmFnZS9vcGVyYXRpb25zLzA2M2UyMTljLTdmYWMtNGNlMC1hNDlkLWFmNGVkODJkZDZmND9tb25pdG9yPXRydWUmYXBpLXZlcnNpb249MjAxNy0wNi0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Storage.StorageManagementClient/6.5.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"d8a8dbd3-6032-4e7e-9545-939107cd8a4f\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2017-06-01T18:25:37.003Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Storage/storageAccounts/sqlcrudtest3491\",\r\n  \"kind\": \"BlobStorage\",\r\n  \"location\": \"japaneast\",\r\n  \"name\": \"sqlcrudtest3491\",\r\n  \"properties\": {\r\n    \"accessTier\": \"Cool\",\r\n    \"creationTime\": \"2017-06-22T05:37:42.1129879Z\",\r\n    \"primaryEndpoints\": {\r\n      \"blob\": \"https://sqlcrudtest3491.blob.core.windows.net/\",\r\n      \"table\": \"https://sqlcrudtest3491.table.core.windows.net/\"\r\n    },\r\n    \"primaryLocation\": \"japaneast\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"statusOfPrimary\": \"available\",\r\n    \"supportsHttpsTrafficOnly\": false\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n  },\r\n  \"tags\": {},\r\n  \"type\": \"Microsoft.Storage/storageAccounts\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:38:12 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-Azure-Storage-Resource-Provider/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "9ef50939-522a-460e-b7ca-48e46dab83d0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14360"
+        ],
+        "x-ms-correlation-request-id": [
+          "9ef50939-522a-460e-b7ca-48e46dab83d0"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170622T053812Z:9ef50939-522a-460e-b7ca-48e46dab83d0"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/providers/Microsoft.Sql/locations/japaneast/serverAzureAsyncOperation/ad797c82-a3da-4330-88de-1877a42d6c9e?api-version=2015-05-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9qYXBhbmVhc3Qvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi9hZDc5N2M4Mi1hM2RhLTQzMzAtODhkZS0xODc3YTQyZDZjOWU/YXBpLXZlcnNpb249MjAxNS0wNS0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"ad797c82-a3da-4330-88de-1877a42d6c9e\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2017-06-22T05:37:43.54Z\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -157,7 +281,7 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:26:07 GMT"
+          "Thu, 22 Jun 2017 05:38:13 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -172,16 +296,16 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "70fb3476-f1c3-478e-b31d-d005b62922f8"
+          "4abb3698-790b-4e2a-ac24-54214ed6901d"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14997"
+          "14992"
         ],
         "x-ms-correlation-request-id": [
-          "0e802ade-b572-44f2-a73f-05f85fbbf885"
+          "bdd0ae66-aa0c-4cd2-8ce4-95105cdd4c88"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182607Z:0e802ade-b572-44f2-a73f-05f85fbbf885"
+          "WESTUS2:20170622T053813Z:bdd0ae66-aa0c-4cd2-8ce4-95105cdd4c88"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -190,17 +314,79 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/providers/Microsoft.Sql/locations/japaneast/serverAzureAsyncOperation/d8a8dbd3-6032-4e7e-9545-939107cd8a4f?api-version=2015-05-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9qYXBhbmVhc3Qvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi9kOGE4ZGJkMy02MDMyLTRlN2UtOTU0NS05MzkxMDdjZDhhNGY/YXBpLXZlcnNpb249MjAxNS0wNS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Storage/storageAccounts/sqlcrudtest3491/listKeys?api-version=2017-06-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TdG9yYWdlL3N0b3JhZ2VBY2NvdW50cy9zcWxjcnVkdGVzdDM0OTEvbGlzdEtleXM/YXBpLXZlcnNpb249MjAxNy0wNi0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "3ecd2cfa-c56c-4e70-8087-ab21875bd282"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Storage.StorageManagementClient/6.5.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"keys\": [\r\n    {\r\n      \"keyName\": \"key1\",\r\n      \"permissions\": \"Full\",\r\n      \"value\": \"wHiSyb8kD9eM1aytXDkDcJvV6YRMphXgQoB7LXsNvSxg0ButTjpeu+apR0XcKZZya43gdwGwv9rc1QNAWmgimA==\"\r\n    },\r\n    {\r\n      \"keyName\": \"key2\",\r\n      \"permissions\": \"Full\",\r\n      \"value\": \"fqTc0HUv00GKHeLVtEAx/lthQtCKat1rc6LOyfJuda4rz7Uz1aCTAhFUkOkPIWlBTJ3rXs75H5dDROtrJWIb+A==\"\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:38:13 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-Azure-Storage-Resource-Provider/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "179d98ba-2392-4f04-a4db-78300c741154"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1197"
+        ],
+        "x-ms-correlation-request-id": [
+          "179d98ba-2392-4f04-a4db-78300c741154"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170622T053813Z:179d98ba-2392-4f04-a4db-78300c741154"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955?api-version=2015-05-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1P2FwaS12ZXJzaW9uPTIwMTUtMDUtMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"d8a8dbd3-6032-4e7e-9545-939107cd8a4f\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2017-06-01T18:25:37.003Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"version\": \"12.0\",\r\n    \"state\": \"Ready\",\r\n    \"fullyQualifiedDomainName\": \"japaneast5955.database.windows.net\"\r\n  },\r\n  \"location\": \"japaneast\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955\",\r\n  \"name\": \"japaneast5955\",\r\n  \"type\": \"Microsoft.Sql/servers\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -212,7 +398,7 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:26:36 GMT"
+          "Thu, 22 Jun 2017 05:38:13 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -227,16 +413,16 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "f8a08bcc-e0f0-44c9-95e0-8b0b3552e2a8"
+          "932e2b78-be23-481c-8373-1cfbc2ad949c"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14996"
+          "14991"
         ],
         "x-ms-correlation-request-id": [
-          "54c8b6ba-2422-4bf4-854d-4de6e803fbd2"
+          "608ce9d4-8d7d-4960-b705-f0b40b67a3d9"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182637Z:54c8b6ba-2422-4bf4-854d-4de6e803fbd2"
+          "WESTUS2:20170622T053813Z:608ce9d4-8d7d-4960-b705-f0b40b67a3d9"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -245,63 +431,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490?api-version=2015-05-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwP2FwaS12ZXJzaW9uPTIwMTUtMDUtMDEtcHJldmlldw==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490\",\r\n  \"name\": \"sqlcrudtest-9490\",\r\n  \"type\": \"Microsoft.Sql/servers\",\r\n  \"location\": \"japaneast\",\r\n  \"kind\": \"v12.0\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"version\": \"12.0\",\r\n    \"state\": \"Ready\",\r\n    \"fullyQualifiedDomainName\": \"sqlcrudtest-9490.database.windows.net\"\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:26:37 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "0b9cb214-4d93-4d0d-9720-0bdf0a71db9c"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14995"
-        ],
-        "x-ms-correlation-request-id": [
-          "1adc3fb3-1225-4dca-9792-949d9e4303a0"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182638Z:1adc3fb3-1225-4dca-9792-949d9e4303a0"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/firewallRules/sqlcrudtest-6127?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2ZpcmV3YWxsUnVsZXMvc3FsY3J1ZHRlc3QtNjEyNz9hcGktdmVyc2lvbj0yMDE0LTA0LTAx",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/firewallRules/sqlcrudtest-3002?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2ZpcmV3YWxsUnVsZXMvc3FsY3J1ZHRlc3QtMzAwMj9hcGktdmVyc2lvbj0yMDE0LTA0LTAx",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"properties\": {\r\n    \"startIpAddress\": \"0.0.0.0\",\r\n    \"endIpAddress\": \"255.255.255.255\"\r\n  }\r\n}",
       "RequestHeaders": {
@@ -312,20 +443,20 @@
           "101"
         ],
         "x-ms-client-request-id": [
-          "18953f11-69a1-47a2-aa43-a6bcb8c3544a"
+          "77270834-ffca-4b14-b1a0-f72cd254a579"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/firewallRules/sqlcrudtest-6127\",\r\n  \"name\": \"sqlcrudtest-6127\",\r\n  \"type\": \"Microsoft.Sql/servers/firewallRules\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"startIpAddress\": \"0.0.0.0\",\r\n    \"endIpAddress\": \"255.255.255.255\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/firewallRules/sqlcrudtest-3002\",\r\n  \"name\": \"sqlcrudtest-3002\",\r\n  \"type\": \"Microsoft.Sql/servers/firewallRules\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"startIpAddress\": \"0.0.0.0\",\r\n    \"endIpAddress\": \"255.255.255.255\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "357"
+          "354"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -334,13 +465,13 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:26:40 GMT"
+          "Thu, 22 Jun 2017 05:38:15 GMT"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "3c7b9fc3-52cd-4a0d-a575-4515ebe20719"
+          "0777d624-1421-4f49-9393-ed9e3719f0e2"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -355,20 +486,20 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1193"
+          "1198"
         ],
         "x-ms-correlation-request-id": [
-          "a8f5c95d-5e3c-4358-b0d7-66e0eb209cc3"
+          "fcabf8bd-bdc3-40a5-82c2-242b764dbe16"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182640Z:a8f5c95d-5e3c-4358-b0d7-66e0eb209cc3"
+          "WESTUS2:20170622T053815Z:fcabf8bd-bdc3-40a5-82c2-242b764dbe16"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0xMzY0P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zMDI4P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"location\": \"japaneast\"\r\n}",
       "RequestHeaders": {
@@ -379,17 +510,17 @@
           "31"
         ],
         "x-ms-client-request-id": [
-          "68618320-71cd-4009-8e92-db1700ecc8ea"
+          "d3e3c6bb-2fa2-400e-b47d-6920009f9ba3"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2017-06-01T11:26:40.686-07:00\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2017-06-21T22:38:18.126-07:00\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "80"
@@ -401,10 +532,10 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:26:42 GMT"
+          "Thu, 22 Jun 2017 05:38:17 GMT"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/operationResults/fb3a7111-91e7-42e4-90c1-d3142b618aeb?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/operationResults/2d71daa7-a0ed-4e11-9537-93c3c09b3d4a?api-version=2014-04-01-Preview"
         ],
         "Retry-After": [
           "30"
@@ -413,7 +544,7 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "fb3a7111-91e7-42e4-90c1-d3142b618aeb"
+          "2d71daa7-a0ed-4e11-9537-93c3c09b3d4a"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -428,32 +559,32 @@
           "max-age=31536000; includeSubDomains"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/azureAsyncOperation/fb3a7111-91e7-42e4-90c1-d3142b618aeb?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/azureAsyncOperation/2d71daa7-a0ed-4e11-9537-93c3c09b3d4a?api-version=2014-04-01-Preview"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1192"
+          "1197"
         ],
         "x-ms-correlation-request-id": [
-          "4cec0d0f-c239-46f6-bc9d-7d41542251fe"
+          "b6c92497-2305-4111-b190-db584f6d1985"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182642Z:4cec0d0f-c239-46f6-bc9d-7d41542251fe"
+          "WESTUS2:20170622T053817Z:b6c92497-2305-4111-b190-db584f6d1985"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/azureAsyncOperation/fb3a7111-91e7-42e4-90c1-d3142b618aeb?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0xMzY0L2F6dXJlQXN5bmNPcGVyYXRpb24vZmIzYTcxMTEtOTFlNy00MmU0LTkwYzEtZDMxNDJiNjE4YWViP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/azureAsyncOperation/2d71daa7-a0ed-4e11-9537-93c3c09b3d4a?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zMDI4L2F6dXJlQXN5bmNPcGVyYXRpb24vMmQ3MWRhYTctYTBlZC00ZTExLTk1MzctOTNjM2MwOWIzZDRhP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"operationId\": \"fb3a7111-91e7-42e4-90c1-d3142b618aeb\",\r\n  \"status\": \"InProgress\",\r\n  \"error\": null\r\n}",
+      "ResponseBody": "{\r\n  \"operationId\": \"2d71daa7-a0ed-4e11-9537-93c3c09b3d4a\",\r\n  \"status\": \"InProgress\",\r\n  \"error\": null\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -462,7 +593,7 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:27:12 GMT"
+          "Thu, 22 Jun 2017 05:38:47 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
@@ -474,7 +605,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "87ce1c75-100f-40fb-a39d-307c5f9b3cd2"
+          "7205c620-ad73-47a2-8eb6-aa496ab3de38"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -486,340 +617,32 @@
           "max-age=31536000; includeSubDomains"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/azureAsyncOperation/fb3a7111-91e7-42e4-90c1-d3142b618aeb?api-version=2014-04-01-Preview"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14994"
-        ],
-        "x-ms-correlation-request-id": [
-          "ac2de443-359a-4c06-9064-71e4dfa8aaf1"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182712Z:ac2de443-359a-4c06-9064-71e4dfa8aaf1"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/azureAsyncOperation/fb3a7111-91e7-42e4-90c1-d3142b618aeb?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0xMzY0L2F6dXJlQXN5bmNPcGVyYXRpb24vZmIzYTcxMTEtOTFlNy00MmU0LTkwYzEtZDMxNDJiNjE4YWViP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"operationId\": \"fb3a7111-91e7-42e4-90c1-d3142b618aeb\",\r\n  \"status\": \"Succeeded\",\r\n  \"error\": null\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:27:42 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "d9d8026f-08f8-4f09-9b19-f2db7afa4ba2"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/azureAsyncOperation/fb3a7111-91e7-42e4-90c1-d3142b618aeb?api-version=2014-04-01-Preview"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14993"
-        ],
-        "x-ms-correlation-request-id": [
-          "6b3290ee-1288-4eb3-82f1-87e166761993"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182743Z:6b3290ee-1288-4eb3-82f1-87e166761993"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0xMzY0P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364\",\r\n  \"name\": \"sqlcrudtest-1364\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"databaseId\": \"914c1f0d-c807-4fa3-a22a-1a131b2218be\",\r\n    \"edition\": \"Standard\",\r\n    \"status\": \"Online\",\r\n    \"serviceLevelObjective\": \"S0\",\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": \"268435456000\",\r\n    \"creationDate\": \"2017-06-01T18:26:41.093Z\",\r\n    \"currentServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveName\": \"S0\",\r\n    \"sampleName\": null,\r\n    \"defaultSecondaryLocation\": \"Japan West\",\r\n    \"earliestRestoreDate\": \"2017-06-01T18:37:23.357Z\",\r\n    \"elasticPoolName\": null,\r\n    \"containmentState\": 2,\r\n    \"readScale\": \"Disabled\",\r\n    \"failoverGroupId\": null\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:27:43 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "0fa450d5-9934-46b2-bb7d-e0afda6b9d52"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14992"
-        ],
-        "x-ms-correlation-request-id": [
-          "f5dad72d-951c-41f6-b751-043151e866b6"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182743Z:f5dad72d-951c-41f6-b751-043151e866b6"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zNjY1P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
-      "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"location\": \"japaneast\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "31"
-        ],
-        "x-ms-client-request-id": [
-          "8540ef1f-81ab-4b59-a13f-25342febfddc"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2017-06-01T11:27:43.251-07:00\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "80"
-        ],
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:27:44 GMT"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/operationResults/b8d17431-0ca3-4276-8aec-081a65b639ae?api-version=2014-04-01-Preview"
-        ],
-        "Retry-After": [
-          "30"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-request-id": [
-          "b8d17431-0ca3-4276-8aec-081a65b639ae"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Preference-Applied": [
-          "return-content"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/azureAsyncOperation/b8d17431-0ca3-4276-8aec-081a65b639ae?api-version=2014-04-01-Preview"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1191"
-        ],
-        "x-ms-correlation-request-id": [
-          "14ddccd4-a012-41e5-9e51-52c788725eaf"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182745Z:14ddccd4-a012-41e5-9e51-52c788725eaf"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/azureAsyncOperation/b8d17431-0ca3-4276-8aec-081a65b639ae?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zNjY1L2F6dXJlQXN5bmNPcGVyYXRpb24vYjhkMTc0MzEtMGNhMy00Mjc2LThhZWMtMDgxYTY1YjYzOWFlP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"operationId\": \"b8d17431-0ca3-4276-8aec-081a65b639ae\",\r\n  \"status\": \"Succeeded\",\r\n  \"error\": null\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:28:14 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "cb998dba-28ef-44b4-84ef-3c64cee5932e"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/azureAsyncOperation/b8d17431-0ca3-4276-8aec-081a65b639ae?api-version=2014-04-01-Preview"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14991"
-        ],
-        "x-ms-correlation-request-id": [
-          "c73ff27a-550a-422b-8d5d-05e8f0cd3239"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182815Z:c73ff27a-550a-422b-8d5d-05e8f0cd3239"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zNjY1P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665\",\r\n  \"name\": \"sqlcrudtest-3665\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"databaseId\": \"1dd95233-01bb-4fe1-b6ae-b41658f706ba\",\r\n    \"edition\": \"Standard\",\r\n    \"status\": \"Online\",\r\n    \"serviceLevelObjective\": \"S0\",\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": \"268435456000\",\r\n    \"creationDate\": \"2017-06-01T18:27:43.533Z\",\r\n    \"currentServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveName\": \"S0\",\r\n    \"sampleName\": null,\r\n    \"defaultSecondaryLocation\": \"Japan West\",\r\n    \"earliestRestoreDate\": \"2017-06-01T18:38:09.85Z\",\r\n    \"elasticPoolName\": null,\r\n    \"containmentState\": 2,\r\n    \"readScale\": \"Disabled\",\r\n    \"failoverGroupId\": null\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:28:14 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "3c720170-1279-49c2-a91c-dbc9db1ddae5"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/azureAsyncOperation/2d71daa7-a0ed-4e11-9537-93c3c09b3d4a?api-version=2014-04-01-Preview"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14990"
         ],
         "x-ms-correlation-request-id": [
-          "4ed9c086-4a95-4b09-862b-138077a0c746"
+          "53bbb18a-efd1-4987-842d-027a3e7bbaf3"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182815Z:4ed9c086-4a95-4b09-862b-138077a0c746"
+          "WESTUS2:20170622T053847Z:53bbb18a-efd1-4987-842d-027a3e7bbaf3"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zNjY1P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/azureAsyncOperation/2d71daa7-a0ed-4e11-9537-93c3c09b3d4a?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zMDI4L2F6dXJlQXN5bmNPcGVyYXRpb24vMmQ3MWRhYTctYTBlZC00ZTExLTk1MzctOTNjM2MwOWIzZDRhP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "ac6702eb-949b-44fa-a56a-521c1095a5cd"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665\",\r\n  \"name\": \"sqlcrudtest-3665\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"databaseId\": \"1dd95233-01bb-4fe1-b6ae-b41658f706ba\",\r\n    \"edition\": \"Standard\",\r\n    \"status\": \"Online\",\r\n    \"serviceLevelObjective\": \"S0\",\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": \"268435456000\",\r\n    \"creationDate\": \"2017-06-01T18:27:43.533Z\",\r\n    \"currentServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveName\": \"S0\",\r\n    \"sampleName\": null,\r\n    \"defaultSecondaryLocation\": \"Japan West\",\r\n    \"earliestRestoreDate\": \"2017-06-01T18:38:09.85Z\",\r\n    \"elasticPoolName\": null,\r\n    \"containmentState\": 2,\r\n    \"readScale\": \"Disabled\",\r\n    \"failoverGroupId\": null\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"operationId\": \"2d71daa7-a0ed-4e11-9537-93c3c09b3d4a\",\r\n  \"status\": \"Succeeded\",\r\n  \"error\": null\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -828,7 +651,7 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:28:14 GMT"
+          "Thu, 22 Jun 2017 05:39:17 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
@@ -840,7 +663,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "1f1a1698-1f61-4cf4-9960-afbd692101ee"
+          "3d628b92-b8a2-4bb2-beac-4a4de6ae61ab"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -850,108 +673,35 @@
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/azureAsyncOperation/2d71daa7-a0ed-4e11-9537-93c3c09b3d4a?api-version=2014-04-01-Preview"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14989"
         ],
         "x-ms-correlation-request-id": [
-          "3b7ef54a-e08d-47e3-bb3a-b37dd5d216cc"
+          "27a25f48-8b7d-41ae-8647-5cb779dddebb"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182815Z:3b7ef54a-e08d-47e3-bb3a-b37dd5d216cc"
+          "WESTUS2:20170622T053917Z:27a25f48-8b7d-41ae-8647-5cb779dddebb"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/export?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0xMzY0L2V4cG9ydD9hcGktdmVyc2lvbj0yMDE0LTA0LTAx",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"storageKeyType\": \"StorageAccessKey\",\r\n  \"storageKey\": \"xxxx\",\r\n  \"storageUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n  \"administratorLogin\": \"dummylogin\",\r\n  \"administratorLoginPassword\": \"Un53cuRE!\",\r\n  \"authenticationType\": \"SQL\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "365"
-        ],
-        "x-ms-client-request-id": [
-          "a520b05e-ea59-46a9-92a4-561515d8d9c8"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"operation\": \"Export\",\r\n  \"startTime\": \"2017-06-01T18:28:15.791Z\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "60"
-        ],
-        "Content-Type": [
-          "application/xml; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:28:17 GMT"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview"
-        ],
-        "Retry-After": [
-          "30"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-request-id": [
-          "3f485a2f-5896-4d92-8132-545afc12029b"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Preference-Applied": [
-          "return-content"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1190"
-        ],
-        "x-ms-correlation-request-id": [
-          "98037b31-9bb3-4a0b-99f8-deae823fd2d6"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182817Z:98037b31-9bb3-4a0b-99f8-deae823fd2d6"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0xMzY0L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvZjBmOTU2N2YtNTJiYi00Nzk1LWI0ZjMtNDk2MzE1MTg2ZTdjP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zMDI4P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"blobUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n  \"databaseName\": \"sqlcrudtest-1364\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:28:18 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:28:17 PM\",\r\n  \"requestId\": \"f0f9567f-52bb-4795-b4f3-496315186e7c\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"sqlcrudtest-9490.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028\",\r\n  \"name\": \"sqlcrudtest-3028\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"databaseId\": \"3dbc408c-8020-43eb-b91d-80dc35b699e8\",\r\n    \"edition\": \"Standard\",\r\n    \"status\": \"Online\",\r\n    \"serviceLevelObjective\": \"S0\",\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": \"268435456000\",\r\n    \"creationDate\": \"2017-06-22T05:38:18.33Z\",\r\n    \"currentServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveName\": \"S0\",\r\n    \"sampleName\": null,\r\n    \"defaultSecondaryLocation\": \"Japan West\",\r\n    \"earliestRestoreDate\": \"2017-06-22T05:48:50.19Z\",\r\n    \"elasticPoolName\": null,\r\n    \"containmentState\": 2,\r\n    \"readScale\": \"Disabled\",\r\n    \"failoverGroupId\": null\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Length": [
-          "387"
-        ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
         ],
@@ -959,19 +709,19 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:28:48 GMT"
+          "Thu, 22 Jun 2017 05:39:18 GMT"
         ],
-        "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview"
-        ],
-        "Retry-After": [
-          "30"
+        "Transfer-Encoding": [
+          "chunked"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
         "x-ms-request-id": [
-          "ad074433-dd84-4169-9da5-702a0cbbe857"
+          "521a0d2d-8f53-448b-a665-f2727df44c51"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -986,29 +736,41 @@
           "14988"
         ],
         "x-ms-correlation-request-id": [
-          "b72207e8-66c4-4660-98b1-5bcc931a5eb7"
+          "9e4b5e44-8720-437a-9feb-e1d742493436"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182848Z:b72207e8-66c4-4660-98b1-5bcc931a5eb7"
+          "WESTUS2:20170622T053918Z:9e4b5e44-8720-437a-9feb-e1d742493436"
         ]
       },
-      "StatusCode": 202
+      "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0xMzY0L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvZjBmOTU2N2YtNTJiYi00Nzk1LWI0ZjMtNDk2MzE1MTg2ZTdjP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zOTc0P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"japaneast\"\r\n}",
       "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "31"
+        ],
+        "x-ms-client-request-id": [
+          "91682ec9-d9ab-4118-8e9c-db1c6171d463"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"blobUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n  \"databaseName\": \"sqlcrudtest-1364\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:28:18 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:28:17 PM\",\r\n  \"requestId\": \"f0f9567f-52bb-4795-b4f3-496315186e7c\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"sqlcrudtest-9490.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2017-06-21T22:39:21.065-07:00\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "387"
+          "80"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -1017,10 +779,10 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:29:18 GMT"
+          "Thu, 22 Jun 2017 05:39:20 GMT"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/operationResults/8c9822f0-f396-4a94-9bf2-bd815aa94dc8?api-version=2014-04-01-Preview"
         ],
         "Retry-After": [
           "30"
@@ -1029,7 +791,68 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "a514ba1e-c93c-4940-a88e-cff511fa3b73"
+          "8c9822f0-f396-4a94-9bf2-bd815aa94dc8"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Preference-Applied": [
+          "return-content"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/azureAsyncOperation/8c9822f0-f396-4a94-9bf2-bd815aa94dc8?api-version=2014-04-01-Preview"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1196"
+        ],
+        "x-ms-correlation-request-id": [
+          "20d681ef-eda2-4957-b5c6-ab36c7674186"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170622T053920Z:20d681ef-eda2-4957-b5c6-ab36c7674186"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/azureAsyncOperation/8c9822f0-f396-4a94-9bf2-bd815aa94dc8?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zOTc0L2F6dXJlQXN5bmNPcGVyYXRpb24vOGM5ODIyZjAtZjM5Ni00YTk0LTliZjItYmQ4MTVhYTk0ZGM4P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"operationId\": \"8c9822f0-f396-4a94-9bf2-bd815aa94dc8\",\r\n  \"status\": \"InProgress\",\r\n  \"error\": null\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:39:50 GMT"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "97009c83-4c1b-48d4-bf92-b641de7baf4b"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1039,35 +862,35 @@
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/azureAsyncOperation/8c9822f0-f396-4a94-9bf2-bd815aa94dc8?api-version=2014-04-01-Preview"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14987"
         ],
         "x-ms-correlation-request-id": [
-          "0b492deb-4e48-4f0f-8e13-31a58f149463"
+          "61380a8c-a8f7-4f7a-904f-69fb7dbe406e"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182918Z:0b492deb-4e48-4f0f-8e13-31a58f149463"
+          "WESTUS2:20170622T053950Z:61380a8c-a8f7-4f7a-904f-69fb7dbe406e"
         ]
       },
-      "StatusCode": 202
+      "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0xMzY0L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvZjBmOTU2N2YtNTJiYi00Nzk1LWI0ZjMtNDk2MzE1MTg2ZTdjP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/azureAsyncOperation/8c9822f0-f396-4a94-9bf2-bd815aa94dc8?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zOTc0L2F6dXJlQXN5bmNPcGVyYXRpb24vOGM5ODIyZjAtZjM5Ni00YTk0LTliZjItYmQ4MTVhYTk0ZGM4P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"blobUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n  \"databaseName\": \"sqlcrudtest-1364\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:28:18 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:28:17 PM\",\r\n  \"requestId\": \"f0f9567f-52bb-4795-b4f3-496315186e7c\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"sqlcrudtest-9490.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseBody": "{\r\n  \"operationId\": \"8c9822f0-f396-4a94-9bf2-bd815aa94dc8\",\r\n  \"status\": \"Succeeded\",\r\n  \"error\": null\r\n}",
       "ResponseHeaders": {
-        "Content-Length": [
-          "387"
-        ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
         ],
@@ -1075,19 +898,19 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:29:48 GMT"
+          "Thu, 22 Jun 2017 05:40:23 GMT"
         ],
-        "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview"
-        ],
-        "Retry-After": [
-          "30"
+        "Transfer-Encoding": [
+          "chunked"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
         "x-ms-request-id": [
-          "e345e4d4-7cde-4474-83c8-ca3534b9e70e"
+          "87268c11-66a1-4c36-bbe1-ef3c613d6bf5"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1098,34 +921,34 @@
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/azureAsyncOperation/8c9822f0-f396-4a94-9bf2-bd815aa94dc8?api-version=2014-04-01-Preview"
+        ],
         "x-ms-ratelimit-remaining-subscription-reads": [
           "14986"
         ],
         "x-ms-correlation-request-id": [
-          "185a38ba-41b1-46a9-a6fe-38e209799780"
+          "677b7c67-d17a-41b8-999c-76aab585b4e0"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T182948Z:185a38ba-41b1-46a9-a6fe-38e209799780"
+          "WESTUS2:20170622T054023Z:677b7c67-d17a-41b8-999c-76aab585b4e0"
         ]
       },
-      "StatusCode": 202
+      "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0xMzY0L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvZjBmOTU2N2YtNTJiYi00Nzk1LWI0ZjMtNDk2MzE1MTg2ZTdjP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zOTc0P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"blobUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n  \"databaseName\": \"sqlcrudtest-1364\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:28:18 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:28:17 PM\",\r\n  \"requestId\": \"f0f9567f-52bb-4795-b4f3-496315186e7c\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"sqlcrudtest-9490.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974\",\r\n  \"name\": \"sqlcrudtest-3974\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"databaseId\": \"47c5da6a-29e6-4ee6-b316-963da3c59d59\",\r\n    \"edition\": \"Standard\",\r\n    \"status\": \"Online\",\r\n    \"serviceLevelObjective\": \"S0\",\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": \"268435456000\",\r\n    \"creationDate\": \"2017-06-22T05:39:21.363Z\",\r\n    \"currentServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveName\": \"S0\",\r\n    \"sampleName\": null,\r\n    \"defaultSecondaryLocation\": \"Japan West\",\r\n    \"earliestRestoreDate\": \"2017-06-22T05:49:57.503Z\",\r\n    \"elasticPoolName\": null,\r\n    \"containmentState\": 2,\r\n    \"readScale\": \"Disabled\",\r\n    \"failoverGroupId\": null\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Length": [
-          "387"
-        ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
         ],
@@ -1133,19 +956,19 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:30:18 GMT"
+          "Thu, 22 Jun 2017 05:40:23 GMT"
         ],
-        "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview"
-        ],
-        "Retry-After": [
-          "30"
+        "Transfer-Encoding": [
+          "chunked"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
         "x-ms-request-id": [
-          "397b853b-2267-47df-859a-a8a5408b6fe4"
+          "aa3577a6-6607-47b6-928d-a8000d72ddfb"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1160,30 +983,33 @@
           "14985"
         ],
         "x-ms-correlation-request-id": [
-          "64a98e5b-870f-4630-b447-30ec822cd6eb"
+          "ba7e0195-8f4f-42de-a46c-2c328192a0e5"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T183018Z:64a98e5b-870f-4630-b447-30ec822cd6eb"
+          "WESTUS2:20170622T054024Z:ba7e0195-8f4f-42de-a46c-2c328192a0e5"
         ]
       },
-      "StatusCode": 202
+      "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0xMzY0L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvZjBmOTU2N2YtNTJiYi00Nzk1LWI0ZjMtNDk2MzE1MTg2ZTdjP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zOTc0P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "bc74df69-a7da-45bd-b71c-af3a6f8139d0"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"blobUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n  \"databaseName\": \"sqlcrudtest-1364\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:28:18 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:28:17 PM\",\r\n  \"requestId\": \"f0f9567f-52bb-4795-b4f3-496315186e7c\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"sqlcrudtest-9490.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974\",\r\n  \"name\": \"sqlcrudtest-3974\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"databaseId\": \"47c5da6a-29e6-4ee6-b316-963da3c59d59\",\r\n    \"edition\": \"Standard\",\r\n    \"status\": \"Online\",\r\n    \"serviceLevelObjective\": \"S0\",\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": \"268435456000\",\r\n    \"creationDate\": \"2017-06-22T05:39:21.363Z\",\r\n    \"currentServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveName\": \"S0\",\r\n    \"sampleName\": null,\r\n    \"defaultSecondaryLocation\": \"Japan West\",\r\n    \"earliestRestoreDate\": \"2017-06-22T05:49:57.503Z\",\r\n    \"elasticPoolName\": null,\r\n    \"containmentState\": 2,\r\n    \"readScale\": \"Disabled\",\r\n    \"failoverGroupId\": null\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Length": [
-          "387"
-        ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
         ],
@@ -1191,19 +1017,19 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:30:49 GMT"
+          "Thu, 22 Jun 2017 05:40:24 GMT"
         ],
-        "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview"
-        ],
-        "Retry-After": [
-          "30"
+        "Transfer-Encoding": [
+          "chunked"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
         "x-ms-request-id": [
-          "5e2b29fb-e1a1-4b98-a963-404c359982bc"
+          "c879e59d-8300-4d7a-865f-700546a47a85"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1218,108 +1044,53 @@
           "14984"
         ],
         "x-ms-correlation-request-id": [
-          "fe9feb6b-250c-45de-9480-f338a250a415"
+          "a029b832-21bd-4217-8b7d-5ad92dd7050f"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T183049Z:fe9feb6b-250c-45de-9480-f338a250a415"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0xMzY0L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvZjBmOTU2N2YtNTJiYi00Nzk1LWI0ZjMtNDk2MzE1MTg2ZTdjP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-1364/importExportOperationResults/f0f9567f-52bb-4795-b4f3-496315186e7c\",\r\n  \"name\": \"f0f9567f-52bb-4795-b4f3-496315186e7c\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/importExportOperationResults\",\r\n  \"properties\": {\r\n    \"requestId\": \"f0f9567f-52bb-4795-b4f3-496315186e7c\",\r\n    \"requestType\": \"Export\",\r\n    \"queuedTime\": \"6/1/2017 6:28:17 PM\",\r\n    \"lastModifiedTime\": \"6/1/2017 6:30:51 PM\",\r\n    \"blobUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n    \"serverName\": \"sqlcrudtest-9490\",\r\n    \"databaseName\": \"sqlcrudtest-1364\",\r\n    \"status\": \"Completed\",\r\n    \"errorMessage\": null\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:31:19 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "cb64c2aa-aa76-4090-bd17-216696fc3af4"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14983"
-        ],
-        "x-ms-correlation-request-id": [
-          "c94eef5d-5039-4bd1-87f6-a5543dc3dc42"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20170601T183119Z:c94eef5d-5039-4bd1-87f6-a5543dc3dc42"
+          "WESTUS2:20170622T054024Z:a029b832-21bd-4217-8b7d-5ad92dd7050f"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/extensions/import?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zNjY1L2V4dGVuc2lvbnMvaW1wb3J0P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
-      "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"storageKeyType\": \"StorageAccessKey\",\r\n    \"storageKey\": \"xxxx\",\r\n    \"storageUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"administratorLoginPassword\": \"Un53cuRE!\",\r\n    \"authenticationType\": \"SQL\",\r\n    \"operationMode\": \"Import\"\r\n  }\r\n}",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/export?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zMDI4L2V4cG9ydD9hcGktdmVyc2lvbj0yMDE0LTA0LTAx",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"storageKeyType\": \"StorageAccessKey\",\r\n  \"storageKey\": \"wHiSyb8kD9eM1aytXDkDcJvV6YRMphXgQoB7LXsNvSxg0ButTjpeu+apR0XcKZZya43gdwGwv9rc1QNAWmgimA==\",\r\n  \"storageUri\": \"https://sqlcrudtest3491.blob.core.windows.net/container/sqlcrudtest-3028.bacpac\",\r\n  \"administratorLogin\": \"dummylogin\",\r\n  \"administratorLoginPassword\": \"Un53cuRE!\",\r\n  \"authenticationType\": \"SQL\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "433"
+          "370"
         ],
         "x-ms-client-request-id": [
-          "56abbafa-51cb-4c52-9243-fcf2a8a78ac3"
+          "13b7c038-26f9-4cf1-85f3-3cad82e0df1b"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"Import\",\r\n  \"startTime\": \"2017-06-01T18:31:22.828Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"Export\",\r\n  \"startTime\": \"2017-06-22T05:40:25.995Z\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "60"
         ],
         "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+          "application/xml; charset=utf-8"
         ],
         "Cache-Control": [
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:31:22 GMT"
+          "Thu, 22 Jun 2017 05:40:25 GMT"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/extensions/import/importExtensionOperationResults/b4cb0f4d-e028-44f4-b979-1482bcf94c5b?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/importExportOperationResults/500ba737-5263-41fd-b19c-e0689a737d98?api-version=2014-04-01-Preview"
         ],
         "Retry-After": [
           "30"
@@ -1328,7 +1099,7 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "0e4c4c8b-4443-4ad7-8f45-1ec8c59d8411"
+          "9c8eda1e-0a16-4d2a-a34e-a07d4092f8a8"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1343,29 +1114,29 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1189"
+          "1195"
         ],
         "x-ms-correlation-request-id": [
-          "b01d584d-8d42-49de-a4c7-d88514b9bd2b"
+          "74b89d65-da0d-44cf-b902-71f330ea3b56"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T183122Z:b01d584d-8d42-49de-a4c7-d88514b9bd2b"
+          "WESTUS2:20170622T054026Z:74b89d65-da0d-44cf-b902-71f330ea3b56"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/extensions/import/importExtensionOperationResults/b4cb0f4d-e028-44f4-b979-1482bcf94c5b?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zNjY1L2V4dGVuc2lvbnMvaW1wb3J0L2ltcG9ydEV4dGVuc2lvbk9wZXJhdGlvblJlc3VsdHMvYjRjYjBmNGQtZTAyOC00NGY0LWI5NzktMTQ4MmJjZjk0YzViP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/importExportOperationResults/500ba737-5263-41fd-b19c-e0689a737d98?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zMDI4L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvNTAwYmE3MzctNTI2My00MWZkLWIxOWMtZTA2ODlhNzM3ZDk4P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"blobUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n  \"databaseName\": \"sqlcrudtest-3665\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:31:27 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:31:22 PM\",\r\n  \"requestId\": \"b4cb0f4d-e028-44f4-b979-1482bcf94c5b\",\r\n  \"requestType\": \"Import\",\r\n  \"serverName\": \"sqlcrudtest-9490.database.windows.net\",\r\n  \"status\": \"Running, Progress = 5.00 %\"\r\n}",
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest3491.blob.core.windows.net/container/sqlcrudtest-3028.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-3028\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:40:28 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:40:27 AM\",\r\n  \"requestId\": \"500ba737-5263-41fd-b19c-e0689a737d98\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"japaneast5955.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "391"
@@ -1377,10 +1148,10 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:31:52 GMT"
+          "Thu, 22 Jun 2017 05:40:56 GMT"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/extensions/import/importExtensionOperationResults/b4cb0f4d-e028-44f4-b979-1482bcf94c5b?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/importExportOperationResults/500ba737-5263-41fd-b19c-e0689a737d98?api-version=2014-04-01-Preview"
         ],
         "Retry-After": [
           "30"
@@ -1389,7 +1160,65 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "ff414903-0890-49d2-813c-82d1305bad76"
+          "af083f72-5e00-46c9-a1ed-55c4a85d68ed"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14983"
+        ],
+        "x-ms-correlation-request-id": [
+          "b1558b39-f6c4-49c0-b416-29ccd4fbf865"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170622T054057Z:b1558b39-f6c4-49c0-b416-29ccd4fbf865"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/importExportOperationResults/500ba737-5263-41fd-b19c-e0689a737d98?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zMDI4L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvNTAwYmE3MzctNTI2My00MWZkLWIxOWMtZTA2ODlhNzM3ZDk4P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest3491.blob.core.windows.net/container/sqlcrudtest-3028.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-3028\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:40:28 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:40:27 AM\",\r\n  \"requestId\": \"500ba737-5263-41fd-b19c-e0689a737d98\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"japaneast5955.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "391"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:41:26 GMT"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/importExportOperationResults/500ba737-5263-41fd-b19c-e0689a737d98?api-version=2014-04-01-Preview"
+        ],
+        "Retry-After": [
+          "30"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "de1ebe7d-6a0a-4f3e-9540-514a342def23"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1404,26 +1233,26 @@
           "14982"
         ],
         "x-ms-correlation-request-id": [
-          "fbfe3bb1-4625-419b-809c-9de797f4acdb"
+          "e2c9f56e-8305-42c1-bcfa-a099248465ab"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T183153Z:fbfe3bb1-4625-419b-809c-9de797f4acdb"
+          "WESTUS2:20170622T054127Z:e2c9f56e-8305-42c1-bcfa-a099248465ab"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/extensions/import/importExtensionOperationResults/b4cb0f4d-e028-44f4-b979-1482bcf94c5b?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zNjY1L2V4dGVuc2lvbnMvaW1wb3J0L2ltcG9ydEV4dGVuc2lvbk9wZXJhdGlvblJlc3VsdHMvYjRjYjBmNGQtZTAyOC00NGY0LWI5NzktMTQ4MmJjZjk0YzViP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/importExportOperationResults/500ba737-5263-41fd-b19c-e0689a737d98?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zMDI4L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvNTAwYmE3MzctNTI2My00MWZkLWIxOWMtZTA2ODlhNzM3ZDk4P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"blobUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n  \"databaseName\": \"sqlcrudtest-3665\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:31:27 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:31:22 PM\",\r\n  \"requestId\": \"b4cb0f4d-e028-44f4-b979-1482bcf94c5b\",\r\n  \"requestType\": \"Import\",\r\n  \"serverName\": \"sqlcrudtest-9490.database.windows.net\",\r\n  \"status\": \"Running, Progress = 5.00 %\"\r\n}",
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest3491.blob.core.windows.net/container/sqlcrudtest-3028.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-3028\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:40:28 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:40:27 AM\",\r\n  \"requestId\": \"500ba737-5263-41fd-b19c-e0689a737d98\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"japaneast5955.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "391"
@@ -1435,10 +1264,10 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:32:23 GMT"
+          "Thu, 22 Jun 2017 05:41:57 GMT"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/extensions/import/importExtensionOperationResults/b4cb0f4d-e028-44f4-b979-1482bcf94c5b?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/importExportOperationResults/500ba737-5263-41fd-b19c-e0689a737d98?api-version=2014-04-01-Preview"
         ],
         "Retry-After": [
           "30"
@@ -1447,7 +1276,7 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "7144e64b-b8b5-4adb-aaaf-f28a7e317c7c"
+          "ac72034c-4d33-4c2b-a930-c908e3ac0921"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1462,26 +1291,26 @@
           "14981"
         ],
         "x-ms-correlation-request-id": [
-          "43410017-56ed-4f76-ba2f-fc5ea698e077"
+          "e1302316-d197-4740-9464-d7844d69de79"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T183223Z:43410017-56ed-4f76-ba2f-fc5ea698e077"
+          "WESTUS2:20170622T054157Z:e1302316-d197-4740-9464-d7844d69de79"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/extensions/import/importExtensionOperationResults/b4cb0f4d-e028-44f4-b979-1482bcf94c5b?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zNjY1L2V4dGVuc2lvbnMvaW1wb3J0L2ltcG9ydEV4dGVuc2lvbk9wZXJhdGlvblJlc3VsdHMvYjRjYjBmNGQtZTAyOC00NGY0LWI5NzktMTQ4MmJjZjk0YzViP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/importExportOperationResults/500ba737-5263-41fd-b19c-e0689a737d98?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zMDI4L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvNTAwYmE3MzctNTI2My00MWZkLWIxOWMtZTA2ODlhNzM3ZDk4P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"blobUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n  \"databaseName\": \"sqlcrudtest-3665\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:31:27 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:31:22 PM\",\r\n  \"requestId\": \"b4cb0f4d-e028-44f4-b979-1482bcf94c5b\",\r\n  \"requestType\": \"Import\",\r\n  \"serverName\": \"sqlcrudtest-9490.database.windows.net\",\r\n  \"status\": \"Running, Progress = 5.00 %\"\r\n}",
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest3491.blob.core.windows.net/container/sqlcrudtest-3028.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-3028\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:40:28 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:40:27 AM\",\r\n  \"requestId\": \"500ba737-5263-41fd-b19c-e0689a737d98\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"japaneast5955.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "391"
@@ -1493,10 +1322,10 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:32:53 GMT"
+          "Thu, 22 Jun 2017 05:42:27 GMT"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/extensions/import/importExtensionOperationResults/b4cb0f4d-e028-44f4-b979-1482bcf94c5b?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/importExportOperationResults/500ba737-5263-41fd-b19c-e0689a737d98?api-version=2014-04-01-Preview"
         ],
         "Retry-After": [
           "30"
@@ -1505,7 +1334,7 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "85e2ef2d-9639-443f-bb33-633102e7fe9b"
+          "41bfd7b6-a047-4ece-bb1a-8c0b7eeac82d"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1520,30 +1349,27 @@
           "14980"
         ],
         "x-ms-correlation-request-id": [
-          "2f6aaed6-ce6f-4bf7-9b54-098704f42a2e"
+          "707cfdeb-1929-4063-af4e-f3187c21ee91"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T183253Z:2f6aaed6-ce6f-4bf7-9b54-098704f42a2e"
+          "WESTUS2:20170622T054227Z:707cfdeb-1929-4063-af4e-f3187c21ee91"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/extensions/import/importExtensionOperationResults/b4cb0f4d-e028-44f4-b979-1482bcf94c5b?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgxNTIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC05NDkwL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zNjY1L2V4dGVuc2lvbnMvaW1wb3J0L2ltcG9ydEV4dGVuc2lvbk9wZXJhdGlvblJlc3VsdHMvYjRjYjBmNGQtZTAyOC00NGY0LWI5NzktMTQ4MmJjZjk0YzViP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/importExportOperationResults/500ba737-5263-41fd-b19c-e0689a737d98?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zMDI4L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvNTAwYmE3MzctNTI2My00MWZkLWIxOWMtZTA2ODlhNzM3ZDk4P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-8152/providers/Microsoft.Sql/servers/sqlcrudtest-9490/databases/sqlcrudtest-3665/extensions/import\",\r\n  \"name\": \"import\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/extensions\",\r\n  \"properties\": {\r\n    \"requestId\": \"b4cb0f4d-e028-44f4-b979-1482bcf94c5b\",\r\n    \"requestType\": \"Import\",\r\n    \"queuedTime\": \"6/1/2017 6:31:22 PM\",\r\n    \"lastModifiedTime\": \"6/1/2017 6:33:15 PM\",\r\n    \"blobUri\": \"sqlcrudtest.blob.core.windows.net\",\r\n    \"serverName\": \"sqlcrudtest-9490\",\r\n    \"databaseName\": \"sqlcrudtest-3665\",\r\n    \"status\": \"Completed\",\r\n    \"errorMessage\": null\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3028/importExportOperationResults/500ba737-5263-41fd-b19c-e0689a737d98\",\r\n  \"name\": \"500ba737-5263-41fd-b19c-e0689a737d98\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/importExportOperationResults\",\r\n  \"properties\": {\r\n    \"requestId\": \"500ba737-5263-41fd-b19c-e0689a737d98\",\r\n    \"requestType\": \"Export\",\r\n    \"queuedTime\": \"6/22/2017 5:40:27 AM\",\r\n    \"lastModifiedTime\": \"6/22/2017 5:42:30 AM\",\r\n    \"blobUri\": \"https://sqlcrudtest3491.blob.core.windows.net/container/sqlcrudtest-3028.bacpac\",\r\n    \"serverName\": \"japaneast5955\",\r\n    \"databaseName\": \"sqlcrudtest-3028\",\r\n    \"status\": \"Completed\",\r\n    \"errorMessage\": null\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Length": [
-          "613"
-        ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
         ],
@@ -1551,13 +1377,19 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:33:24 GMT"
+          "Thu, 22 Jun 2017 05:42:57 GMT"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
         "x-ms-request-id": [
-          "73335249-42d3-4af8-90cb-ed38f6aaf15a"
+          "2bd6ef1d-f4b4-43a0-bb47-e4d54237abad"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1572,22 +1404,321 @@
           "14979"
         ],
         "x-ms-correlation-request-id": [
-          "eaf13109-e05a-47ba-9f0e-c88d4f2a4e10"
+          "3a68f3b8-296d-4fed-8571-b257dcb54e7b"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T183324Z:eaf13109-e05a-47ba-9f0e-c88d4f2a4e10"
+          "WESTUS2:20170622T054258Z:3a68f3b8-296d-4fed-8571-b257dcb54e7b"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/extensions/import?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zOTc0L2V4dGVuc2lvbnMvaW1wb3J0P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"storageKeyType\": \"StorageAccessKey\",\r\n    \"storageKey\": \"wHiSyb8kD9eM1aytXDkDcJvV6YRMphXgQoB7LXsNvSxg0ButTjpeu+apR0XcKZZya43gdwGwv9rc1QNAWmgimA==\",\r\n    \"storageUri\": \"https://sqlcrudtest3491.blob.core.windows.net/container/sqlcrudtest-3028.bacpac\",\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"administratorLoginPassword\": \"Un53cuRE!\",\r\n    \"authenticationType\": \"SQL\",\r\n    \"operationMode\": \"Import\"\r\n  }\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "438"
+        ],
+        "x-ms-client-request-id": [
+          "085d5f63-1103-45a3-a081-c12e6228fa37"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"operation\": \"Import\",\r\n  \"startTime\": \"2017-06-22T05:43:01.801Z\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "60"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:43:00 GMT"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/extensions/import/importExtensionOperationResults/4b046a4b-8c9a-4136-84f0-49f3e2cbb553?api-version=2014-04-01-Preview"
+        ],
+        "Retry-After": [
+          "30"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "29a4fbe2-f040-40b1-a658-a523706a9f6d"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Preference-Applied": [
+          "return-content"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1194"
+        ],
+        "x-ms-correlation-request-id": [
+          "e689478a-ff3c-4228-86fd-b6b75ee5db0b"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170622T054301Z:e689478a-ff3c-4228-86fd-b6b75ee5db0b"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/extensions/import/importExtensionOperationResults/4b046a4b-8c9a-4136-84f0-49f3e2cbb553?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zOTc0L2V4dGVuc2lvbnMvaW1wb3J0L2ltcG9ydEV4dGVuc2lvbk9wZXJhdGlvblJlc3VsdHMvNGIwNDZhNGItOGM5YS00MTM2LTg0ZjAtNDlmM2UyY2JiNTUzP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest3491.blob.core.windows.net/container/sqlcrudtest-3028.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-3974\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:43:01 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:43:01 AM\",\r\n  \"requestId\": \"4b046a4b-8c9a-4136-84f0-49f3e2cbb553\",\r\n  \"requestType\": \"Import\",\r\n  \"serverName\": \"japaneast5955.database.windows.net\",\r\n  \"status\": \"Running, Progress = 5.00 %\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "395"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:43:32 GMT"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/extensions/import/importExtensionOperationResults/4b046a4b-8c9a-4136-84f0-49f3e2cbb553?api-version=2014-04-01-Preview"
+        ],
+        "Retry-After": [
+          "30"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "ad125b4c-135c-438b-be72-eb950f9d6a22"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14978"
+        ],
+        "x-ms-correlation-request-id": [
+          "2dab167c-5405-4ffc-8777-9964d40767e5"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170622T054332Z:2dab167c-5405-4ffc-8777-9964d40767e5"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/extensions/import/importExtensionOperationResults/4b046a4b-8c9a-4136-84f0-49f3e2cbb553?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zOTc0L2V4dGVuc2lvbnMvaW1wb3J0L2ltcG9ydEV4dGVuc2lvbk9wZXJhdGlvblJlc3VsdHMvNGIwNDZhNGItOGM5YS00MTM2LTg0ZjAtNDlmM2UyY2JiNTUzP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest3491.blob.core.windows.net/container/sqlcrudtest-3028.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-3974\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:43:01 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:43:01 AM\",\r\n  \"requestId\": \"4b046a4b-8c9a-4136-84f0-49f3e2cbb553\",\r\n  \"requestType\": \"Import\",\r\n  \"serverName\": \"japaneast5955.database.windows.net\",\r\n  \"status\": \"Running, Progress = 5.00 %\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "395"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:44:02 GMT"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/extensions/import/importExtensionOperationResults/4b046a4b-8c9a-4136-84f0-49f3e2cbb553?api-version=2014-04-01-Preview"
+        ],
+        "Retry-After": [
+          "30"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "7364e036-9f5e-439a-b2aa-e298cdf928ae"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14977"
+        ],
+        "x-ms-correlation-request-id": [
+          "968eeb87-a80f-40b9-a447-ac71db3b7e31"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170622T054402Z:968eeb87-a80f-40b9-a447-ac71db3b7e31"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/extensions/import/importExtensionOperationResults/4b046a4b-8c9a-4136-84f0-49f3e2cbb553?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zOTc0L2V4dGVuc2lvbnMvaW1wb3J0L2ltcG9ydEV4dGVuc2lvbk9wZXJhdGlvblJlc3VsdHMvNGIwNDZhNGItOGM5YS00MTM2LTg0ZjAtNDlmM2UyY2JiNTUzP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest3491.blob.core.windows.net/container/sqlcrudtest-3028.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-3974\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:43:01 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:43:01 AM\",\r\n  \"requestId\": \"4b046a4b-8c9a-4136-84f0-49f3e2cbb553\",\r\n  \"requestType\": \"Import\",\r\n  \"serverName\": \"japaneast5955.database.windows.net\",\r\n  \"status\": \"Running, Progress = 5.00 %\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "395"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:44:32 GMT"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/extensions/import/importExtensionOperationResults/4b046a4b-8c9a-4136-84f0-49f3e2cbb553?api-version=2014-04-01-Preview"
+        ],
+        "Retry-After": [
+          "30"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "01993bc8-7c5a-4a0b-84dd-99a812ab0ebe"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14976"
+        ],
+        "x-ms-correlation-request-id": [
+          "35ee4091-fdb7-4a1d-b805-1155f7249c73"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170622T054432Z:35ee4091-fdb7-4a1d-b805-1155f7249c73"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/extensions/import/importExtensionOperationResults/4b046a4b-8c9a-4136-84f0-49f3e2cbb553?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU5ODcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q1OTU1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC0zOTc0L2V4dGVuc2lvbnMvaW1wb3J0L2ltcG9ydEV4dGVuc2lvbk9wZXJhdGlvblJlc3VsdHMvNGIwNDZhNGItOGM5YS00MTM2LTg0ZjAtNDlmM2UyY2JiNTUzP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5987/providers/Microsoft.Sql/servers/japaneast5955/databases/sqlcrudtest-3974/extensions/import\",\r\n  \"name\": \"import\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/extensions\",\r\n  \"properties\": {\r\n    \"requestId\": \"4b046a4b-8c9a-4136-84f0-49f3e2cbb553\",\r\n    \"requestType\": \"Import\",\r\n    \"queuedTime\": \"6/22/2017 5:43:01 AM\",\r\n    \"lastModifiedTime\": \"6/22/2017 5:45:01 AM\",\r\n    \"blobUri\": \"https://sqlcrudtest3491.blob.core.windows.net/container/sqlcrudtest-3028.bacpac\",\r\n    \"serverName\": \"japaneast5955\",\r\n    \"databaseName\": \"sqlcrudtest-3974\",\r\n    \"status\": \"Completed\",\r\n    \"errorMessage\": null\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "614"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:45:02 GMT"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "8889c1d2-8a64-4f30-a759-a975d5605182"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14975"
+        ],
+        "x-ms-correlation-request-id": [
+          "f7262cb4-f6e7-47d7-a02e-3236a5f22ffe"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170622T054503Z:f7262cb4-f6e7-47d7-a02e-3236a5f22ffe"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourcegroups/sqlcrudtest-8152?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTgxNTI/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourcegroups/sqlcrudtest-5987?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTU5ODc/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "c95b48ae-5a1f-4846-8ee6-d38f3195ea87"
+          "6912002a-79bd-495f-843a-6c2100209905"
         ],
         "accept-language": [
           "en-US"
@@ -1609,28 +1740,28 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:33:26 GMT"
+          "Thu, 22 Jun 2017 05:45:05 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TUUxDUlVEVEVTVDoyRDgxNTItSkFQQU5FQVNUIiwiam9iTG9jYXRpb24iOiJqYXBhbmVhc3QifQ?api-version=2017-05-10"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TUUxDUlVEVEVTVDoyRDU5ODctSkFQQU5FQVNUIiwiam9iTG9jYXRpb24iOiJqYXBhbmVhc3QifQ?api-version=2017-05-10"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1188"
+          "1198"
         ],
         "x-ms-request-id": [
-          "f2d5d08d-4834-441f-a4db-89cbf3f02867"
+          "c81f7a4d-89d2-40ca-8abb-05bc3e9e142b"
         ],
         "x-ms-correlation-request-id": [
-          "f2d5d08d-4834-441f-a4db-89cbf3f02867"
+          "c81f7a4d-89d2-40ca-8abb-05bc3e9e142b"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20170601T183326Z:f2d5d08d-4834-441f-a4db-89cbf3f02867"
+          "WESTUS2:20170622T054505Z:c81f7a4d-89d2-40ca-8abb-05bc3e9e142b"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1640,20 +1771,23 @@
     }
   ],
   "Names": {
-    "RunTestInNewResourceGroup": [
-      "sqlcrudtest-8152"
+    "CreateResourceGroup": [
+      "sqlcrudtest-5987"
+    ],
+    "CreateStorageContainer": [
+      "sqlcrudtest3491"
     ],
     "CreateServer": [
-      "sqlcrudtest-9490"
+      "japaneast5955"
     ],
     "TestImportExport": [
-      "sqlcrudtest-1364",
-      "sqlcrudtest-3665",
-      "sqlcrudstorage3273",
-      "sqlcrudtest-6127"
+      "sqlcrudtest-3028",
+      "sqlcrudtest-3974",
+      "sqlcrudstorage2689",
+      "sqlcrudtest-3002"
     ]
   },
   "Variables": {
-    "SubscriptionId": "f28872d6-4a93-4bb1-84b9-aecb02b6af4c"
+    "SubscriptionId": "2e7fe4bd-90c7-454e-8bb6-dc44649f27b2"
   }
 }

--- a/src/SDKs/SqlManagement/Sql.Tests/SessionRecords/Sql.Tests.ImportExportScenarioTests/TestImportNewDatabase.json
+++ b/src/SDKs/SqlManagement/Sql.Tests/SessionRecords/Sql.Tests.ImportExportScenarioTests/TestImportNewDatabase.json
@@ -1,10 +1,10 @@
 {
   "Entries": [
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourcegroups/sqlcrudtest-2393?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTIzOTM/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourcegroups/sqlcrudtest-5872?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTU4NzI/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"location\": \"Japan East\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-2393\": \"2017-06-01 18:33:30Z\"\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"location\": \"Japan East\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-5872\": \"2017-06-22 05:48:17Z\"\r\n  }\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -13,7 +13,7 @@
           "99"
         ],
         "x-ms-client-request-id": [
-          "1af7be6f-3bbf-4df4-a0a4-9ddb81cbacbb"
+          "af9eb778-d998-4e3e-ac2d-d0b18e2aa7c0"
         ],
         "accept-language": [
           "en-US"
@@ -23,7 +23,7 @@
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393\",\r\n  \"name\": \"sqlcrudtest-2393\",\r\n  \"location\": \"japaneast\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-2393\": \"2017-06-01 18:33:30Z\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872\",\r\n  \"name\": \"sqlcrudtest-5872\",\r\n  \"location\": \"japaneast\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-5872\": \"2017-06-22 05:48:17Z\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "239"
@@ -38,7 +38,7 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:33:32 GMT"
+          "Thu, 22 Jun 2017 05:48:19 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -47,13 +47,13 @@
           "1199"
         ],
         "x-ms-request-id": [
-          "aaca8919-5e31-43c2-9002-dc093ad8169f"
+          "8563b507-645e-4f53-ab1d-ebce1ab91905"
         ],
         "x-ms-correlation-request-id": [
-          "aaca8919-5e31-43c2-9002-dc093ad8169f"
+          "8563b507-645e-4f53-ab1d-ebce1ab91905"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183332Z:aaca8919-5e31-43c2-9002-dc093ad8169f"
+          "WESTUS:20170622T054819Z:8563b507-645e-4f53-ab1d-ebce1ab91905"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -62,8 +62,76 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252?api-version=2015-05-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyP2FwaS12ZXJzaW9uPTIwMTUtMDUtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Storage/storageAccounts/sqlcrudtest5550?api-version=2017-06-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TdG9yYWdlL3N0b3JhZ2VBY2NvdW50cy9zcWxjcnVkdGVzdDU1NTA/YXBpLXZlcnNpb249MjAxNy0wNi0wMQ==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\"\r\n  },\r\n  \"kind\": \"BlobStorage\",\r\n  \"location\": \"japaneast\",\r\n  \"properties\": {\r\n    \"accessTier\": \"Cool\"\r\n  }\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "154"
+        ],
+        "x-ms-client-request-id": [
+          "525bf844-056f-4746-ba0c-ceada07c5ecf"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Storage.StorageManagementClient/6.5.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:48:24 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/providers/Microsoft.Storage/operations/fb2ec8e4-fb56-478d-9f65-37eb62b21b4c?monitor=true&api-version=2017-06-01"
+        ],
+        "Retry-After": [
+          "17"
+        ],
+        "Server": [
+          "Microsoft-Azure-Storage-Resource-Provider/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "x-ms-request-id": [
+          "434879c9-8fcf-46b7-9595-3a9c0c3d92c5"
+        ],
+        "x-ms-correlation-request-id": [
+          "434879c9-8fcf-46b7-9595-3a9c0c3d92c5"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170622T054824Z:434879c9-8fcf-46b7-9595-3a9c0c3d92c5"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154?api-version=2015-05-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0P2FwaS12ZXJzaW9uPTIwMTUtMDUtMDEtcHJldmlldw==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"administratorLoginPassword\": \"Un53cuRE!\",\r\n    \"version\": \"12.0\"\r\n  },\r\n  \"tags\": {},\r\n  \"location\": \"japaneast\"\r\n}",
       "RequestHeaders": {
@@ -74,17 +142,17 @@
           "183"
         ],
         "x-ms-client-request-id": [
-          "92b8c626-60ff-4caf-8c9e-13ab496de740"
+          "d810d98a-add7-4831-9644-2771d69522d4"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"UpsertLogicalServer\",\r\n  \"startTime\": \"2017-06-01T18:33:33.353Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"UpsertLogicalServer\",\r\n  \"startTime\": \"2017-06-22T05:48:25.103Z\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "74"
@@ -99,13 +167,13 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:33:34 GMT"
+          "Thu, 22 Jun 2017 05:48:23 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/providers/Microsoft.Sql/locations/japaneast/serverOperationResults/011e16de-b346-4930-bd2f-bff0b1172cd4?api-version=2015-05-01-preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/providers/Microsoft.Sql/locations/japaneast/serverOperationResults/b5f65f04-6758-4795-bbe4-3c3022b2c1a8?api-version=2015-05-01-preview"
         ],
         "Retry-After": [
           "60"
@@ -114,19 +182,19 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/providers/Microsoft.Sql/locations/japaneast/serverAzureAsyncOperation/011e16de-b346-4930-bd2f-bff0b1172cd4?api-version=2015-05-01-preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/providers/Microsoft.Sql/locations/japaneast/serverAzureAsyncOperation/b5f65f04-6758-4795-bbe4-3c3022b2c1a8?api-version=2015-05-01-preview"
         ],
         "x-ms-request-id": [
-          "011e16de-b346-4930-bd2f-bff0b1172cd4"
+          "b5f65f04-6758-4795-bbe4-3c3022b2c1a8"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1198"
+          "1199"
         ],
         "x-ms-correlation-request-id": [
-          "04a2f66a-b348-4147-bb71-291ef90de4b1"
+          "3ccbc304-2464-429d-801d-715e964db7ea"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183334Z:04a2f66a-b348-4147-bb71-291ef90de4b1"
+          "WESTUS:20170622T054824Z:3ccbc304-2464-429d-801d-715e964db7ea"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -135,17 +203,73 @@
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/providers/Microsoft.Sql/locations/japaneast/serverAzureAsyncOperation/011e16de-b346-4930-bd2f-bff0b1172cd4?api-version=2015-05-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9qYXBhbmVhc3Qvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8wMTFlMTZkZS1iMzQ2LTQ5MzAtYmQyZi1iZmYwYjExNzJjZDQ/YXBpLXZlcnNpb249MjAxNS0wNS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/providers/Microsoft.Storage/operations/fb2ec8e4-fb56-478d-9f65-37eb62b21b4c?monitor=true&api-version=2017-06-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3RvcmFnZS9vcGVyYXRpb25zL2ZiMmVjOGU0LWZiNTYtNDc4ZC05ZjY1LTM3ZWI2MmIyMWI0Yz9tb25pdG9yPXRydWUmYXBpLXZlcnNpb249MjAxNy0wNi0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Storage.StorageManagementClient/6.5.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"011e16de-b346-4930-bd2f-bff0b1172cd4\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2017-06-01T18:33:33.353Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Storage/storageAccounts/sqlcrudtest5550\",\r\n  \"kind\": \"BlobStorage\",\r\n  \"location\": \"japaneast\",\r\n  \"name\": \"sqlcrudtest5550\",\r\n  \"properties\": {\r\n    \"accessTier\": \"Cool\",\r\n    \"creationTime\": \"2017-06-22T05:48:24.1221223Z\",\r\n    \"primaryEndpoints\": {\r\n      \"blob\": \"https://sqlcrudtest5550.blob.core.windows.net/\",\r\n      \"table\": \"https://sqlcrudtest5550.table.core.windows.net/\"\r\n    },\r\n    \"primaryLocation\": \"japaneast\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"statusOfPrimary\": \"available\",\r\n    \"supportsHttpsTrafficOnly\": false\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n  },\r\n  \"tags\": {},\r\n  \"type\": \"Microsoft.Storage/storageAccounts\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:48:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-Azure-Storage-Resource-Provider/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "90f2298b-a017-457f-af68-23754107eb63"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14994"
+        ],
+        "x-ms-correlation-request-id": [
+          "90f2298b-a017-457f-af68-23754107eb63"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170622T054855Z:90f2298b-a017-457f-af68-23754107eb63"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/providers/Microsoft.Sql/locations/japaneast/serverAzureAsyncOperation/b5f65f04-6758-4795-bbe4-3c3022b2c1a8?api-version=2015-05-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9qYXBhbmVhc3Qvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi9iNWY2NWYwNC02NzU4LTQ3OTUtYmJlNC0zYzMwMjJiMmMxYTg/YXBpLXZlcnNpb249MjAxNS0wNS0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"b5f65f04-6758-4795-bbe4-3c3022b2c1a8\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2017-06-22T05:48:25.103Z\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -157,7 +281,7 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:34:04 GMT"
+          "Thu, 22 Jun 2017 05:48:55 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -172,16 +296,16 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "caf3cdd6-98a5-47d3-8766-f04bdc8d417b"
+          "e50ab230-2fe2-4f25-bd29-d3980e30e964"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14999"
+          "14987"
         ],
         "x-ms-correlation-request-id": [
-          "39a55839-98ea-4ea2-ba89-4c050c32e64f"
+          "7b83b86c-5dcc-4252-99c1-84e1085325c1"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183405Z:39a55839-98ea-4ea2-ba89-4c050c32e64f"
+          "WESTUS:20170622T054855Z:7b83b86c-5dcc-4252-99c1-84e1085325c1"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -190,17 +314,17 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/providers/Microsoft.Sql/locations/japaneast/serverAzureAsyncOperation/011e16de-b346-4930-bd2f-bff0b1172cd4?api-version=2015-05-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9qYXBhbmVhc3Qvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8wMTFlMTZkZS1iMzQ2LTQ5MzAtYmQyZi1iZmYwYjExNzJjZDQ/YXBpLXZlcnNpb249MjAxNS0wNS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154?api-version=2015-05-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0P2FwaS12ZXJzaW9uPTIwMTUtMDUtMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"011e16de-b346-4930-bd2f-bff0b1172cd4\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2017-06-01T18:33:33.353Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"version\": \"12.0\",\r\n    \"state\": \"Ready\",\r\n    \"fullyQualifiedDomainName\": \"japaneast4154.database.windows.net\"\r\n  },\r\n  \"location\": \"japaneast\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154\",\r\n  \"name\": \"japaneast4154\",\r\n  \"type\": \"Microsoft.Sql/servers\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -212,7 +336,7 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:34:34 GMT"
+          "Thu, 22 Jun 2017 05:48:56 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -227,16 +351,16 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "4ec840a3-1040-43ff-942a-86827b1f6f4e"
+          "51ff9d5e-796c-4670-8bac-20f2ea78cbef"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14998"
+          "14986"
         ],
         "x-ms-correlation-request-id": [
-          "c36af36a-059f-43e5-92be-cf6b92cb32cf"
+          "1ce1fcc8-d31a-4a38-82bf-455b48de5bc4"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183435Z:c36af36a-059f-43e5-92be-cf6b92cb32cf"
+          "WESTUS:20170622T054856Z:1ce1fcc8-d31a-4a38-82bf-455b48de5bc4"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -245,20 +369,26 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252?api-version=2015-05-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyP2FwaS12ZXJzaW9uPTIwMTUtMDUtMDEtcHJldmlldw==",
-      "RequestMethod": "GET",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Storage/storageAccounts/sqlcrudtest5550/listKeys?api-version=2017-06-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TdG9yYWdlL3N0b3JhZ2VBY2NvdW50cy9zcWxjcnVkdGVzdDU1NTAvbGlzdEtleXM/YXBpLXZlcnNpb249MjAxNy0wNi0wMQ==",
+      "RequestMethod": "POST",
       "RequestBody": "",
       "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "1fe4d930-6007-4d1b-8d29-3923672bada5"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Storage.StorageManagementClient/6.5.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252\",\r\n  \"name\": \"sqlcrudtest-1252\",\r\n  \"type\": \"Microsoft.Sql/servers\",\r\n  \"location\": \"japaneast\",\r\n  \"kind\": \"v12.0\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"version\": \"12.0\",\r\n    \"state\": \"Ready\",\r\n    \"fullyQualifiedDomainName\": \"sqlcrudtest-1252.database.windows.net\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"keys\": [\r\n    {\r\n      \"keyName\": \"key1\",\r\n      \"permissions\": \"Full\",\r\n      \"value\": \"a68yk4cJ4ISuWtYyV5q/pMfrUdDQooy/e5/v+0CYz2PaeiVb0pYflsUYnk6Wa8KJXDeBF6X6WBATx7t3zHo+8g==\"\r\n    },\r\n    {\r\n      \"keyName\": \"key2\",\r\n      \"permissions\": \"Full\",\r\n      \"value\": \"d0AlfoO+o5fmxOb9liA+wy3BII6pDHs3e0VhtEGOK4tTkkhCQAurFcOVm9zsALh4fep+C7q7/Kj5hBnCUx0Vjw==\"\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
-          "application/json; charset=utf-8"
+          "application/json"
         ],
         "Expires": [
           "-1"
@@ -267,7 +397,7 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:34:35 GMT"
+          "Thu, 22 Jun 2017 05:48:56 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -276,22 +406,23 @@
           "chunked"
         ],
         "Server": [
+          "Microsoft-Azure-Storage-Resource-Provider/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Vary": [
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "035e2f52-443d-4bf9-bef8-2738857e3c15"
+          "c7654d3d-5a66-47ff-a62a-98c72669ba71"
         ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14997"
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1198"
         ],
         "x-ms-correlation-request-id": [
-          "a8547bc9-bdb8-4591-b186-0c567d9d4eae"
+          "c7654d3d-5a66-47ff-a62a-98c72669ba71"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183436Z:a8547bc9-bdb8-4591-b186-0c567d9d4eae"
+          "WESTUS:20170622T054857Z:c7654d3d-5a66-47ff-a62a-98c72669ba71"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -300,8 +431,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/firewallRules/sqlcrudtest-6510?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2ZpcmV3YWxsUnVsZXMvc3FsY3J1ZHRlc3QtNjUxMD9hcGktdmVyc2lvbj0yMDE0LTA0LTAx",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/firewallRules/sqlcrudtest-5583?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2ZpcmV3YWxsUnVsZXMvc3FsY3J1ZHRlc3QtNTU4Mz9hcGktdmVyc2lvbj0yMDE0LTA0LTAx",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"properties\": {\r\n    \"startIpAddress\": \"0.0.0.0\",\r\n    \"endIpAddress\": \"255.255.255.255\"\r\n  }\r\n}",
       "RequestHeaders": {
@@ -312,20 +443,20 @@
           "101"
         ],
         "x-ms-client-request-id": [
-          "18ec51c3-8698-4fdf-b664-f65b712c8783"
+          "fbe41db2-f789-4ddc-bc42-a5c15970f3ab"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/firewallRules/sqlcrudtest-6510\",\r\n  \"name\": \"sqlcrudtest-6510\",\r\n  \"type\": \"Microsoft.Sql/servers/firewallRules\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"startIpAddress\": \"0.0.0.0\",\r\n    \"endIpAddress\": \"255.255.255.255\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/firewallRules/sqlcrudtest-5583\",\r\n  \"name\": \"sqlcrudtest-5583\",\r\n  \"type\": \"Microsoft.Sql/servers/firewallRules\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"startIpAddress\": \"0.0.0.0\",\r\n    \"endIpAddress\": \"255.255.255.255\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "357"
+          "354"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -334,13 +465,13 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:34:37 GMT"
+          "Thu, 22 Jun 2017 05:48:58 GMT"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "f34e4280-fb05-4d2b-801f-88cf77bc36f2"
+          "5dcb2e97-4663-4999-8f4a-792cc44fa222"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -355,20 +486,20 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1197"
+          "1198"
         ],
         "x-ms-correlation-request-id": [
-          "375413cd-4e9f-468c-808f-a3d32412077b"
+          "7023c324-8b7b-43d0-84e7-17dd3d6641cb"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183438Z:375413cd-4e9f-468c-808f-a3d32412077b"
+          "WESTUS:20170622T054858Z:7023c324-8b7b-43d0-84e7-17dd3d6641cb"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NTg1P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01Njk/YXBpLXZlcnNpb249MjAxNC0wNC0wMQ==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"location\": \"japaneast\"\r\n}",
       "RequestHeaders": {
@@ -379,17 +510,17 @@
           "31"
         ],
         "x-ms-client-request-id": [
-          "02c16e2f-0b2c-4b1e-927f-5f3b133a78dc"
+          "703570bd-b758-40fb-8b60-16951d918afd"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2017-06-01T11:34:40.531-07:00\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2017-06-21T22:49:00.972-07:00\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "80"
@@ -401,10 +532,10 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:34:39 GMT"
+          "Thu, 22 Jun 2017 05:49:00 GMT"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/operationResults/e031bb0e-44a2-4393-81eb-7579fd89bc0d?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/operationResults/3e93d2b7-4e33-4b84-bfd5-1c1ce9879222?api-version=2014-04-01-Preview"
         ],
         "Retry-After": [
           "30"
@@ -413,7 +544,7 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "e031bb0e-44a2-4393-81eb-7579fd89bc0d"
+          "3e93d2b7-4e33-4b84-bfd5-1c1ce9879222"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -428,32 +559,32 @@
           "max-age=31536000; includeSubDomains"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/azureAsyncOperation/e031bb0e-44a2-4393-81eb-7579fd89bc0d?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/azureAsyncOperation/3e93d2b7-4e33-4b84-bfd5-1c1ce9879222?api-version=2014-04-01-Preview"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1196"
+          "1197"
         ],
         "x-ms-correlation-request-id": [
-          "0ef2d92b-9a62-4fa2-860d-951d683d1841"
+          "01e20971-8da0-4997-8c0a-45817a20d9bb"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183440Z:0ef2d92b-9a62-4fa2-860d-951d683d1841"
+          "WESTUS:20170622T054900Z:01e20971-8da0-4997-8c0a-45817a20d9bb"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/azureAsyncOperation/e031bb0e-44a2-4393-81eb-7579fd89bc0d?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NTg1L2F6dXJlQXN5bmNPcGVyYXRpb24vZTAzMWJiMGUtNDRhMi00MzkzLTgxZWItNzU3OWZkODliYzBkP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/azureAsyncOperation/3e93d2b7-4e33-4b84-bfd5-1c1ce9879222?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NjkvYXp1cmVBc3luY09wZXJhdGlvbi8zZTkzZDJiNy00ZTMzLTRiODQtYmZkNS0xYzFjZTk4NzkyMjI/YXBpLXZlcnNpb249MjAxNC0wNC0wMS1QcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"operationId\": \"e031bb0e-44a2-4393-81eb-7579fd89bc0d\",\r\n  \"status\": \"InProgress\",\r\n  \"error\": null\r\n}",
+      "ResponseBody": "{\r\n  \"operationId\": \"3e93d2b7-4e33-4b84-bfd5-1c1ce9879222\",\r\n  \"status\": \"InProgress\",\r\n  \"error\": null\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -462,7 +593,7 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:35:10 GMT"
+          "Thu, 22 Jun 2017 05:49:31 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
@@ -474,7 +605,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "74f6a517-c99b-4638-8fd0-b3e26c515272"
+          "e2e5861c-5747-439e-80d3-81f3b4202bcb"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -486,32 +617,32 @@
           "max-age=31536000; includeSubDomains"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/azureAsyncOperation/e031bb0e-44a2-4393-81eb-7579fd89bc0d?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/azureAsyncOperation/3e93d2b7-4e33-4b84-bfd5-1c1ce9879222?api-version=2014-04-01-Preview"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14996"
+          "14985"
         ],
         "x-ms-correlation-request-id": [
-          "748399a7-97ed-4bf6-91df-177d11de1124"
+          "3bc6d415-219f-4056-a868-baf69168672b"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183510Z:748399a7-97ed-4bf6-91df-177d11de1124"
+          "WESTUS:20170622T054931Z:3bc6d415-219f-4056-a868-baf69168672b"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/azureAsyncOperation/e031bb0e-44a2-4393-81eb-7579fd89bc0d?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NTg1L2F6dXJlQXN5bmNPcGVyYXRpb24vZTAzMWJiMGUtNDRhMi00MzkzLTgxZWItNzU3OWZkODliYzBkP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/azureAsyncOperation/3e93d2b7-4e33-4b84-bfd5-1c1ce9879222?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NjkvYXp1cmVBc3luY09wZXJhdGlvbi8zZTkzZDJiNy00ZTMzLTRiODQtYmZkNS0xYzFjZTk4NzkyMjI/YXBpLXZlcnNpb249MjAxNC0wNC0wMS1QcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"operationId\": \"e031bb0e-44a2-4393-81eb-7579fd89bc0d\",\r\n  \"status\": \"Succeeded\",\r\n  \"error\": null\r\n}",
+      "ResponseBody": "{\r\n  \"operationId\": \"3e93d2b7-4e33-4b84-bfd5-1c1ce9879222\",\r\n  \"status\": \"Succeeded\",\r\n  \"error\": null\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -520,7 +651,7 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:35:40 GMT"
+          "Thu, 22 Jun 2017 05:50:01 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
@@ -532,7 +663,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "bba31221-5d76-4017-8bb6-89119845acae"
+          "e24938cf-deb5-4d09-963b-f796576942a3"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -544,32 +675,32 @@
           "max-age=31536000; includeSubDomains"
         ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/azureAsyncOperation/e031bb0e-44a2-4393-81eb-7579fd89bc0d?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/azureAsyncOperation/3e93d2b7-4e33-4b84-bfd5-1c1ce9879222?api-version=2014-04-01-Preview"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14995"
+          "14985"
         ],
         "x-ms-correlation-request-id": [
-          "9d1c9451-1a2b-4c4f-b6c1-75fb2d0f6750"
+          "237cd6a0-3e1a-4313-9396-a3bbe10ae227"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183540Z:9d1c9451-1a2b-4c4f-b6c1-75fb2d0f6750"
+          "WESTUS:20170622T055001Z:237cd6a0-3e1a-4313-9396-a3bbe10ae227"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NTg1P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01Njk/YXBpLXZlcnNpb249MjAxNC0wNC0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585\",\r\n  \"name\": \"sqlcrudtest-8585\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"databaseId\": \"24b627bf-671b-4baf-833e-feea1ef3a87a\",\r\n    \"edition\": \"Standard\",\r\n    \"status\": \"Online\",\r\n    \"serviceLevelObjective\": \"S0\",\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": \"268435456000\",\r\n    \"creationDate\": \"2017-06-01T18:34:40.78Z\",\r\n    \"currentServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveName\": \"S0\",\r\n    \"sampleName\": null,\r\n    \"defaultSecondaryLocation\": \"Japan West\",\r\n    \"earliestRestoreDate\": \"2017-06-01T18:45:17.447Z\",\r\n    \"elasticPoolName\": null,\r\n    \"containmentState\": 2,\r\n    \"readScale\": \"Disabled\",\r\n    \"failoverGroupId\": null\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569\",\r\n  \"name\": \"sqlcrudtest-569\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\",\r\n  \"location\": \"Japan East\",\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"databaseId\": \"85ffc533-807e-4bf9-bae2-485190cf0ad7\",\r\n    \"edition\": \"Standard\",\r\n    \"status\": \"Online\",\r\n    \"serviceLevelObjective\": \"S0\",\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": \"268435456000\",\r\n    \"creationDate\": \"2017-06-22T05:49:01.257Z\",\r\n    \"currentServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveId\": \"f1173c43-91bd-4aaa-973c-54e79e15235b\",\r\n    \"requestedServiceObjectiveName\": \"S0\",\r\n    \"sampleName\": null,\r\n    \"defaultSecondaryLocation\": \"Japan West\",\r\n    \"earliestRestoreDate\": \"2017-06-22T05:59:36.293Z\",\r\n    \"elasticPoolName\": null,\r\n    \"containmentState\": 2,\r\n    \"readScale\": \"Disabled\",\r\n    \"failoverGroupId\": null\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -578,7 +709,7 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:35:41 GMT"
+          "Thu, 22 Jun 2017 05:50:01 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
@@ -590,7 +721,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "ccc8e496-9ac2-44a3-9764-3a0945881fc4"
+          "76b834c1-12ab-425a-acc9-5cc91e6da9d8"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -602,41 +733,41 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14994"
+          "14984"
         ],
         "x-ms-correlation-request-id": [
-          "66d2c074-d325-46d0-b9e0-ad1de67a8fbe"
+          "ec591537-d9ab-434e-8dc8-a02d62b404a0"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183541Z:66d2c074-d325-46d0-b9e0-ad1de67a8fbe"
+          "WESTUS:20170622T055002Z:ec591537-d9ab-434e-8dc8-a02d62b404a0"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/export?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NTg1L2V4cG9ydD9hcGktdmVyc2lvbj0yMDE0LTA0LTAx",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/export?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NjkvZXhwb3J0P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDE=",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"storageKeyType\": \"StorageAccessKey\",\r\n  \"storageKey\": \"xxxx\",\r\n  \"storageUri\": \"https://sqlcrudtest.blob.core.windows.net/bacpacs/sqlcrudtest-8585.bacpac\",\r\n  \"administratorLogin\": \"dummylogin\",\r\n  \"administratorLoginPassword\": \"Un53cuRE!\",\r\n  \"authenticationType\": \"SQL\"\r\n}",
+      "RequestBody": "{\r\n  \"storageKeyType\": \"StorageAccessKey\",\r\n  \"storageKey\": \"a68yk4cJ4ISuWtYyV5q/pMfrUdDQooy/e5/v+0CYz2PaeiVb0pYflsUYnk6Wa8KJXDeBF6X6WBATx7t3zHo+8g==\",\r\n  \"storageUri\": \"https://sqlcrudtest5550.blob.core.windows.net/container/sqlcrudtest-569.bacpac\",\r\n  \"administratorLogin\": \"dummylogin\",\r\n  \"administratorLoginPassword\": \"Un53cuRE!\",\r\n  \"authenticationType\": \"SQL\"\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "365"
+          "369"
         ],
         "x-ms-client-request-id": [
-          "d602e8fe-8464-4bc8-b198-ca6180f833a4"
+          "fc684d06-1af3-485f-ac30-7ed92cffcda6"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"Export\",\r\n  \"startTime\": \"2017-06-01T18:35:41.182Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"Export\",\r\n  \"startTime\": \"2017-06-22T05:50:04.061Z\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "60"
@@ -648,10 +779,10 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:35:42 GMT"
+          "Thu, 22 Jun 2017 05:50:03 GMT"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/importExportOperationResults/cb70d4fe-ef43-42c6-a603-4309e95894c7?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview"
         ],
         "Retry-After": [
           "30"
@@ -660,7 +791,425 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "fb281492-9b77-451d-9050-5edfe7c8d0c4"
+          "da840aa9-aa7a-4e06-97af-aef3027cbe13"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Preference-Applied": [
+          "return-content"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1196"
+        ],
+        "x-ms-correlation-request-id": [
+          "7d26c515-03a5-416d-8350-a25a6c2785a7"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170622T055004Z:7d26c515-03a5-416d-8350-a25a6c2785a7"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NjkvaW1wb3J0RXhwb3J0T3BlcmF0aW9uUmVzdWx0cy80NTExMzg5ZC01NjNhLTQxNGYtYTMxNy0wNDMyOWY0ZmFmZTY/YXBpLXZlcnNpb249MjAxNC0wNC0wMS1QcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest5550.blob.core.windows.net/container/sqlcrudtest-569.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-569\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:50:06 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:50:04 AM\",\r\n  \"requestId\": \"4511389d-563a-414f-a317-04329f4fafe6\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"japaneast4154.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "389"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:50:34 GMT"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview"
+        ],
+        "Retry-After": [
+          "30"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "586d2a6b-7af6-4cb6-9f1a-5bdafae6bfe0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14983"
+        ],
+        "x-ms-correlation-request-id": [
+          "7d56a582-a345-4565-af31-5a16736102c1"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170622T055034Z:7d56a582-a345-4565-af31-5a16736102c1"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NjkvaW1wb3J0RXhwb3J0T3BlcmF0aW9uUmVzdWx0cy80NTExMzg5ZC01NjNhLTQxNGYtYTMxNy0wNDMyOWY0ZmFmZTY/YXBpLXZlcnNpb249MjAxNC0wNC0wMS1QcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest5550.blob.core.windows.net/container/sqlcrudtest-569.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-569\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:50:06 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:50:04 AM\",\r\n  \"requestId\": \"4511389d-563a-414f-a317-04329f4fafe6\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"japaneast4154.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "389"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:51:04 GMT"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview"
+        ],
+        "Retry-After": [
+          "30"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "ec01b3ad-85be-4b2e-8563-9f0aac5168a0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14982"
+        ],
+        "x-ms-correlation-request-id": [
+          "bfbf3467-b1e9-4b3c-9bcd-54082e94de69"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170622T055105Z:bfbf3467-b1e9-4b3c-9bcd-54082e94de69"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NjkvaW1wb3J0RXhwb3J0T3BlcmF0aW9uUmVzdWx0cy80NTExMzg5ZC01NjNhLTQxNGYtYTMxNy0wNDMyOWY0ZmFmZTY/YXBpLXZlcnNpb249MjAxNC0wNC0wMS1QcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest5550.blob.core.windows.net/container/sqlcrudtest-569.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-569\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:50:06 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:50:04 AM\",\r\n  \"requestId\": \"4511389d-563a-414f-a317-04329f4fafe6\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"japaneast4154.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "389"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:51:34 GMT"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview"
+        ],
+        "Retry-After": [
+          "30"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "fb4e287a-cb06-4f01-946e-0c9bfae4119b"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14981"
+        ],
+        "x-ms-correlation-request-id": [
+          "8db7a35e-d058-4d37-9e57-be1e679341c1"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170622T055135Z:8db7a35e-d058-4d37-9e57-be1e679341c1"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NjkvaW1wb3J0RXhwb3J0T3BlcmF0aW9uUmVzdWx0cy80NTExMzg5ZC01NjNhLTQxNGYtYTMxNy0wNDMyOWY0ZmFmZTY/YXBpLXZlcnNpb249MjAxNC0wNC0wMS1QcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest5550.blob.core.windows.net/container/sqlcrudtest-569.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-569\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:50:06 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:50:04 AM\",\r\n  \"requestId\": \"4511389d-563a-414f-a317-04329f4fafe6\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"japaneast4154.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "389"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:52:04 GMT"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview"
+        ],
+        "Retry-After": [
+          "30"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "43d26c65-e874-4792-b418-6f03c696d49f"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14980"
+        ],
+        "x-ms-correlation-request-id": [
+          "42200721-9ab0-4fed-913c-087300fa468d"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170622T055205Z:42200721-9ab0-4fed-913c-087300fa468d"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NjkvaW1wb3J0RXhwb3J0T3BlcmF0aW9uUmVzdWx0cy80NTExMzg5ZC01NjNhLTQxNGYtYTMxNy0wNDMyOWY0ZmFmZTY/YXBpLXZlcnNpb249MjAxNC0wNC0wMS1QcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest5550.blob.core.windows.net/container/sqlcrudtest-569.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-569\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:50:06 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:50:04 AM\",\r\n  \"requestId\": \"4511389d-563a-414f-a317-04329f4fafe6\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"japaneast4154.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "389"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:52:35 GMT"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview"
+        ],
+        "Retry-After": [
+          "30"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "d7be7b63-8c98-4c66-93d5-d0ba08a3e649"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14979"
+        ],
+        "x-ms-correlation-request-id": [
+          "e347750b-bd48-488d-b4b4-3c067fea5183"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170622T055235Z:e347750b-bd48-488d-b4b4-3c067fea5183"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NjkvaW1wb3J0RXhwb3J0T3BlcmF0aW9uUmVzdWx0cy80NTExMzg5ZC01NjNhLTQxNGYtYTMxNy0wNDMyOWY0ZmFmZTY/YXBpLXZlcnNpb249MjAxNC0wNC0wMS1QcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/databases/sqlcrudtest-569/importExportOperationResults/4511389d-563a-414f-a317-04329f4fafe6\",\r\n  \"name\": \"4511389d-563a-414f-a317-04329f4fafe6\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/importExportOperationResults\",\r\n  \"properties\": {\r\n    \"requestId\": \"4511389d-563a-414f-a317-04329f4fafe6\",\r\n    \"requestType\": \"Export\",\r\n    \"queuedTime\": \"6/22/2017 5:50:04 AM\",\r\n    \"lastModifiedTime\": \"6/22/2017 5:52:47 AM\",\r\n    \"blobUri\": \"https://sqlcrudtest5550.blob.core.windows.net/container/sqlcrudtest-569.bacpac\",\r\n    \"serverName\": \"japaneast4154\",\r\n    \"databaseName\": \"sqlcrudtest-569\",\r\n    \"status\": \"Completed\",\r\n    \"errorMessage\": null\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:53:06 GMT"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "9cbc49de-c231-4237-a47e-804bf8699e14"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14978"
+        ],
+        "x-ms-correlation-request-id": [
+          "860130b5-853c-4186-916c-ea3a45a3a34d"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170622T055306Z:860130b5-853c-4186-916c-ea3a45a3a34d"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/import?api-version=2014-04-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2ltcG9ydD9hcGktdmVyc2lvbj0yMDE0LTA0LTAx",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"databaseName\": \"sqlcrudtest-5280\",\r\n  \"edition\": \"Basic\",\r\n  \"serviceObjectiveName\": \"Basic\",\r\n  \"maxSizeBytes\": \"2147483648\",\r\n  \"storageKeyType\": \"StorageAccessKey\",\r\n  \"storageKey\": \"a68yk4cJ4ISuWtYyV5q/pMfrUdDQooy/e5/v+0CYz2PaeiVb0pYflsUYnk6Wa8KJXDeBF6X6WBATx7t3zHo+8g==\",\r\n  \"storageUri\": \"https://sqlcrudtest5550.blob.core.windows.net/container/sqlcrudtest-569.bacpac\",\r\n  \"administratorLogin\": \"dummylogin\",\r\n  \"administratorLoginPassword\": \"Un53cuRE!\",\r\n  \"authenticationType\": \"SQL\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "500"
+        ],
+        "x-ms-client-request-id": [
+          "7bb0e871-bee0-4999-a6fc-865c42e40e74"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"operation\": \"Import\",\r\n  \"startTime\": \"2017-06-22T05:53:07.282Z\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "60"
+        ],
+        "Content-Type": [
+          "application/xml; charset=utf-8"
+        ],
+        "Cache-Control": [
+          "no-store, no-cache"
+        ],
+        "Date": [
+          "Thu, 22 Jun 2017 05:53:07 GMT"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/importExportOperationResults/9313cf68-bf63-495c-bc9d-694fa0c3d051?api-version=2014-04-01-Preview"
+        ],
+        "Retry-After": [
+          "30"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "4ad7b22a-66c8-44f4-8558-1df928d1819b"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -678,29 +1227,29 @@
           "1195"
         ],
         "x-ms-correlation-request-id": [
-          "774f9c50-2ef1-4cd6-b8f3-d422dc3d7684"
+          "38cdd108-ff9a-4070-b0f5-cca0774a40ab"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183543Z:774f9c50-2ef1-4cd6-b8f3-d422dc3d7684"
+          "WESTUS:20170622T055308Z:38cdd108-ff9a-4070-b0f5-cca0774a40ab"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/importExportOperationResults/cb70d4fe-ef43-42c6-a603-4309e95894c7?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NTg1L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvY2I3MGQ0ZmUtZWY0My00MmM2LWE2MDMtNDMwOWU5NTg5NGM3P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/importExportOperationResults/9313cf68-bf63-495c-bc9d-694fa0c3d051?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvOTMxM2NmNjgtYmY2My00OTVjLWJjOWQtNjk0ZmEwYzNkMDUxP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest.blob.core.windows.net/bacpacs/sqlcrudtest-8585.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-8585\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:35:44 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:35:42 PM\",\r\n  \"requestId\": \"cb70d4fe-ef43-42c6-a603-4309e95894c7\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"sqlcrudtest-1252.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest5550.blob.core.windows.net/container/sqlcrudtest-569.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-5280\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:53:08 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:53:08 AM\",\r\n  \"requestId\": \"9313cf68-bf63-495c-bc9d-694fa0c3d051\",\r\n  \"requestType\": \"Import\",\r\n  \"serverName\": \"japaneast4154.database.windows.net\",\r\n  \"status\": \"Running, Progress = 5.00 %\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "387"
+          "394"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -709,10 +1258,10 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:36:13 GMT"
+          "Thu, 22 Jun 2017 05:53:38 GMT"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/importExportOperationResults/cb70d4fe-ef43-42c6-a603-4309e95894c7?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/importExportOperationResults/9313cf68-bf63-495c-bc9d-694fa0c3d051?api-version=2014-04-01-Preview"
         ],
         "Retry-After": [
           "30"
@@ -721,7 +1270,7 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "3d39ec82-dd55-46bc-83a4-25e28fe5fcdb"
+          "4925afc7-a9c8-4902-b770-b95f85f344d0"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -733,32 +1282,32 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14993"
+          "14977"
         ],
         "x-ms-correlation-request-id": [
-          "37140d8e-f43a-4649-9ac0-552aaadc2cd3"
+          "bf8702a6-2b76-4b3b-98b2-db0b4a01c83f"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183614Z:37140d8e-f43a-4649-9ac0-552aaadc2cd3"
+          "WESTUS:20170622T055339Z:bf8702a6-2b76-4b3b-98b2-db0b4a01c83f"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/importExportOperationResults/cb70d4fe-ef43-42c6-a603-4309e95894c7?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NTg1L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvY2I3MGQ0ZmUtZWY0My00MmM2LWE2MDMtNDMwOWU5NTg5NGM3P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/importExportOperationResults/9313cf68-bf63-495c-bc9d-694fa0c3d051?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvOTMxM2NmNjgtYmY2My00OTVjLWJjOWQtNjk0ZmEwYzNkMDUxP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest.blob.core.windows.net/bacpacs/sqlcrudtest-8585.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-8585\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:35:44 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:35:42 PM\",\r\n  \"requestId\": \"cb70d4fe-ef43-42c6-a603-4309e95894c7\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"sqlcrudtest-1252.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
+      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest5550.blob.core.windows.net/container/sqlcrudtest-569.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-5280\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/22/2017 5:53:08 AM\",\r\n  \"queuedTime\": \"6/22/2017 5:53:08 AM\",\r\n  \"requestId\": \"9313cf68-bf63-495c-bc9d-694fa0c3d051\",\r\n  \"requestType\": \"Import\",\r\n  \"serverName\": \"japaneast4154.database.windows.net\",\r\n  \"status\": \"Running, Progress = 5.00 %\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "387"
+          "394"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -767,10 +1316,10 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:36:43 GMT"
+          "Thu, 22 Jun 2017 05:54:08 GMT"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/importExportOperationResults/cb70d4fe-ef43-42c6-a603-4309e95894c7?api-version=2014-04-01-Preview"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/importExportOperationResults/9313cf68-bf63-495c-bc9d-694fa0c3d051?api-version=2014-04-01-Preview"
         ],
         "Retry-After": [
           "30"
@@ -779,7 +1328,7 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-id": [
-          "ff2b7acd-ab56-49e7-a2d9-0bb8fcad1086"
+          "90f70958-f4d5-4977-843f-2a427ada7c4c"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -791,145 +1340,29 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14992"
+          "14976"
         ],
         "x-ms-correlation-request-id": [
-          "4a708f9a-59b8-47c7-89f7-ad674e94370d"
+          "12955ba4-217b-4bdf-a51b-07d35912b3db"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183644Z:4a708f9a-59b8-47c7-89f7-ad674e94370d"
+          "WESTUS:20170622T055409Z:12955ba4-217b-4bdf-a51b-07d35912b3db"
         ]
       },
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/importExportOperationResults/cb70d4fe-ef43-42c6-a603-4309e95894c7?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NTg1L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvY2I3MGQ0ZmUtZWY0My00MmM2LWE2MDMtNDMwOWU5NTg5NGM3P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/importExportOperationResults/9313cf68-bf63-495c-bc9d-694fa0c3d051?api-version=2014-04-01-Preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTU4NzIvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9qYXBhbmVhc3Q0MTU0L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvOTMxM2NmNjgtYmY2My00OTVjLWJjOWQtNjk0ZmEwYzNkMDUxP2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest.blob.core.windows.net/bacpacs/sqlcrudtest-8585.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-8585\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:35:44 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:35:42 PM\",\r\n  \"requestId\": \"cb70d4fe-ef43-42c6-a603-4309e95894c7\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"sqlcrudtest-1252.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "387"
-        ],
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:37:14 GMT"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/importExportOperationResults/cb70d4fe-ef43-42c6-a603-4309e95894c7?api-version=2014-04-01-Preview"
-        ],
-        "Retry-After": [
-          "30"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-request-id": [
-          "95020137-4a7a-4c50-92f4-a6dbe802718e"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14991"
-        ],
-        "x-ms-correlation-request-id": [
-          "1e756954-2fe5-48a3-9463-70092b87f876"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS:20170601T183714Z:1e756954-2fe5-48a3-9463-70092b87f876"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/importExportOperationResults/cb70d4fe-ef43-42c6-a603-4309e95894c7?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NTg1L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvY2I3MGQ0ZmUtZWY0My00MmM2LWE2MDMtNDMwOWU5NTg5NGM3P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest.blob.core.windows.net/bacpacs/sqlcrudtest-8585.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-8585\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:35:44 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:35:42 PM\",\r\n  \"requestId\": \"cb70d4fe-ef43-42c6-a603-4309e95894c7\",\r\n  \"requestType\": \"Export\",\r\n  \"serverName\": \"sqlcrudtest-1252.database.windows.net\",\r\n  \"status\": \"Running, Progress = 0%\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "387"
-        ],
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:37:44 GMT"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/importExportOperationResults/cb70d4fe-ef43-42c6-a603-4309e95894c7?api-version=2014-04-01-Preview"
-        ],
-        "Retry-After": [
-          "30"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-request-id": [
-          "8be9729d-060e-4dae-ba9c-c42e38c33e81"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14990"
-        ],
-        "x-ms-correlation-request-id": [
-          "377feba4-ba02-44b6-99ed-af3b7788dc47"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS:20170601T183745Z:377feba4-ba02-44b6-99ed-af3b7788dc47"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/importExportOperationResults/cb70d4fe-ef43-42c6-a603-4309e95894c7?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NTg1L2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvY2I3MGQ0ZmUtZWY0My00MmM2LWE2MDMtNDMwOWU5NTg5NGM3P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/databases/sqlcrudtest-8585/importExportOperationResults/cb70d4fe-ef43-42c6-a603-4309e95894c7\",\r\n  \"name\": \"cb70d4fe-ef43-42c6-a603-4309e95894c7\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/importExportOperationResults\",\r\n  \"properties\": {\r\n    \"requestId\": \"cb70d4fe-ef43-42c6-a603-4309e95894c7\",\r\n    \"requestType\": \"Export\",\r\n    \"queuedTime\": \"6/1/2017 6:35:42 PM\",\r\n    \"lastModifiedTime\": \"6/1/2017 6:37:54 PM\",\r\n    \"blobUri\": \"https://sqlcrudtest.blob.core.windows.net/bacpacs/sqlcrudtest-8585.bacpac\",\r\n    \"serverName\": \"sqlcrudtest-1252\",\r\n    \"databaseName\": \"sqlcrudtest-8585\",\r\n    \"status\": \"Completed\",\r\n    \"errorMessage\": null\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourceGroups/sqlcrudtest-5872/providers/Microsoft.Sql/servers/japaneast4154/importExportOperationResult/9313cf68-bf63-495c-bc9d-694fa0c3d051\",\r\n  \"name\": \"9313cf68-bf63-495c-bc9d-694fa0c3d051\",\r\n  \"type\": \"Microsoft.Sql/servers/importExportOperationResults\",\r\n  \"properties\": {\r\n    \"requestId\": \"9313cf68-bf63-495c-bc9d-694fa0c3d051\",\r\n    \"requestType\": \"Import\",\r\n    \"queuedTime\": \"6/22/2017 5:53:08 AM\",\r\n    \"lastModifiedTime\": \"6/22/2017 5:54:26 AM\",\r\n    \"blobUri\": \"https://sqlcrudtest5550.blob.core.windows.net/container/sqlcrudtest-569.bacpac\",\r\n    \"serverName\": \"japaneast4154\",\r\n    \"databaseName\": \"sqlcrudtest-5280\",\r\n    \"status\": \"Completed\",\r\n    \"errorMessage\": null\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -938,7 +1371,7 @@
           "no-store, no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:38:14 GMT"
+          "Thu, 22 Jun 2017 05:54:39 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
@@ -950,7 +1383,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "6dbf1615-6d41-4fdc-beca-738db86601f9"
+          "e740bf1a-f0e6-4a80-a06c-ed8d17bc0708"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -962,269 +1395,25 @@
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14989"
+          "14975"
         ],
         "x-ms-correlation-request-id": [
-          "bcca5771-f855-4786-88d5-51231d6cdabc"
+          "f948653c-8425-465c-a8f7-787d580e7862"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183815Z:bcca5771-f855-4786-88d5-51231d6cdabc"
+          "WESTUS:20170622T055440Z:f948653c-8425-465c-a8f7-787d580e7862"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/import?api-version=2014-04-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2ltcG9ydD9hcGktdmVyc2lvbj0yMDE0LTA0LTAx",
-      "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"databaseName\": \"sqlcrudtest-7566\",\r\n  \"edition\": \"Basic\",\r\n  \"serviceObjectiveName\": \"Basic\",\r\n  \"maxSizeBytes\": \"2147483648\",\r\n  \"storageKeyType\": \"StorageAccessKey\",\r\n  \"storageKey\": \"xxxx\",\r\n  \"storageUri\": \"https://sqlcrudtest.blob.core.windows.net/bacpacs/sqlcrudtest-8585.bacpac\",\r\n  \"administratorLogin\": \"dummylogin\",\r\n  \"administratorLoginPassword\": \"Un53cuRE!\",\r\n  \"authenticationType\": \"SQL\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "496"
-        ],
-        "x-ms-client-request-id": [
-          "ac09d879-93bf-4aff-b58d-d5ae4c251128"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"operation\": \"Import\",\r\n  \"startTime\": \"2017-06-01T18:38:17.794Z\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "60"
-        ],
-        "Content-Type": [
-          "application/xml; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:38:16 GMT"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/importExportOperationResults/f9efbb4a-9171-4301-8cc1-67e985b6d3d4?api-version=2014-04-01-Preview"
-        ],
-        "Retry-After": [
-          "30"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-request-id": [
-          "f4a365d5-1e73-40c0-9fa1-c1e3f4b0142b"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Preference-Applied": [
-          "return-content"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1194"
-        ],
-        "x-ms-correlation-request-id": [
-          "fd5aebcb-7ffb-446d-848d-e311c016e129"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS:20170601T183817Z:fd5aebcb-7ffb-446d-848d-e311c016e129"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/importExportOperationResults/f9efbb4a-9171-4301-8cc1-67e985b6d3d4?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvZjllZmJiNGEtOTE3MS00MzAxLThjYzEtNjdlOTg1YjZkM2Q0P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest.blob.core.windows.net/bacpacs/sqlcrudtest-8585.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-7566\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:38:18 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:38:17 PM\",\r\n  \"requestId\": \"f9efbb4a-9171-4301-8cc1-67e985b6d3d4\",\r\n  \"requestType\": \"Import\",\r\n  \"serverName\": \"sqlcrudtest-1252.database.windows.net\",\r\n  \"status\": \"Running, Progress = 5.00 %\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "391"
-        ],
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:38:48 GMT"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/importExportOperationResults/f9efbb4a-9171-4301-8cc1-67e985b6d3d4?api-version=2014-04-01-Preview"
-        ],
-        "Retry-After": [
-          "30"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-request-id": [
-          "8b07d33b-d586-44a5-8217-ad09b05e2edb"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14988"
-        ],
-        "x-ms-correlation-request-id": [
-          "838f1215-b19b-4f63-9aca-c8487b79ffa5"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS:20170601T183848Z:838f1215-b19b-4f63-9aca-c8487b79ffa5"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/importExportOperationResults/f9efbb4a-9171-4301-8cc1-67e985b6d3d4?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvZjllZmJiNGEtOTE3MS00MzAxLThjYzEtNjdlOTg1YjZkM2Q0P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"blobUri\": \"https://sqlcrudtest.blob.core.windows.net/bacpacs/sqlcrudtest-8585.bacpac\",\r\n  \"databaseName\": \"sqlcrudtest-7566\",\r\n  \"errorMessage\": null,\r\n  \"lastModifiedTime\": \"6/1/2017 6:38:18 PM\",\r\n  \"queuedTime\": \"6/1/2017 6:38:17 PM\",\r\n  \"requestId\": \"f9efbb4a-9171-4301-8cc1-67e985b6d3d4\",\r\n  \"requestType\": \"Import\",\r\n  \"serverName\": \"sqlcrudtest-1252.database.windows.net\",\r\n  \"status\": \"Running, Progress = 5.00 %\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "391"
-        ],
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:39:18 GMT"
-        ],
-        "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/importExportOperationResults/f9efbb4a-9171-4301-8cc1-67e985b6d3d4?api-version=2014-04-01-Preview"
-        ],
-        "Retry-After": [
-          "30"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-request-id": [
-          "d59e5448-f76d-4579-a645-898f88cb586e"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14987"
-        ],
-        "x-ms-correlation-request-id": [
-          "fbf866b5-d56d-444d-99a3-c99f246cc00f"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS:20170601T183919Z:fbf866b5-d56d-444d-99a3-c99f246cc00f"
-        ]
-      },
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/importExportOperationResults/f9efbb4a-9171-4301-8cc1-67e985b6d3d4?api-version=2014-04-01-Preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTIzOTMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjUyL2ltcG9ydEV4cG9ydE9wZXJhdGlvblJlc3VsdHMvZjllZmJiNGEtOTE3MS00MzAxLThjYzEtNjdlOTg1YjZkM2Q0P2FwaS12ZXJzaW9uPTIwMTQtMDQtMDEtUHJldmlldw==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.4.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourceGroups/sqlcrudtest-2393/providers/Microsoft.Sql/servers/sqlcrudtest-1252/importExportOperationResult/f9efbb4a-9171-4301-8cc1-67e985b6d3d4\",\r\n  \"name\": \"f9efbb4a-9171-4301-8cc1-67e985b6d3d4\",\r\n  \"type\": \"Microsoft.Sql/servers/importExportOperationResults\",\r\n  \"properties\": {\r\n    \"requestId\": \"f9efbb4a-9171-4301-8cc1-67e985b6d3d4\",\r\n    \"requestType\": \"Import\",\r\n    \"queuedTime\": \"6/1/2017 6:38:17 PM\",\r\n    \"lastModifiedTime\": \"6/1/2017 6:39:40 PM\",\r\n    \"blobUri\": \"https://sqlcrudtest.blob.core.windows.net/bacpacs/sqlcrudtest-8585.bacpac\",\r\n    \"serverName\": \"sqlcrudtest-1252\",\r\n    \"databaseName\": \"sqlcrudtest-7566\",\r\n    \"status\": \"Completed\",\r\n    \"errorMessage\": null\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache"
-        ],
-        "Date": [
-          "Thu, 01 Jun 2017 18:39:48 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "b218420c-8f45-4733-95e4-238b9ab99eb4"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14986"
-        ],
-        "x-ms-correlation-request-id": [
-          "7e6f5553-583e-483c-8d10-cf51497e473b"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS:20170601T183949Z:7e6f5553-583e-483c-8d10-cf51497e473b"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/resourcegroups/sqlcrudtest-2393?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZjI4ODcyZDYtNGE5My00YmIxLTg0YjktYWVjYjAyYjZhZjRjL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTIzOTM/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestUri": "/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/resourcegroups/sqlcrudtest-5872?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMmU3ZmU0YmQtOTBjNy00NTRlLThiYjYtZGM0NDY0OWYyN2IyL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTU4NzI/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "936a3fd4-f46f-454f-9ef5-752e2807316b"
+          "bf19e8ea-3065-4bde-be6d-dde4bc4a14f0"
         ],
         "accept-language": [
           "en-US"
@@ -1246,28 +1435,28 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 01 Jun 2017 18:39:51 GMT"
+          "Thu, 22 Jun 2017 05:54:42 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/f28872d6-4a93-4bb1-84b9-aecb02b6af4c/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TUUxDUlVEVEVTVDoyRDIzOTMtSkFQQU5FQVNUIiwiam9iTG9jYXRpb24iOiJqYXBhbmVhc3QifQ?api-version=2017-05-10"
+          "https://management.azure.com/subscriptions/2e7fe4bd-90c7-454e-8bb6-dc44649f27b2/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TUUxDUlVEVEVTVDoyRDU4NzItSkFQQU5FQVNUIiwiam9iTG9jYXRpb24iOiJqYXBhbmVhc3QifQ?api-version=2017-05-10"
         ],
         "Retry-After": [
           "15"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1193"
+          "1196"
         ],
         "x-ms-request-id": [
-          "4d8fd505-371b-49d0-9256-ae64c131c898"
+          "104f5e5a-3349-4404-b18c-fe463e693fbc"
         ],
         "x-ms-correlation-request-id": [
-          "4d8fd505-371b-49d0-9256-ae64c131c898"
+          "104f5e5a-3349-4404-b18c-fe463e693fbc"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS:20170601T183952Z:4d8fd505-371b-49d0-9256-ae64c131c898"
+          "WESTUS:20170622T055443Z:104f5e5a-3349-4404-b18c-fe463e693fbc"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1277,20 +1466,23 @@
     }
   ],
   "Names": {
-    "RunTestInNewResourceGroup": [
-      "sqlcrudtest-2393"
+    "CreateResourceGroup": [
+      "sqlcrudtest-5872"
+    ],
+    "CreateStorageContainer": [
+      "sqlcrudtest5550"
     ],
     "CreateServer": [
-      "sqlcrudtest-1252"
+      "japaneast4154"
     ],
     "TestImportExport": [
-      "sqlcrudtest-8585",
-      "sqlcrudtest-7566",
-      "sqlcrudstorage8541",
-      "sqlcrudtest-6510"
+      "sqlcrudtest-569",
+      "sqlcrudtest-5280",
+      "sqlcrudstorage9162",
+      "sqlcrudtest-5583"
     ]
   },
   "Variables": {
-    "SubscriptionId": "f28872d6-4a93-4bb1-84b9-aecb02b6af4c"
+    "SubscriptionId": "2e7fe4bd-90c7-454e-8bb6-dc44649f27b2"
   }
 }

--- a/src/SDKs/SqlManagement/Sql.Tests/Sql.Tests.csproj
+++ b/src/SDKs/SqlManagement/Sql.Tests/Sql.Tests.csproj
@@ -14,10 +14,12 @@
     <PackageReference Include="Microsoft.Azure.Management.RecoveryServices" Version="4.2.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.RecoveryServices.Backup" Version="1.2.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />
+    <PackageReference Include="Microsoft.Azure.Management.Storage" Version="6.5.0-preview" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
     <PackageReference Include="System.Data.SqlClient" Version="4.3.1" />
+    <PackageReference Include="WindowsAzure.Storage" Version="8.1.4" />
   </ItemGroup>
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Azure.Management.Sql" Version="1.2.0-preview" />-->


### PR DESCRIPTION
This allows them to be easily re-recorded later.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
