### PR TITLE
1.1.3 hot-fix package versioning

### DIFF
--- a/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent.csproj
+++ b/src/ResourceManagement/AppService/Microsoft.Azure.Management.AppService.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.AppService.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.AppService.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.AppService.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure App Service Management Library</AssemblyTitle>
@@ -31,9 +31,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.KeyVault.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.KeyVault.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/AppService/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/AppService/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure App Service management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/Azure.Fluent/Microsoft.Azure.Management.Fluent.csproj
+++ b/src/ResourceManagement/Azure.Fluent/Microsoft.Azure.Management.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Management Client Library</AssemblyTitle>
@@ -30,22 +30,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Batch.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Cdn.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Compute.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.ContainerRegistry.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Dns.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.DocumentDB.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Graph.RBAC.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.KeyVault.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Network.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Redis.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.ServiceBus.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Sql.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.TrafficManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Batch.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Cdn.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Compute.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.ContainerRegistry.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Dns.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.DocumentDB.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Graph.RBAC.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.KeyVault.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Network.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Redis.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.ServiceBus.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Sql.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.TrafficManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/Azure.Fluent/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Azure.Fluent/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Rollup Management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent.csproj
+++ b/src/ResourceManagement/Batch/Microsoft.Azure.Management.Batch.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Batch.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.Batch.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.Batch.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Batch Management Library</AssemblyTitle>
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/Batch/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Batch/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Batch Management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent.csproj
+++ b/src/ResourceManagement/Cdn/Microsoft.Azure.Management.Cdn.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Cdn.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.Cdn.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.Cdn.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure CDN Management Library</AssemblyTitle>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/Cdn/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Cdn/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure CDN management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent.csproj
+++ b/src/ResourceManagement/Compute/Microsoft.Azure.Management.Compute.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Compute.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.Compute.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.Compute.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Compute Management Library</AssemblyTitle>
@@ -31,9 +31,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Network.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Network.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/Compute/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Compute/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Compute management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/ContainerRegistry/Microsoft.Azure.Management.ContainerRegistry.Fluent.csproj
+++ b/src/ResourceManagement/ContainerRegistry/Microsoft.Azure.Management.ContainerRegistry.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.ContainerRegistry.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.ContainerRegistry.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.ContainerRegistry.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Container Registry Management Library</AssemblyTitle>
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.Storage.Fluent" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/ContainerRegistry/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/ContainerRegistry/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Container Registry management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent.csproj
+++ b/src/ResourceManagement/Dns/Microsoft.Azure.Management.Dns.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Dns.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.Dns.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.Dns.Fluent</RootNamespace>    
     <AssemblyTitle>Microsoft Azure DNS Management Library</AssemblyTitle>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/Dns/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Dns/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure DNS management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/DocumentDB/Microsoft.Azure.Management.DocumentDB.Fluent.csproj
+++ b/src/ResourceManagement/DocumentDB/Microsoft.Azure.Management.DocumentDB.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.DocumentDB.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.DocumentDB.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.DocumentDB.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure DocumentDB Management Library</AssemblyTitle>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/DocumentDB/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/DocumentDB/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure DocumentDB management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent.csproj
+++ b/src/ResourceManagement/Graph.RBAC/Microsoft.Azure.Management.Graph.RBAC.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Graph.RBAC.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.Graph.RBAC.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.Graph.RBAC.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Graph RBAC Management Library</AssemblyTitle>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/Graph.RBAC/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Graph.RBAC/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Graph RBAC management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/KeyVault/Microsoft.Azure.Management.KeyVault.Fluent.csproj
+++ b/src/ResourceManagement/KeyVault/Microsoft.Azure.Management.KeyVault.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.KeyVault.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.KeyVault.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.KeyVault.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Key Vault Management Library</AssemblyTitle>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/KeyVault/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/KeyVault/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Key Vault management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent.csproj
+++ b/src/ResourceManagement/Network/Microsoft.Azure.Management.Network.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Network.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.Network.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.Network.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Network Management Library</AssemblyTitle>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/Network/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Network/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Network management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent.csproj
+++ b/src/ResourceManagement/RedisCache/Microsoft.Azure.Management.Redis.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Redis.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.Redis.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.Redis.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Redis Cache Management Library</AssemblyTitle>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/RedisCache/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/RedisCache/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Redis Cache management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent.csproj
+++ b/src/ResourceManagement/ResourceManager/Microsoft.Azure.Management.ResourceManager.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.ResourceManager.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.ResourceManager.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.ResourceManager.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Resource Management Library</AssemblyTitle>

--- a/src/ResourceManagement/ResourceManager/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/ResourceManager/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Resource Manager management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent.csproj
+++ b/src/ResourceManagement/ServiceBus/Microsoft.Azure.Management.ServiceBus.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.ServiceBus.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.ServiceBus.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.ServiceBus.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Service Bus Management Library</AssemblyTitle>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/ServiceBus/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/ServiceBus/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure ServiceBus management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent.csproj
+++ b/src/ResourceManagement/Sql/Microsoft.Azure.Management.Sql.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Sql.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.Sql.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.Sql.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Sql Management Library</AssemblyTitle>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/Sql/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Sql/Properties/AssemblyInfo.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/ResourceManagement/Storage/Microsoft.Azure.Management.Storage.Fluent.csproj
+++ b/src/ResourceManagement/Storage/Microsoft.Azure.Management.Storage.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Storage.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.Storage.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.Storage.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Storage Management Library</AssemblyTitle>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/Storage/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/Storage/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Storage management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/ResourceManagement/TrafficManager/Microsoft.Azure.Management.TrafficManager.Fluent.csproj
+++ b/src/ResourceManagement/TrafficManager/Microsoft.Azure.Management.TrafficManager.Fluent.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.TrafficManager.Fluent</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <AssemblyName>Microsoft.Azure.Management.TrafficManager.Fluent</AssemblyName>
     <RootNamespace>Microsoft.Azure.Management.TrafficManager.Fluent</RootNamespace>
     <AssemblyTitle>Microsoft Azure Traffic Manager Management Library</AssemblyTitle>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.1.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/ResourceManagement/TrafficManager/Properties/AssemblyInfo.cs
+++ b/src/ResourceManagement/TrafficManager/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Traffic Manager management APIs.")]
 
 [assembly: AssemblyVersion("1.0.0.60")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
