### PR TITLE
Discussion spec for extending Batch file conventions

### DIFF
--- a/src/SDKs/Batch/Support/FileConventions/README.md
+++ b/src/SDKs/Batch/Support/FileConventions/README.md
@@ -73,10 +73,18 @@ methods on CloudJob and CloudTask.
 ## Conventions
 
 The conventions library defines paths in Azure blob storage for output storage.
+
 All outputs from a job, including task outputs, are stored in a single container.
 Within that container, outputs are stored by kind and (for task outputs) task ID.
-This section describes the conventions for the job output container name and for
-paths within the job output container.
+(There are additional conventions for tasks that may run on multiple nodes using the
+same ID, such as job preparation tasks.)
+
+Similarly, all outputs relating to a pool (specifically start task outputs) are
+stored in a single container.  Within that container, outputs are stored by kind
+and by node ID.
+
+This section describes the conventions for the output container names and for
+paths within the output containers.
 
 ### Job Output Container Name
 
@@ -118,10 +126,11 @@ unique container names, while preserving human readability as far as possible,
 by where possible using the job ID, and in other cases including a prefix
 based on the job ID.
 
-### Blob Path
+### Job Output Blob Path
 
-The blob path within the container depends on whether the output is being stored
-as a job output or task output.
+The blob path within the job output container depends on whether the output is being stored
+as a job output or task output, and for task outputs whether the task runs on
+multiple nodes (such as the job preparation task).
 
 Job outputs are stored as "${kind}/{filename}".  For example, if the file
 "out/mergeresults.txt" is stored under JobOutputKind.JobOutput, then its path
@@ -131,6 +140,29 @@ Task outputs are stored as "{taskid}/${kind}/{filename}".  For example, if
 the file "analytics.log" from task "analysis-309" is stored under TaskOutputKind.TaskLog,
 then its path within the container is "analysis-309/$TaskLog/analytics.log".
 
+Job preparation and release task outputs are stored as "{taskId}/{nodeId}/${kind}/{filename}".
+For example, if the file "install.log" from job preparation task "jobpreparation"
+on node "node123" is stored under TaskOutputKind.TaskLog, then its path within the
+container is "jobpreparation/node123/$TaskLog/install.log".
+
+**TODO: validate that node IDs always give legal blob names.**
+
 The purpose behind this structure is to enable clients to readily locate
 outputs based on their kind - for example, "list the main outputs of the job"
 or "list the log files for task analysis-309".
+
+### Pool Output Container Name
+
+The pool output container name is calculated from its ID using the same algorithm
+as for the job output container name, except using the prefix "pool-" instead of
+"job-" in all places.
+
+**TODO: add examples a la job output container.**
+
+### Pool Output Blob Path
+
+Start task outputs are stored as "starttask/{nodeId}/${kind}/{filename}".  For example,
+if the file "analytics.log" from node "node123" is stored under TaskOutputKind.TaskLog,
+then its path within the container is "starttask/node123/$TaskLog/analytics.log".
+
+**TODO: validate that node IDs always give legal blob names.**


### PR DESCRIPTION
## Description

The Azure Batch file conventions library supports persisting, listing and retrieving job and 'normal' task outputs.  However, it does not currently support 'special' tasks: start tasks, job preparation tasks and job release tasks.  This PR defines a draft specification for file conventions for special tasks.  It is **for discussion** and does not include an implementation of the specification.  Once the spec is agreed we will proceed to implementation.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
