### PR TITLE
XUnitTracingInterceptor to log http traffic

### DIFF
--- a/Tests/Fluent.Tests/Common/XunitTracingInterceptor.cs
+++ b/Tests/Fluent.Tests/Common/XunitTracingInterceptor.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -7,15 +9,16 @@ using Xunit.Abstractions;
 
 namespace Fluent.Tests.Common
 {
-
-//  This class allows to output http requests and responses to console for tests. To use, add following code as test class constructor:
-//
-//    public TestClass(ITestOutputHelper output)
-//    {
-//        TestHelper.TestLogger = output;
-//        ServiceClientTracing.IsEnabled = true;
-//        ServiceClientTracing.AddTracingInterceptor(new XunitTracingInterceptor(output));
-//    }
+    /// <summary>
+    /// This class allows to output http requests and responses to console for tests. To use, add following code as test class constructor:
+    ///
+    /// public TestClass(ITestOutputHelper output)
+    /// {
+    ///     TestHelper.TestLogger = output;
+    ///     ServiceClientTracing.IsEnabled = true;
+    ///     ServiceClientTracing.AddTracingInterceptor(new XunitTracingInterceptor(output));
+    /// }
+    /// </summary>
     public class XunitTracingInterceptor : IServiceClientTracingInterceptor
     {
         private ITestOutputHelper _logger;

--- a/Tests/Fluent.Tests/Common/XunitTracingInterceptor.cs
+++ b/Tests/Fluent.Tests/Common/XunitTracingInterceptor.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http;
+using Microsoft.Rest;
+using Xunit.Abstractions;
+
+namespace Fluent.Tests.Common
+{
+
+//  This class allows to output http requests and responses to console for tests. To use, add following code as test class constructor:
+//
+//    public TestClass(ITestOutputHelper output)
+//    {
+//        TestHelper.TestLogger = output;
+//        ServiceClientTracing.IsEnabled = true;
+//        ServiceClientTracing.AddTracingInterceptor(new XunitTracingInterceptor(output));
+//    }
+    public class XunitTracingInterceptor : IServiceClientTracingInterceptor
+    {
+        private ITestOutputHelper _logger;
+
+        public XunitTracingInterceptor(ITestOutputHelper output)
+        {
+            _logger = output;
+        }
+
+        public void Configuration(string source, string name, string value)
+        {
+        }
+
+        public void EnterMethod(string invocationId, object instance, string method, IDictionary<string, object> parameters)
+        {
+        }
+
+        public void ExitMethod(string invocationId, object returnValue)
+        {
+        }
+
+        public void Information(string message)
+        {
+            _logger.WriteLine("INFO: " + message);
+        }
+
+        public void ReceiveResponse(string invocationId, HttpResponseMessage response)
+        {
+            string requestAsString = (response == null ? string.Empty : response.AsFormattedString());
+            _logger.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                "invocationId: {0}\r\nresponse: {1}", invocationId, requestAsString));
+        }
+
+        public void SendRequest(string invocationId, HttpRequestMessage request)
+        {
+            string requestAsString = (request == null ? string.Empty : request.AsFormattedString());
+            _logger.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                "invocationId: {0}\r\nrequest: {1}", invocationId, requestAsString));
+        }
+
+        public void TraceError(string invocationId, Exception exception)
+        {
+            _logger.WriteLine("ERROR: invocationId: " + invocationId, exception);
+        }
+    }
+
+}


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
