### PR TITLE
[DO NOT MERGE] add read only fields'

### DIFF
--- a/src/SDKs/Network/Management.Network/Generated/Models/BackendAddressPool.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/BackendAddressPool.cs
@@ -87,11 +87,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public SubResource OutboundNatRule { get; private set; }
 
         /// <summary>
-        /// Gets or sets get provisioning state of the public IP resource.
-        /// Possible values are: 'Updating', 'Deleting', and 'Failed'.
+        /// Gets get provisioning state of the public IP resource. Possible
+        /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets name of the resource that is unique within a resource group.
@@ -101,11 +101,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/FrontendIpConfiguration.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/FrontendIpConfiguration.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets or sets the name of the resource that is unique within a
@@ -147,11 +147,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/IPConfiguration.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/IPConfiguration.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets or sets the name of the resource that is unique within a
@@ -109,11 +109,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/InboundNatPool.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/InboundNatPool.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets or sets the name of the resource that is unique within a
@@ -127,11 +127,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
         /// <summary>
         /// Validate the object.

--- a/src/SDKs/Network/Management.Network/Generated/Models/InboundNatRule.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/InboundNatRule.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets name of the resource that is unique within a resource group.
@@ -155,11 +155,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/LoadBalancer.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/LoadBalancer.cs
@@ -169,11 +169,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string ProvisioningState { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/LoadBalancingRule.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/LoadBalancingRule.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets or sets the name of the resource that is unique within a
@@ -177,11 +177,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
         /// <summary>
         /// Validate the object.

--- a/src/SDKs/Network/Management.Network/Generated/Models/NetworkInterface.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/NetworkInterface.cs
@@ -86,10 +86,10 @@ namespace Microsoft.Azure.Management.Network.Models
         partial void CustomInit();
 
         /// <summary>
-        /// Gets or sets the reference of a virtual machine.
+        /// Gets the reference of a virtual machine.
         /// </summary>
         [JsonProperty(PropertyName = "properties.virtualMachine")]
-        public SubResource VirtualMachine { get; set; }
+        public SubResource VirtualMachine { get; private set; }
 
         /// <summary>
         /// Gets or sets the reference of the NetworkSecurityGroup resource.
@@ -110,17 +110,17 @@ namespace Microsoft.Azure.Management.Network.Models
         public NetworkInterfaceDnsSettings DnsSettings { get; set; }
 
         /// <summary>
-        /// Gets or sets the MAC address of the network interface.
+        /// Gets the MAC address of the network interface.
         /// </summary>
         [JsonProperty(PropertyName = "properties.macAddress")]
-        public string MacAddress { get; set; }
+        public string MacAddress { get; private set; }
 
         /// <summary>
         /// Gets whether this is a primary network interface on a virtual
         /// machine.
         /// </summary>
         [JsonProperty(PropertyName = "properties.primary")]
-        public bool? Primary { get; set; }
+        public bool? Primary { get; private set; }
 
         /// <summary>
         /// Gets or sets if the network interface is accelerated networking
@@ -137,25 +137,24 @@ namespace Microsoft.Azure.Management.Network.Models
         public bool? EnableIPForwarding { get; set; }
 
         /// <summary>
-        /// Gets or sets the resource GUID property of the network interface
-        /// resource.
+        /// Gets the resource GUID property of the network interface resource.
         /// </summary>
         [JsonProperty(PropertyName = "properties.resourceGuid")]
-        public string ResourceGuid { get; set; }
+        public string ResourceGuid { get; private set; }
 
         /// <summary>
-        /// Gets or sets the provisioning state of the public IP resource.
-        /// Possible values are: 'Updating', 'Deleting', and 'Failed'.
+        /// Gets the provisioning state of the public IP resource. Possible
+        /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/NetworkInterfaceDnsSettings.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/NetworkInterfaceDnsSettings.cs
@@ -78,13 +78,13 @@ namespace Microsoft.Azure.Management.Network.Models
         public IList<string> DnsServers { get; set; }
 
         /// <summary>
-        /// Gets or sets if the VM that uses this NIC is part of an
-        /// Availability Set, then this list will have the union of all DNS
-        /// servers from all NICs that are part of the Availability Set. This
-        /// property is what is configured on each of those VMs.
+        /// Gets if the VM that uses this NIC is part of an Availability Set,
+        /// then this list will have the union of all DNS servers from all NICs
+        /// that are part of the Availability Set. This property is what is
+        /// configured on each of those VMs.
         /// </summary>
         [JsonProperty(PropertyName = "appliedDnsServers")]
-        public IList<string> AppliedDnsServers { get; set; }
+        public IList<string> AppliedDnsServers { get; private set; }
 
         /// <summary>
         /// Gets or sets relative DNS name for this NIC used for internal
@@ -101,13 +101,13 @@ namespace Microsoft.Azure.Management.Network.Models
         public string InternalFqdn { get; set; }
 
         /// <summary>
-        /// Gets or sets even if internalDnsNameLabel is not specified, a DNS
-        /// entry is created for the primary NIC of the VM. This DNS name can
-        /// be constructed by concatenating the VM name with the value of
+        /// Gets even if internalDnsNameLabel is not specified, a DNS entry is
+        /// created for the primary NIC of the VM. This DNS name can be
+        /// constructed by concatenating the VM name with the value of
         /// internalDomainNameSuffix.
         /// </summary>
         [JsonProperty(PropertyName = "internalDomainNameSuffix")]
-        public string InternalDomainNameSuffix { get; set; }
+        public string InternalDomainNameSuffix { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/NetworkInterfaceIpConfiguration.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/NetworkInterfaceIpConfiguration.cs
@@ -154,11 +154,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/NetworkSecurityGroup.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/NetworkSecurityGroup.cs
@@ -99,25 +99,25 @@ namespace Microsoft.Azure.Management.Network.Models
         public IList<Subnet> Subnets { get; private set; }
 
         /// <summary>
-        /// Gets or sets the resource GUID property of the network security
-        /// group resource.
+        /// Gets the resource GUID property of the network security group
+        /// resource.
         /// </summary>
         [JsonProperty(PropertyName = "properties.resourceGuid")]
-        public string ResourceGuid { get; set; }
+        public string ResourceGuid { get; private set; }
 
         /// <summary>
-        /// Gets or sets the provisioning state of the public IP resource.
-        /// Possible values are: 'Updating', 'Deleting', and 'Failed'.
+        /// Gets the provisioning state of the public IP resource. Possible
+        /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/OutboundNatRule.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/OutboundNatRule.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets or sets the name of the resource that is unique within a
@@ -102,11 +102,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
         /// <summary>
         /// Validate the object.

--- a/src/SDKs/Network/Management.Network/Generated/Models/PrivateAccessServicePropertiesFormat.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/PrivateAccessServicePropertiesFormat.cs
@@ -58,16 +58,16 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Service { get; set; }
 
         /// <summary>
-        /// Gets or sets a list of locations.
+        /// Gets a list of locations.
         /// </summary>
         [JsonProperty(PropertyName = "locations")]
-        public IList<string> Locations { get; set; }
+        public IList<string> Locations { get; private set; }
 
         /// <summary>
-        /// Gets or sets the provisioning state of the resource.
+        /// Gets the provisioning state of the resource.
         /// </summary>
         [JsonProperty(PropertyName = "provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/Probe.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/Probe.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets name of the resource that is unique within a resource group.
@@ -152,11 +152,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
         /// <summary>
         /// Validate the object.

--- a/src/SDKs/Network/Management.Network/Generated/Models/PublicIpAddress.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/PublicIpAddress.cs
@@ -48,6 +48,8 @@ namespace Microsoft.Azure.Management.Network.Models
         /// 'IPv4', 'IPv6'</param>
         /// <param name="dnsSettings">The FQDN of the DNS record associated
         /// with the public IP address.</param>
+        /// <param name="ipAddress">The IP address associated with the public
+        /// IP address resource</param>
         /// <param name="idleTimeoutInMinutes">The idle timeout of the public
         /// IP address.</param>
         /// <param name="resourceGuid">The resource GUID property of the public
@@ -105,9 +107,10 @@ namespace Microsoft.Azure.Management.Network.Models
         public PublicIPAddressDnsSettings DnsSettings { get; set; }
 
         /// <summary>
+        /// Gets the IP address associated with the public IP address resource
         /// </summary>
         [JsonProperty(PropertyName = "properties.ipAddress")]
-        public string IpAddress { get; set; }
+        public string IpAddress { get; private set; }
 
         /// <summary>
         /// Gets or sets the idle timeout of the public IP address.
@@ -116,24 +119,24 @@ namespace Microsoft.Azure.Management.Network.Models
         public int? IdleTimeoutInMinutes { get; set; }
 
         /// <summary>
-        /// Gets or sets the resource GUID property of the public IP resource.
+        /// Gets the resource GUID property of the public IP resource.
         /// </summary>
         [JsonProperty(PropertyName = "properties.resourceGuid")]
-        public string ResourceGuid { get; set; }
+        public string ResourceGuid { get; private set; }
 
         /// <summary>
-        /// Gets or sets the provisioning state of the PublicIP resource.
-        /// Possible values are: 'Updating', 'Deleting', and 'Failed'.
+        /// Gets the provisioning state of the PublicIP resource. Possible
+        /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/PublicIpAddressDnsSettings.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/PublicIpAddressDnsSettings.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// domainNameLabel and the regionalized DNS zone.
         /// </summary>
         [JsonProperty(PropertyName = "fqdn")]
-        public string Fqdn { get; set; }
+        public string Fqdn { get; private set; }
 
         /// <summary>
         /// Gets or Sets the Reverse FQDN. A user-visible, fully qualified

--- a/src/SDKs/Network/Management.Network/Generated/Models/Route.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/Route.cs
@@ -94,11 +94,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string NextHopIpAddress { get; set; }
 
         /// <summary>
-        /// Gets or sets the provisioning state of the resource. Possible
-        /// values are: 'Updating', 'Deleting', and 'Failed'.
+        /// Gets the provisioning state of the resource. Possible values are:
+        /// 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets or sets the name of the resource that is unique within a
@@ -108,11 +108,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
         /// <summary>
         /// Validate the object.

--- a/src/SDKs/Network/Management.Network/Generated/Models/RouteTable.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/RouteTable.cs
@@ -77,18 +77,18 @@ namespace Microsoft.Azure.Management.Network.Models
         public IList<Subnet> Subnets { get; private set; }
 
         /// <summary>
-        /// Gets or sets the provisioning state of the resource. Possible
-        /// values are: 'Updating', 'Deleting', and 'Failed'.
+        /// Gets the provisioning state of the resource. Possible values are:
+        /// 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets a unique read-only string that changes whenever the resource
         /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/SecurityRule.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/SecurityRule.cs
@@ -171,11 +171,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Direction { get; set; }
 
         /// <summary>
-        /// Gets or sets the provisioning state of the public IP resource.
-        /// Possible values are: 'Updating', 'Deleting', and 'Failed'.
+        /// Gets the provisioning state of the public IP resource. Possible
+        /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets or sets the name of the resource that is unique within a
@@ -185,11 +185,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
         /// <summary>
         /// Validate the object.

--- a/src/SDKs/Network/Management.Network/Generated/Models/Subnet.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/Subnet.cs
@@ -126,11 +126,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetwork.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetwork.cs
@@ -101,25 +101,24 @@ namespace Microsoft.Azure.Management.Network.Models
         public IList<VirtualNetworkPeering> VirtualNetworkPeerings { get; set; }
 
         /// <summary>
-        /// Gets or sets the resourceGuid property of the Virtual Network
-        /// resource.
+        /// Gets the resourceGuid property of the Virtual Network resource.
         /// </summary>
         [JsonProperty(PropertyName = "properties.resourceGuid")]
-        public string ResourceGuid { get; set; }
+        public string ResourceGuid { get; private set; }
 
         /// <summary>
-        /// Gets or sets the provisioning state of the PublicIP resource.
-        /// Possible values are: 'Updating', 'Deleting', and 'Failed'.
+        /// Gets the provisioning state of the PublicIP resource. Possible
+        /// values are: 'Updating', 'Deleting', and 'Failed'.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets a unique read-only string that changes whenever the resource
         /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetworkPeering.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetworkPeering.cs
@@ -120,18 +120,18 @@ namespace Microsoft.Azure.Management.Network.Models
         public SubResource RemoteVirtualNetwork { get; set; }
 
         /// <summary>
-        /// Gets or sets the status of the virtual network peering. Possible
-        /// values are 'Initiated', 'Connected', and 'Disconnected'. Possible
-        /// values include: 'Initiated', 'Connected', 'Disconnected'
+        /// Gets the status of the virtual network peering. Possible values are
+        /// 'Initiated', 'Connected', and 'Disconnected'. Possible values
+        /// include: 'Initiated', 'Connected', 'Disconnected'
         /// </summary>
         [JsonProperty(PropertyName = "properties.peeringState")]
-        public string PeeringState { get; set; }
+        public string PeeringState { get; private set; }
 
         /// <summary>
-        /// Gets or sets the provisioning state of the resource.
+        /// Gets the provisioning state of the resource.
         /// </summary>
         [JsonProperty(PropertyName = "properties.provisioningState")]
-        public string ProvisioningState { get; set; }
+        public string ProvisioningState { get; private set; }
 
         /// <summary>
         /// Gets or sets the name of the resource that is unique within a
@@ -141,11 +141,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a unique read-only string that changes whenever the
-        /// resource is updated.
+        /// Gets a unique read-only string that changes whenever the resource
+        /// is updated.
         /// </summary>
         [JsonProperty(PropertyName = "etag")]
-        public string Etag { get; set; }
+        public string Etag { get; private set; }
 
     }
 }

--- a/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
+++ b/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
@@ -4,11 +4,11 @@
     <PackageId>Microsoft.Azure.Management.Network</PackageId>
     <Description>Provides management capabilities for Network services.</Description>
     <AssemblyName>Microsoft.Azure.Management.Network</AssemblyName>
-    <VersionPrefix>11.1.1-preview</VersionPrefix>
+    <VersionPrefix>12.0.0-preview</VersionPrefix>
     <PackageTags>Microsoft Azure Network management;Network;Network management;windowsazureofficial</PackageTags>    
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>
-    <Version>11.1.1-preview</Version>
+    <Version>12.0.0-preview</Version>
   </PropertyGroup>  
 </Project>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
