### PR TITLE
Fix disk swagger

### DIFF
--- a/src/SDKs/Compute/Management.Compute/Generated/Models/Snapshot.cs
+++ b/src/SDKs/Compute/Management.Compute/Generated/Models/Snapshot.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// <param name="name">Resource name</param>
         /// <param name="type">Resource type</param>
         /// <param name="tags">Resource tags</param>
+        /// <param name="managedBy">A relative URI containing the ID of the VM
+        /// that has the disk attached.</param>
         /// <param name="timeCreated">The time when the disk was
         /// created.</param>
         /// <param name="osType">The Operating System type. Possible values
@@ -54,9 +56,10 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// snapshot</param>
         /// <param name="provisioningState">The disk provisioning
         /// state.</param>
-        public Snapshot(string location, CreationData creationData, string id = default(string), string name = default(string), string type = default(string), IDictionary<string, string> tags = default(IDictionary<string, string>), DiskSku sku = default(DiskSku), System.DateTime? timeCreated = default(System.DateTime?), OperatingSystemTypes? osType = default(OperatingSystemTypes?), int? diskSizeGB = default(int?), EncryptionSettings encryptionSettings = default(EncryptionSettings), string provisioningState = default(string))
+        public Snapshot(string location, CreationData creationData, string id = default(string), string name = default(string), string type = default(string), IDictionary<string, string> tags = default(IDictionary<string, string>), string managedBy = default(string), DiskSku sku = default(DiskSku), System.DateTime? timeCreated = default(System.DateTime?), OperatingSystemTypes? osType = default(OperatingSystemTypes?), int? diskSizeGB = default(int?), EncryptionSettings encryptionSettings = default(EncryptionSettings), string provisioningState = default(string))
             : base(location, id, name, type, tags)
         {
+            ManagedBy = managedBy;
             Sku = sku;
             TimeCreated = timeCreated;
             OsType = osType;
@@ -65,6 +68,13 @@ namespace Microsoft.Azure.Management.Compute.Models
             EncryptionSettings = encryptionSettings;
             ProvisioningState = provisioningState;
         }
+
+        /// <summary>
+        /// Gets a relative URI containing the ID of the VM that has the disk
+        /// attached.
+        /// </summary>
+        [JsonProperty(PropertyName = "managedBy")]
+        public string ManagedBy { get; protected set; }
 
         /// <summary>
         /// </summary>

--- a/src/SDKs/Compute/Management.Compute/Microsoft.Azure.Management.Compute.csproj
+++ b/src/SDKs/Compute/Management.Compute/Microsoft.Azure.Management.Compute.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Compute</PackageId>
     <Description>Provides developers with libraries for the updated compute platform under Azure Resource manager to deploy virtual machine, virtual machine extensions and availability set management capabilities. Launch, restart, scale, capture and manage VMs, VM Extensions and more. Note: This client library is for Virtual Machines under Azure Resource Manager.</Description>
-    <VersionPrefix>15.0.0</VersionPrefix>
+    <VersionPrefix>15.1.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.Management.Compute</AssemblyName>
     <PackageTags>Microsoft Azure resource management;virtual machine;compute;REST HTTP client;azureofficial;windowsazureofficial;netcore451511</PackageTags>
   </PropertyGroup>

--- a/src/SDKs/Compute/Management.Compute/Microsoft.Azure.Management.Compute.csproj
+++ b/src/SDKs/Compute/Management.Compute/Microsoft.Azure.Management.Compute.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Compute</PackageId>
     <Description>Provides developers with libraries for the updated compute platform under Azure Resource manager to deploy virtual machine, virtual machine extensions and availability set management capabilities. Launch, restart, scale, capture and manage VMs, VM Extensions and more. Note: This client library is for Virtual Machines under Azure Resource Manager.</Description>
-    <VersionPrefix>15.1.0</VersionPrefix>
+    <VersionPrefix>16.0.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.Management.Compute</AssemblyName>
     <PackageTags>Microsoft Azure resource management;virtual machine;compute;REST HTTP client;azureofficial;windowsazureofficial;netcore451511</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
