### PR TITLE
Add support for X509Certificate2 in .Net452 

### DIFF
--- a/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
@@ -101,6 +101,13 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
                         credentialsCache[adSettings.TokenAudience] = await ApplicationTokenProvider.LoginSilentAsync(
                             TenantId, servicePrincipalLoginInformation.ClientId, servicePrincipalLoginInformation.ClientSecret, adSettings, TokenCache.DefaultShared);
                     }
+#if NET45
+                    else if (servicePrincipalLoginInformation.X509Certificate != null)
+                    {
+                        credentialsCache[adSettings.TokenAudience] = await ApplicationTokenProvider.LoginSilentAsync(
+                            TenantId, new ClientAssertionCertificate(servicePrincipalLoginInformation.ClientId, servicePrincipalLoginInformation.X509Certificate), adSettings, TokenCache.DefaultShared);
+                    }
+#endif
                     else
                     {
                         credentialsCache[adSettings.TokenAudience] = await ApplicationTokenProvider.LoginSilentAsync(

--- a/src/ResourceManagement/ResourceManager/Authentication/AzureCredentialsFactory.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/AzureCredentialsFactory.cs
@@ -88,6 +88,25 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
             }, tenantId, environment);
         }
 
+#if NET45
+        /// <summary>
+        /// Creates a credentials object from a service principal.
+        /// </summary>
+        /// <param name="clientId">the client ID of the application the service principal is associated with</param>
+        /// <param name="certificate">the X509 certificate for the client ID</param>
+        /// <param name="tenantId">the tenant ID or domain the application is in</param>
+        /// <param name="environment">the environment to authenticate to</param>
+        /// <returns></returns>
+        public AzureCredentials FromServicePrincipal(string clientId, X509Certificate2 certificate, string tenantId, AzureEnvironment environment)
+        {
+            return new AzureCredentials(new ServicePrincipalLoginInformation
+            {
+                ClientId = clientId,
+                X509Certificate = certificate
+            }, tenantId, environment);
+        }
+#endif
+
         /// <summary>
         /// Creates a credentials object from a file in the following format:
         ///

--- a/src/ResourceManagement/ResourceManager/Authentication/ServicePrincipalLoginInformation.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/ServicePrincipalLoginInformation.cs
@@ -15,5 +15,9 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
         public byte[] Certificate { get; set; }
 
         public string CertificatePassword { get; set; }
+
+#if NET45
+        public X509Certificate2 X509Certificate { get; set; }
+#endif
     }
 }


### PR DESCRIPTION
Fix for #3373
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
