### PR TITLE
[DO NOT MERGE] Search SDK: Fix for issue :3309 SearchSDK tries to read a property marked with JsonIgnore.

### DIFF
--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Customizations/Indexes/FieldBuilder.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Customizations/Indexes/FieldBuilder.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Search
     using Microsoft.Azure.Search.Models;
     using Microsoft.Spatial;
     using Newtonsoft.Json.Serialization;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// Builds field definitions for an Azure Search index by reflecting over a user-defined model type.
@@ -53,17 +54,21 @@ namespace Microsoft.Azure.Search
             var fields = new List<Field>();
             foreach (JsonProperty prop in contract.Properties)
             {
+                IList<Attribute> attributes = prop.AttributeProvider.GetAttributes(true);
+                if(attributes.Any(attr => attr is JsonIgnoreAttribute))
+                {
+                    continue;
+                }
                 DataType dataType = GetDataType(prop.PropertyType, prop.PropertyName);
 
                 var field = new Field(prop.PropertyName, dataType);
-
-                IList<Attribute> attributes = prop.AttributeProvider.GetAttributes(true);
+                                
                 foreach (Attribute attribute in attributes)
                 {
                     IsRetrievableAttribute isRetrievableAttribute;
                     AnalyzerAttribute analyzerAttribute;
                     SearchAnalyzerAttribute searchAnalyzerAttribute;
-                    IndexAnalyzerAttribute indexAnalyzerAttribute;
+                    IndexAnalyzerAttribute indexAnalyzerAttribute;                    
                     if (attribute is IsSearchableAttribute)
                     {
                         field.IsSearchable = true;

--- a/src/SDKs/Search/DataPlane/Search.Tests/Tests/Models/ReflectableModel.cs
+++ b/src/SDKs/Search/DataPlane/Search.Tests/Tests/Models/ReflectableModel.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Search.Tests
     using Microsoft.Azure.Search;
     using Microsoft.Azure.Search.Models;
     using Microsoft.Spatial;
+    using Newtonsoft.Json;
 
     public class ReflectableModel
     {
@@ -69,5 +70,15 @@ namespace Microsoft.Azure.Search.Tests
         public int? NullableInt { get; set; }
 
         public GeographyPoint GeographyPoint { get; set; }
+
+        [JsonIgnore]
+        [IsRetrievable(false)]
+        public RecordEnum recordEnum { get; set; }
+    }
+
+    public enum RecordEnum
+    {
+        Test1,
+        Test2
     }
 }


### PR DESCRIPTION
SearchSDK tries to read a property marked with JsonIgnore.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Originally, SearchSDK was reading properties marked with JsonIgnore attribute. 
With this change, properties marked with JsonIgnore will not be read.
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
