### PR TITLE
Fixed ASP.NET and Windows Forms async Creatable and sync method deadlocks.

### DIFF
--- a/src/ResourceManagement/AppService/AppServiceBaseImpl.cs
+++ b/src/ResourceManagement/AppService/AppServiceBaseImpl.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:EB8C33DACE377CBB07C354F38C5BEA32:391885361D8D6FDB8CD9E96400E16B73
         public override void VerifyDomainOwnership(string certificateOrderName, string domainVerificationToken)
         {
-            VerifyDomainOwnershipAsync(certificateOrderName, domainVerificationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => VerifyDomainOwnershipAsync(certificateOrderName, domainVerificationToken));
         }
 
         ///GENMHASH:9EC0529BA0D08B75AD65E98A4BA01D5D:AD50571B7362BCAADE526027DA36B58F

--- a/src/ResourceManagement/AppService/AppServiceBaseImpl.cs
+++ b/src/ResourceManagement/AppService/AppServiceBaseImpl.cs
@@ -42,8 +42,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
 
         public override void Stop()
         {
-            Manager.Inner.WebApps.Stop(ResourceGroupName, Name);
-
+            Extensions.Synchronize(() => Manager.Inner.WebApps.StopAsync(ResourceGroupName, Name));
         }
 
         ///GENMHASH:6779D3D3C7AB7AAAE805BA0ABEE95C51:512E3D0409D7A159D1D192520CB3A8DB
@@ -112,7 +111,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:1AD5C303B4B7C1709305A18733B506B2:B2AAE3FC1D57B875FAA6AD38F9DB069C
         public override void ResetSlotConfigurations()
         {
-            Manager.Inner.WebApps.ResetProductionSlotConfig(ResourceGroupName, Name);
+            Extensions.Synchronize(() => Manager.Inner.WebApps.ResetProductionSlotConfigAsync(ResourceGroupName, Name));
         }
 
         ///GENMHASH:2EDD4B59BAFACBDD881E1EB427AFB76D:6899DBE410B89E7D8EEB69725B8CE588
@@ -136,13 +135,13 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:08CFC096AC6388D1C0E041ECDF099E3D:192EA146CBED61BBAAC7B336DA07F261
         public override void Restart()
         {
-            Manager.Inner.WebApps.Restart(ResourceGroupName, Name);
+            Extensions.Synchronize(() => Manager.Inner.WebApps.RestartAsync(ResourceGroupName, Name));
         }
 
         ///GENMHASH:3F0152723C985A22C1032733AB942C96:9A3E19132DCD027C4BA1BBB085642F29
         public override IPublishingProfile GetPublishingProfile()
         {
-            Stream stream = Manager.Inner.WebApps.ListPublishingProfileXmlWithSecrets(ResourceGroupName, Name, new CsmPublishingProfileOptionsInner());
+            Stream stream = Extensions.Synchronize(() => Manager.Inner.WebApps.ListPublishingProfileXmlWithSecretsAsync(ResourceGroupName, Name, new CsmPublishingProfileOptionsInner()));
             StreamReader reader = new StreamReader(stream);
             string xml = reader.ReadToEnd();
             return new PublishingProfileImpl(xml);
@@ -157,10 +156,10 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:924482EE7AA6A01820720743C2A59A72:AA2A43E94B10FDB1A9E9E89ED9CA279B
         public override void ApplySlotConfigurations(string slotName)
         {
-            Manager.Inner.WebApps.ApplySlotConfigToProduction(ResourceGroupName, Name, new CsmSlotEntityInner()
+            Extensions.Synchronize(() => Manager.Inner.WebApps.ApplySlotConfigToProductionAsync(ResourceGroupName, Name, new CsmSlotEntityInner()
             {
                 TargetSlot = slotName
-            });
+            }));
             Refresh();
         }
 
@@ -204,7 +203,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:8C5F8B18192B4F8FD7D43AB4D318EA69:E232113DB866C8D255AE12F7A61042E8
         public override IReadOnlyDictionary<string, IHostNameBinding> GetHostNameBindings()
         {
-            var collectionInner = Manager.Inner.WebApps.ListHostNameBindings(ResourceGroupName, Name);
+            var collectionInner = Extensions.Synchronize(() => Manager.Inner.WebApps.ListHostNameBindingsAsync(ResourceGroupName, Name));
             var hostNameBindings = new List<IHostNameBinding>();
             foreach (var inner in collectionInner)
             {
@@ -230,14 +229,14 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:BC96AA8FDB678157AC1E6F0AA511AB65:20A70C4EEFBA9DE9AD6AA6D9133187D7
         public override IWebAppSourceControl GetSourceControl()
         {
-            SiteSourceControlInner siteSourceControlInner = Manager.Inner.WebApps.GetSourceControl(ResourceGroupName, Name);
+            SiteSourceControlInner siteSourceControlInner = Extensions.Synchronize(() => Manager.Inner.WebApps.GetSourceControlAsync(ResourceGroupName, Name));
             return new WebAppSourceControlImpl<FluentT, FluentImplT, DefAfterRegionT, DefAfterGroupT, UpdateT>(siteSourceControlInner, (FluentImplT) this);
         }
 
         ///GENMHASH:0F38250A3837DF9C2C345D4A038B654B:57465AB4A649A705C9DC2183EE743214
         public override void Start()
         {
-            Manager.Inner.WebApps.Start(ResourceGroupName, Name);
+            Extensions.Synchronize(() => Manager.Inner.WebApps.StartAsync(ResourceGroupName, Name));
         }
 
         ///GENMHASH:B22FA99F4432342EBBDB2AB426A8D2A2:DB92CE96AE133E965FE6DE31D475D7ED
@@ -253,10 +252,10 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:DFC52755A97E7B13EB10FA2EB9538E4A:FCF3A2AD2F52743B995DDA1FE7D020CB
         public override void Swap(string slotName)
         {
-            Manager.Inner.WebApps.SwapSlotWithProduction(ResourceGroupName, Name, new CsmSlotEntityInner
+            Extensions.Synchronize(() => Manager.Inner.WebApps.SwapSlotWithProductionAsync(ResourceGroupName, Name, new CsmSlotEntityInner
             {
                 TargetSlot = slotName
-            });
+            }));
             Refresh();
         }
 

--- a/src/ResourceManagement/AppService/AppServiceDomainsImpl.cs
+++ b/src/ResourceManagement/AppService/AppServiceDomainsImpl.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         {
             var topLevelDomains = Manager.Inner.TopLevelDomains;
 
-            return topLevelDomains.ListAgreements(topLevelExtension, new TopLevelDomainAgreementOptionInner())
-                                  .AsContinuousCollection(link => topLevelDomains.ListAgreementsNext(link))
+            return Extensions.Synchronize(() => topLevelDomains.ListAgreementsAsync(topLevelExtension, new TopLevelDomainAgreementOptionInner()))
+                                  .AsContinuousCollection(link => Extensions.Synchronize(() => topLevelDomains.ListAgreementsNextAsync(link)))
                                   .Select(inner => new DomainLegalAgreementImpl(inner));
         }
 

--- a/src/ResourceManagement/AppService/AppServicePlansImpl.cs
+++ b/src/ResourceManagement/AppService/AppServicePlansImpl.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Azure.Management.AppService.Fluent
 
         public IEnumerable<IAppServicePlan> ListByGroup(string resourceGroupName)
         {
-            return WrapList(Inner.ListByResourceGroup(resourceGroupName)
-                                 .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link)));
+            return WrapList(Extensions.Synchronize(() => Inner.ListByResourceGroupAsync(resourceGroupName))
+                                 .AsContinuousCollection(link => Extensions.Synchronize(() => Inner.ListByResourceGroupNextAsync(link))));
         }
         protected async override Task<IPage<AppServicePlanInner>> ListInnerByGroupAsync(string groupName, CancellationToken cancellationToken)
         {

--- a/src/ResourceManagement/AppService/DeploymentSlotImpl.cs
+++ b/src/ResourceManagement/AppService/DeploymentSlotImpl.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:EB854F18026EDB6E01762FA4580BE789:E08F92567FBEC84BEB0BF3AD4DF89EDC
         public override void Stop()
         {
-            Manager.Inner.WebApps.StopSlot(ResourceGroupName, parent.Name, Name());
+            Extensions.Synchronize(() => Manager.Inner.WebApps.StopSlotAsync(ResourceGroupName, parent.Name, Name()));
         }
 
         ///GENMHASH:88806945F575AAA522C2E09EBC366CC0:648365CFF3D36F6215B51C13E63240EA
@@ -146,19 +146,19 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:1AD5C303B4B7C1709305A18733B506B2:0BA6545E2E5A5E654CE278DD5968E11F
         public override void ResetSlotConfigurations()
         {
-            Manager.Inner.WebApps.ResetSlotConfigurationSlot(ResourceGroupName, parent.Name, Name());
+            Extensions.Synchronize(() => Manager.Inner.WebApps.ResetSlotConfigurationSlotAsync(ResourceGroupName, parent.Name, Name()));
         }
 
         ///GENMHASH:08CFC096AC6388D1C0E041ECDF099E3D:44C76716F153B9042AE98C1BCBC503F2
         public override void Restart()
         {
-            Manager.Inner.WebApps.RestartSlot(ResourceGroupName, parent.Name, Name());
+            Extensions.Synchronize(() => Manager.Inner.WebApps.RestartSlotAsync(ResourceGroupName, parent.Name, Name()));
         }
 
         ///GENMHASH:3F0152723C985A22C1032733AB942C96:6FCE951A1B9813960CE8873DF107297F
         public override IPublishingProfile GetPublishingProfile()
         {
-            Stream stream = Manager.Inner.WebApps.ListPublishingProfileXmlWithSecretsSlot(ResourceGroupName, Parent().Name, new CsmPublishingProfileOptionsInner(), Name());
+            Stream stream = Extensions.Synchronize(() => Manager.Inner.WebApps.ListPublishingProfileXmlWithSecretsSlotAsync(ResourceGroupName, Parent().Name, new CsmPublishingProfileOptionsInner(), Name()));
             StreamReader reader = new StreamReader(stream);
             string xml = reader.ReadToEnd();
             return new PublishingProfileImpl(xml);
@@ -173,10 +173,10 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:924482EE7AA6A01820720743C2A59A72:E50B17913B8A65047092DD2C6D6AFE8C
         public override void ApplySlotConfigurations(string slotName)
         {
-            Manager.Inner.WebApps.ApplySlotConfigurationSlot(ResourceGroupName, parent.Name, new CsmSlotEntityInner()
+            Extensions.Synchronize(() => Manager.Inner.WebApps.ApplySlotConfigurationSlotAsync(ResourceGroupName, parent.Name, new CsmSlotEntityInner()
             {
                 TargetSlot = slotName
-            }, Name());
+            }, Name()));
             Refresh();
         }
 
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:8C5F8B18192B4F8FD7D43AB4D318EA69:3D9AAF779EB9D14F1D1CEB4D1C1D5CA2
         public override IReadOnlyDictionary<string, Microsoft.Azure.Management.AppService.Fluent.IHostNameBinding> GetHostNameBindings()
         {
-            var collectionInner = Manager.Inner.WebApps.ListHostNameBindingsSlot(ResourceGroupName, parent.Name, Name());
+            var collectionInner = Extensions.Synchronize(() => Manager.Inner.WebApps.ListHostNameBindingsSlotAsync(ResourceGroupName, parent.Name, Name()));
             return collectionInner.ToDictionary(input => input.Name.Replace(Name() + "/", ""),
                 inner => (IHostNameBinding)new HostNameBindingImpl<IDeploymentSlot, DeploymentSlotImpl, object, object, IUpdate>(
                     inner,
@@ -238,7 +238,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:BC96AA8FDB678157AC1E6F0AA511AB65:55CBEA763E5EA0A02A785BC1273C63B0
         public override IWebAppSourceControl GetSourceControl()
         {
-            var siteSourceControlInner = Manager.Inner.WebApps.GetSourceControlSlot(ResourceGroupName, parent.Name, Name());
+            var siteSourceControlInner = Extensions.Synchronize(() => Manager.Inner.WebApps.GetSourceControlSlotAsync(ResourceGroupName, parent.Name, Name()));
             return new WebAppSourceControlImpl<IDeploymentSlot, DeploymentSlotImpl, object, object, IUpdate>(
                 siteSourceControlInner,
                 this);
@@ -253,7 +253,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:0F38250A3837DF9C2C345D4A038B654B:01DA6136E32014808DDE7F0C637CF668
         public override void Start()
         {
-            Manager.Inner.WebApps.StartSlot(ResourceGroupName, parent.Name, Name());
+            Extensions.Synchronize(() => Manager.Inner.WebApps.StartSlotAsync(ResourceGroupName, parent.Name, Name()));
         }
 
         ///GENMHASH:9754CAF64EAC70E3B92A0EEED2DC1120:F4C48AA95D98CB150D145294CB2F63A3
@@ -265,10 +265,10 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:DFC52755A97E7B13EB10FA2EB9538E4A:31BC86C370122E939BA1BA0EC17B6967
         public override void Swap(string slotName)
         {
-            Manager.Inner.WebApps.SwapSlotSlot(ResourceGroupName, parent.Name, new CsmSlotEntityInner()
+            Extensions.Synchronize(() => Manager.Inner.WebApps.SwapSlotSlotAsync(ResourceGroupName, parent.Name, new CsmSlotEntityInner()
             {
                 TargetSlot = slotName
-            }, Name());
+            }, Name()));
 
             Refresh();
         }

--- a/src/ResourceManagement/AppService/FunctionAppImpl.cs
+++ b/src/ResourceManagement/AppService/FunctionAppImpl.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
 
         public string GetMasterKey()
         {
-            return GetMasterKeyAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetMasterKeyAsync());
         }
 
         /// <summary>
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
 
         public void SyncTriggers()
         {
-            SyncTriggersAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => SyncTriggersAsync());
         }
 
         public async Task SyncTriggersAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/AppService/FunctionAppsImpl.cs
+++ b/src/ResourceManagement/AppService/FunctionAppsImpl.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         {
             Func<SiteInner, IFunctionApp> converter = inner =>
             {
-                return PopulateModelAsync(inner).ConfigureAwait(false).GetAwaiter().GetResult();
+                return Extensions.Synchronize(() => PopulateModelAsync(inner));
             };
 
             return Inner.ListByResourceGroup(resourceGroupName)

--- a/src/ResourceManagement/AppService/FunctionAppsImpl.cs
+++ b/src/ResourceManagement/AppService/FunctionAppsImpl.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 return Extensions.Synchronize(() => PopulateModelAsync(inner));
             };
 
-            return Inner.ListByResourceGroup(resourceGroupName)
-                        .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link))
+            return Extensions.Synchronize(() => Inner.ListByResourceGroupAsync(resourceGroupName))
+                        .AsContinuousCollection(link => Extensions.Synchronize(() => Inner.ListByResourceGroupNextAsync(link)))
                         .Select(inner => converter(inner));
         }
 

--- a/src/ResourceManagement/AppService/Generated/AppServiceCertificateOrdersOperationsExtensions.cs
+++ b/src/ResourceManagement/AppService/Generated/AppServiceCertificateOrdersOperationsExtensions.cs
@@ -33,20 +33,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
-            public static IPage<AppServiceCertificateOrderInner> List(this IAppServiceCertificateOrdersOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// List all certificate orders in a subscription.
-            /// </summary>
-            /// <remarks>
-            /// List all certificate orders in a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
@@ -56,23 +42,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 {
                     return _result.Body;
                 }
-            }
-
-            /// <summary>
-            /// Validate information for a certificate order.
-            /// </summary>
-            /// <remarks>
-            /// Validate information for a certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='appServiceCertificateOrder'>
-            /// Information for a certificate order.
-            /// </param>
-            public static void ValidatePurchaseInformation(this IAppServiceCertificateOrdersOperations operations, AppServiceCertificateOrderInner appServiceCertificateOrder)
-            {
-                operations.ValidatePurchaseInformationAsync(appServiceCertificateOrder).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -107,23 +76,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='resourceGroupName'>
             /// Name of the resource group to which the resource belongs.
             /// </param>
-            public static IPage<AppServiceCertificateOrderInner> ListByResourceGroup(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Get certificate orders in a resource group.
-            /// </summary>
-            /// <remarks>
-            /// Get certificate orders in a resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
@@ -133,26 +85,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 {
                     return _result.Body;
                 }
-            }
-
-            /// <summary>
-            /// Get a certificate order.
-            /// </summary>
-            /// <remarks>
-            /// Get a certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order..
-            /// </param>
-            public static AppServiceCertificateOrderInner Get(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName)
-            {
-                return operations.GetAsync(resourceGroupName, certificateOrderName).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -199,29 +131,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='certificateDistinguishedName'>
             /// Distinguished name to to use for the certificate order.
             /// </param>
-            public static AppServiceCertificateOrderInner CreateOrUpdate(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, AppServiceCertificateOrderInner certificateDistinguishedName)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, certificateOrderName, certificateDistinguishedName).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Create or update a certificate purchase order.
-            /// </summary>
-            /// <remarks>
-            /// Create or update a certificate purchase order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
-            /// <param name='certificateDistinguishedName'>
-            /// Distinguished name to to use for the certificate order.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
@@ -231,26 +140,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 {
                     return _result.Body;
                 }
-            }
-
-            /// <summary>
-            /// Delete an existing certificate order.
-            /// </summary>
-            /// <remarks>
-            /// Delete an existing certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
-            public static void Delete(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName)
-            {
-                operations.DeleteAsync(resourceGroupName, certificateOrderName).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -291,26 +180,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='certificateOrderName'>
             /// Name of the certificate order.
             /// </param>
-            public static IPage<AppServiceCertificateResourceInner> ListCertificates(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName)
-            {
-                return operations.ListCertificatesAsync(resourceGroupName, certificateOrderName).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// List all certificates associated with a certificate order.
-            /// </summary>
-            /// <remarks>
-            /// List all certificates associated with a certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
@@ -320,29 +189,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 {
                     return _result.Body;
                 }
-            }
-
-            /// <summary>
-            /// Get the certificate associated with a certificate order.
-            /// </summary>
-            /// <remarks>
-            /// Get the certificate associated with a certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the certificate.
-            /// </param>
-            public static AppServiceCertificateResourceInner GetCertificate(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, string name)
-            {
-                return operations.GetCertificateAsync(resourceGroupName, certificateOrderName, name).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -395,32 +241,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='keyVaultCertificate'>
             /// Key vault certificate resource Id.
             /// </param>
-            public static AppServiceCertificateResourceInner CreateOrUpdateCertificate(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, string name, AppServiceCertificateResourceInner keyVaultCertificate)
-            {
-                return operations.CreateOrUpdateCertificateAsync(resourceGroupName, certificateOrderName, name, keyVaultCertificate).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Creates or updates a certificate and associates with key vault secret.
-            /// </summary>
-            /// <remarks>
-            /// Creates or updates a certificate and associates with key vault secret.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the certificate.
-            /// </param>
-            /// <param name='keyVaultCertificate'>
-            /// Key vault certificate resource Id.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
@@ -430,29 +250,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 {
                     return _result.Body;
                 }
-            }
-
-            /// <summary>
-            /// Delete the certificate associated with a certificate order.
-            /// </summary>
-            /// <remarks>
-            /// Delete the certificate associated with a certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the certificate.
-            /// </param>
-            public static void DeleteCertificate(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, string name)
-            {
-                operations.DeleteCertificateAsync(resourceGroupName, certificateOrderName, name).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -499,58 +296,12 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='reissueCertificateOrderRequest'>
             /// Parameters for the reissue.
             /// </param>
-            public static void Reissue(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, ReissueCertificateOrderRequestInner reissueCertificateOrderRequest)
-            {
-                operations.ReissueAsync(resourceGroupName, certificateOrderName, reissueCertificateOrderRequest).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Reissue an existing certificate order.
-            /// </summary>
-            /// <remarks>
-            /// Reissue an existing certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
-            /// <param name='reissueCertificateOrderRequest'>
-            /// Parameters for the reissue.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
             public static async Task ReissueAsync(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, ReissueCertificateOrderRequestInner reissueCertificateOrderRequest, CancellationToken cancellationToken = default(CancellationToken))
             {
                 (await operations.ReissueWithHttpMessagesAsync(resourceGroupName, certificateOrderName, reissueCertificateOrderRequest, null, cancellationToken).ConfigureAwait(false)).Dispose();
-            }
-
-            /// <summary>
-            /// Renew an existing certificate order.
-            /// </summary>
-            /// <remarks>
-            /// Renew an existing certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
-            /// <param name='renewCertificateOrderRequest'>
-            /// Renew parameters
-            /// </param>
-            public static void Renew(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, RenewCertificateOrderRequestInner renewCertificateOrderRequest)
-            {
-                operations.RenewAsync(resourceGroupName, certificateOrderName, renewCertificateOrderRequest).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -594,55 +345,12 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='certificateOrderName'>
             /// Name of the certificate order.
             /// </param>
-            public static void ResendEmail(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName)
-            {
-                operations.ResendEmailAsync(resourceGroupName, certificateOrderName).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Resend certificate email.
-            /// </summary>
-            /// <remarks>
-            /// Resend certificate email.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
             public static async Task ResendEmailAsync(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, CancellationToken cancellationToken = default(CancellationToken))
             {
                 (await operations.ResendEmailWithHttpMessagesAsync(resourceGroupName, certificateOrderName, null, cancellationToken).ConfigureAwait(false)).Dispose();
-            }
-
-            /// <summary>
-            /// Verify domain ownership for this certificate order.
-            /// </summary>
-            /// <remarks>
-            /// Verify domain ownership for this certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
-            /// <param name='nameIdentifier'>
-            /// Email address
-            /// </param>
-            public static void ResendRequestEmails(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, NameIdentifierInner nameIdentifier)
-            {
-                operations.ResendRequestEmailsAsync(resourceGroupName, certificateOrderName, nameIdentifier).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -689,29 +397,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='siteSealRequest'>
             /// Site seal request.
             /// </param>
-            public static SiteSealInner RetrieveSiteSeal(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, SiteSealRequestInner siteSealRequest)
-            {
-                return operations.RetrieveSiteSealAsync(resourceGroupName, certificateOrderName, siteSealRequest).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Verify domain ownership for this certificate order.
-            /// </summary>
-            /// <remarks>
-            /// Verify domain ownership for this certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
-            /// <param name='siteSealRequest'>
-            /// Site seal request.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
@@ -738,52 +423,12 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='certificateOrderName'>
             /// Name of the certificate order.
             /// </param>
-            public static void VerifyDomainOwnership(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName)
-            {
-                operations.VerifyDomainOwnershipAsync(resourceGroupName, certificateOrderName).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Verify domain ownership for this certificate order.
-            /// </summary>
-            /// <remarks>
-            /// Verify domain ownership for this certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
             public static async Task VerifyDomainOwnershipAsync(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, CancellationToken cancellationToken = default(CancellationToken))
             {
                 (await operations.VerifyDomainOwnershipWithHttpMessagesAsync(resourceGroupName, certificateOrderName, null, cancellationToken).ConfigureAwait(false)).Dispose();
-            }
-
-            /// <summary>
-            /// Retrieve the list of certificate actions.
-            /// </summary>
-            /// <remarks>
-            /// Retrieve the list of certificate actions.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the certificate order.
-            /// </param>
-            public static IList<CertificateOrderActionInner> RetrieveCertificateActions(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string name)
-            {
-                return operations.RetrieveCertificateActionsAsync(resourceGroupName, name).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -827,26 +472,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='name'>
             /// Name of the certificate order.
             /// </param>
-            public static IList<CertificateEmailInner> RetrieveCertificateEmailHistory(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string name)
-            {
-                return operations.RetrieveCertificateEmailHistoryAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Retrieve email history.
-            /// </summary>
-            /// <remarks>
-            /// Retrieve email history.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the certificate order.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
@@ -856,29 +481,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 {
                     return _result.Body;
                 }
-            }
-
-            /// <summary>
-            /// Create or update a certificate purchase order.
-            /// </summary>
-            /// <remarks>
-            /// Create or update a certificate purchase order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
-            /// <param name='certificateDistinguishedName'>
-            /// Distinguished name to to use for the certificate order.
-            /// </param>
-            public static AppServiceCertificateOrderInner BeginCreateOrUpdate(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, AppServiceCertificateOrderInner certificateDistinguishedName)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, certificateOrderName, certificateDistinguishedName).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -931,32 +533,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='keyVaultCertificate'>
             /// Key vault certificate resource Id.
             /// </param>
-            public static AppServiceCertificateResourceInner BeginCreateOrUpdateCertificate(this IAppServiceCertificateOrdersOperations operations, string resourceGroupName, string certificateOrderName, string name, AppServiceCertificateResourceInner keyVaultCertificate)
-            {
-                return operations.BeginCreateOrUpdateCertificateAsync(resourceGroupName, certificateOrderName, name, keyVaultCertificate).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Creates or updates a certificate and associates with key vault secret.
-            /// </summary>
-            /// <remarks>
-            /// Creates or updates a certificate and associates with key vault secret.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='certificateOrderName'>
-            /// Name of the certificate order.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the certificate.
-            /// </param>
-            /// <param name='keyVaultCertificate'>
-            /// Key vault certificate resource Id.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
@@ -966,23 +542,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 {
                     return _result.Body;
                 }
-            }
-
-            /// <summary>
-            /// List all certificate orders in a subscription.
-            /// </summary>
-            /// <remarks>
-            /// List all certificate orders in a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<AppServiceCertificateOrderInner> ListNext(this IAppServiceCertificateOrdersOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -1020,23 +579,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             /// <param name='nextPageLink'>
             /// The NextLink from the previous successful call to List operation.
             /// </param>
-            public static IPage<AppServiceCertificateOrderInner> ListByResourceGroupNext(this IAppServiceCertificateOrdersOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Get certificate orders in a resource group.
-            /// </summary>
-            /// <remarks>
-            /// Get certificate orders in a resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
@@ -1046,23 +588,6 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 {
                     return _result.Body;
                 }
-            }
-
-            /// <summary>
-            /// List all certificates associated with a certificate order.
-            /// </summary>
-            /// <remarks>
-            /// List all certificates associated with a certificate order.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<AppServiceCertificateResourceInner> ListCertificatesNext(this IAppServiceCertificateOrdersOperations operations, string nextPageLink)
-            {
-                return operations.ListCertificatesNextAsync(nextPageLink).GetAwaiter().GetResult();
             }
 
             /// <summary>

--- a/src/ResourceManagement/AppService/Generated/AppServiceEnvironmentsOperationsExtensions.cs
+++ b/src/ResourceManagement/AppService/Generated/AppServiceEnvironmentsOperationsExtensions.cs
@@ -24,20 +24,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     public static partial class AppServiceEnvironmentsOperationsExtensions
     {
-            /// <summary>
-            /// Get all App Service Environments for a subscription.
-            /// </summary>
-            /// <remarks>
-            /// Get all App Service Environments for a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<AppServiceEnvironment> List(this IAppServiceEnvironmentsOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all App Service Environments for a subscription.
             /// </summary>
@@ -58,23 +45,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all App Service Environments in a resource group.
-            /// </summary>
-            /// <remarks>
-            /// Get all App Service Environments in a resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            public static IPage<AppServiceEnvironment> ListByResourceGroup(this IAppServiceEnvironmentsOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all App Service Environments in a resource group.
             /// </summary>
@@ -98,26 +69,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the properties of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get the properties of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static AppServiceEnvironmentResourceInner Get(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the properties of an App Service Environment.
             /// </summary>
@@ -144,29 +96,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or update an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Create or update an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='hostingEnvironmentEnvelope'>
-            /// Configuration details of the App Service Environment.
-            /// </param>
-            public static AppServiceEnvironmentResourceInner CreateOrUpdate(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, AppServiceEnvironmentResourceInner hostingEnvironmentEnvelope)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, name, hostingEnvironmentEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update an App Service Environment.
             /// </summary>
@@ -196,31 +126,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Delete an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='forceDelete'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to force the deletion even if the App
-            /// Service Environment contains resources. The default is
-            /// &lt;code&gt;false&lt;/code&gt;.
-            /// </param>
-            public static void Delete(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, bool? forceDelete = default(bool?))
-            {
-                operations.DeleteAsync(resourceGroupName, name, forceDelete).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete an App Service Environment.
             /// </summary>
@@ -249,28 +155,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, name, forceDelete, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get the used, available, and total worker capacity an App Service
-            /// Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get the used, available, and total worker capacity an App Service
-            /// Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IPage<StampCapacity> ListCapacities(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListCapacitiesAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the used, available, and total worker capacity an App Service
             /// Environment.
@@ -299,26 +184,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get IP addresses assigned to an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get IP addresses assigned to an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static AddressResponseInner ListVips(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListVipsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get IP addresses assigned to an App Service Environment.
             /// </summary>
@@ -345,26 +211,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get diagnostic information for an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get diagnostic information for an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IList<HostingEnvironmentDiagnosticsInner> ListDiagnostics(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListDiagnosticsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get diagnostic information for an App Service Environment.
             /// </summary>
@@ -391,29 +238,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a diagnostics item for an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get a diagnostics item for an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='diagnosticsName'>
-            /// Name of the diagnostics item.
-            /// </param>
-            public static HostingEnvironmentDiagnosticsInner GetDiagnosticsItem(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string diagnosticsName)
-            {
-                return operations.GetDiagnosticsItemAsync(resourceGroupName, name, diagnosticsName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a diagnostics item for an App Service Environment.
             /// </summary>
@@ -443,26 +268,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get global metric definitions of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get global metric definitions of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static MetricDefinitionInner ListMetricDefinitions(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListMetricDefinitionsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get global metric definitions of an App Service Environment.
             /// </summary>
@@ -489,36 +295,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get global metrics of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get global metrics of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='details'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to include instance details. The
-            /// default is &lt;code&gt;false&lt;/code&gt;.
-            /// </param>
-            /// <param name='filter'>
-            /// Return only usages/metrics specified in the filter. Filter conforms to
-            /// odata syntax. Example: $filter=(name.value eq 'Metric1' or name.value eq
-            /// 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and endTime eq
-            /// '2014-12-31T23:59:59Z' and timeGrain eq duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<ResourceMetric> ListMetrics(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, bool? details = default(bool?), string filter = default(string))
-            {
-                return operations.ListMetricsAsync(resourceGroupName, name, details, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get global metrics of an App Service Environment.
             /// </summary>
@@ -555,26 +332,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all multi-role pools.
-            /// </summary>
-            /// <remarks>
-            /// Get all multi-role pools.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IPage<WorkerPoolResourceInner> ListMultiRolePools(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListMultiRolePoolsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all multi-role pools.
             /// </summary>
@@ -601,26 +359,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get properties of a multi-role pool.
-            /// </summary>
-            /// <remarks>
-            /// Get properties of a multi-role pool.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static WorkerPoolResourceInner GetMultiRolePool(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetMultiRolePoolAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get properties of a multi-role pool.
             /// </summary>
@@ -647,29 +386,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or update a multi-role pool.
-            /// </summary>
-            /// <remarks>
-            /// Create or update a multi-role pool.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='multiRolePoolEnvelope'>
-            /// Properties of the multi-role pool.
-            /// </param>
-            public static WorkerPoolResourceInner CreateOrUpdateMultiRolePool(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, WorkerPoolResourceInner multiRolePoolEnvelope)
-            {
-                return operations.CreateOrUpdateMultiRolePoolAsync(resourceGroupName, name, multiRolePoolEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a multi-role pool.
             /// </summary>
@@ -699,31 +416,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metric definitions for a specific instance of a multi-role pool of an
-            /// App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metric definitions for a specific instance of a multi-role pool of an
-            /// App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='instance'>
-            /// Name of the instance in the multi-role pool.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListMultiRolePoolInstanceMetricDefinitions(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string instance)
-            {
-                return operations.ListMultiRolePoolInstanceMetricDefinitionsAsync(resourceGroupName, name, instance).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metric definitions for a specific instance of a multi-role pool of an
             /// App Service Environment.
@@ -755,35 +448,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics for a specific instance of a multi-role pool of an App Service
-            /// Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metrics for a specific instance of a multi-role pool of an App Service
-            /// Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='instance'>
-            /// Name of the instance in the multi-role pool.
-            /// </param>
-            /// <param name='details'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to include instance details. The
-            /// default is &lt;code&gt;false&lt;/code&gt;.
-            /// </param>
-            public static IPage<ResourceMetric> ListMultiRolePoolInstanceMetrics(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string instance, bool? details = default(bool?))
-            {
-                return operations.ListMultiRolePoolInstanceMetricsAsync(resourceGroupName, name, instance, details).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics for a specific instance of a multi-role pool of an App Service
             /// Environment.
@@ -819,26 +484,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metric definitions for a multi-role pool of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metric definitions for a multi-role pool of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListMultiRoleMetricDefinitions(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListMultiRoleMetricDefinitionsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metric definitions for a multi-role pool of an App Service Environment.
             /// </summary>
@@ -865,45 +511,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics for a multi-role pool of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metrics for a multi-role pool of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='startTime'>
-            /// Beginning time of the metrics query.
-            /// </param>
-            /// <param name='endTime'>
-            /// End time of the metrics query.
-            /// </param>
-            /// <param name='timeGrain'>
-            /// Time granularity of the metrics query.
-            /// </param>
-            /// <param name='details'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to include instance details. The
-            /// default is &lt;code&gt;false&lt;/code&gt;.
-            /// </param>
-            /// <param name='filter'>
-            /// Return only usages/metrics specified in the filter. Filter conforms to
-            /// odata syntax. Example: $filter=(name.value eq 'Metric1' or name.value eq
-            /// 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and endTime eq
-            /// '2014-12-31T23:59:59Z' and timeGrain eq duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<ResourceMetric> ListMultiRoleMetrics(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string startTime = default(string), string endTime = default(string), string timeGrain = default(string), bool? details = default(bool?), string filter = default(string))
-            {
-                return operations.ListMultiRoleMetricsAsync(resourceGroupName, name, startTime, endTime, timeGrain, details, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics for a multi-role pool of an App Service Environment.
             /// </summary>
@@ -949,26 +557,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get available SKUs for scaling a multi-role pool.
-            /// </summary>
-            /// <remarks>
-            /// Get available SKUs for scaling a multi-role pool.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IPage<SkuInfo> ListMultiRolePoolSkus(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListMultiRolePoolSkusAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get available SKUs for scaling a multi-role pool.
             /// </summary>
@@ -995,26 +584,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get usage metrics for a multi-role pool of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get usage metrics for a multi-role pool of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IPage<UsageInner> ListMultiRoleUsages(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListMultiRoleUsagesAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get usage metrics for a multi-role pool of an App Service Environment.
             /// </summary>
@@ -1041,26 +611,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List all currently running operations on the App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// List all currently running operations on the App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IList<OperationInner> ListOperations(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListOperationsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List all currently running operations on the App Service Environment.
             /// </summary>
@@ -1087,26 +638,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Reboot all machines in an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Reboot all machines in an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static void Reboot(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                operations.RebootAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reboot all machines in an App Service Environment.
             /// </summary>
@@ -1130,26 +662,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.RebootWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Resume an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Resume an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IPage<SiteInner> Resume(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ResumeAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Resume an App Service Environment.
             /// </summary>
@@ -1176,26 +689,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all App Service plans in an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get all App Service plans in an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IPage<AppServicePlanInner> ListAppServicePlans(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListAppServicePlansAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all App Service plans in an App Service Environment.
             /// </summary>
@@ -1222,29 +716,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all apps in an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get all apps in an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='propertiesToInclude'>
-            /// Comma separated list of app properties to include.
-            /// </param>
-            public static IPage<SiteInner> ListWebApps(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string propertiesToInclude = default(string))
-            {
-                return operations.ListWebAppsAsync(resourceGroupName, name, propertiesToInclude).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all apps in an App Service Environment.
             /// </summary>
@@ -1274,26 +746,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Suspend an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Suspend an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IPage<SiteInner> Suspend(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.SuspendAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Suspend an App Service Environment.
             /// </summary>
@@ -1320,32 +773,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get global usage metrics of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get global usage metrics of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='filter'>
-            /// Return only usages/metrics specified in the filter. Filter conforms to
-            /// odata syntax. Example: $filter=(name.value eq 'Metric1' or name.value eq
-            /// 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and endTime eq
-            /// '2014-12-31T23:59:59Z' and timeGrain eq duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<CsmUsageQuota> ListUsages(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string filter = default(string))
-            {
-                return operations.ListUsagesAsync(resourceGroupName, name, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get global usage metrics of an App Service Environment.
             /// </summary>
@@ -1378,26 +806,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all worker pools of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get all worker pools of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IPage<WorkerPoolResourceInner> ListWorkerPools(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListWorkerPoolsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all worker pools of an App Service Environment.
             /// </summary>
@@ -1424,29 +833,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get properties of a worker pool.
-            /// </summary>
-            /// <remarks>
-            /// Get properties of a worker pool.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='workerPoolName'>
-            /// Name of the worker pool.
-            /// </param>
-            public static WorkerPoolResourceInner GetWorkerPool(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string workerPoolName)
-            {
-                return operations.GetWorkerPoolAsync(resourceGroupName, name, workerPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get properties of a worker pool.
             /// </summary>
@@ -1476,32 +863,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or update a worker pool.
-            /// </summary>
-            /// <remarks>
-            /// Create or update a worker pool.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='workerPoolName'>
-            /// Name of the worker pool.
-            /// </param>
-            /// <param name='workerPoolEnvelope'>
-            /// Properties of the worker pool.
-            /// </param>
-            public static WorkerPoolResourceInner CreateOrUpdateWorkerPool(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string workerPoolName, WorkerPoolResourceInner workerPoolEnvelope)
-            {
-                return operations.CreateOrUpdateWorkerPoolAsync(resourceGroupName, name, workerPoolName, workerPoolEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a worker pool.
             /// </summary>
@@ -1534,34 +896,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metric definitions for a specific instance of a worker pool of an App
-            /// Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metric definitions for a specific instance of a worker pool of an App
-            /// Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='workerPoolName'>
-            /// Name of the worker pool.
-            /// </param>
-            /// <param name='instance'>
-            /// Name of the instance in the worker pool.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListWorkerPoolInstanceMetricDefinitions(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string workerPoolName, string instance)
-            {
-                return operations.ListWorkerPoolInstanceMetricDefinitionsAsync(resourceGroupName, name, workerPoolName, instance).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metric definitions for a specific instance of a worker pool of an App
             /// Service Environment.
@@ -1596,44 +931,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics for a specific instance of a worker pool of an App Service
-            /// Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metrics for a specific instance of a worker pool of an App Service
-            /// Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='workerPoolName'>
-            /// Name of the worker pool.
-            /// </param>
-            /// <param name='instance'>
-            /// Name of the instance in the worker pool.
-            /// </param>
-            /// <param name='details'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to include instance details. The
-            /// default is &lt;code&gt;false&lt;/code&gt;.
-            /// </param>
-            /// <param name='filter'>
-            /// Return only usages/metrics specified in the filter. Filter conforms to
-            /// odata syntax. Example: $filter=(name.value eq 'Metric1' or name.value eq
-            /// 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and endTime eq
-            /// '2014-12-31T23:59:59Z' and timeGrain eq duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<ResourceMetric> ListWorkerPoolInstanceMetrics(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string workerPoolName, string instance, bool? details = default(bool?), string filter = default(string))
-            {
-                return operations.ListWorkerPoolInstanceMetricsAsync(resourceGroupName, name, workerPoolName, instance, details, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics for a specific instance of a worker pool of an App Service
             /// Environment.
@@ -1678,29 +976,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metric definitions for a worker pool of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metric definitions for a worker pool of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='workerPoolName'>
-            /// Name of the worker pool.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListWebWorkerMetricDefinitions(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string workerPoolName)
-            {
-                return operations.ListWebWorkerMetricDefinitionsAsync(resourceGroupName, name, workerPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metric definitions for a worker pool of an App Service Environment.
             /// </summary>
@@ -1730,41 +1006,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics for a worker pool of a AppServiceEnvironment (App Service
-            /// Environment).
-            /// </summary>
-            /// <remarks>
-            /// Get metrics for a worker pool of a AppServiceEnvironment (App Service
-            /// Environment).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='workerPoolName'>
-            /// Name of worker pool
-            /// </param>
-            /// <param name='details'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to include instance details. The
-            /// default is &lt;code&gt;false&lt;/code&gt;.
-            /// </param>
-            /// <param name='filter'>
-            /// Return only usages/metrics specified in the filter. Filter conforms to
-            /// odata syntax. Example: $filter=(name.value eq 'Metric1' or name.value eq
-            /// 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and endTime eq
-            /// '2014-12-31T23:59:59Z' and timeGrain eq duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<ResourceMetric> ListWebWorkerMetrics(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string workerPoolName, bool? details = default(bool?), string filter = default(string))
-            {
-                return operations.ListWebWorkerMetricsAsync(resourceGroupName, name, workerPoolName, details, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics for a worker pool of a AppServiceEnvironment (App Service
             /// Environment).
@@ -1806,29 +1048,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get available SKUs for scaling a worker pool.
-            /// </summary>
-            /// <remarks>
-            /// Get available SKUs for scaling a worker pool.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='workerPoolName'>
-            /// Name of the worker pool.
-            /// </param>
-            public static IPage<SkuInfo> ListWorkerPoolSkus(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string workerPoolName)
-            {
-                return operations.ListWorkerPoolSkusAsync(resourceGroupName, name, workerPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get available SKUs for scaling a worker pool.
             /// </summary>
@@ -1858,29 +1078,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get usage metrics for a worker pool of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get usage metrics for a worker pool of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='workerPoolName'>
-            /// Name of the worker pool.
-            /// </param>
-            public static IPage<UsageInner> ListWebWorkerUsages(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string workerPoolName)
-            {
-                return operations.ListWebWorkerUsagesAsync(resourceGroupName, name, workerPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get usage metrics for a worker pool of an App Service Environment.
             /// </summary>
@@ -1910,29 +1108,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or update an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Create or update an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='hostingEnvironmentEnvelope'>
-            /// Configuration details of the App Service Environment.
-            /// </param>
-            public static AppServiceEnvironmentResourceInner BeginCreateOrUpdate(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, AppServiceEnvironmentResourceInner hostingEnvironmentEnvelope)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, name, hostingEnvironmentEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update an App Service Environment.
             /// </summary>
@@ -1962,31 +1138,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Delete an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='forceDelete'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to force the deletion even if the App
-            /// Service Environment contains resources. The default is
-            /// &lt;code&gt;false&lt;/code&gt;.
-            /// </param>
-            public static void BeginDelete(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, bool? forceDelete = default(bool?))
-            {
-                operations.BeginDeleteAsync(resourceGroupName, name, forceDelete).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete an App Service Environment.
             /// </summary>
@@ -2015,29 +1167,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, name, forceDelete, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Create or update a multi-role pool.
-            /// </summary>
-            /// <remarks>
-            /// Create or update a multi-role pool.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='multiRolePoolEnvelope'>
-            /// Properties of the multi-role pool.
-            /// </param>
-            public static WorkerPoolResourceInner BeginCreateOrUpdateMultiRolePool(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, WorkerPoolResourceInner multiRolePoolEnvelope)
-            {
-                return operations.BeginCreateOrUpdateMultiRolePoolAsync(resourceGroupName, name, multiRolePoolEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a multi-role pool.
             /// </summary>
@@ -2067,26 +1197,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Resume an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Resume an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IPage<SiteInner> BeginResume(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.BeginResumeAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Resume an App Service Environment.
             /// </summary>
@@ -2113,26 +1224,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Suspend an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Suspend an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            public static IPage<SiteInner> BeginSuspend(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.BeginSuspendAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Suspend an App Service Environment.
             /// </summary>
@@ -2159,32 +1251,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or update a worker pool.
-            /// </summary>
-            /// <remarks>
-            /// Create or update a worker pool.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service Environment.
-            /// </param>
-            /// <param name='workerPoolName'>
-            /// Name of the worker pool.
-            /// </param>
-            /// <param name='workerPoolEnvelope'>
-            /// Properties of the worker pool.
-            /// </param>
-            public static WorkerPoolResourceInner BeginCreateOrUpdateWorkerPool(this IAppServiceEnvironmentsOperations operations, string resourceGroupName, string name, string workerPoolName, WorkerPoolResourceInner workerPoolEnvelope)
-            {
-                return operations.BeginCreateOrUpdateWorkerPoolAsync(resourceGroupName, name, workerPoolName, workerPoolEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a worker pool.
             /// </summary>
@@ -2217,23 +1284,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all App Service Environments for a subscription.
-            /// </summary>
-            /// <remarks>
-            /// Get all App Service Environments for a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<AppServiceEnvironment> ListNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all App Service Environments for a subscription.
             /// </summary>
@@ -2257,23 +1308,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all App Service Environments in a resource group.
-            /// </summary>
-            /// <remarks>
-            /// Get all App Service Environments in a resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<AppServiceEnvironment> ListByResourceGroupNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all App Service Environments in a resource group.
             /// </summary>
@@ -2297,25 +1332,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the used, available, and total worker capacity an App Service
-            /// Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get the used, available, and total worker capacity an App Service
-            /// Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<StampCapacity> ListCapacitiesNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListCapacitiesNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the used, available, and total worker capacity an App Service
             /// Environment.
@@ -2341,23 +1358,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get global metrics of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get global metrics of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetric> ListMetricsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListMetricsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get global metrics of an App Service Environment.
             /// </summary>
@@ -2381,23 +1382,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all multi-role pools.
-            /// </summary>
-            /// <remarks>
-            /// Get all multi-role pools.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<WorkerPoolResourceInner> ListMultiRolePoolsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListMultiRolePoolsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all multi-role pools.
             /// </summary>
@@ -2421,25 +1406,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metric definitions for a specific instance of a multi-role pool of an
-            /// App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metric definitions for a specific instance of a multi-role pool of an
-            /// App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListMultiRolePoolInstanceMetricDefinitionsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListMultiRolePoolInstanceMetricDefinitionsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metric definitions for a specific instance of a multi-role pool of an
             /// App Service Environment.
@@ -2465,25 +1432,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics for a specific instance of a multi-role pool of an App Service
-            /// Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metrics for a specific instance of a multi-role pool of an App Service
-            /// Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetric> ListMultiRolePoolInstanceMetricsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListMultiRolePoolInstanceMetricsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics for a specific instance of a multi-role pool of an App Service
             /// Environment.
@@ -2509,23 +1458,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metric definitions for a multi-role pool of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metric definitions for a multi-role pool of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListMultiRoleMetricDefinitionsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListMultiRoleMetricDefinitionsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metric definitions for a multi-role pool of an App Service Environment.
             /// </summary>
@@ -2549,23 +1482,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics for a multi-role pool of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metrics for a multi-role pool of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetric> ListMultiRoleMetricsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListMultiRoleMetricsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics for a multi-role pool of an App Service Environment.
             /// </summary>
@@ -2589,23 +1506,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get available SKUs for scaling a multi-role pool.
-            /// </summary>
-            /// <remarks>
-            /// Get available SKUs for scaling a multi-role pool.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SkuInfo> ListMultiRolePoolSkusNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListMultiRolePoolSkusNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get available SKUs for scaling a multi-role pool.
             /// </summary>
@@ -2629,23 +1530,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get usage metrics for a multi-role pool of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get usage metrics for a multi-role pool of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<UsageInner> ListMultiRoleUsagesNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListMultiRoleUsagesNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get usage metrics for a multi-role pool of an App Service Environment.
             /// </summary>
@@ -2669,23 +1554,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Resume an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Resume an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteInner> ResumeNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ResumeNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Resume an App Service Environment.
             /// </summary>
@@ -2709,23 +1578,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all App Service plans in an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get all App Service plans in an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<AppServicePlanInner> ListAppServicePlansNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListAppServicePlansNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all App Service plans in an App Service Environment.
             /// </summary>
@@ -2749,23 +1602,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all apps in an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get all apps in an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteInner> ListWebAppsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListWebAppsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all apps in an App Service Environment.
             /// </summary>
@@ -2789,23 +1626,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Suspend an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Suspend an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteInner> SuspendNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.SuspendNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Suspend an App Service Environment.
             /// </summary>
@@ -2829,23 +1650,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get global usage metrics of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get global usage metrics of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<CsmUsageQuota> ListUsagesNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListUsagesNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get global usage metrics of an App Service Environment.
             /// </summary>
@@ -2869,23 +1674,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all worker pools of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get all worker pools of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<WorkerPoolResourceInner> ListWorkerPoolsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListWorkerPoolsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all worker pools of an App Service Environment.
             /// </summary>
@@ -2909,25 +1698,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metric definitions for a specific instance of a worker pool of an App
-            /// Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metric definitions for a specific instance of a worker pool of an App
-            /// Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListWorkerPoolInstanceMetricDefinitionsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListWorkerPoolInstanceMetricDefinitionsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metric definitions for a specific instance of a worker pool of an App
             /// Service Environment.
@@ -2953,25 +1724,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics for a specific instance of a worker pool of an App Service
-            /// Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metrics for a specific instance of a worker pool of an App Service
-            /// Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetric> ListWorkerPoolInstanceMetricsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListWorkerPoolInstanceMetricsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics for a specific instance of a worker pool of an App Service
             /// Environment.
@@ -2997,23 +1750,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metric definitions for a worker pool of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get metric definitions for a worker pool of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListWebWorkerMetricDefinitionsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListWebWorkerMetricDefinitionsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metric definitions for a worker pool of an App Service Environment.
             /// </summary>
@@ -3037,25 +1774,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics for a worker pool of a AppServiceEnvironment (App Service
-            /// Environment).
-            /// </summary>
-            /// <remarks>
-            /// Get metrics for a worker pool of a AppServiceEnvironment (App Service
-            /// Environment).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetric> ListWebWorkerMetricsNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListWebWorkerMetricsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics for a worker pool of a AppServiceEnvironment (App Service
             /// Environment).
@@ -3081,23 +1800,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get available SKUs for scaling a worker pool.
-            /// </summary>
-            /// <remarks>
-            /// Get available SKUs for scaling a worker pool.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SkuInfo> ListWorkerPoolSkusNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListWorkerPoolSkusNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get available SKUs for scaling a worker pool.
             /// </summary>
@@ -3121,23 +1824,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get usage metrics for a worker pool of an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Get usage metrics for a worker pool of an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<UsageInner> ListWebWorkerUsagesNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListWebWorkerUsagesNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get usage metrics for a worker pool of an App Service Environment.
             /// </summary>
@@ -3161,23 +1848,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Resume an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Resume an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteInner> BeginResumeNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.BeginResumeNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Resume an App Service Environment.
             /// </summary>
@@ -3201,23 +1872,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Suspend an App Service Environment.
-            /// </summary>
-            /// <remarks>
-            /// Suspend an App Service Environment.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteInner> BeginSuspendNext(this IAppServiceEnvironmentsOperations operations, string nextPageLink)
-            {
-                return operations.BeginSuspendNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Suspend an App Service Environment.
             /// </summary>

--- a/src/ResourceManagement/AppService/Generated/AppServicePlansOperationsExtensions.cs
+++ b/src/ResourceManagement/AppService/Generated/AppServicePlansOperationsExtensions.cs
@@ -24,26 +24,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     public static partial class AppServicePlansOperationsExtensions
     {
-            /// <summary>
-            /// Get all App Service plans for a subcription.
-            /// </summary>
-            /// <remarks>
-            /// Get all App Service plans for a subcription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='detailed'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to return all App Service plan
-            /// properties. The default is &lt;code&gt;false&lt;/code&gt;, which returns a
-            /// subset of the properties.
-            /// Retrieval of all properties may increase the API latency.
-            /// </param>
-            public static IPage<AppServicePlanInner> List(this IAppServicePlansOperations operations, bool? detailed = default(bool?))
-            {
-                return operations.ListAsync(detailed).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all App Service plans for a subcription.
             /// </summary>
@@ -70,23 +51,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all App Service plans in a resource group.
-            /// </summary>
-            /// <remarks>
-            /// Get all App Service plans in a resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            public static IPage<AppServicePlanInner> ListByResourceGroup(this IAppServicePlansOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all App Service plans in a resource group.
             /// </summary>
@@ -110,26 +75,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Get an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            public static AppServicePlanInner Get(this IAppServicePlansOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get an App Service plan.
             /// </summary>
@@ -156,29 +102,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates an App Service Plan.
-            /// </summary>
-            /// <remarks>
-            /// Creates or updates an App Service Plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='appServicePlan'>
-            /// Details of the App Service plan.
-            /// </param>
-            public static AppServicePlanInner CreateOrUpdate(this IAppServicePlansOperations operations, string resourceGroupName, string name, AppServicePlanInner appServicePlan)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, name, appServicePlan).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates an App Service Plan.
             /// </summary>
@@ -208,26 +132,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Delete an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            public static void Delete(this IAppServicePlansOperations operations, string resourceGroupName, string name)
-            {
-                operations.DeleteAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete an App Service plan.
             /// </summary>
@@ -251,26 +156,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// List all capabilities of an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// List all capabilities of an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            public static IList<CapabilityInner> ListCapabilities(this IAppServicePlansOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListCapabilitiesAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List all capabilities of an App Service plan.
             /// </summary>
@@ -297,32 +183,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Retrieve a Hybrid Connection in use in an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Retrieve a Hybrid Connection in use in an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// Name of the Service Bus namespace.
-            /// </param>
-            /// <param name='relayName'>
-            /// Name of the Service Bus relay.
-            /// </param>
-            public static HybridConnectionInner GetHybridConnection(this IAppServicePlansOperations operations, string resourceGroupName, string name, string namespaceName, string relayName)
-            {
-                return operations.GetHybridConnectionAsync(resourceGroupName, name, namespaceName, relayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Retrieve a Hybrid Connection in use in an App Service plan.
             /// </summary>
@@ -355,32 +216,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete a Hybrid Connection in use in an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Delete a Hybrid Connection in use in an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// Name of the Service Bus namespace.
-            /// </param>
-            /// <param name='relayName'>
-            /// Name of the Service Bus relay.
-            /// </param>
-            public static void DeleteHybridConnection(this IAppServicePlansOperations operations, string resourceGroupName, string name, string namespaceName, string relayName)
-            {
-                operations.DeleteHybridConnectionAsync(resourceGroupName, name, namespaceName, relayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a Hybrid Connection in use in an App Service plan.
             /// </summary>
@@ -410,32 +246,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteHybridConnectionWithHttpMessagesAsync(resourceGroupName, name, namespaceName, relayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get the send key name and value of a Hybrid Connection.
-            /// </summary>
-            /// <remarks>
-            /// Get the send key name and value of a Hybrid Connection.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The name of the Service Bus namespace.
-            /// </param>
-            /// <param name='relayName'>
-            /// The name of the Service Bus relay.
-            /// </param>
-            public static HybridConnectionKeyInner ListHybridConnectionKeys(this IAppServicePlansOperations operations, string resourceGroupName, string name, string namespaceName, string relayName)
-            {
-                return operations.ListHybridConnectionKeysAsync(resourceGroupName, name, namespaceName, relayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the send key name and value of a Hybrid Connection.
             /// </summary>
@@ -468,32 +279,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all apps that use a Hybrid Connection in an App Service Plan.
-            /// </summary>
-            /// <remarks>
-            /// Get all apps that use a Hybrid Connection in an App Service Plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// Name of the Hybrid Connection namespace.
-            /// </param>
-            /// <param name='relayName'>
-            /// Name of the Hybrid Connection relay.
-            /// </param>
-            public static IPage<string> ListWebAppsByHybridConnection(this IAppServicePlansOperations operations, string resourceGroupName, string name, string namespaceName, string relayName)
-            {
-                return operations.ListWebAppsByHybridConnectionAsync(resourceGroupName, name, namespaceName, relayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all apps that use a Hybrid Connection in an App Service Plan.
             /// </summary>
@@ -526,28 +312,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the maximum number of Hybrid Connections allowed in an App Service
-            /// plan.
-            /// </summary>
-            /// <remarks>
-            /// Get the maximum number of Hybrid Connections allowed in an App Service
-            /// plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            public static HybridConnectionLimitsInner GetHybridConnectionPlanLimit(this IAppServicePlansOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetHybridConnectionPlanLimitAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the maximum number of Hybrid Connections allowed in an App Service
             /// plan.
@@ -576,26 +341,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Retrieve all Hybrid Connections in use in an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Retrieve all Hybrid Connections in use in an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            public static IPage<HybridConnectionInner> ListHybridConnections(this IAppServicePlansOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListHybridConnectionsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Retrieve all Hybrid Connections in use in an App Service plan.
             /// </summary>
@@ -622,28 +368,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics that can be queried for an App Service plan, and their
-            /// definitions.
-            /// </summary>
-            /// <remarks>
-            /// Get metrics that can be queried for an App Service plan, and their
-            /// definitions.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListMetricDefintions(this IAppServicePlansOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListMetricDefintionsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics that can be queried for an App Service plan, and their
             /// definitions.
@@ -672,36 +397,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics for an App Serice plan.
-            /// </summary>
-            /// <remarks>
-            /// Get metrics for an App Serice plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='details'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to include instance details. The
-            /// default is &lt;code&gt;false&lt;/code&gt;.
-            /// </param>
-            /// <param name='filter'>
-            /// Return only usages/metrics specified in the filter. Filter conforms to
-            /// odata syntax. Example: $filter=(name.value eq 'Metric1' or name.value eq
-            /// 'Metric2') and startTime eq '2014-01-01T00:00:00Z' and endTime eq
-            /// '2014-12-31T23:59:59Z' and timeGrain eq duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<ResourceMetric> ListMetrics(this IAppServicePlansOperations operations, string resourceGroupName, string name, bool? details = default(bool?), string filter = default(string))
-            {
-                return operations.ListMetricsAsync(resourceGroupName, name, details, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics for an App Serice plan.
             /// </summary>
@@ -738,32 +434,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restart all apps in an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Restart all apps in an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='softRestart'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to performa a soft restart, applies
-            /// the configuration settings and restarts the apps if necessary. The default
-            /// is &lt;code&gt;false&lt;/code&gt;, which always restarts and reprovisions
-            /// the apps
-            /// </param>
-            public static void RestartWebApps(this IAppServicePlansOperations operations, string resourceGroupName, string name, bool? softRestart = default(bool?))
-            {
-                operations.RestartWebAppsAsync(resourceGroupName, name, softRestart).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restart all apps in an App Service plan.
             /// </summary>
@@ -793,39 +464,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.RestartWebAppsWithHttpMessagesAsync(resourceGroupName, name, softRestart, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get all apps associated with an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Get all apps associated with an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='skipToken'>
-            /// Skip to a web app in the list of webapps associated with app service plan.
-            /// If specified, the resulting list will contain web apps starting from
-            /// (including) the skipToken. Otherwise, the resulting list contains web apps
-            /// from the start of the list
-            /// </param>
-            /// <param name='filter'>
-            /// Supported filter: $filter=state eq running. Returns only web apps that are
-            /// currently running
-            /// </param>
-            /// <param name='top'>
-            /// List page size. If specified, results are paged.
-            /// </param>
-            public static IPage<SiteInner> ListWebApps(this IAppServicePlansOperations operations, string resourceGroupName, string name, string skipToken = default(string), string filter = default(string), string top = default(string))
-            {
-                return operations.ListWebAppsAsync(resourceGroupName, name, skipToken, filter, top).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all apps associated with an App Service plan.
             /// </summary>
@@ -865,26 +504,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all Virtual Networks associated with an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Get all Virtual Networks associated with an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            public static IList<VnetInfoInner> ListVnets(this IAppServicePlansOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListVnetsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all Virtual Networks associated with an App Service plan.
             /// </summary>
@@ -911,29 +531,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a Virtual Network associated with an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Get a Virtual Network associated with an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            public static VnetInfoInner GetVnetFromServerFarm(this IAppServicePlansOperations operations, string resourceGroupName, string name, string vnetName)
-            {
-                return operations.GetVnetFromServerFarmAsync(resourceGroupName, name, vnetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a Virtual Network associated with an App Service plan.
             /// </summary>
@@ -963,32 +561,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a Virtual Network gateway.
-            /// </summary>
-            /// <remarks>
-            /// Get a Virtual Network gateway.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='gatewayName'>
-            /// Name of the gateway. Only the 'primary' gateway is supported.
-            /// </param>
-            public static VnetGatewayInner GetVnetGateway(this IAppServicePlansOperations operations, string resourceGroupName, string name, string vnetName, string gatewayName)
-            {
-                return operations.GetVnetGatewayAsync(resourceGroupName, name, vnetName, gatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a Virtual Network gateway.
             /// </summary>
@@ -1021,35 +594,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Update a Virtual Network gateway.
-            /// </summary>
-            /// <remarks>
-            /// Update a Virtual Network gateway.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='gatewayName'>
-            /// Name of the gateway. Only the 'primary' gateway is supported.
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// Definition of the gateway.
-            /// </param>
-            public static VnetGatewayInner UpdateVnetGateway(this IAppServicePlansOperations operations, string resourceGroupName, string name, string vnetName, string gatewayName, VnetGatewayInner connectionEnvelope)
-            {
-                return operations.UpdateVnetGatewayAsync(resourceGroupName, name, vnetName, gatewayName, connectionEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Update a Virtual Network gateway.
             /// </summary>
@@ -1085,31 +630,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all routes that are associated with a Virtual Network in an App Service
-            /// plan.
-            /// </summary>
-            /// <remarks>
-            /// Get all routes that are associated with a Virtual Network in an App Service
-            /// plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            public static IList<VnetRouteInner> ListRoutesForVnet(this IAppServicePlansOperations operations, string resourceGroupName, string name, string vnetName)
-            {
-                return operations.ListRoutesForVnetAsync(resourceGroupName, name, vnetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all routes that are associated with a Virtual Network in an App Service
             /// plan.
@@ -1141,32 +662,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a Virtual Network route in an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Get a Virtual Network route in an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='routeName'>
-            /// Name of the Virtual Network route.
-            /// </param>
-            public static IList<VnetRouteInner> GetRouteForVnet(this IAppServicePlansOperations operations, string resourceGroupName, string name, string vnetName, string routeName)
-            {
-                return operations.GetRouteForVnetAsync(resourceGroupName, name, vnetName, routeName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a Virtual Network route in an App Service plan.
             /// </summary>
@@ -1199,35 +695,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or update a Virtual Network route in an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Create or update a Virtual Network route in an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='routeName'>
-            /// Name of the Virtual Network route.
-            /// </param>
-            /// <param name='route'>
-            /// Definition of the Virtual Network route.
-            /// </param>
-            public static VnetRouteInner CreateOrUpdateVnetRoute(this IAppServicePlansOperations operations, string resourceGroupName, string name, string vnetName, string routeName, VnetRouteInner route)
-            {
-                return operations.CreateOrUpdateVnetRouteAsync(resourceGroupName, name, vnetName, routeName, route).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a Virtual Network route in an App Service plan.
             /// </summary>
@@ -1263,32 +731,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete a Virtual Network route in an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Delete a Virtual Network route in an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='routeName'>
-            /// Name of the Virtual Network route.
-            /// </param>
-            public static void DeleteVnetRoute(this IAppServicePlansOperations operations, string resourceGroupName, string name, string vnetName, string routeName)
-            {
-                operations.DeleteVnetRouteAsync(resourceGroupName, name, vnetName, routeName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a Virtual Network route in an App Service plan.
             /// </summary>
@@ -1318,35 +761,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteVnetRouteWithHttpMessagesAsync(resourceGroupName, name, vnetName, routeName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Create or update a Virtual Network route in an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Create or update a Virtual Network route in an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='routeName'>
-            /// Name of the Virtual Network route.
-            /// </param>
-            /// <param name='route'>
-            /// Definition of the Virtual Network route.
-            /// </param>
-            public static VnetRouteInner UpdateVnetRoute(this IAppServicePlansOperations operations, string resourceGroupName, string name, string vnetName, string routeName, VnetRouteInner route)
-            {
-                return operations.UpdateVnetRouteAsync(resourceGroupName, name, vnetName, routeName, route).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a Virtual Network route in an App Service plan.
             /// </summary>
@@ -1382,29 +797,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Reboot a worker machine in an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Reboot a worker machine in an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='workerName'>
-            /// Name of worker machine, which typically starts with RD.
-            /// </param>
-            public static void RebootWorker(this IAppServicePlansOperations operations, string resourceGroupName, string name, string workerName)
-            {
-                operations.RebootWorkerAsync(resourceGroupName, name, workerName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reboot a worker machine in an App Service plan.
             /// </summary>
@@ -1431,29 +824,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.RebootWorkerWithHttpMessagesAsync(resourceGroupName, name, workerName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates an App Service Plan.
-            /// </summary>
-            /// <remarks>
-            /// Creates or updates an App Service Plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the App Service plan.
-            /// </param>
-            /// <param name='appServicePlan'>
-            /// Details of the App Service plan.
-            /// </param>
-            public static AppServicePlanInner BeginCreateOrUpdate(this IAppServicePlansOperations operations, string resourceGroupName, string name, AppServicePlanInner appServicePlan)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, name, appServicePlan).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates an App Service Plan.
             /// </summary>
@@ -1483,23 +854,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all App Service plans for a subcription.
-            /// </summary>
-            /// <remarks>
-            /// Get all App Service plans for a subcription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<AppServicePlanInner> ListNext(this IAppServicePlansOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all App Service plans for a subcription.
             /// </summary>
@@ -1523,23 +878,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all App Service plans in a resource group.
-            /// </summary>
-            /// <remarks>
-            /// Get all App Service plans in a resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<AppServicePlanInner> ListByResourceGroupNext(this IAppServicePlansOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all App Service plans in a resource group.
             /// </summary>
@@ -1563,23 +902,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all apps that use a Hybrid Connection in an App Service Plan.
-            /// </summary>
-            /// <remarks>
-            /// Get all apps that use a Hybrid Connection in an App Service Plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<string> ListWebAppsByHybridConnectionNext(this IAppServicePlansOperations operations, string nextPageLink)
-            {
-                return operations.ListWebAppsByHybridConnectionNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all apps that use a Hybrid Connection in an App Service Plan.
             /// </summary>
@@ -1603,23 +926,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Retrieve all Hybrid Connections in use in an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Retrieve all Hybrid Connections in use in an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<HybridConnectionInner> ListHybridConnectionsNext(this IAppServicePlansOperations operations, string nextPageLink)
-            {
-                return operations.ListHybridConnectionsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Retrieve all Hybrid Connections in use in an App Service plan.
             /// </summary>
@@ -1643,25 +950,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics that can be queried for an App Service plan, and their
-            /// definitions.
-            /// </summary>
-            /// <remarks>
-            /// Get metrics that can be queried for an App Service plan, and their
-            /// definitions.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListMetricDefintionsNext(this IAppServicePlansOperations operations, string nextPageLink)
-            {
-                return operations.ListMetricDefintionsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics that can be queried for an App Service plan, and their
             /// definitions.
@@ -1687,23 +976,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get metrics for an App Serice plan.
-            /// </summary>
-            /// <remarks>
-            /// Get metrics for an App Serice plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetric> ListMetricsNext(this IAppServicePlansOperations operations, string nextPageLink)
-            {
-                return operations.ListMetricsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get metrics for an App Serice plan.
             /// </summary>
@@ -1727,23 +1000,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all apps associated with an App Service plan.
-            /// </summary>
-            /// <remarks>
-            /// Get all apps associated with an App Service plan.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteInner> ListWebAppsNext(this IAppServicePlansOperations operations, string nextPageLink)
-            {
-                return operations.ListWebAppsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all apps associated with an App Service plan.
             /// </summary>

--- a/src/ResourceManagement/AppService/Generated/CertificatesOperationsExtensions.cs
+++ b/src/ResourceManagement/AppService/Generated/CertificatesOperationsExtensions.cs
@@ -22,20 +22,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     public static partial class CertificatesOperationsExtensions
     {
-            /// <summary>
-            /// Get all certificates for a subscription.
-            /// </summary>
-            /// <remarks>
-            /// Get all certificates for a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<CertificateInner> List(this ICertificatesOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all certificates for a subscription.
             /// </summary>
@@ -56,23 +43,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all certificates in a resource group.
-            /// </summary>
-            /// <remarks>
-            /// Get all certificates in a resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            public static IPage<CertificateInner> ListByResourceGroup(this ICertificatesOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all certificates in a resource group.
             /// </summary>
@@ -96,26 +67,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a certificate.
-            /// </summary>
-            /// <remarks>
-            /// Get a certificate.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the certificate.
-            /// </param>
-            public static CertificateInner Get(this ICertificatesOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a certificate.
             /// </summary>
@@ -142,29 +94,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or update a certificate.
-            /// </summary>
-            /// <remarks>
-            /// Create or update a certificate.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the certificate.
-            /// </param>
-            /// <param name='certificateEnvelope'>
-            /// Details of certificate, if it exists already.
-            /// </param>
-            public static CertificateInner CreateOrUpdate(this ICertificatesOperations operations, string resourceGroupName, string name, CertificateInner certificateEnvelope)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, name, certificateEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a certificate.
             /// </summary>
@@ -194,26 +124,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete a certificate.
-            /// </summary>
-            /// <remarks>
-            /// Delete a certificate.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the certificate.
-            /// </param>
-            public static void Delete(this ICertificatesOperations operations, string resourceGroupName, string name)
-            {
-                operations.DeleteAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a certificate.
             /// </summary>
@@ -237,29 +148,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Create or update a certificate.
-            /// </summary>
-            /// <remarks>
-            /// Create or update a certificate.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the certificate.
-            /// </param>
-            /// <param name='certificateEnvelope'>
-            /// Details of certificate, if it exists already.
-            /// </param>
-            public static CertificateInner Update(this ICertificatesOperations operations, string resourceGroupName, string name, CertificateInner certificateEnvelope)
-            {
-                return operations.UpdateAsync(resourceGroupName, name, certificateEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a certificate.
             /// </summary>
@@ -289,23 +178,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all certificates for a subscription.
-            /// </summary>
-            /// <remarks>
-            /// Get all certificates for a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<CertificateInner> ListNext(this ICertificatesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all certificates for a subscription.
             /// </summary>
@@ -329,23 +202,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all certificates in a resource group.
-            /// </summary>
-            /// <remarks>
-            /// Get all certificates in a resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<CertificateInner> ListByResourceGroupNext(this ICertificatesOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all certificates in a resource group.
             /// </summary>

--- a/src/ResourceManagement/AppService/Generated/DeletedWebAppsOperationsExtensions.cs
+++ b/src/ResourceManagement/AppService/Generated/DeletedWebAppsOperationsExtensions.cs
@@ -22,20 +22,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     public static partial class DeletedWebAppsOperationsExtensions
     {
-            /// <summary>
-            /// Get all deleted apps for a subscription.
-            /// </summary>
-            /// <remarks>
-            /// Get all deleted apps for a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<DeletedSiteInner> List(this IDeletedWebAppsOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all deleted apps for a subscription.
             /// </summary>
@@ -56,23 +43,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets deleted web apps in subscription.
-            /// </summary>
-            /// <remarks>
-            /// Gets deleted web apps in subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            public static IPage<DeletedSiteInner> ListByResourceGroup(this IDeletedWebAppsOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets deleted web apps in subscription.
             /// </summary>
@@ -96,23 +67,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all deleted apps for a subscription.
-            /// </summary>
-            /// <remarks>
-            /// Get all deleted apps for a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DeletedSiteInner> ListNext(this IDeletedWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all deleted apps for a subscription.
             /// </summary>
@@ -136,23 +91,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets deleted web apps in subscription.
-            /// </summary>
-            /// <remarks>
-            /// Gets deleted web apps in subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DeletedSiteInner> ListByResourceGroupNext(this IDeletedWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets deleted web apps in subscription.
             /// </summary>

--- a/src/ResourceManagement/AppService/Generated/DomainsOperationsExtensions.cs
+++ b/src/ResourceManagement/AppService/Generated/DomainsOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     public static partial class DomainsOperationsExtensions
     {
-            /// <summary>
-            /// Check if a domain is available for registration.
-            /// </summary>
-            /// <remarks>
-            /// Check if a domain is available for registration.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='identifier'>
-            /// Name of the domain.
-            /// </param>
-            public static DomainAvailablilityCheckResultInner CheckAvailability(this IDomainsOperations operations, NameIdentifierInner identifier)
-            {
-                return operations.CheckAvailabilityAsync(identifier).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Check if a domain is available for registration.
             /// </summary>
@@ -62,20 +46,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all domains in a subscription.
-            /// </summary>
-            /// <remarks>
-            /// Get all domains in a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<DomainInner> List(this IDomainsOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all domains in a subscription.
             /// </summary>
@@ -96,20 +67,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Generate a single sign-on request for the domain management portal.
-            /// </summary>
-            /// <remarks>
-            /// Generate a single sign-on request for the domain management portal.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static DomainControlCenterSsoRequestInner GetControlCenterSsoRequest(this IDomainsOperations operations)
-            {
-                return operations.GetControlCenterSsoRequestAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Generate a single sign-on request for the domain management portal.
             /// </summary>
@@ -130,23 +88,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get domain name recommendations based on keywords.
-            /// </summary>
-            /// <remarks>
-            /// Get domain name recommendations based on keywords.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='parameters'>
-            /// Search parameters for domain name recommendations.
-            /// </param>
-            public static IPage<NameIdentifierInner> ListRecommendations(this IDomainsOperations operations, DomainRecommendationSearchParametersInner parameters)
-            {
-                return operations.ListRecommendationsAsync(parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get domain name recommendations based on keywords.
             /// </summary>
@@ -170,23 +112,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all domains in a resource group.
-            /// </summary>
-            /// <remarks>
-            /// Get all domains in a resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            public static IPage<DomainInner> ListByResourceGroup(this IDomainsOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all domains in a resource group.
             /// </summary>
@@ -210,26 +136,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a domain.
-            /// </summary>
-            /// <remarks>
-            /// Get a domain.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='domainName'>
-            /// Name of the domain.
-            /// </param>
-            public static DomainInner Get(this IDomainsOperations operations, string resourceGroupName, string domainName)
-            {
-                return operations.GetAsync(resourceGroupName, domainName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a domain.
             /// </summary>
@@ -256,29 +163,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a domain.
-            /// </summary>
-            /// <remarks>
-            /// Creates or updates a domain.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='domainName'>
-            /// Name of the domain.
-            /// </param>
-            /// <param name='domain'>
-            /// Domain registration information.
-            /// </param>
-            public static DomainInner CreateOrUpdate(this IDomainsOperations operations, string resourceGroupName, string domainName, DomainInner domain)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, domainName, domain).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a domain.
             /// </summary>
@@ -308,31 +193,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete a domain.
-            /// </summary>
-            /// <remarks>
-            /// Delete a domain.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='domainName'>
-            /// Name of the domain.
-            /// </param>
-            /// <param name='forceHardDeleteDomain'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to delete the domain immediately. The
-            /// default is &lt;code&gt;false&lt;/code&gt; which deletes the domain after 24
-            /// hours.
-            /// </param>
-            public static void Delete(this IDomainsOperations operations, string resourceGroupName, string domainName, bool? forceHardDeleteDomain = default(bool?))
-            {
-                operations.DeleteAsync(resourceGroupName, domainName, forceHardDeleteDomain).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a domain.
             /// </summary>
@@ -361,26 +222,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, domainName, forceHardDeleteDomain, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Lists domain ownership identifiers.
-            /// </summary>
-            /// <remarks>
-            /// Lists domain ownership identifiers.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='domainName'>
-            /// Name of domain.
-            /// </param>
-            public static IPage<DomainOwnershipIdentifierInner> ListOwnershipIdentifiers(this IDomainsOperations operations, string resourceGroupName, string domainName)
-            {
-                return operations.ListOwnershipIdentifiersAsync(resourceGroupName, domainName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists domain ownership identifiers.
             /// </summary>
@@ -407,29 +249,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get ownership identifier for domain
-            /// </summary>
-            /// <remarks>
-            /// Get ownership identifier for domain
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='domainName'>
-            /// Name of domain.
-            /// </param>
-            /// <param name='name'>
-            /// Name of identifier.
-            /// </param>
-            public static DomainOwnershipIdentifierInner GetOwnershipIdentifier(this IDomainsOperations operations, string resourceGroupName, string domainName, string name)
-            {
-                return operations.GetOwnershipIdentifierAsync(resourceGroupName, domainName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get ownership identifier for domain
             /// </summary>
@@ -459,34 +279,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates an ownership identifier for a domain or updates identifier details
-            /// for an existing identifer
-            /// </summary>
-            /// <remarks>
-            /// Creates an ownership identifier for a domain or updates identifier details
-            /// for an existing identifer
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='domainName'>
-            /// Name of domain.
-            /// </param>
-            /// <param name='name'>
-            /// Name of identifier.
-            /// </param>
-            /// <param name='domainOwnershipIdentifier'>
-            /// A JSON representation of the domain ownership properties.
-            /// </param>
-            public static DomainOwnershipIdentifierInner CreateOrUpdateOwnershipIdentifier(this IDomainsOperations operations, string resourceGroupName, string domainName, string name, DomainOwnershipIdentifierInner domainOwnershipIdentifier)
-            {
-                return operations.CreateOrUpdateOwnershipIdentifierAsync(resourceGroupName, domainName, name, domainOwnershipIdentifier).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates an ownership identifier for a domain or updates identifier details
             /// for an existing identifer
@@ -521,29 +314,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete ownership identifier for domain
-            /// </summary>
-            /// <remarks>
-            /// Delete ownership identifier for domain
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='domainName'>
-            /// Name of domain.
-            /// </param>
-            /// <param name='name'>
-            /// Name of identifier.
-            /// </param>
-            public static void DeleteOwnershipIdentifier(this IDomainsOperations operations, string resourceGroupName, string domainName, string name)
-            {
-                operations.DeleteOwnershipIdentifierAsync(resourceGroupName, domainName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete ownership identifier for domain
             /// </summary>
@@ -570,34 +341,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteOwnershipIdentifierWithHttpMessagesAsync(resourceGroupName, domainName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates an ownership identifier for a domain or updates identifier details
-            /// for an existing identifer
-            /// </summary>
-            /// <remarks>
-            /// Creates an ownership identifier for a domain or updates identifier details
-            /// for an existing identifer
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='domainName'>
-            /// Name of domain.
-            /// </param>
-            /// <param name='name'>
-            /// Name of identifier.
-            /// </param>
-            /// <param name='domainOwnershipIdentifier'>
-            /// A JSON representation of the domain ownership properties.
-            /// </param>
-            public static DomainOwnershipIdentifierInner UpdateOwnershipIdentifier(this IDomainsOperations operations, string resourceGroupName, string domainName, string name, DomainOwnershipIdentifierInner domainOwnershipIdentifier)
-            {
-                return operations.UpdateOwnershipIdentifierAsync(resourceGroupName, domainName, name, domainOwnershipIdentifier).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates an ownership identifier for a domain or updates identifier details
             /// for an existing identifer
@@ -632,29 +376,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a domain.
-            /// </summary>
-            /// <remarks>
-            /// Creates or updates a domain.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='domainName'>
-            /// Name of the domain.
-            /// </param>
-            /// <param name='domain'>
-            /// Domain registration information.
-            /// </param>
-            public static DomainInner BeginCreateOrUpdate(this IDomainsOperations operations, string resourceGroupName, string domainName, DomainInner domain)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, domainName, domain).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a domain.
             /// </summary>
@@ -684,23 +406,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all domains in a subscription.
-            /// </summary>
-            /// <remarks>
-            /// Get all domains in a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DomainInner> ListNext(this IDomainsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all domains in a subscription.
             /// </summary>
@@ -724,23 +430,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get domain name recommendations based on keywords.
-            /// </summary>
-            /// <remarks>
-            /// Get domain name recommendations based on keywords.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<NameIdentifierInner> ListRecommendationsNext(this IDomainsOperations operations, string nextPageLink)
-            {
-                return operations.ListRecommendationsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get domain name recommendations based on keywords.
             /// </summary>
@@ -764,23 +454,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all domains in a resource group.
-            /// </summary>
-            /// <remarks>
-            /// Get all domains in a resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DomainInner> ListByResourceGroupNext(this IDomainsOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all domains in a resource group.
             /// </summary>
@@ -804,23 +478,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists domain ownership identifiers.
-            /// </summary>
-            /// <remarks>
-            /// Lists domain ownership identifiers.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DomainOwnershipIdentifierInner> ListOwnershipIdentifiersNext(this IDomainsOperations operations, string nextPageLink)
-            {
-                return operations.ListOwnershipIdentifiersNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists domain ownership identifiers.
             /// </summary>

--- a/src/ResourceManagement/AppService/Generated/ProviderOperationsExtensions.cs
+++ b/src/ResourceManagement/AppService/Generated/ProviderOperationsExtensions.cs
@@ -22,20 +22,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     public static partial class ProviderOperationsExtensions
     {
-            /// <summary>
-            /// Get available application frameworks and their versions
-            /// </summary>
-            /// <remarks>
-            /// Get available application frameworks and their versions
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static object GetAvailableStacks(this IProviderOperations operations)
-            {
-                return operations.GetAvailableStacksAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get available application frameworks and their versions
             /// </summary>
@@ -56,20 +43,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get available application frameworks and their versions
-            /// </summary>
-            /// <remarks>
-            /// Get available application frameworks and their versions
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static object GetAvailableStacksOnPrem(this IProviderOperations operations)
-            {
-                return operations.GetAvailableStacksOnPremAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get available application frameworks and their versions
             /// </summary>

--- a/src/ResourceManagement/AppService/Generated/RecommendationsOperationsExtensions.cs
+++ b/src/ResourceManagement/AppService/Generated/RecommendationsOperationsExtensions.cs
@@ -24,31 +24,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     public static partial class RecommendationsOperationsExtensions
     {
-            /// <summary>
-            /// List all recommendations for a subscription.
-            /// </summary>
-            /// <remarks>
-            /// List all recommendations for a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='featured'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to return only the most critical
-            /// recommendations. The default is &lt;code&gt;false&lt;/code&gt;, which
-            /// returns all recommendations.
-            /// </param>
-            /// <param name='filter'>
-            /// Filter is specified by using OData syntax. Example: $filter=channels eq
-            /// 'Api' or channel eq 'Notification' and startTime eq '2014-01-01T00:00:00Z'
-            /// and endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
-            /// duration'[PT1H|PT1M|P1D]
-            /// </param>
-            public static IList<RecommendationInner> List(this IRecommendationsOperations operations, bool? featured = default(bool?), string filter = default(string))
-            {
-                return operations.ListAsync(featured, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List all recommendations for a subscription.
             /// </summary>
@@ -80,20 +56,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Reset all recommendation opt-out settings for a subscription.
-            /// </summary>
-            /// <remarks>
-            /// Reset all recommendation opt-out settings for a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static void ResetAllFilters(this IRecommendationsOperations operations)
-            {
-                operations.ResetAllFiltersAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reset all recommendation opt-out settings for a subscription.
             /// </summary>
@@ -111,34 +74,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.ResetAllFiltersWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get past recommendations for an app, optionally specified by the time
-            /// range.
-            /// </summary>
-            /// <remarks>
-            /// Get past recommendations for an app, optionally specified by the time
-            /// range.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='siteName'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='filter'>
-            /// Filter is specified by using OData syntax. Example: $filter=channels eq
-            /// 'Api' or channel eq 'Notification' and startTime eq '2014-01-01T00:00:00Z'
-            /// and endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
-            /// duration'[PT1H|PT1M|P1D]
-            /// </param>
-            public static IList<RecommendationInner> ListHistoryForWebApp(this IRecommendationsOperations operations, string resourceGroupName, string siteName, string filter = default(string))
-            {
-                return operations.ListHistoryForWebAppAsync(resourceGroupName, siteName, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get past recommendations for an app, optionally specified by the time
             /// range.
@@ -173,36 +109,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all recommendations for an app.
-            /// </summary>
-            /// <remarks>
-            /// Get all recommendations for an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='siteName'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='featured'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to return only the most critical
-            /// recommendations. The default is &lt;code&gt;false&lt;/code&gt;, which
-            /// returns all recommendations.
-            /// </param>
-            /// <param name='filter'>
-            /// Return only channels specified in the filter. Filter is specified by using
-            /// OData syntax. Example: $filter=channels eq 'Api' or channel eq
-            /// 'Notification'
-            /// </param>
-            public static IList<RecommendationInner> ListRecommendedRulesForWebApp(this IRecommendationsOperations operations, string resourceGroupName, string siteName, bool? featured = default(bool?), string filter = default(string))
-            {
-                return operations.ListRecommendedRulesForWebAppAsync(resourceGroupName, siteName, featured, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all recommendations for an app.
             /// </summary>
@@ -239,26 +146,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Disable all recommendations for an app.
-            /// </summary>
-            /// <remarks>
-            /// Disable all recommendations for an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='siteName'>
-            /// Name of the app.
-            /// </param>
-            public static void DisableAllForWebApp(this IRecommendationsOperations operations, string resourceGroupName, string siteName)
-            {
-                operations.DisableAllForWebAppAsync(resourceGroupName, siteName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Disable all recommendations for an app.
             /// </summary>
@@ -282,26 +170,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DisableAllForWebAppWithHttpMessagesAsync(resourceGroupName, siteName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Reset all recommendation opt-out settings for an app.
-            /// </summary>
-            /// <remarks>
-            /// Reset all recommendation opt-out settings for an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='siteName'>
-            /// Name of the app.
-            /// </param>
-            public static void ResetAllFiltersForWebApp(this IRecommendationsOperations operations, string resourceGroupName, string siteName)
-            {
-                operations.ResetAllFiltersForWebAppAsync(resourceGroupName, siteName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reset all recommendation opt-out settings for an app.
             /// </summary>
@@ -325,33 +194,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.ResetAllFiltersForWebAppWithHttpMessagesAsync(resourceGroupName, siteName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get a recommendation rule for an app.
-            /// </summary>
-            /// <remarks>
-            /// Get a recommendation rule for an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='siteName'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the recommendation.
-            /// </param>
-            /// <param name='updateSeen'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; to update the last-seen timestamp of
-            /// the recommendation object.
-            /// </param>
-            public static RecommendationRuleInner GetRuleDetailsByWebApp(this IRecommendationsOperations operations, string resourceGroupName, string siteName, string name, bool? updateSeen = default(bool?))
-            {
-                return operations.GetRuleDetailsByWebAppAsync(resourceGroupName, siteName, name, updateSeen).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a recommendation rule for an app.
             /// </summary>

--- a/src/ResourceManagement/AppService/Generated/TopLevelDomainsOperationsExtensions.cs
+++ b/src/ResourceManagement/AppService/Generated/TopLevelDomainsOperationsExtensions.cs
@@ -22,20 +22,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     public static partial class TopLevelDomainsOperationsExtensions
     {
-            /// <summary>
-            /// Get all top-level domains supported for registration.
-            /// </summary>
-            /// <remarks>
-            /// Get all top-level domains supported for registration.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<TopLevelDomainInner> List(this ITopLevelDomainsOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all top-level domains supported for registration.
             /// </summary>
@@ -56,23 +43,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get details of a top-level domain.
-            /// </summary>
-            /// <remarks>
-            /// Get details of a top-level domain.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the top-level domain.
-            /// </param>
-            public static TopLevelDomainInner Get(this ITopLevelDomainsOperations operations, string name)
-            {
-                return operations.GetAsync(name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get details of a top-level domain.
             /// </summary>
@@ -96,28 +67,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all legal agreements that user needs to accept before purchasing a
-            /// domain.
-            /// </summary>
-            /// <remarks>
-            /// Gets all legal agreements that user needs to accept before purchasing a
-            /// domain.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the top-level domain.
-            /// </param>
-            /// <param name='agreementOption'>
-            /// Domain agreement options.
-            /// </param>
-            public static IPage<TldLegalAgreement> ListAgreements(this ITopLevelDomainsOperations operations, string name, TopLevelDomainAgreementOptionInner agreementOption)
-            {
-                return operations.ListAgreementsAsync(name, agreementOption).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all legal agreements that user needs to accept before purchasing a
             /// domain.
@@ -146,23 +96,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all top-level domains supported for registration.
-            /// </summary>
-            /// <remarks>
-            /// Get all top-level domains supported for registration.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<TopLevelDomainInner> ListNext(this ITopLevelDomainsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all top-level domains supported for registration.
             /// </summary>
@@ -186,25 +120,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all legal agreements that user needs to accept before purchasing a
-            /// domain.
-            /// </summary>
-            /// <remarks>
-            /// Gets all legal agreements that user needs to accept before purchasing a
-            /// domain.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<TldLegalAgreement> ListAgreementsNext(this ITopLevelDomainsOperations operations, string nextPageLink)
-            {
-                return operations.ListAgreementsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all legal agreements that user needs to accept before purchasing a
             /// domain.

--- a/src/ResourceManagement/AppService/Generated/WebAppsOperationsExtensions.cs
+++ b/src/ResourceManagement/AppService/Generated/WebAppsOperationsExtensions.cs
@@ -25,20 +25,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     public static partial class WebAppsOperationsExtensions
     {
-            /// <summary>
-            /// Get all apps for a subscription.
-            /// </summary>
-            /// <remarks>
-            /// Get all apps for a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<SiteInner> List(this IWebAppsOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all apps for a subscription.
             /// </summary>
@@ -59,28 +46,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all web, mobile, and API apps in the specified resource group.
-            /// </summary>
-            /// <remarks>
-            /// Gets all web, mobile, and API apps in the specified resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='includeSlots'>
-            /// Specify &lt;strong&gt;true&lt;/strong&gt; to include deployment slots in
-            /// results. The default is false, which only gives you the production slot of
-            /// all apps.
-            /// </param>
-            public static IPage<SiteInner> ListByResourceGroup(this IWebAppsOperations operations, string resourceGroupName, bool? includeSlots = default(bool?))
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName, includeSlots).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all web, mobile, and API apps in the specified resource group.
             /// </summary>
@@ -109,26 +75,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the details of a web, mobile, or API app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the details of a web, mobile, or API app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static SiteInner Get(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the details of a web, mobile, or API app.
             /// </summary>
@@ -155,47 +102,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new web, mobile, or API app in an existing resource group, or
-            /// updates an existing app.
-            /// </summary>
-            /// <remarks>
-            /// Creates a new web, mobile, or API app in an existing resource group, or
-            /// updates an existing app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Unique name of the app to create or update. To create or update a
-            /// deployment slot, use the {slot} parameter.
-            /// </param>
-            /// <param name='siteEnvelope'>
-            /// A JSON representation of the app properties. See example.
-            /// </param>
-            /// <param name='skipDnsRegistration'>
-            /// If true web app hostname is not registered with DNS on creation. This
-            /// parameter is
-            /// only used for app creation
-            /// </param>
-            /// <param name='skipCustomDomainVerification'>
-            /// If true, custom (non *.azurewebsites.net) domains associated with web app
-            /// are not verified.
-            /// </param>
-            /// <param name='forceDnsRegistration'>
-            /// If true, web app hostname is force registered with DNS
-            /// </param>
-            /// <param name='ttlInSeconds'>
-            /// Time to live in seconds for web app's default domain name
-            /// </param>
-            public static SiteInner CreateOrUpdate(this IWebAppsOperations operations, string resourceGroupName, string name, SiteInner siteEnvelope, bool? skipDnsRegistration = default(bool?), bool? skipCustomDomainVerification = default(bool?), bool? forceDnsRegistration = default(bool?), string ttlInSeconds = default(string))
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, name, siteEnvelope, skipDnsRegistration, skipCustomDomainVerification, forceDnsRegistration, ttlInSeconds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new web, mobile, or API app in an existing resource group, or
             /// updates an existing app.
@@ -243,37 +150,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a web, mobile, or API app, or one of the deployment slots.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a web, mobile, or API app, or one of the deployment slots.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app to delete.
-            /// </param>
-            /// <param name='deleteMetrics'>
-            /// If true, web app metrics are also deleted
-            /// </param>
-            /// <param name='deleteEmptyServerFarm'>
-            /// Specify true if the App Service plan will be empty after app deletion and
-            /// you want to delete the empty App Service plan. By default, the empty App
-            /// Service plan is not deleted.
-            /// </param>
-            /// <param name='skipDnsRegistration'>
-            /// If true, DNS registration is skipped
-            /// </param>
-            public static void Delete(this IWebAppsOperations operations, string resourceGroupName, string name, bool? deleteMetrics = default(bool?), bool? deleteEmptyServerFarm = default(bool?), bool? skipDnsRegistration = default(bool?))
-            {
-                operations.DeleteAsync(resourceGroupName, name, deleteMetrics, deleteEmptyServerFarm, skipDnsRegistration).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a web, mobile, or API app, or one of the deployment slots.
             /// </summary>
@@ -308,29 +185,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, name, deleteMetrics, deleteEmptyServerFarm, skipDnsRegistration, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Analyze a custom hostname.
-            /// </summary>
-            /// <remarks>
-            /// Analyze a custom hostname.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='hostName'>
-            /// Custom hostname
-            /// </param>
-            public static CustomHostnameAnalysisResultInner AnalyzeCustomHostname(this IWebAppsOperations operations, string resourceGroupName, string name, string hostName = default(string))
-            {
-                return operations.AnalyzeCustomHostnameAsync(resourceGroupName, name, hostName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Analyze a custom hostname.
             /// </summary>
@@ -360,31 +215,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Applies the configuration settings from the target slot onto the current
-            /// slot.
-            /// </summary>
-            /// <remarks>
-            /// Applies the configuration settings from the target slot onto the current
-            /// slot.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slotSwapEntity'>
-            /// JSON object that contains the target slot name. See example.
-            /// </param>
-            public static void ApplySlotConfigToProduction(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSlotEntityInner slotSwapEntity)
-            {
-                operations.ApplySlotConfigToProductionAsync(resourceGroupName, name, slotSwapEntity).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Applies the configuration settings from the target slot onto the current
             /// slot.
@@ -413,30 +244,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.ApplySlotConfigToProductionWithHttpMessagesAsync(resourceGroupName, name, slotSwapEntity, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates a backup of an app.
-            /// </summary>
-            /// <remarks>
-            /// Creates a backup of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='request'>
-            /// Backup configuration. You can use the JSON response from the POST action as
-            /// input here.
-            /// </param>
-            public static BackupItemInner Backup(this IWebAppsOperations operations, string resourceGroupName, string name, BackupRequestInner request)
-            {
-                return operations.BackupAsync(resourceGroupName, name, request).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a backup of an app.
             /// </summary>
@@ -467,26 +275,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets existing backups of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets existing backups of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static IPage<BackupItemInner> ListBackups(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListBackupsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets existing backups of an app.
             /// </summary>
@@ -513,32 +302,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Discovers an existing app backup that can be restored from a blob in Azure
-            /// storage.
-            /// </summary>
-            /// <remarks>
-            /// Discovers an existing app backup that can be restored from a blob in Azure
-            /// storage.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='request'>
-            /// A RestoreRequest object that includes Azure storage URL and blog name for
-            /// discovery of backup.
-            /// </param>
-            public static RestoreRequestInner DiscoverRestore(this IWebAppsOperations operations, string resourceGroupName, string name, RestoreRequestInner request)
-            {
-                return operations.DiscoverRestoreAsync(resourceGroupName, name, request).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Discovers an existing app backup that can be restored from a blob in Azure
             /// storage.
@@ -571,29 +335,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a backup of an app by its ID.
-            /// </summary>
-            /// <remarks>
-            /// Gets a backup of an app by its ID.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='backupId'>
-            /// ID of the backup.
-            /// </param>
-            public static BackupItemInner GetBackupStatus(this IWebAppsOperations operations, string resourceGroupName, string name, string backupId)
-            {
-                return operations.GetBackupStatusAsync(resourceGroupName, name, backupId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a backup of an app by its ID.
             /// </summary>
@@ -623,29 +365,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a backup of an app by its ID.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a backup of an app by its ID.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='backupId'>
-            /// ID of the backup.
-            /// </param>
-            public static void DeleteBackup(this IWebAppsOperations operations, string resourceGroupName, string name, string backupId)
-            {
-                operations.DeleteBackupAsync(resourceGroupName, name, backupId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a backup of an app by its ID.
             /// </summary>
@@ -672,38 +392,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteBackupWithHttpMessagesAsync(resourceGroupName, name, backupId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets status of a web app backup that may be in progress, including secrets
-            /// associated with the backup, such as the Azure Storage SAS URL. Also can be
-            /// used to update the SAS URL for the backup if a new URL is passed in the
-            /// request body.
-            /// </summary>
-            /// <remarks>
-            /// Gets status of a web app backup that may be in progress, including secrets
-            /// associated with the backup, such as the Azure Storage SAS URL. Also can be
-            /// used to update the SAS URL for the backup if a new URL is passed in the
-            /// request body.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='backupId'>
-            /// Id of backup
-            /// </param>
-            /// <param name='request'>
-            /// Information on backup request
-            /// </param>
-            public static BackupItemInner ListBackupStatusSecrets(this IWebAppsOperations operations, string resourceGroupName, string name, string backupId, BackupRequestInner request)
-            {
-                return operations.ListBackupStatusSecretsAsync(resourceGroupName, name, backupId, request).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets status of a web app backup that may be in progress, including secrets
             /// associated with the backup, such as the Azure Storage SAS URL. Also can be
@@ -742,34 +431,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restores a specific backup to another app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Restores a specific backup to another app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='backupId'>
-            /// ID of the backup.
-            /// </param>
-            /// <param name='request'>
-            /// Information on restore request
-            /// </param>
-            public static RestoreResponseInner Restore(this IWebAppsOperations operations, string resourceGroupName, string name, string backupId, RestoreRequestInner request)
-            {
-                return operations.RestoreAsync(resourceGroupName, name, backupId, request).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restores a specific backup to another app (or deployment slot, if
             /// specified).
@@ -804,26 +466,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List the configurations of an app
-            /// </summary>
-            /// <remarks>
-            /// List the configurations of an app
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static IPage<SiteConfigResourceInner> ListConfigurations(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListConfigurationsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List the configurations of an app
             /// </summary>
@@ -850,29 +493,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Replaces the application settings of an app.
-            /// </summary>
-            /// <remarks>
-            /// Replaces the application settings of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='appSettings'>
-            /// Application settings of the app.
-            /// </param>
-            public static StringDictionaryInner UpdateApplicationSettings(this IWebAppsOperations operations, string resourceGroupName, string name, StringDictionaryInner appSettings)
-            {
-                return operations.UpdateApplicationSettingsAsync(resourceGroupName, name, appSettings).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Replaces the application settings of an app.
             /// </summary>
@@ -902,26 +523,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the application settings of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the application settings of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static StringDictionaryInner ListApplicationSettings(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListApplicationSettingsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the application settings of an app.
             /// </summary>
@@ -948,31 +550,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the Authentication / Authorization settings associated with web
-            /// app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the Authentication / Authorization settings associated with web
-            /// app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='siteAuthSettings'>
-            /// Auth settings associated with web app
-            /// </param>
-            public static SiteAuthSettingsInner UpdateAuthSettings(this IWebAppsOperations operations, string resourceGroupName, string name, SiteAuthSettingsInner siteAuthSettings)
-            {
-                return operations.UpdateAuthSettingsAsync(resourceGroupName, name, siteAuthSettings).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the Authentication / Authorization settings associated with web
             /// app.
@@ -1004,26 +582,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the Authentication/Authorization settings of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the Authentication/Authorization settings of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static SiteAuthSettingsInner GetAuthSettings(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetAuthSettingsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the Authentication/Authorization settings of an app.
             /// </summary>
@@ -1050,29 +609,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the backup configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the backup configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='request'>
-            /// Edited backup configuration.
-            /// </param>
-            public static BackupRequestInner UpdateBackupConfiguration(this IWebAppsOperations operations, string resourceGroupName, string name, BackupRequestInner request)
-            {
-                return operations.UpdateBackupConfigurationAsync(resourceGroupName, name, request).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the backup configuration of an app.
             /// </summary>
@@ -1102,26 +639,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the backup configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Deletes the backup configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static void DeleteBackupConfiguration(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                operations.DeleteBackupConfigurationAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the backup configuration of an app.
             /// </summary>
@@ -1145,26 +663,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteBackupConfigurationWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the backup configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the backup configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static BackupRequestInner GetBackupConfiguration(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetBackupConfigurationAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the backup configuration of an app.
             /// </summary>
@@ -1191,29 +690,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Replaces the connection strings of an app.
-            /// </summary>
-            /// <remarks>
-            /// Replaces the connection strings of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='connectionStrings'>
-            /// Connection strings of the app or deployment slot. See example.
-            /// </param>
-            public static ConnectionStringDictionaryInner UpdateConnectionStrings(this IWebAppsOperations operations, string resourceGroupName, string name, ConnectionStringDictionaryInner connectionStrings)
-            {
-                return operations.UpdateConnectionStringsAsync(resourceGroupName, name, connectionStrings).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Replaces the connection strings of an app.
             /// </summary>
@@ -1243,26 +720,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the connection strings of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the connection strings of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static ConnectionStringDictionaryInner ListConnectionStrings(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListConnectionStringsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the connection strings of an app.
             /// </summary>
@@ -1289,26 +747,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the logging configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the logging configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static SiteLogsConfigInner GetDiagnosticLogsConfiguration(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetDiagnosticLogsConfigurationAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the logging configuration of an app.
             /// </summary>
@@ -1335,30 +774,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the logging configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the logging configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='siteLogsConfig'>
-            /// A SiteLogsConfig JSON object that contains the logging configuration to
-            /// change in the "properties" property.
-            /// </param>
-            public static SiteLogsConfigInner UpdateDiagnosticLogsConfig(this IWebAppsOperations operations, string resourceGroupName, string name, SiteLogsConfigInner siteLogsConfig)
-            {
-                return operations.UpdateDiagnosticLogsConfigAsync(resourceGroupName, name, siteLogsConfig).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the logging configuration of an app.
             /// </summary>
@@ -1389,29 +805,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Replaces the metadata of an app.
-            /// </summary>
-            /// <remarks>
-            /// Replaces the metadata of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='metadata'>
-            /// Edited metadata of the app or deployment slot. See example.
-            /// </param>
-            public static StringDictionaryInner UpdateMetadata(this IWebAppsOperations operations, string resourceGroupName, string name, StringDictionaryInner metadata)
-            {
-                return operations.UpdateMetadataAsync(resourceGroupName, name, metadata).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Replaces the metadata of an app.
             /// </summary>
@@ -1441,26 +835,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the metadata of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the metadata of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static StringDictionaryInner ListMetadata(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListMetadataAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the metadata of an app.
             /// </summary>
@@ -1487,26 +862,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the Git/FTP publishing credentials of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the Git/FTP publishing credentials of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static UserInner ListPublishingCredentials(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListPublishingCredentialsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the Git/FTP publishing credentials of an app.
             /// </summary>
@@ -1533,29 +889,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the Push settings associated with web app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the Push settings associated with web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='pushSettings'>
-            /// Push settings associated with web app
-            /// </param>
-            public static PushSettingsInner UpdateSitePushSettings(this IWebAppsOperations operations, string resourceGroupName, string name, PushSettingsInner pushSettings)
-            {
-                return operations.UpdateSitePushSettingsAsync(resourceGroupName, name, pushSettings).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the Push settings associated with web app.
             /// </summary>
@@ -1585,26 +919,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the Push settings associated with web app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the Push settings associated with web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            public static PushSettingsInner ListSitePushSettings(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListSitePushSettingsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the Push settings associated with web app.
             /// </summary>
@@ -1631,28 +946,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the names of app settings and connection strings that stick to the
-            /// slot (not swapped).
-            /// </summary>
-            /// <remarks>
-            /// Gets the names of app settings and connection strings that stick to the
-            /// slot (not swapped).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static SlotConfigNamesResourceInner ListSlotConfigurationNames(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListSlotConfigurationNamesAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the names of app settings and connection strings that stick to the
             /// slot (not swapped).
@@ -1681,31 +975,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the names of application settings and connection string that remain
-            /// with the slot during swap operation.
-            /// </summary>
-            /// <remarks>
-            /// Updates the names of application settings and connection string that remain
-            /// with the slot during swap operation.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slotConfigNames'>
-            /// Names of application settings and connection strings. See example.
-            /// </param>
-            public static SlotConfigNamesResourceInner UpdateSlotConfigurationNames(this IWebAppsOperations operations, string resourceGroupName, string name, SlotConfigNamesResourceInner slotConfigNames)
-            {
-                return operations.UpdateSlotConfigurationNamesAsync(resourceGroupName, name, slotConfigNames).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the names of application settings and connection string that remain
             /// with the slot during swap operation.
@@ -1737,28 +1007,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the configuration of an app, such as platform version and bitness,
-            /// default documents, virtual applications, Always On, etc.
-            /// </summary>
-            /// <remarks>
-            /// Gets the configuration of an app, such as platform version and bitness,
-            /// default documents, virtual applications, Always On, etc.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static SiteConfigResourceInner GetConfiguration(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetConfigurationAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the configuration of an app, such as platform version and bitness,
             /// default documents, virtual applications, Always On, etc.
@@ -1787,29 +1036,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='siteConfig'>
-            /// JSON representation of a SiteConfig object. See example.
-            /// </param>
-            public static SiteConfigResourceInner CreateOrUpdateConfiguration(this IWebAppsOperations operations, string resourceGroupName, string name, SiteConfigResourceInner siteConfig)
-            {
-                return operations.CreateOrUpdateConfigurationAsync(resourceGroupName, name, siteConfig).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the configuration of an app.
             /// </summary>
@@ -1839,29 +1066,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='siteConfig'>
-            /// JSON representation of a SiteConfig object. See example.
-            /// </param>
-            public static SiteConfigResourceInner UpdateConfiguration(this IWebAppsOperations operations, string resourceGroupName, string name, SiteConfigResourceInner siteConfig)
-            {
-                return operations.UpdateConfigurationAsync(resourceGroupName, name, siteConfig).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the configuration of an app.
             /// </summary>
@@ -1891,28 +1096,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of web app configuration snapshots identifiers. Each element of
-            /// the list contains a timestamp and the ID of the snapshot.
-            /// </summary>
-            /// <remarks>
-            /// Gets a list of web app configuration snapshots identifiers. Each element of
-            /// the list contains a timestamp and the ID of the snapshot.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static IList<SiteConfigurationSnapshotInfoInner> ListConfigurationSnapshotInfo(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListConfigurationSnapshotInfoAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of web app configuration snapshots identifiers. Each element of
             /// the list contains a timestamp and the ID of the snapshot.
@@ -1941,29 +1125,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a snapshot of the configuration of an app at a previous point in time.
-            /// </summary>
-            /// <remarks>
-            /// Gets a snapshot of the configuration of an app at a previous point in time.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='snapshotId'>
-            /// The ID of the snapshot to read.
-            /// </param>
-            public static SiteConfigResourceInner GetConfigurationSnapshot(this IWebAppsOperations operations, string resourceGroupName, string name, string snapshotId)
-            {
-                return operations.GetConfigurationSnapshotAsync(resourceGroupName, name, snapshotId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a snapshot of the configuration of an app at a previous point in time.
             /// </summary>
@@ -1993,29 +1155,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Reverts the configuration of an app to a previous snapshot.
-            /// </summary>
-            /// <remarks>
-            /// Reverts the configuration of an app to a previous snapshot.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='snapshotId'>
-            /// The ID of the snapshot to read.
-            /// </param>
-            public static void RecoverSiteConfigurationSnapshot(this IWebAppsOperations operations, string resourceGroupName, string name, string snapshotId)
-            {
-                operations.RecoverSiteConfigurationSnapshotAsync(resourceGroupName, name, snapshotId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reverts the configuration of an app to a previous snapshot.
             /// </summary>
@@ -2042,28 +1182,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.RecoverSiteConfigurationSnapshotWithHttpMessagesAsync(resourceGroupName, name, snapshotId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </summary>
-            /// <remarks>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static IPage<DeploymentInner> ListDeployments(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListDeploymentsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List deployments for an app, or a deployment slot, or for an instance of a
             /// scaled-out app.
@@ -2092,31 +1211,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// Deployment ID.
-            /// </param>
-            public static DeploymentInner GetDeployment(this IWebAppsOperations operations, string resourceGroupName, string name, string id)
-            {
-                return operations.GetDeploymentAsync(resourceGroupName, name, id).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
             /// specific scaled-out instance.
@@ -2148,34 +1243,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create a deployment for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Create a deployment for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// ID of an existing deployment.
-            /// </param>
-            /// <param name='deployment'>
-            /// Deployment details.
-            /// </param>
-            public static DeploymentInner CreateDeployment(this IWebAppsOperations operations, string resourceGroupName, string name, string id, DeploymentInner deployment)
-            {
-                return operations.CreateDeploymentAsync(resourceGroupName, name, id, deployment).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a deployment for an app, a specific deployment slot, and/or a
             /// specific scaled-out instance.
@@ -2210,31 +1278,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete a deployment by its ID for an app, a specific deployment slot,
-            /// and/or a specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Delete a deployment by its ID for an app, a specific deployment slot,
-            /// and/or a specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// Deployment ID.
-            /// </param>
-            public static void DeleteDeployment(this IWebAppsOperations operations, string resourceGroupName, string name, string id)
-            {
-                operations.DeleteDeploymentAsync(resourceGroupName, name, id).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a deployment by its ID for an app, a specific deployment slot,
             /// and/or a specific scaled-out instance.
@@ -2263,26 +1307,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteDeploymentWithHttpMessagesAsync(resourceGroupName, name, id, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Lists ownership identifiers for domain associated with web app.
-            /// </summary>
-            /// <remarks>
-            /// Lists ownership identifiers for domain associated with web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static IPage<IdentifierInner> ListDomainOwnershipIdentifiers(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListDomainOwnershipIdentifiersAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists ownership identifiers for domain associated with web app.
             /// </summary>
@@ -2309,29 +1334,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get domain ownership identifier for web app.
-            /// </summary>
-            /// <remarks>
-            /// Get domain ownership identifier for web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='domainOwnershipIdentifierName'>
-            /// Name of domain ownership identifier.
-            /// </param>
-            public static IdentifierInner GetDomainOwnershipIdentifier(this IWebAppsOperations operations, string resourceGroupName, string name, string domainOwnershipIdentifierName)
-            {
-                return operations.GetDomainOwnershipIdentifierAsync(resourceGroupName, name, domainOwnershipIdentifierName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get domain ownership identifier for web app.
             /// </summary>
@@ -2361,34 +1364,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a domain ownership identifier for web app, or updates an existing
-            /// ownership identifier.
-            /// </summary>
-            /// <remarks>
-            /// Creates a domain ownership identifier for web app, or updates an existing
-            /// ownership identifier.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='domainOwnershipIdentifierName'>
-            /// Name of domain ownership identifier.
-            /// </param>
-            /// <param name='domainOwnershipIdentifier'>
-            /// A JSON representation of the domain ownership properties.
-            /// </param>
-            public static IdentifierInner CreateOrUpdateDomainOwnershipIdentifier(this IWebAppsOperations operations, string resourceGroupName, string name, string domainOwnershipIdentifierName, IdentifierInner domainOwnershipIdentifier)
-            {
-                return operations.CreateOrUpdateDomainOwnershipIdentifierAsync(resourceGroupName, name, domainOwnershipIdentifierName, domainOwnershipIdentifier).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a domain ownership identifier for web app, or updates an existing
             /// ownership identifier.
@@ -2423,29 +1399,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a domain ownership identifier for a web app.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a domain ownership identifier for a web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='domainOwnershipIdentifierName'>
-            /// Name of domain ownership identifier.
-            /// </param>
-            public static void DeleteDomainOwnershipIdentifier(this IWebAppsOperations operations, string resourceGroupName, string name, string domainOwnershipIdentifierName)
-            {
-                operations.DeleteDomainOwnershipIdentifierAsync(resourceGroupName, name, domainOwnershipIdentifierName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a domain ownership identifier for a web app.
             /// </summary>
@@ -2472,34 +1426,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteDomainOwnershipIdentifierWithHttpMessagesAsync(resourceGroupName, name, domainOwnershipIdentifierName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates a domain ownership identifier for web app, or updates an existing
-            /// ownership identifier.
-            /// </summary>
-            /// <remarks>
-            /// Creates a domain ownership identifier for web app, or updates an existing
-            /// ownership identifier.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='domainOwnershipIdentifierName'>
-            /// Name of domain ownership identifier.
-            /// </param>
-            /// <param name='domainOwnershipIdentifier'>
-            /// A JSON representation of the domain ownership properties.
-            /// </param>
-            public static IdentifierInner UpdateDomainOwnershipIdentifier(this IWebAppsOperations operations, string resourceGroupName, string name, string domainOwnershipIdentifierName, IdentifierInner domainOwnershipIdentifier)
-            {
-                return operations.UpdateDomainOwnershipIdentifierAsync(resourceGroupName, name, domainOwnershipIdentifierName, domainOwnershipIdentifier).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a domain ownership identifier for web app, or updates an existing
             /// ownership identifier.
@@ -2534,26 +1461,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get hostname bindings for an app or a deployment slot.
-            /// </summary>
-            /// <remarks>
-            /// Get hostname bindings for an app or a deployment slot.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static IPage<HostNameBindingInner> ListHostNameBindings(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListHostNameBindingsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get hostname bindings for an app or a deployment slot.
             /// </summary>
@@ -2580,31 +1488,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the named hostname binding for an app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Get the named hostname binding for an app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='hostName'>
-            /// Hostname in the hostname binding.
-            /// </param>
-            public static HostNameBindingInner GetHostNameBinding(this IWebAppsOperations operations, string resourceGroupName, string name, string hostName)
-            {
-                return operations.GetHostNameBindingAsync(resourceGroupName, name, hostName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the named hostname binding for an app (or deployment slot, if
             /// specified).
@@ -2636,33 +1520,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a hostname binding for an app.
-            /// </summary>
-            /// <remarks>
-            /// Creates a hostname binding for an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='hostName'>
-            /// Hostname in the hostname binding.
-            /// </param>
-            /// <param name='hostNameBinding'>
-            /// Binding details. This is the JSON representation of a HostNameBinding
-            /// object.
-            /// </param>
-            public static HostNameBindingInner CreateOrUpdateHostNameBinding(this IWebAppsOperations operations, string resourceGroupName, string name, string hostName, HostNameBindingInner hostNameBinding)
-            {
-                return operations.CreateOrUpdateHostNameBindingAsync(resourceGroupName, name, hostName, hostNameBinding).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a hostname binding for an app.
             /// </summary>
@@ -2696,29 +1554,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a hostname binding for an app.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a hostname binding for an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='hostName'>
-            /// Hostname in the hostname binding.
-            /// </param>
-            public static void DeleteHostNameBinding(this IWebAppsOperations operations, string resourceGroupName, string name, string hostName)
-            {
-                operations.DeleteHostNameBindingAsync(resourceGroupName, name, hostName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a hostname binding for an app.
             /// </summary>
@@ -2745,32 +1581,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteHostNameBindingWithHttpMessagesAsync(resourceGroupName, name, hostName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Retrieves a specific Service Bus Hybrid Connection used by this Web App.
-            /// </summary>
-            /// <remarks>
-            /// Retrieves a specific Service Bus Hybrid Connection used by this Web App.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace for this hybrid connection
-            /// </param>
-            /// <param name='relayName'>
-            /// The relay name for this hybrid connection
-            /// </param>
-            public static HybridConnectionInner GetHybridConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string namespaceName, string relayName)
-            {
-                return operations.GetHybridConnectionAsync(resourceGroupName, name, namespaceName, relayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Retrieves a specific Service Bus Hybrid Connection used by this Web App.
             /// </summary>
@@ -2803,35 +1614,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new Hybrid Connection using a Service Bus relay.
-            /// </summary>
-            /// <remarks>
-            /// Creates a new Hybrid Connection using a Service Bus relay.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace for this hybrid connection
-            /// </param>
-            /// <param name='relayName'>
-            /// The relay name for this hybrid connection
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// The details of the hybrid connection
-            /// </param>
-            public static HybridConnectionInner CreateOrUpdateHybridConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string namespaceName, string relayName, HybridConnectionInner connectionEnvelope)
-            {
-                return operations.CreateOrUpdateHybridConnectionAsync(resourceGroupName, name, namespaceName, relayName, connectionEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new Hybrid Connection using a Service Bus relay.
             /// </summary>
@@ -2867,32 +1650,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Removes a Hybrid Connection from this site.
-            /// </summary>
-            /// <remarks>
-            /// Removes a Hybrid Connection from this site.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace for this hybrid connection
-            /// </param>
-            /// <param name='relayName'>
-            /// The relay name for this hybrid connection
-            /// </param>
-            public static void DeleteHybridConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string namespaceName, string relayName)
-            {
-                operations.DeleteHybridConnectionAsync(resourceGroupName, name, namespaceName, relayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Removes a Hybrid Connection from this site.
             /// </summary>
@@ -2922,35 +1680,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteHybridConnectionWithHttpMessagesAsync(resourceGroupName, name, namespaceName, relayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates a new Hybrid Connection using a Service Bus relay.
-            /// </summary>
-            /// <remarks>
-            /// Creates a new Hybrid Connection using a Service Bus relay.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace for this hybrid connection
-            /// </param>
-            /// <param name='relayName'>
-            /// The relay name for this hybrid connection
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// The details of the hybrid connection
-            /// </param>
-            public static HybridConnectionInner UpdateHybridConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string namespaceName, string relayName, HybridConnectionInner connectionEnvelope)
-            {
-                return operations.UpdateHybridConnectionAsync(resourceGroupName, name, namespaceName, relayName, connectionEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new Hybrid Connection using a Service Bus relay.
             /// </summary>
@@ -2986,32 +1716,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the send key name and value for a Hybrid Connection.
-            /// </summary>
-            /// <remarks>
-            /// Gets the send key name and value for a Hybrid Connection.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace for this hybrid connection
-            /// </param>
-            /// <param name='relayName'>
-            /// The relay name for this hybrid connection
-            /// </param>
-            public static HybridConnectionKeyInner ListHybridConnectionKeys(this IWebAppsOperations operations, string resourceGroupName, string name, string namespaceName, string relayName)
-            {
-                return operations.ListHybridConnectionKeysAsync(resourceGroupName, name, namespaceName, relayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the send key name and value for a Hybrid Connection.
             /// </summary>
@@ -3044,26 +1749,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Retrieves all Service Bus Hybrid Connections used by this Web App.
-            /// </summary>
-            /// <remarks>
-            /// Retrieves all Service Bus Hybrid Connections used by this Web App.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            public static HybridConnectionInner ListHybridConnections(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListHybridConnectionsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Retrieves all Service Bus Hybrid Connections used by this Web App.
             /// </summary>
@@ -3090,28 +1776,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets hybrid connections configured for an app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets hybrid connections configured for an app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static RelayServiceConnectionEntityInner ListRelayServiceConnections(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListRelayServiceConnectionsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets hybrid connections configured for an app (or deployment slot, if
             /// specified).
@@ -3140,29 +1805,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a hybrid connection configuration by its name.
-            /// </summary>
-            /// <remarks>
-            /// Gets a hybrid connection configuration by its name.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='entityName'>
-            /// Name of the hybrid connection.
-            /// </param>
-            public static RelayServiceConnectionEntityInner GetRelayServiceConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string entityName)
-            {
-                return operations.GetRelayServiceConnectionAsync(resourceGroupName, name, entityName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a hybrid connection configuration by its name.
             /// </summary>
@@ -3192,34 +1835,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new hybrid connection configuration (PUT), or updates an existing
-            /// one (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Creates a new hybrid connection configuration (PUT), or updates an existing
-            /// one (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='entityName'>
-            /// Name of the hybrid connection configuration.
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// Details of the hybrid connection configuration.
-            /// </param>
-            public static RelayServiceConnectionEntityInner CreateOrUpdateRelayServiceConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string entityName, RelayServiceConnectionEntityInner connectionEnvelope)
-            {
-                return operations.CreateOrUpdateRelayServiceConnectionAsync(resourceGroupName, name, entityName, connectionEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new hybrid connection configuration (PUT), or updates an existing
             /// one (PATCH).
@@ -3254,29 +1870,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a relay service connection by its name.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a relay service connection by its name.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='entityName'>
-            /// Name of the hybrid connection configuration.
-            /// </param>
-            public static void DeleteRelayServiceConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string entityName)
-            {
-                operations.DeleteRelayServiceConnectionAsync(resourceGroupName, name, entityName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a relay service connection by its name.
             /// </summary>
@@ -3303,34 +1897,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteRelayServiceConnectionWithHttpMessagesAsync(resourceGroupName, name, entityName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates a new hybrid connection configuration (PUT), or updates an existing
-            /// one (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Creates a new hybrid connection configuration (PUT), or updates an existing
-            /// one (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='entityName'>
-            /// Name of the hybrid connection configuration.
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// Details of the hybrid connection configuration.
-            /// </param>
-            public static RelayServiceConnectionEntityInner UpdateRelayServiceConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string entityName, RelayServiceConnectionEntityInner connectionEnvelope)
-            {
-                return operations.UpdateRelayServiceConnectionAsync(resourceGroupName, name, entityName, connectionEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new hybrid connection configuration (PUT), or updates an existing
             /// one (PATCH).
@@ -3365,26 +1932,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all scale-out instances of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets all scale-out instances of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static IPage<SiteInstanceInner> ListInstanceIdentifiers(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListInstanceIdentifiersAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all scale-out instances of an app.
             /// </summary>
@@ -3411,32 +1959,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </summary>
-            /// <remarks>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The ID of a specific scaled-out instance. This is the value of the name
-            /// property in the JSON response from "GET api/sites/{siteName}/instances"
-            /// </param>
-            public static IPage<DeploymentInner> ListInstanceDeployments(this IWebAppsOperations operations, string resourceGroupName, string name, string instanceId)
-            {
-                return operations.ListInstanceDeploymentsAsync(resourceGroupName, name, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List deployments for an app, or a deployment slot, or for an instance of a
             /// scaled-out app.
@@ -3469,35 +1992,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// Deployment ID.
-            /// </param>
-            /// <param name='instanceId'>
-            /// ID of a specific scaled-out instance. This is the value of the name
-            /// property in the JSON response from "GET api/sites/{siteName}/instances"
-            /// </param>
-            public static DeploymentInner GetInstanceDeployment(this IWebAppsOperations operations, string resourceGroupName, string name, string id, string instanceId)
-            {
-                return operations.GetInstanceDeploymentAsync(resourceGroupName, name, id, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
             /// specific scaled-out instance.
@@ -3533,38 +2028,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create a deployment for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Create a deployment for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// ID of an existing deployment.
-            /// </param>
-            /// <param name='instanceId'>
-            /// ID of a specific scaled-out instance. This is the value of the name
-            /// property in the JSON response from "GET api/sites/{siteName}/instances"
-            /// </param>
-            /// <param name='deployment'>
-            /// Deployment details.
-            /// </param>
-            public static DeploymentInner CreateInstanceDeployment(this IWebAppsOperations operations, string resourceGroupName, string name, string id, string instanceId, DeploymentInner deployment)
-            {
-                return operations.CreateInstanceDeploymentAsync(resourceGroupName, name, id, instanceId, deployment).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a deployment for an app, a specific deployment slot, and/or a
             /// specific scaled-out instance.
@@ -3603,35 +2067,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete a deployment by its ID for an app, a specific deployment slot,
-            /// and/or a specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Delete a deployment by its ID for an app, a specific deployment slot,
-            /// and/or a specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// Deployment ID.
-            /// </param>
-            /// <param name='instanceId'>
-            /// ID of a specific scaled-out instance. This is the value of the name
-            /// property in the JSON response from "GET api/sites/{siteName}/instances"
-            /// </param>
-            public static void DeleteInstanceDeployment(this IWebAppsOperations operations, string resourceGroupName, string name, string id, string instanceId)
-            {
-                operations.DeleteInstanceDeploymentAsync(resourceGroupName, name, id, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a deployment by its ID for an app, a specific deployment slot,
             /// and/or a specific scaled-out instance.
@@ -3664,28 +2100,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteInstanceDeploymentWithHttpMessagesAsync(resourceGroupName, name, id, instanceId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Shows whether an app can be cloned to another resource group or
-            /// subscription.
-            /// </summary>
-            /// <remarks>
-            /// Shows whether an app can be cloned to another resource group or
-            /// subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static SiteCloneabilityInner IsCloneable(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.IsCloneableAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Shows whether an app can be cloned to another resource group or
             /// subscription.
@@ -3714,26 +2129,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all metric definitions of an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets all metric definitions of an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListMetricDefinitions(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListMetricDefinitionsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all metric definitions of an app (or deployment slot, if specified).
             /// </summary>
@@ -3760,36 +2156,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets performance metrics of an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets performance metrics of an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='details'>
-            /// Specify "true" to include metric details in the response. It is "false" by
-            /// default.
-            /// </param>
-            /// <param name='filter'>
-            /// Return only metrics specified in the filter (using OData syntax). For
-            /// example: $filter=(name.value eq 'Metric1' or name.value eq 'Metric2') and
-            /// startTime eq '2014-01-01T00:00:00Z' and endTime eq '2014-12-31T23:59:59Z'
-            /// and timeGrain eq duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<ResourceMetric> ListMetrics(this IWebAppsOperations operations, string resourceGroupName, string name, bool? details = default(bool?), string filter = default(string))
-            {
-                return operations.ListMetricsAsync(resourceGroupName, name, details, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets performance metrics of an app (or deployment slot, if specified).
             /// </summary>
@@ -3826,32 +2193,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restores a web app.
-            /// </summary>
-            /// <remarks>
-            /// Restores a web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='subscriptionName'>
-            /// Azure subscription
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='migrationOptions'>
-            /// Migration migrationOptions
-            /// </param>
-            public static StorageMigrationResponseInner MigrateStorage(this IWebAppsOperations operations, string subscriptionName, string resourceGroupName, string name, StorageMigrationOptionsInner migrationOptions)
-            {
-                return operations.MigrateStorageAsync(subscriptionName, resourceGroupName, name, migrationOptions).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restores a web app.
             /// </summary>
@@ -3884,29 +2226,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Migrates a local (in-app) MySql database to a remote MySql database.
-            /// </summary>
-            /// <remarks>
-            /// Migrates a local (in-app) MySql database to a remote MySql database.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='migrationRequestEnvelope'>
-            /// MySql migration options
-            /// </param>
-            public static OperationInner MigrateMySql(this IWebAppsOperations operations, string resourceGroupName, string name, MigrateMySqlRequestInner migrationRequestEnvelope)
-            {
-                return operations.MigrateMySqlAsync(resourceGroupName, name, migrationRequestEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Migrates a local (in-app) MySql database to a remote MySql database.
             /// </summary>
@@ -3936,28 +2256,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns the status of MySql in app migration, if one is active, and whether
-            /// or not MySql in app is enabled
-            /// </summary>
-            /// <remarks>
-            /// Returns the status of MySql in app migration, if one is active, and whether
-            /// or not MySql in app is enabled
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            public static MigrateMySqlStatusInner GetMigrateMySqlStatus(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetMigrateMySqlStatusAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns the status of MySql in app migration, if one is active, and whether
             /// or not MySql in app is enabled
@@ -3986,31 +2285,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network features used by the app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets all network features used by the app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='view'>
-            /// The type of view. This can either be "summary" or "detailed".
-            /// </param>
-            public static NetworkFeaturesInner ListNetworkFeatures(this IWebAppsOperations operations, string resourceGroupName, string name, string view)
-            {
-                return operations.ListNetworkFeaturesAsync(resourceGroupName, name, view).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network features used by the app (or deployment slot, if
             /// specified).
@@ -4042,35 +2317,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Start capturing network packets for the site.
-            /// </summary>
-            /// <remarks>
-            /// Start capturing network packets for the site.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app.
-            /// </param>
-            /// <param name='durationInSeconds'>
-            /// The duration to keep capturing in seconds.
-            /// </param>
-            /// <param name='maxFrameLength'>
-            /// The maximum frame length in bytes (Optional).
-            /// </param>
-            /// <param name='sasUrl'>
-            /// The Blob URL to store capture file.
-            /// </param>
-            public static string StartWebSiteNetworkTrace(this IWebAppsOperations operations, string resourceGroupName, string name, int? durationInSeconds = default(int?), int? maxFrameLength = default(int?), string sasUrl = default(string))
-            {
-                return operations.StartWebSiteNetworkTraceAsync(resourceGroupName, name, durationInSeconds, maxFrameLength, sasUrl).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Start capturing network packets for the site.
             /// </summary>
@@ -4106,26 +2353,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Stop ongoing capturing network packets for the site.
-            /// </summary>
-            /// <remarks>
-            /// Stop ongoing capturing network packets for the site.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app.
-            /// </param>
-            public static string StopWebSiteNetworkTrace(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.StopWebSiteNetworkTraceAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Stop ongoing capturing network packets for the site.
             /// </summary>
@@ -4152,28 +2380,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Generates a new publishing password for an app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Generates a new publishing password for an app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static void GenerateNewSitePublishingPassword(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                operations.GenerateNewSitePublishingPasswordAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Generates a new publishing password for an app (or deployment slot, if
             /// specified).
@@ -4199,32 +2406,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.GenerateNewSitePublishingPasswordWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets perfmon counters for web app.
-            /// </summary>
-            /// <remarks>
-            /// Gets perfmon counters for web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='filter'>
-            /// Return only usages/metrics specified in the filter. Filter conforms to
-            /// odata syntax. Example: $filter=(startTime eq '2014-01-01T00:00:00Z' and
-            /// endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
-            /// duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<PerfMonResponse> ListPerfMonCounters(this IWebAppsOperations operations, string resourceGroupName, string name, string filter = default(string))
-            {
-                return operations.ListPerfMonCountersAsync(resourceGroupName, name, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets perfmon counters for web app.
             /// </summary>
@@ -4257,26 +2439,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets web app's event logs.
-            /// </summary>
-            /// <remarks>
-            /// Gets web app's event logs.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            public static SitePhpErrorLogFlagInner GetSitePhpErrorLogFlag(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetSitePhpErrorLogFlagAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets web app's event logs.
             /// </summary>
@@ -4303,26 +2466,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the premier add-ons of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the premier add-ons of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static PremierAddOnInner ListPremierAddOns(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListPremierAddOnsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the premier add-ons of an app.
             /// </summary>
@@ -4349,29 +2493,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a named add-on of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets a named add-on of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='premierAddOnName'>
-            /// Add-on name.
-            /// </param>
-            public static PremierAddOnInner GetPremierAddOn(this IWebAppsOperations operations, string resourceGroupName, string name, string premierAddOnName)
-            {
-                return operations.GetPremierAddOnAsync(resourceGroupName, name, premierAddOnName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a named add-on of an app.
             /// </summary>
@@ -4401,32 +2523,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates a named add-on of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates a named add-on of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='premierAddOnName'>
-            /// Add-on name.
-            /// </param>
-            /// <param name='premierAddOn'>
-            /// A JSON representation of the edited premier add-on.
-            /// </param>
-            public static PremierAddOnInner AddPremierAddOn(this IWebAppsOperations operations, string resourceGroupName, string name, string premierAddOnName, PremierAddOnInner premierAddOn)
-            {
-                return operations.AddPremierAddOnAsync(resourceGroupName, name, premierAddOnName, premierAddOn).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates a named add-on of an app.
             /// </summary>
@@ -4459,29 +2556,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete a premier add-on from an app.
-            /// </summary>
-            /// <remarks>
-            /// Delete a premier add-on from an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='premierAddOnName'>
-            /// Add-on name.
-            /// </param>
-            public static void DeletePremierAddOn(this IWebAppsOperations operations, string resourceGroupName, string name, string premierAddOnName)
-            {
-                operations.DeletePremierAddOnAsync(resourceGroupName, name, premierAddOnName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a premier add-on from an app.
             /// </summary>
@@ -4508,30 +2583,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeletePremierAddOnWithHttpMessagesAsync(resourceGroupName, name, premierAddOnName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the publishing profile for an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets the publishing profile for an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='publishingProfileOptions'>
-            /// Specifies publishingProfileOptions for publishing profile. For example, use
-            /// {"format": "FileZilla3"} to get a FileZilla publishing profile.
-            /// </param>
-            public static Stream ListPublishingProfileXmlWithSecrets(this IWebAppsOperations operations, string resourceGroupName, string name, CsmPublishingProfileOptionsInner publishingProfileOptions)
-            {
-                return operations.ListPublishingProfileXmlWithSecretsAsync(resourceGroupName, name, publishingProfileOptions).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the publishing profile for an app (or deployment slot, if specified).
             /// </summary>
@@ -4561,30 +2613,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 return _result.Body;
             }
 
-            /// <summary>
-            /// Recovers a deleted web app.
-            /// </summary>
-            /// <remarks>
-            /// Recovers a deleted web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='recoveryEntity'>
-            /// Snapshot data used for web app recovery. Snapshot information can be
-            /// obtained by calling GetDeletedSites or GetSiteSnapshots API.
-            /// </param>
-            public static RecoverResponseInner Recover(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSiteRecoveryEntityInner recoveryEntity)
-            {
-                return operations.RecoverAsync(resourceGroupName, name, recoveryEntity).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Recovers a deleted web app.
             /// </summary>
@@ -4615,28 +2644,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Resets the configuration settings of the current slot if they were
-            /// previously modified by calling the API with POST.
-            /// </summary>
-            /// <remarks>
-            /// Resets the configuration settings of the current slot if they were
-            /// previously modified by calling the API with POST.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static void ResetProductionSlotConfig(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                operations.ResetProductionSlotConfigAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Resets the configuration settings of the current slot if they were
             /// previously modified by calling the API with POST.
@@ -4662,26 +2670,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.ResetProductionSlotConfigWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the category of ResourceHealthMetadata to use for the given site
-            /// </summary>
-            /// <remarks>
-            /// Gets the category of ResourceHealthMetadata to use for the given site
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            public static ResourceHealthMetadataInner GetResourceHealthMetadata(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetResourceHealthMetadataAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the category of ResourceHealthMetadata to use for the given site
             /// </summary>
@@ -4708,34 +2697,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restarts an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Restarts an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='softRestart'>
-            /// Specify true to apply the configuration settings and restarts the app only
-            /// if necessary. By default, the API always restarts and reprovisions the app.
-            /// </param>
-            /// <param name='synchronous'>
-            /// Specify true to block until the app is restarted. By default, it is set to
-            /// false, and the API responds immediately (asynchronous).
-            /// </param>
-            public static void Restart(this IWebAppsOperations operations, string resourceGroupName, string name, bool? softRestart = default(bool?), bool? synchronous = default(bool?))
-            {
-                operations.RestartAsync(resourceGroupName, name, softRestart, synchronous).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restarts an app (or deployment slot, if specified).
             /// </summary>
@@ -4767,26 +2729,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.RestartWithHttpMessagesAsync(resourceGroupName, name, softRestart, synchronous, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets an app's deployment slots.
-            /// </summary>
-            /// <remarks>
-            /// Gets an app's deployment slots.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static IPage<SiteInner> ListSlots(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListSlotsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets an app's deployment slots.
             /// </summary>
@@ -4813,30 +2756,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the details of a web, mobile, or API app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the details of a web, mobile, or API app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. By default, this API returns the production
-            /// slot.
-            /// </param>
-            public static SiteInner GetSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.GetSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the details of a web, mobile, or API app.
             /// </summary>
@@ -4867,51 +2787,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new web, mobile, or API app in an existing resource group, or
-            /// updates an existing app.
-            /// </summary>
-            /// <remarks>
-            /// Creates a new web, mobile, or API app in an existing resource group, or
-            /// updates an existing app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Unique name of the app to create or update. To create or update a
-            /// deployment slot, use the {slot} parameter.
-            /// </param>
-            /// <param name='siteEnvelope'>
-            /// A JSON representation of the app properties. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot to create or update. By default, this API
-            /// attempts to create or modify the production slot.
-            /// </param>
-            /// <param name='skipDnsRegistration'>
-            /// If true web app hostname is not registered with DNS on creation. This
-            /// parameter is
-            /// only used for app creation
-            /// </param>
-            /// <param name='skipCustomDomainVerification'>
-            /// If true, custom (non *.azurewebsites.net) domains associated with web app
-            /// are not verified.
-            /// </param>
-            /// <param name='forceDnsRegistration'>
-            /// If true, web app hostname is force registered with DNS
-            /// </param>
-            /// <param name='ttlInSeconds'>
-            /// Time to live in seconds for web app's default domain name
-            /// </param>
-            public static SiteInner CreateOrUpdateSlot(this IWebAppsOperations operations, string resourceGroupName, string name, SiteInner siteEnvelope, string slot, bool? skipDnsRegistration = default(bool?), bool? skipCustomDomainVerification = default(bool?), bool? forceDnsRegistration = default(bool?), string ttlInSeconds = default(string))
-            {
-                return operations.CreateOrUpdateSlotAsync(resourceGroupName, name, siteEnvelope, slot, skipDnsRegistration, skipCustomDomainVerification, forceDnsRegistration, ttlInSeconds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new web, mobile, or API app in an existing resource group, or
             /// updates an existing app.
@@ -4963,41 +2839,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a web, mobile, or API app, or one of the deployment slots.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a web, mobile, or API app, or one of the deployment slots.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app to delete.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot to delete. By default, the API deletes the
-            /// production slot.
-            /// </param>
-            /// <param name='deleteMetrics'>
-            /// If true, web app metrics are also deleted
-            /// </param>
-            /// <param name='deleteEmptyServerFarm'>
-            /// Specify true if the App Service plan will be empty after app deletion and
-            /// you want to delete the empty App Service plan. By default, the empty App
-            /// Service plan is not deleted.
-            /// </param>
-            /// <param name='skipDnsRegistration'>
-            /// If true, DNS registration is skipped
-            /// </param>
-            public static void DeleteSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot, bool? deleteMetrics = default(bool?), bool? deleteEmptyServerFarm = default(bool?), bool? skipDnsRegistration = default(bool?))
-            {
-                operations.DeleteSlotAsync(resourceGroupName, name, slot, deleteMetrics, deleteEmptyServerFarm, skipDnsRegistration).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a web, mobile, or API app, or one of the deployment slots.
             /// </summary>
@@ -5036,33 +2878,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteSlotWithHttpMessagesAsync(resourceGroupName, name, slot, deleteMetrics, deleteEmptyServerFarm, skipDnsRegistration, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Analyze a custom hostname.
-            /// </summary>
-            /// <remarks>
-            /// Analyze a custom hostname.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='slot'>
-            /// Name of web app slot. If not specified then will default to production
-            /// slot.
-            /// </param>
-            /// <param name='hostName'>
-            /// Custom hostname
-            /// </param>
-            public static CustomHostnameAnalysisResultInner AnalyzeCustomHostnameSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot, string hostName = default(string))
-            {
-                return operations.AnalyzeCustomHostnameSlotAsync(resourceGroupName, name, slot, hostName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Analyze a custom hostname.
             /// </summary>
@@ -5096,35 +2912,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Applies the configuration settings from the target slot onto the current
-            /// slot.
-            /// </summary>
-            /// <remarks>
-            /// Applies the configuration settings from the target slot onto the current
-            /// slot.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slotSwapEntity'>
-            /// JSON object that contains the target slot name. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the source slot. If a slot is not specified, the production slot is
-            /// used as the source slot.
-            /// </param>
-            public static void ApplySlotConfigurationSlot(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSlotEntityInner slotSwapEntity, string slot)
-            {
-                operations.ApplySlotConfigurationSlotAsync(resourceGroupName, name, slotSwapEntity, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Applies the configuration settings from the target slot onto the current
             /// slot.
@@ -5157,34 +2945,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.ApplySlotConfigurationSlotWithHttpMessagesAsync(resourceGroupName, name, slotSwapEntity, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates a backup of an app.
-            /// </summary>
-            /// <remarks>
-            /// Creates a backup of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='request'>
-            /// Backup configuration. You can use the JSON response from the POST action as
-            /// input here.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// create a backup for the production slot.
-            /// </param>
-            public static BackupItemInner BackupSlot(this IWebAppsOperations operations, string resourceGroupName, string name, BackupRequestInner request, string slot)
-            {
-                return operations.BackupSlotAsync(resourceGroupName, name, request, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a backup of an app.
             /// </summary>
@@ -5219,30 +2980,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets existing backups of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets existing backups of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// backups of the production slot.
-            /// </param>
-            public static IPage<BackupItemInner> ListBackupsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListBackupsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets existing backups of an app.
             /// </summary>
@@ -5273,36 +3011,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Discovers an existing app backup that can be restored from a blob in Azure
-            /// storage.
-            /// </summary>
-            /// <remarks>
-            /// Discovers an existing app backup that can be restored from a blob in Azure
-            /// storage.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='request'>
-            /// A RestoreRequest object that includes Azure storage URL and blog name for
-            /// discovery of backup.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// perform discovery for the production slot.
-            /// </param>
-            public static RestoreRequestInner DiscoverRestoreSlot(this IWebAppsOperations operations, string resourceGroupName, string name, RestoreRequestInner request, string slot)
-            {
-                return operations.DiscoverRestoreSlotAsync(resourceGroupName, name, request, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Discovers an existing app backup that can be restored from a blob in Azure
             /// storage.
@@ -5339,33 +3048,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a backup of an app by its ID.
-            /// </summary>
-            /// <remarks>
-            /// Gets a backup of an app by its ID.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='backupId'>
-            /// ID of the backup.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get a
-            /// backup of the production slot.
-            /// </param>
-            public static BackupItemInner GetBackupStatusSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string backupId, string slot)
-            {
-                return operations.GetBackupStatusSlotAsync(resourceGroupName, name, backupId, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a backup of an app by its ID.
             /// </summary>
@@ -5399,33 +3082,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a backup of an app by its ID.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a backup of an app by its ID.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='backupId'>
-            /// ID of the backup.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete a backup of the production slot.
-            /// </param>
-            public static void DeleteBackupSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string backupId, string slot)
-            {
-                operations.DeleteBackupSlotAsync(resourceGroupName, name, backupId, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a backup of an app by its ID.
             /// </summary>
@@ -5456,42 +3113,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteBackupSlotWithHttpMessagesAsync(resourceGroupName, name, backupId, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets status of a web app backup that may be in progress, including secrets
-            /// associated with the backup, such as the Azure Storage SAS URL. Also can be
-            /// used to update the SAS URL for the backup if a new URL is passed in the
-            /// request body.
-            /// </summary>
-            /// <remarks>
-            /// Gets status of a web app backup that may be in progress, including secrets
-            /// associated with the backup, such as the Azure Storage SAS URL. Also can be
-            /// used to update the SAS URL for the backup if a new URL is passed in the
-            /// request body.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='backupId'>
-            /// Id of backup
-            /// </param>
-            /// <param name='request'>
-            /// Information on backup request
-            /// </param>
-            /// <param name='slot'>
-            /// Name of web app slot. If not specified then will default to production
-            /// slot.
-            /// </param>
-            public static BackupItemInner ListBackupStatusSecretsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string backupId, BackupRequestInner request, string slot)
-            {
-                return operations.ListBackupStatusSecretsSlotAsync(resourceGroupName, name, backupId, request, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets status of a web app backup that may be in progress, including secrets
             /// associated with the backup, such as the Azure Storage SAS URL. Also can be
@@ -5534,38 +3156,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restores a specific backup to another app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Restores a specific backup to another app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='backupId'>
-            /// ID of the backup.
-            /// </param>
-            /// <param name='request'>
-            /// Information on restore request
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// restore a backup of the production slot.
-            /// </param>
-            public static RestoreResponseInner RestoreSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string backupId, RestoreRequestInner request, string slot)
-            {
-                return operations.RestoreSlotAsync(resourceGroupName, name, backupId, request, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restores a specific backup to another app (or deployment slot, if
             /// specified).
@@ -5604,30 +3195,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List the configurations of an app
-            /// </summary>
-            /// <remarks>
-            /// List the configurations of an app
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// return configuration for the production slot.
-            /// </param>
-            public static IPage<SiteConfigResourceInner> ListConfigurationsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListConfigurationsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List the configurations of an app
             /// </summary>
@@ -5658,33 +3226,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Replaces the application settings of an app.
-            /// </summary>
-            /// <remarks>
-            /// Replaces the application settings of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='appSettings'>
-            /// Application settings of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// update the application settings for the production slot.
-            /// </param>
-            public static StringDictionaryInner UpdateApplicationSettingsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, StringDictionaryInner appSettings, string slot)
-            {
-                return operations.UpdateApplicationSettingsSlotAsync(resourceGroupName, name, appSettings, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Replaces the application settings of an app.
             /// </summary>
@@ -5718,30 +3260,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the application settings of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the application settings of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the application settings for the production slot.
-            /// </param>
-            public static StringDictionaryInner ListApplicationSettingsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListApplicationSettingsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the application settings of an app.
             /// </summary>
@@ -5772,35 +3291,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the Authentication / Authorization settings associated with web
-            /// app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the Authentication / Authorization settings associated with web
-            /// app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='siteAuthSettings'>
-            /// Auth settings associated with web app
-            /// </param>
-            /// <param name='slot'>
-            /// Name of web app slot. If not specified then will default to production
-            /// slot.
-            /// </param>
-            public static SiteAuthSettingsInner UpdateAuthSettingsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, SiteAuthSettingsInner siteAuthSettings, string slot)
-            {
-                return operations.UpdateAuthSettingsSlotAsync(resourceGroupName, name, siteAuthSettings, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the Authentication / Authorization settings associated with web
             /// app.
@@ -5836,30 +3327,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the Authentication/Authorization settings of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the Authentication/Authorization settings of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the settings for the production slot.
-            /// </param>
-            public static SiteAuthSettingsInner GetAuthSettingsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.GetAuthSettingsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the Authentication/Authorization settings of an app.
             /// </summary>
@@ -5890,33 +3358,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the backup configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the backup configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='request'>
-            /// Edited backup configuration.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// update the backup configuration for the production slot.
-            /// </param>
-            public static BackupRequestInner UpdateBackupConfigurationSlot(this IWebAppsOperations operations, string resourceGroupName, string name, BackupRequestInner request, string slot)
-            {
-                return operations.UpdateBackupConfigurationSlotAsync(resourceGroupName, name, request, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the backup configuration of an app.
             /// </summary>
@@ -5950,30 +3392,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the backup configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Deletes the backup configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete the backup configuration for the production slot.
-            /// </param>
-            public static void DeleteBackupConfigurationSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                operations.DeleteBackupConfigurationSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the backup configuration of an app.
             /// </summary>
@@ -6001,30 +3420,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteBackupConfigurationSlotWithHttpMessagesAsync(resourceGroupName, name, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the backup configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the backup configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the backup configuration for the production slot.
-            /// </param>
-            public static BackupRequestInner GetBackupConfigurationSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.GetBackupConfigurationSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the backup configuration of an app.
             /// </summary>
@@ -6055,33 +3451,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Replaces the connection strings of an app.
-            /// </summary>
-            /// <remarks>
-            /// Replaces the connection strings of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='connectionStrings'>
-            /// Connection strings of the app or deployment slot. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// update the connection settings for the production slot.
-            /// </param>
-            public static ConnectionStringDictionaryInner UpdateConnectionStringsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, ConnectionStringDictionaryInner connectionStrings, string slot)
-            {
-                return operations.UpdateConnectionStringsSlotAsync(resourceGroupName, name, connectionStrings, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Replaces the connection strings of an app.
             /// </summary>
@@ -6115,30 +3485,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the connection strings of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the connection strings of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the connection settings for the production slot.
-            /// </param>
-            public static ConnectionStringDictionaryInner ListConnectionStringsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListConnectionStringsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the connection strings of an app.
             /// </summary>
@@ -6169,30 +3516,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the logging configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the logging configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the logging configuration for the production slot.
-            /// </param>
-            public static SiteLogsConfigInner GetDiagnosticLogsConfigurationSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.GetDiagnosticLogsConfigurationSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the logging configuration of an app.
             /// </summary>
@@ -6223,34 +3547,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the logging configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the logging configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='siteLogsConfig'>
-            /// A SiteLogsConfig JSON object that contains the logging configuration to
-            /// change in the "properties" property.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// update the logging configuration for the production slot.
-            /// </param>
-            public static SiteLogsConfigInner UpdateDiagnosticLogsConfigSlot(this IWebAppsOperations operations, string resourceGroupName, string name, SiteLogsConfigInner siteLogsConfig, string slot)
-            {
-                return operations.UpdateDiagnosticLogsConfigSlotAsync(resourceGroupName, name, siteLogsConfig, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the logging configuration of an app.
             /// </summary>
@@ -6285,33 +3582,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Replaces the metadata of an app.
-            /// </summary>
-            /// <remarks>
-            /// Replaces the metadata of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='metadata'>
-            /// Edited metadata of the app or deployment slot. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// update the metadata for the production slot.
-            /// </param>
-            public static StringDictionaryInner UpdateMetadataSlot(this IWebAppsOperations operations, string resourceGroupName, string name, StringDictionaryInner metadata, string slot)
-            {
-                return operations.UpdateMetadataSlotAsync(resourceGroupName, name, metadata, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Replaces the metadata of an app.
             /// </summary>
@@ -6345,30 +3616,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the metadata of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the metadata of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the metadata for the production slot.
-            /// </param>
-            public static StringDictionaryInner ListMetadataSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListMetadataSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the metadata of an app.
             /// </summary>
@@ -6399,30 +3647,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the Git/FTP publishing credentials of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the Git/FTP publishing credentials of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the publishing credentials for the production slot.
-            /// </param>
-            public static UserInner ListPublishingCredentialsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListPublishingCredentialsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the Git/FTP publishing credentials of an app.
             /// </summary>
@@ -6453,33 +3678,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the Push settings associated with web app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the Push settings associated with web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='pushSettings'>
-            /// Push settings associated with web app
-            /// </param>
-            /// <param name='slot'>
-            /// Name of web app slot. If not specified then will default to production
-            /// slot.
-            /// </param>
-            public static PushSettingsInner UpdateSitePushSettingsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, PushSettingsInner pushSettings, string slot)
-            {
-                return operations.UpdateSitePushSettingsSlotAsync(resourceGroupName, name, pushSettings, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the Push settings associated with web app.
             /// </summary>
@@ -6513,30 +3712,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the Push settings associated with web app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the Push settings associated with web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='slot'>
-            /// Name of web app slot. If not specified then will default to production
-            /// slot.
-            /// </param>
-            public static PushSettingsInner ListSitePushSettingsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListSitePushSettingsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the Push settings associated with web app.
             /// </summary>
@@ -6567,32 +3743,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the configuration of an app, such as platform version and bitness,
-            /// default documents, virtual applications, Always On, etc.
-            /// </summary>
-            /// <remarks>
-            /// Gets the configuration of an app, such as platform version and bitness,
-            /// default documents, virtual applications, Always On, etc.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// return configuration for the production slot.
-            /// </param>
-            public static SiteConfigResourceInner GetConfigurationSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.GetConfigurationSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the configuration of an app, such as platform version and bitness,
             /// default documents, virtual applications, Always On, etc.
@@ -6625,33 +3776,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='siteConfig'>
-            /// JSON representation of a SiteConfig object. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// update configuration for the production slot.
-            /// </param>
-            public static SiteConfigResourceInner CreateOrUpdateConfigurationSlot(this IWebAppsOperations operations, string resourceGroupName, string name, SiteConfigResourceInner siteConfig, string slot)
-            {
-                return operations.CreateOrUpdateConfigurationSlotAsync(resourceGroupName, name, siteConfig, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the configuration of an app.
             /// </summary>
@@ -6685,33 +3810,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='siteConfig'>
-            /// JSON representation of a SiteConfig object. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// update configuration for the production slot.
-            /// </param>
-            public static SiteConfigResourceInner UpdateConfigurationSlot(this IWebAppsOperations operations, string resourceGroupName, string name, SiteConfigResourceInner siteConfig, string slot)
-            {
-                return operations.UpdateConfigurationSlotAsync(resourceGroupName, name, siteConfig, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the configuration of an app.
             /// </summary>
@@ -6745,32 +3844,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of web app configuration snapshots identifiers. Each element of
-            /// the list contains a timestamp and the ID of the snapshot.
-            /// </summary>
-            /// <remarks>
-            /// Gets a list of web app configuration snapshots identifiers. Each element of
-            /// the list contains a timestamp and the ID of the snapshot.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// return configuration for the production slot.
-            /// </param>
-            public static IList<SiteConfigurationSnapshotInfoInner> ListConfigurationSnapshotInfoSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListConfigurationSnapshotInfoSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of web app configuration snapshots identifiers. Each element of
             /// the list contains a timestamp and the ID of the snapshot.
@@ -6803,33 +3877,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a snapshot of the configuration of an app at a previous point in time.
-            /// </summary>
-            /// <remarks>
-            /// Gets a snapshot of the configuration of an app at a previous point in time.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='snapshotId'>
-            /// The ID of the snapshot to read.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// return configuration for the production slot.
-            /// </param>
-            public static SiteConfigResourceInner GetConfigurationSnapshotSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string snapshotId, string slot)
-            {
-                return operations.GetConfigurationSnapshotSlotAsync(resourceGroupName, name, snapshotId, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a snapshot of the configuration of an app at a previous point in time.
             /// </summary>
@@ -6863,33 +3911,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Reverts the configuration of an app to a previous snapshot.
-            /// </summary>
-            /// <remarks>
-            /// Reverts the configuration of an app to a previous snapshot.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='snapshotId'>
-            /// The ID of the snapshot to read.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// return configuration for the production slot.
-            /// </param>
-            public static void RecoverSiteConfigurationSnapshotSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string snapshotId, string slot)
-            {
-                operations.RecoverSiteConfigurationSnapshotSlotAsync(resourceGroupName, name, snapshotId, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reverts the configuration of an app to a previous snapshot.
             /// </summary>
@@ -6920,32 +3942,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.RecoverSiteConfigurationSnapshotSlotWithHttpMessagesAsync(resourceGroupName, name, snapshotId, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </summary>
-            /// <remarks>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API returns
-            /// deployments for the production slot.
-            /// </param>
-            public static IPage<DeploymentInner> ListDeploymentsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListDeploymentsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List deployments for an app, or a deployment slot, or for an instance of a
             /// scaled-out app.
@@ -6978,35 +3975,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// Deployment ID.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API gets a
-            /// deployment for the production slot.
-            /// </param>
-            public static DeploymentInner GetDeploymentSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string id, string slot)
-            {
-                return operations.GetDeploymentSlotAsync(resourceGroupName, name, id, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
             /// specific scaled-out instance.
@@ -7042,38 +4011,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create a deployment for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Create a deployment for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// ID of an existing deployment.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API creates a
-            /// deployment for the production slot.
-            /// </param>
-            /// <param name='deployment'>
-            /// Deployment details.
-            /// </param>
-            public static DeploymentInner CreateDeploymentSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string id, string slot, DeploymentInner deployment)
-            {
-                return operations.CreateDeploymentSlotAsync(resourceGroupName, name, id, slot, deployment).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a deployment for an app, a specific deployment slot, and/or a
             /// specific scaled-out instance.
@@ -7112,35 +4050,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete a deployment by its ID for an app, a specific deployment slot,
-            /// and/or a specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Delete a deployment by its ID for an app, a specific deployment slot,
-            /// and/or a specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// Deployment ID.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API deletes a
-            /// deployment for the production slot.
-            /// </param>
-            public static void DeleteDeploymentSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string id, string slot)
-            {
-                operations.DeleteDeploymentSlotAsync(resourceGroupName, name, id, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a deployment by its ID for an app, a specific deployment slot,
             /// and/or a specific scaled-out instance.
@@ -7173,30 +4083,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteDeploymentSlotWithHttpMessagesAsync(resourceGroupName, name, id, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Lists ownership identifiers for domain associated with web app.
-            /// </summary>
-            /// <remarks>
-            /// Lists ownership identifiers for domain associated with web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete the binding for the production slot.
-            /// </param>
-            public static IPage<IdentifierInner> ListDomainOwnershipIdentifiersSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListDomainOwnershipIdentifiersSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists ownership identifiers for domain associated with web app.
             /// </summary>
@@ -7227,33 +4114,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get domain ownership identifier for web app.
-            /// </summary>
-            /// <remarks>
-            /// Get domain ownership identifier for web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='domainOwnershipIdentifierName'>
-            /// Name of domain ownership identifier.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete the binding for the production slot.
-            /// </param>
-            public static IdentifierInner GetDomainOwnershipIdentifierSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string domainOwnershipIdentifierName, string slot)
-            {
-                return operations.GetDomainOwnershipIdentifierSlotAsync(resourceGroupName, name, domainOwnershipIdentifierName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get domain ownership identifier for web app.
             /// </summary>
@@ -7287,38 +4148,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a domain ownership identifier for web app, or updates an existing
-            /// ownership identifier.
-            /// </summary>
-            /// <remarks>
-            /// Creates a domain ownership identifier for web app, or updates an existing
-            /// ownership identifier.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='domainOwnershipIdentifierName'>
-            /// Name of domain ownership identifier.
-            /// </param>
-            /// <param name='domainOwnershipIdentifier'>
-            /// A JSON representation of the domain ownership properties.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete the binding for the production slot.
-            /// </param>
-            public static IdentifierInner CreateOrUpdateDomainOwnershipIdentifierSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string domainOwnershipIdentifierName, IdentifierInner domainOwnershipIdentifier, string slot)
-            {
-                return operations.CreateOrUpdateDomainOwnershipIdentifierSlotAsync(resourceGroupName, name, domainOwnershipIdentifierName, domainOwnershipIdentifier, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a domain ownership identifier for web app, or updates an existing
             /// ownership identifier.
@@ -7357,33 +4187,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a domain ownership identifier for a web app.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a domain ownership identifier for a web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='domainOwnershipIdentifierName'>
-            /// Name of domain ownership identifier.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete the binding for the production slot.
-            /// </param>
-            public static void DeleteDomainOwnershipIdentifierSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string domainOwnershipIdentifierName, string slot)
-            {
-                operations.DeleteDomainOwnershipIdentifierSlotAsync(resourceGroupName, name, domainOwnershipIdentifierName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a domain ownership identifier for a web app.
             /// </summary>
@@ -7414,38 +4218,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteDomainOwnershipIdentifierSlotWithHttpMessagesAsync(resourceGroupName, name, domainOwnershipIdentifierName, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates a domain ownership identifier for web app, or updates an existing
-            /// ownership identifier.
-            /// </summary>
-            /// <remarks>
-            /// Creates a domain ownership identifier for web app, or updates an existing
-            /// ownership identifier.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='domainOwnershipIdentifierName'>
-            /// Name of domain ownership identifier.
-            /// </param>
-            /// <param name='domainOwnershipIdentifier'>
-            /// A JSON representation of the domain ownership properties.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete the binding for the production slot.
-            /// </param>
-            public static IdentifierInner UpdateDomainOwnershipIdentifierSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string domainOwnershipIdentifierName, IdentifierInner domainOwnershipIdentifier, string slot)
-            {
-                return operations.UpdateDomainOwnershipIdentifierSlotAsync(resourceGroupName, name, domainOwnershipIdentifierName, domainOwnershipIdentifier, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a domain ownership identifier for web app, or updates an existing
             /// ownership identifier.
@@ -7484,30 +4257,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get hostname bindings for an app or a deployment slot.
-            /// </summary>
-            /// <remarks>
-            /// Get hostname bindings for an app or a deployment slot.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API gets
-            /// hostname bindings for the production slot.
-            /// </param>
-            public static IPage<HostNameBindingInner> ListHostNameBindingsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListHostNameBindingsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get hostname bindings for an app or a deployment slot.
             /// </summary>
@@ -7538,35 +4288,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the named hostname binding for an app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Get the named hostname binding for an app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API the named
-            /// binding for the production slot.
-            /// </param>
-            /// <param name='hostName'>
-            /// Hostname in the hostname binding.
-            /// </param>
-            public static HostNameBindingInner GetHostNameBindingSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot, string hostName)
-            {
-                return operations.GetHostNameBindingSlotAsync(resourceGroupName, name, slot, hostName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the named hostname binding for an app (or deployment slot, if
             /// specified).
@@ -7602,37 +4324,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a hostname binding for an app.
-            /// </summary>
-            /// <remarks>
-            /// Creates a hostname binding for an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='hostName'>
-            /// Hostname in the hostname binding.
-            /// </param>
-            /// <param name='hostNameBinding'>
-            /// Binding details. This is the JSON representation of a HostNameBinding
-            /// object.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// create a binding for the production slot.
-            /// </param>
-            public static HostNameBindingInner CreateOrUpdateHostNameBindingSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string hostName, HostNameBindingInner hostNameBinding, string slot)
-            {
-                return operations.CreateOrUpdateHostNameBindingSlotAsync(resourceGroupName, name, hostName, hostNameBinding, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a hostname binding for an app.
             /// </summary>
@@ -7670,33 +4362,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a hostname binding for an app.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a hostname binding for an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete the binding for the production slot.
-            /// </param>
-            /// <param name='hostName'>
-            /// Hostname in the hostname binding.
-            /// </param>
-            public static void DeleteHostNameBindingSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot, string hostName)
-            {
-                operations.DeleteHostNameBindingSlotAsync(resourceGroupName, name, slot, hostName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a hostname binding for an app.
             /// </summary>
@@ -7727,35 +4393,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteHostNameBindingSlotWithHttpMessagesAsync(resourceGroupName, name, slot, hostName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Retrieves a specific Service Bus Hybrid Connection used by this Web App.
-            /// </summary>
-            /// <remarks>
-            /// Retrieves a specific Service Bus Hybrid Connection used by this Web App.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace for this hybrid connection
-            /// </param>
-            /// <param name='relayName'>
-            /// The relay name for this hybrid connection
-            /// </param>
-            /// <param name='slot'>
-            /// The name of the slot for the web app.
-            /// </param>
-            public static HybridConnectionInner GetHybridConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string namespaceName, string relayName, string slot)
-            {
-                return operations.GetHybridConnectionSlotAsync(resourceGroupName, name, namespaceName, relayName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Retrieves a specific Service Bus Hybrid Connection used by this Web App.
             /// </summary>
@@ -7791,38 +4429,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new Hybrid Connection using a Service Bus relay.
-            /// </summary>
-            /// <remarks>
-            /// Creates a new Hybrid Connection using a Service Bus relay.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace for this hybrid connection
-            /// </param>
-            /// <param name='relayName'>
-            /// The relay name for this hybrid connection
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// The details of the hybrid connection
-            /// </param>
-            /// <param name='slot'>
-            /// The name of the slot for the web app.
-            /// </param>
-            public static HybridConnectionInner CreateOrUpdateHybridConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string namespaceName, string relayName, HybridConnectionInner connectionEnvelope, string slot)
-            {
-                return operations.CreateOrUpdateHybridConnectionSlotAsync(resourceGroupName, name, namespaceName, relayName, connectionEnvelope, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new Hybrid Connection using a Service Bus relay.
             /// </summary>
@@ -7861,35 +4468,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Removes a Hybrid Connection from this site.
-            /// </summary>
-            /// <remarks>
-            /// Removes a Hybrid Connection from this site.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace for this hybrid connection
-            /// </param>
-            /// <param name='relayName'>
-            /// The relay name for this hybrid connection
-            /// </param>
-            /// <param name='slot'>
-            /// The name of the slot for the web app.
-            /// </param>
-            public static void DeleteHybridConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string namespaceName, string relayName, string slot)
-            {
-                operations.DeleteHybridConnectionSlotAsync(resourceGroupName, name, namespaceName, relayName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Removes a Hybrid Connection from this site.
             /// </summary>
@@ -7922,38 +4501,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteHybridConnectionSlotWithHttpMessagesAsync(resourceGroupName, name, namespaceName, relayName, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates a new Hybrid Connection using a Service Bus relay.
-            /// </summary>
-            /// <remarks>
-            /// Creates a new Hybrid Connection using a Service Bus relay.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace for this hybrid connection
-            /// </param>
-            /// <param name='relayName'>
-            /// The relay name for this hybrid connection
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// The details of the hybrid connection
-            /// </param>
-            /// <param name='slot'>
-            /// The name of the slot for the web app.
-            /// </param>
-            public static HybridConnectionInner UpdateHybridConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string namespaceName, string relayName, HybridConnectionInner connectionEnvelope, string slot)
-            {
-                return operations.UpdateHybridConnectionSlotAsync(resourceGroupName, name, namespaceName, relayName, connectionEnvelope, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new Hybrid Connection using a Service Bus relay.
             /// </summary>
@@ -7992,35 +4540,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the send key name and value for a Hybrid Connection.
-            /// </summary>
-            /// <remarks>
-            /// Gets the send key name and value for a Hybrid Connection.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace for this hybrid connection
-            /// </param>
-            /// <param name='relayName'>
-            /// The relay name for this hybrid connection
-            /// </param>
-            /// <param name='slot'>
-            /// The name of the slot for the web app.
-            /// </param>
-            public static HybridConnectionKeyInner ListHybridConnectionKeysSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string namespaceName, string relayName, string slot)
-            {
-                return operations.ListHybridConnectionKeysSlotAsync(resourceGroupName, name, namespaceName, relayName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the send key name and value for a Hybrid Connection.
             /// </summary>
@@ -8056,29 +4576,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Retrieves all Service Bus Hybrid Connections used by this Web App.
-            /// </summary>
-            /// <remarks>
-            /// Retrieves all Service Bus Hybrid Connections used by this Web App.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app
-            /// </param>
-            /// <param name='slot'>
-            /// The name of the slot for the web app.
-            /// </param>
-            public static HybridConnectionInner ListHybridConnectionsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListHybridConnectionsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Retrieves all Service Bus Hybrid Connections used by this Web App.
             /// </summary>
@@ -8108,32 +4606,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets hybrid connections configured for an app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets hybrid connections configured for an app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// hybrid connections for the production slot.
-            /// </param>
-            public static RelayServiceConnectionEntityInner ListRelayServiceConnectionsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListRelayServiceConnectionsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets hybrid connections configured for an app (or deployment slot, if
             /// specified).
@@ -8166,33 +4639,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a hybrid connection configuration by its name.
-            /// </summary>
-            /// <remarks>
-            /// Gets a hybrid connection configuration by its name.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='entityName'>
-            /// Name of the hybrid connection.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get a
-            /// hybrid connection for the production slot.
-            /// </param>
-            public static RelayServiceConnectionEntityInner GetRelayServiceConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string entityName, string slot)
-            {
-                return operations.GetRelayServiceConnectionSlotAsync(resourceGroupName, name, entityName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a hybrid connection configuration by its name.
             /// </summary>
@@ -8226,38 +4673,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new hybrid connection configuration (PUT), or updates an existing
-            /// one (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Creates a new hybrid connection configuration (PUT), or updates an existing
-            /// one (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='entityName'>
-            /// Name of the hybrid connection configuration.
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// Details of the hybrid connection configuration.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// create or update a hybrid connection for the production slot.
-            /// </param>
-            public static RelayServiceConnectionEntityInner CreateOrUpdateRelayServiceConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string entityName, RelayServiceConnectionEntityInner connectionEnvelope, string slot)
-            {
-                return operations.CreateOrUpdateRelayServiceConnectionSlotAsync(resourceGroupName, name, entityName, connectionEnvelope, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new hybrid connection configuration (PUT), or updates an existing
             /// one (PATCH).
@@ -8296,33 +4712,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a relay service connection by its name.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a relay service connection by its name.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='entityName'>
-            /// Name of the hybrid connection configuration.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete a hybrid connection for the production slot.
-            /// </param>
-            public static void DeleteRelayServiceConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string entityName, string slot)
-            {
-                operations.DeleteRelayServiceConnectionSlotAsync(resourceGroupName, name, entityName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a relay service connection by its name.
             /// </summary>
@@ -8353,38 +4743,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteRelayServiceConnectionSlotWithHttpMessagesAsync(resourceGroupName, name, entityName, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates a new hybrid connection configuration (PUT), or updates an existing
-            /// one (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Creates a new hybrid connection configuration (PUT), or updates an existing
-            /// one (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='entityName'>
-            /// Name of the hybrid connection configuration.
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// Details of the hybrid connection configuration.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// create or update a hybrid connection for the production slot.
-            /// </param>
-            public static RelayServiceConnectionEntityInner UpdateRelayServiceConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string entityName, RelayServiceConnectionEntityInner connectionEnvelope, string slot)
-            {
-                return operations.UpdateRelayServiceConnectionSlotAsync(resourceGroupName, name, entityName, connectionEnvelope, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new hybrid connection configuration (PUT), or updates an existing
             /// one (PATCH).
@@ -8423,30 +4782,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all scale-out instances of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets all scale-out instances of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API gets the
-            /// production slot instances.
-            /// </param>
-            public static IPage<SiteInstanceInner> ListInstanceIdentifiersSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListInstanceIdentifiersSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all scale-out instances of an app.
             /// </summary>
@@ -8477,36 +4813,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </summary>
-            /// <remarks>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API returns
-            /// deployments for the production slot.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The ID of a specific scaled-out instance. This is the value of the name
-            /// property in the JSON response from "GET api/sites/{siteName}/instances"
-            /// </param>
-            public static IPage<DeploymentInner> ListInstanceDeploymentsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot, string instanceId)
-            {
-                return operations.ListInstanceDeploymentsSlotAsync(resourceGroupName, name, slot, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List deployments for an app, or a deployment slot, or for an instance of a
             /// scaled-out app.
@@ -8543,39 +4850,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// Deployment ID.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API gets a
-            /// deployment for the production slot.
-            /// </param>
-            /// <param name='instanceId'>
-            /// ID of a specific scaled-out instance. This is the value of the name
-            /// property in the JSON response from "GET api/sites/{siteName}/instances"
-            /// </param>
-            public static DeploymentInner GetInstanceDeploymentSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string id, string slot, string instanceId)
-            {
-                return operations.GetInstanceDeploymentSlotAsync(resourceGroupName, name, id, slot, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a deployment by its ID for an app, a specific deployment slot, and/or a
             /// specific scaled-out instance.
@@ -8615,42 +4890,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create a deployment for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Create a deployment for an app, a specific deployment slot, and/or a
-            /// specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// ID of an existing deployment.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API creates a
-            /// deployment for the production slot.
-            /// </param>
-            /// <param name='instanceId'>
-            /// ID of a specific scaled-out instance. This is the value of the name
-            /// property in the JSON response from "GET api/sites/{siteName}/instances"
-            /// </param>
-            /// <param name='deployment'>
-            /// Deployment details.
-            /// </param>
-            public static DeploymentInner CreateInstanceDeploymentSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string id, string slot, string instanceId, DeploymentInner deployment)
-            {
-                return operations.CreateInstanceDeploymentSlotAsync(resourceGroupName, name, id, slot, instanceId, deployment).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a deployment for an app, a specific deployment slot, and/or a
             /// specific scaled-out instance.
@@ -8693,39 +4933,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete a deployment by its ID for an app, a specific deployment slot,
-            /// and/or a specific scaled-out instance.
-            /// </summary>
-            /// <remarks>
-            /// Delete a deployment by its ID for an app, a specific deployment slot,
-            /// and/or a specific scaled-out instance.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='id'>
-            /// Deployment ID.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API deletes a
-            /// deployment for the production slot.
-            /// </param>
-            /// <param name='instanceId'>
-            /// ID of a specific scaled-out instance. This is the value of the name
-            /// property in the JSON response from "GET api/sites/{siteName}/instances"
-            /// </param>
-            public static void DeleteInstanceDeploymentSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string id, string slot, string instanceId)
-            {
-                operations.DeleteInstanceDeploymentSlotAsync(resourceGroupName, name, id, slot, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a deployment by its ID for an app, a specific deployment slot,
             /// and/or a specific scaled-out instance.
@@ -8762,32 +4970,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteInstanceDeploymentSlotWithHttpMessagesAsync(resourceGroupName, name, id, slot, instanceId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Shows whether an app can be cloned to another resource group or
-            /// subscription.
-            /// </summary>
-            /// <remarks>
-            /// Shows whether an app can be cloned to another resource group or
-            /// subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. By default, this API returns information on
-            /// the production slot.
-            /// </param>
-            public static SiteCloneabilityInner IsCloneableSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.IsCloneableSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Shows whether an app can be cloned to another resource group or
             /// subscription.
@@ -8820,30 +5003,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all metric definitions of an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets all metric definitions of an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// metric definitions of the production slot.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListMetricDefinitionsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListMetricDefinitionsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all metric definitions of an app (or deployment slot, if specified).
             /// </summary>
@@ -8874,40 +5034,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets performance metrics of an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets performance metrics of an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// metrics of the production slot.
-            /// </param>
-            /// <param name='details'>
-            /// Specify "true" to include metric details in the response. It is "false" by
-            /// default.
-            /// </param>
-            /// <param name='filter'>
-            /// Return only metrics specified in the filter (using OData syntax). For
-            /// example: $filter=(name.value eq 'Metric1' or name.value eq 'Metric2') and
-            /// startTime eq '2014-01-01T00:00:00Z' and endTime eq '2014-12-31T23:59:59Z'
-            /// and timeGrain eq duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<ResourceMetric> ListMetricsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot, bool? details = default(bool?), string filter = default(string))
-            {
-                return operations.ListMetricsSlotAsync(resourceGroupName, name, slot, details, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets performance metrics of an app (or deployment slot, if specified).
             /// </summary>
@@ -8948,31 +5075,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns the status of MySql in app migration, if one is active, and whether
-            /// or not MySql in app is enabled
-            /// </summary>
-            /// <remarks>
-            /// Returns the status of MySql in app migration, if one is active, and whether
-            /// or not MySql in app is enabled
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot
-            /// </param>
-            public static MigrateMySqlStatusInner GetMigrateMySqlStatusSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.GetMigrateMySqlStatusSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns the status of MySql in app migration, if one is active, and whether
             /// or not MySql in app is enabled
@@ -9004,35 +5107,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network features used by the app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets all network features used by the app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='view'>
-            /// The type of view. This can either be "summary" or "detailed".
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// network features for the production slot.
-            /// </param>
-            public static NetworkFeaturesInner ListNetworkFeaturesSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string view, string slot)
-            {
-                return operations.ListNetworkFeaturesSlotAsync(resourceGroupName, name, view, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network features used by the app (or deployment slot, if
             /// specified).
@@ -9068,38 +5143,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Start capturing network packets for the site.
-            /// </summary>
-            /// <remarks>
-            /// Start capturing network packets for the site.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app.
-            /// </param>
-            /// <param name='slot'>
-            /// The name of the slot for this web app.
-            /// </param>
-            /// <param name='durationInSeconds'>
-            /// The duration to keep capturing in seconds.
-            /// </param>
-            /// <param name='maxFrameLength'>
-            /// The maximum frame length in bytes (Optional).
-            /// </param>
-            /// <param name='sasUrl'>
-            /// The Blob URL to store capture file.
-            /// </param>
-            public static string StartWebSiteNetworkTraceSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot, int? durationInSeconds = default(int?), int? maxFrameLength = default(int?), string sasUrl = default(string))
-            {
-                return operations.StartWebSiteNetworkTraceSlotAsync(resourceGroupName, name, slot, durationInSeconds, maxFrameLength, sasUrl).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Start capturing network packets for the site.
             /// </summary>
@@ -9138,29 +5182,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Stop ongoing capturing network packets for the site.
-            /// </summary>
-            /// <remarks>
-            /// Stop ongoing capturing network packets for the site.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the web app.
-            /// </param>
-            /// <param name='slot'>
-            /// The name of the slot for this web app.
-            /// </param>
-            public static string StopWebSiteNetworkTraceSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.StopWebSiteNetworkTraceSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Stop ongoing capturing network packets for the site.
             /// </summary>
@@ -9190,32 +5212,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Generates a new publishing password for an app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Generates a new publishing password for an app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API generate a
-            /// new publishing password for the production slot.
-            /// </param>
-            public static void GenerateNewSitePublishingPasswordSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                operations.GenerateNewSitePublishingPasswordSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Generates a new publishing password for an app (or deployment slot, if
             /// specified).
@@ -9245,36 +5242,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.GenerateNewSitePublishingPasswordSlotWithHttpMessagesAsync(resourceGroupName, name, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets perfmon counters for web app.
-            /// </summary>
-            /// <remarks>
-            /// Gets perfmon counters for web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='slot'>
-            /// Name of web app slot. If not specified then will default to production
-            /// slot. **** CURRENTLY UNUSED *****
-            /// </param>
-            /// <param name='filter'>
-            /// Return only usages/metrics specified in the filter. Filter conforms to
-            /// odata syntax. Example: $filter=(startTime eq '2014-01-01T00:00:00Z' and
-            /// endTime eq '2014-12-31T23:59:59Z' and timeGrain eq
-            /// duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<PerfMonResponse> ListPerfMonCountersSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot, string filter = default(string))
-            {
-                return operations.ListPerfMonCountersSlotAsync(resourceGroupName, name, slot, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets perfmon counters for web app.
             /// </summary>
@@ -9311,30 +5279,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets web app's event logs.
-            /// </summary>
-            /// <remarks>
-            /// Gets web app's event logs.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='slot'>
-            /// Name of web app slot. If not specified then will default to production
-            /// slot.
-            /// </param>
-            public static SitePhpErrorLogFlagInner GetSitePhpErrorLogFlagSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.GetSitePhpErrorLogFlagSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets web app's event logs.
             /// </summary>
@@ -9365,30 +5310,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the premier add-ons of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the premier add-ons of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the premier add-ons for the production slot.
-            /// </param>
-            public static PremierAddOnInner ListPremierAddOnsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListPremierAddOnsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the premier add-ons of an app.
             /// </summary>
@@ -9419,33 +5341,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a named add-on of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets a named add-on of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='premierAddOnName'>
-            /// Add-on name.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the named add-on for the production slot.
-            /// </param>
-            public static PremierAddOnInner GetPremierAddOnSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string premierAddOnName, string slot)
-            {
-                return operations.GetPremierAddOnSlotAsync(resourceGroupName, name, premierAddOnName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a named add-on of an app.
             /// </summary>
@@ -9479,36 +5375,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates a named add-on of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates a named add-on of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='premierAddOnName'>
-            /// Add-on name.
-            /// </param>
-            /// <param name='premierAddOn'>
-            /// A JSON representation of the edited premier add-on.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// update the named add-on for the production slot.
-            /// </param>
-            public static PremierAddOnInner AddPremierAddOnSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string premierAddOnName, PremierAddOnInner premierAddOn, string slot)
-            {
-                return operations.AddPremierAddOnSlotAsync(resourceGroupName, name, premierAddOnName, premierAddOn, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates a named add-on of an app.
             /// </summary>
@@ -9545,33 +5412,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete a premier add-on from an app.
-            /// </summary>
-            /// <remarks>
-            /// Delete a premier add-on from an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='premierAddOnName'>
-            /// Add-on name.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete the named add-on for the production slot.
-            /// </param>
-            public static void DeletePremierAddOnSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string premierAddOnName, string slot)
-            {
-                operations.DeletePremierAddOnSlotAsync(resourceGroupName, name, premierAddOnName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a premier add-on from an app.
             /// </summary>
@@ -9602,34 +5443,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeletePremierAddOnSlotWithHttpMessagesAsync(resourceGroupName, name, premierAddOnName, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the publishing profile for an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets the publishing profile for an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='publishingProfileOptions'>
-            /// Specifies publishingProfileOptions for publishing profile. For example, use
-            /// {"format": "FileZilla3"} to get a FileZilla publishing profile.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the publishing profile for the production slot.
-            /// </param>
-            public static Stream ListPublishingProfileXmlWithSecretsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, CsmPublishingProfileOptionsInner publishingProfileOptions, string slot)
-            {
-                return operations.ListPublishingProfileXmlWithSecretsSlotAsync(resourceGroupName, name, publishingProfileOptions, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the publishing profile for an app (or deployment slot, if specified).
             /// </summary>
@@ -9663,34 +5477,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 return _result.Body;
             }
 
-            /// <summary>
-            /// Recovers a deleted web app.
-            /// </summary>
-            /// <remarks>
-            /// Recovers a deleted web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='recoveryEntity'>
-            /// Snapshot data used for web app recovery. Snapshot information can be
-            /// obtained by calling GetDeletedSites or GetSiteSnapshots API.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of web app slot. If not specified then will default to production
-            /// slot.
-            /// </param>
-            public static RecoverResponseInner RecoverSlot(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSiteRecoveryEntityInner recoveryEntity, string slot)
-            {
-                return operations.RecoverSlotAsync(resourceGroupName, name, recoveryEntity, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Recovers a deleted web app.
             /// </summary>
@@ -9725,32 +5512,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Resets the configuration settings of the current slot if they were
-            /// previously modified by calling the API with POST.
-            /// </summary>
-            /// <remarks>
-            /// Resets the configuration settings of the current slot if they were
-            /// previously modified by calling the API with POST.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API resets
-            /// configuration settings for the production slot.
-            /// </param>
-            public static void ResetSlotConfigurationSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                operations.ResetSlotConfigurationSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Resets the configuration settings of the current slot if they were
             /// previously modified by calling the API with POST.
@@ -9780,30 +5542,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.ResetSlotConfigurationSlotWithHttpMessagesAsync(resourceGroupName, name, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the category of ResourceHealthMetadata to use for the given site
-            /// </summary>
-            /// <remarks>
-            /// Gets the category of ResourceHealthMetadata to use for the given site
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='slot'>
-            /// Name of web app slot. If not specified then will default to production
-            /// slot.
-            /// </param>
-            public static ResourceHealthMetadataInner GetResourceHealthMetadataSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.GetResourceHealthMetadataSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the category of ResourceHealthMetadata to use for the given site
             /// </summary>
@@ -9834,38 +5573,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restarts an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Restarts an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// restart the production slot.
-            /// </param>
-            /// <param name='softRestart'>
-            /// Specify true to apply the configuration settings and restarts the app only
-            /// if necessary. By default, the API always restarts and reprovisions the app.
-            /// </param>
-            /// <param name='synchronous'>
-            /// Specify true to block until the app is restarted. By default, it is set to
-            /// false, and the API responds immediately (asynchronous).
-            /// </param>
-            public static void RestartSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot, bool? softRestart = default(bool?), bool? synchronous = default(bool?))
-            {
-                operations.RestartSlotAsync(resourceGroupName, name, slot, softRestart, synchronous).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restarts an app (or deployment slot, if specified).
             /// </summary>
@@ -9901,33 +5609,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.RestartSlotWithHttpMessagesAsync(resourceGroupName, name, slot, softRestart, synchronous, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get the difference in configuration settings between two web app slots.
-            /// </summary>
-            /// <remarks>
-            /// Get the difference in configuration settings between two web app slots.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slotSwapEntity'>
-            /// JSON object that contains the target slot name. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the source slot. If a slot is not specified, the production slot is
-            /// used as the source slot.
-            /// </param>
-            public static IPage<SlotDifferenceInner> ListSlotDifferencesSlot(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSlotEntityInner slotSwapEntity, string slot)
-            {
-                return operations.ListSlotDifferencesSlotAsync(resourceGroupName, name, slotSwapEntity, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the difference in configuration settings between two web app slots.
             /// </summary>
@@ -9961,33 +5643,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Swaps two deployment slots of an app.
-            /// </summary>
-            /// <remarks>
-            /// Swaps two deployment slots of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slotSwapEntity'>
-            /// JSON object that contains the target slot name. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the source slot. If a slot is not specified, the production slot is
-            /// used as the source slot.
-            /// </param>
-            public static void SwapSlotSlot(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSlotEntityInner slotSwapEntity, string slot)
-            {
-                operations.SwapSlotSlotAsync(resourceGroupName, name, slotSwapEntity, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Swaps two deployment slots of an app.
             /// </summary>
@@ -10018,29 +5674,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.SwapSlotSlotWithHttpMessagesAsync(resourceGroupName, name, slotSwapEntity, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Returns all Snapshots to the user.
-            /// </summary>
-            /// <remarks>
-            /// Returns all Snapshots to the user.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Website Name
-            /// </param>
-            /// <param name='slot'>
-            /// Website Slot
-            /// </param>
-            public static IPage<SnapshotInner> ListSnapshotsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListSnapshotsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns all Snapshots to the user.
             /// </summary>
@@ -10070,30 +5704,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the source control configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the source control configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the source control configuration for the production slot.
-            /// </param>
-            public static SiteSourceControlInner GetSourceControlSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.GetSourceControlSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the source control configuration of an app.
             /// </summary>
@@ -10124,33 +5735,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the source control configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the source control configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='siteSourceControl'>
-            /// JSON representation of a SiteSourceControl object. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// update the source control configuration for the production slot.
-            /// </param>
-            public static SiteSourceControlInner CreateOrUpdateSourceControlSlot(this IWebAppsOperations operations, string resourceGroupName, string name, SiteSourceControlInner siteSourceControl, string slot)
-            {
-                return operations.CreateOrUpdateSourceControlSlotAsync(resourceGroupName, name, siteSourceControl, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the source control configuration of an app.
             /// </summary>
@@ -10184,30 +5769,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the source control configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Deletes the source control configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete the source control configuration for the production slot.
-            /// </param>
-            public static void DeleteSourceControlSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                operations.DeleteSourceControlSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the source control configuration of an app.
             /// </summary>
@@ -10235,30 +5797,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteSourceControlSlotWithHttpMessagesAsync(resourceGroupName, name, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Starts an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Starts an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will start
-            /// the production slot.
-            /// </param>
-            public static void StartSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                operations.StartSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Starts an app (or deployment slot, if specified).
             /// </summary>
@@ -10286,30 +5825,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.StartSlotWithHttpMessagesAsync(resourceGroupName, name, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Stops an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Stops an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will stop
-            /// the production slot.
-            /// </param>
-            public static void StopSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                operations.StopSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Stops an app (or deployment slot, if specified).
             /// </summary>
@@ -10337,30 +5853,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.StopSlotWithHttpMessagesAsync(resourceGroupName, name, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Sync web app repository.
-            /// </summary>
-            /// <remarks>
-            /// Sync web app repository.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='slot'>
-            /// Name of web app slot. If not specified then will default to production
-            /// slot.
-            /// </param>
-            public static void SyncRepositorySlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                operations.SyncRepositorySlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Sync web app repository.
             /// </summary>
@@ -10388,30 +5881,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.SyncRepositorySlotWithHttpMessagesAsync(resourceGroupName, name, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Syncs function trigger metadata to the scale controller
-            /// </summary>
-            /// <remarks>
-            /// Syncs function trigger metadata to the scale controller
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// restore a backup of the production slot.
-            /// </param>
-            public static void SyncFunctionTriggersSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                operations.SyncFunctionTriggersSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Syncs function trigger metadata to the scale controller
             /// </summary>
@@ -10439,38 +5909,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.SyncFunctionTriggersSlotWithHttpMessagesAsync(resourceGroupName, name, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the quota usage information of an app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets the quota usage information of an app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// quota information of the production slot.
-            /// </param>
-            /// <param name='filter'>
-            /// Return only information specified in the filter (using OData syntax). For
-            /// example: $filter=(name.value eq 'Metric1' or name.value eq 'Metric2') and
-            /// startTime eq '2014-01-01T00:00:00Z' and endTime eq '2014-12-31T23:59:59Z'
-            /// and timeGrain eq duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<CsmUsageQuota> ListUsagesSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot, string filter = default(string))
-            {
-                return operations.ListUsagesSlotAsync(resourceGroupName, name, slot, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the quota usage information of an app (or deployment slot, if
             /// specified).
@@ -10509,30 +5948,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the virtual networks the app (or deployment slot) is connected to.
-            /// </summary>
-            /// <remarks>
-            /// Gets the virtual networks the app (or deployment slot) is connected to.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// virtual network connections for the production slot.
-            /// </param>
-            public static IList<VnetInfoInner> ListVnetConnectionsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.ListVnetConnectionsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the virtual networks the app (or deployment slot) is connected to.
             /// </summary>
@@ -10563,35 +5979,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a virtual network the app (or deployment slot) is connected to by
-            /// name.
-            /// </summary>
-            /// <remarks>
-            /// Gets a virtual network the app (or deployment slot) is connected to by
-            /// name.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the virtual network.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the named virtual network for the production slot.
-            /// </param>
-            public static VnetInfoInner GetVnetConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, string slot)
-            {
-                return operations.GetVnetConnectionSlotAsync(resourceGroupName, name, vnetName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a virtual network the app (or deployment slot) is connected to by
             /// name.
@@ -10627,38 +6015,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
-            /// connection properties (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
-            /// connection properties (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of an existing Virtual Network.
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// Properties of the Virtual Network connection. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will add
-            /// or update connections for the production slot.
-            /// </param>
-            public static VnetInfoInner CreateOrUpdateVnetConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, VnetInfoInner connectionEnvelope, string slot)
-            {
-                return operations.CreateOrUpdateVnetConnectionSlotAsync(resourceGroupName, name, vnetName, connectionEnvelope, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
             /// connection properties (PATCH).
@@ -10697,35 +6054,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a connection from an app (or deployment slot to a named virtual
-            /// network.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a connection from an app (or deployment slot to a named virtual
-            /// network.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the virtual network.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// delete the connection for the production slot.
-            /// </param>
-            public static void DeleteVnetConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, string slot)
-            {
-                operations.DeleteVnetConnectionSlotAsync(resourceGroupName, name, vnetName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a connection from an app (or deployment slot to a named virtual
             /// network.
@@ -10758,38 +6087,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteVnetConnectionSlotWithHttpMessagesAsync(resourceGroupName, name, vnetName, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
-            /// connection properties (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
-            /// connection properties (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of an existing Virtual Network.
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// Properties of the Virtual Network connection. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will add
-            /// or update connections for the production slot.
-            /// </param>
-            public static VnetInfoInner UpdateVnetConnectionSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, VnetInfoInner connectionEnvelope, string slot)
-            {
-                return operations.UpdateVnetConnectionSlotAsync(resourceGroupName, name, vnetName, connectionEnvelope, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
             /// connection properties (PATCH).
@@ -10828,36 +6126,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets an app's Virtual Network gateway.
-            /// </summary>
-            /// <remarks>
-            /// Gets an app's Virtual Network gateway.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='gatewayName'>
-            /// Name of the gateway. Currently, the only supported string is "primary".
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get a
-            /// gateway for the production slot's Virtual Network.
-            /// </param>
-            public static VnetGatewayInner GetVnetConnectionGatewaySlot(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, string gatewayName, string slot)
-            {
-                return operations.GetVnetConnectionGatewaySlotAsync(resourceGroupName, name, vnetName, gatewayName, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets an app's Virtual Network gateway.
             /// </summary>
@@ -10894,39 +6163,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='gatewayName'>
-            /// Name of the gateway. Currently, the only supported string is "primary".
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// The properties to update this gateway with.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will add
-            /// or update a gateway for the production slot's Virtual Network.
-            /// </param>
-            public static VnetGatewayInner CreateOrUpdateVnetConnectionGatewaySlot(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, string gatewayName, VnetGatewayInner connectionEnvelope, string slot)
-            {
-                return operations.CreateOrUpdateVnetConnectionGatewaySlotAsync(resourceGroupName, name, vnetName, gatewayName, connectionEnvelope, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
             /// </summary>
@@ -10966,39 +6203,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='gatewayName'>
-            /// Name of the gateway. Currently, the only supported string is "primary".
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// The properties to update this gateway with.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will add
-            /// or update a gateway for the production slot's Virtual Network.
-            /// </param>
-            public static VnetGatewayInner UpdateVnetConnectionGatewaySlot(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, string gatewayName, VnetGatewayInner connectionEnvelope, string slot)
-            {
-                return operations.UpdateVnetConnectionGatewaySlotAsync(resourceGroupName, name, vnetName, gatewayName, connectionEnvelope, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
             /// </summary>
@@ -11038,29 +6243,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the difference in configuration settings between two web app slots.
-            /// </summary>
-            /// <remarks>
-            /// Get the difference in configuration settings between two web app slots.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slotSwapEntity'>
-            /// JSON object that contains the target slot name. See example.
-            /// </param>
-            public static IPage<SlotDifferenceInner> ListSlotDifferencesFromProduction(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSlotEntityInner slotSwapEntity)
-            {
-                return operations.ListSlotDifferencesFromProductionAsync(resourceGroupName, name, slotSwapEntity).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the difference in configuration settings between two web app slots.
             /// </summary>
@@ -11090,29 +6273,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Swaps two deployment slots of an app.
-            /// </summary>
-            /// <remarks>
-            /// Swaps two deployment slots of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slotSwapEntity'>
-            /// JSON object that contains the target slot name. See example.
-            /// </param>
-            public static void SwapSlotWithProduction(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSlotEntityInner slotSwapEntity)
-            {
-                operations.SwapSlotWithProductionAsync(resourceGroupName, name, slotSwapEntity).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Swaps two deployment slots of an app.
             /// </summary>
@@ -11139,26 +6300,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.SwapSlotWithProductionWithHttpMessagesAsync(resourceGroupName, name, slotSwapEntity, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Returns all Snapshots to the user.
-            /// </summary>
-            /// <remarks>
-            /// Returns all Snapshots to the user.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Website Name
-            /// </param>
-            public static IPage<SnapshotInner> ListSnapshots(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListSnapshotsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns all Snapshots to the user.
             /// </summary>
@@ -11185,26 +6327,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the source control configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the source control configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static SiteSourceControlInner GetSourceControl(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetSourceControlAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the source control configuration of an app.
             /// </summary>
@@ -11231,29 +6354,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the source control configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the source control configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='siteSourceControl'>
-            /// JSON representation of a SiteSourceControl object. See example.
-            /// </param>
-            public static SiteSourceControlInner CreateOrUpdateSourceControl(this IWebAppsOperations operations, string resourceGroupName, string name, SiteSourceControlInner siteSourceControl)
-            {
-                return operations.CreateOrUpdateSourceControlAsync(resourceGroupName, name, siteSourceControl).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the source control configuration of an app.
             /// </summary>
@@ -11283,26 +6384,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the source control configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Deletes the source control configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static void DeleteSourceControl(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                operations.DeleteSourceControlAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the source control configuration of an app.
             /// </summary>
@@ -11326,26 +6408,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteSourceControlWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Starts an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Starts an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static void Start(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                operations.StartAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Starts an app (or deployment slot, if specified).
             /// </summary>
@@ -11369,26 +6432,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.StartWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Stops an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Stops an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static void Stop(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                operations.StopAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Stops an app (or deployment slot, if specified).
             /// </summary>
@@ -11412,26 +6456,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.StopWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Sync web app repository.
-            /// </summary>
-            /// <remarks>
-            /// Sync web app repository.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            public static void SyncRepository(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                operations.SyncRepositoryAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Sync web app repository.
             /// </summary>
@@ -11455,26 +6480,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.SyncRepositoryWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Syncs function trigger metadata to the scale controller
-            /// </summary>
-            /// <remarks>
-            /// Syncs function trigger metadata to the scale controller
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static void SyncFunctionTriggers(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                operations.SyncFunctionTriggersAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Syncs function trigger metadata to the scale controller
             /// </summary>
@@ -11498,34 +6504,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.SyncFunctionTriggersWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the quota usage information of an app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets the quota usage information of an app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='filter'>
-            /// Return only information specified in the filter (using OData syntax). For
-            /// example: $filter=(name.value eq 'Metric1' or name.value eq 'Metric2') and
-            /// startTime eq '2014-01-01T00:00:00Z' and endTime eq '2014-12-31T23:59:59Z'
-            /// and timeGrain eq duration'[Hour|Minute|Day]'.
-            /// </param>
-            public static IPage<CsmUsageQuota> ListUsages(this IWebAppsOperations operations, string resourceGroupName, string name, string filter = default(string))
-            {
-                return operations.ListUsagesAsync(resourceGroupName, name, filter).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the quota usage information of an app (or deployment slot, if
             /// specified).
@@ -11560,26 +6539,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the virtual networks the app (or deployment slot) is connected to.
-            /// </summary>
-            /// <remarks>
-            /// Gets the virtual networks the app (or deployment slot) is connected to.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static IList<VnetInfoInner> ListVnetConnections(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListVnetConnectionsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the virtual networks the app (or deployment slot) is connected to.
             /// </summary>
@@ -11606,31 +6566,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a virtual network the app (or deployment slot) is connected to by
-            /// name.
-            /// </summary>
-            /// <remarks>
-            /// Gets a virtual network the app (or deployment slot) is connected to by
-            /// name.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the virtual network.
-            /// </param>
-            public static VnetInfoInner GetVnetConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName)
-            {
-                return operations.GetVnetConnectionAsync(resourceGroupName, name, vnetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a virtual network the app (or deployment slot) is connected to by
             /// name.
@@ -11662,34 +6598,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
-            /// connection properties (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
-            /// connection properties (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of an existing Virtual Network.
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// Properties of the Virtual Network connection. See example.
-            /// </param>
-            public static VnetInfoInner CreateOrUpdateVnetConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, VnetInfoInner connectionEnvelope)
-            {
-                return operations.CreateOrUpdateVnetConnectionAsync(resourceGroupName, name, vnetName, connectionEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
             /// connection properties (PATCH).
@@ -11724,31 +6633,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a connection from an app (or deployment slot to a named virtual
-            /// network.
-            /// </summary>
-            /// <remarks>
-            /// Deletes a connection from an app (or deployment slot to a named virtual
-            /// network.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the virtual network.
-            /// </param>
-            public static void DeleteVnetConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName)
-            {
-                operations.DeleteVnetConnectionAsync(resourceGroupName, name, vnetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a connection from an app (or deployment slot to a named virtual
             /// network.
@@ -11777,34 +6662,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.DeleteVnetConnectionWithHttpMessagesAsync(resourceGroupName, name, vnetName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
-            /// connection properties (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
-            /// connection properties (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of an existing Virtual Network.
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// Properties of the Virtual Network connection. See example.
-            /// </param>
-            public static VnetInfoInner UpdateVnetConnection(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, VnetInfoInner connectionEnvelope)
-            {
-                return operations.UpdateVnetConnectionAsync(resourceGroupName, name, vnetName, connectionEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Adds a Virtual Network connection to an app or slot (PUT) or updates the
             /// connection properties (PATCH).
@@ -11839,32 +6697,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets an app's Virtual Network gateway.
-            /// </summary>
-            /// <remarks>
-            /// Gets an app's Virtual Network gateway.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='gatewayName'>
-            /// Name of the gateway. Currently, the only supported string is "primary".
-            /// </param>
-            public static VnetGatewayInner GetVnetConnectionGateway(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, string gatewayName)
-            {
-                return operations.GetVnetConnectionGatewayAsync(resourceGroupName, name, vnetName, gatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets an app's Virtual Network gateway.
             /// </summary>
@@ -11897,35 +6730,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='gatewayName'>
-            /// Name of the gateway. Currently, the only supported string is "primary".
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// The properties to update this gateway with.
-            /// </param>
-            public static VnetGatewayInner CreateOrUpdateVnetConnectionGateway(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, string gatewayName, VnetGatewayInner connectionEnvelope)
-            {
-                return operations.CreateOrUpdateVnetConnectionGatewayAsync(resourceGroupName, name, vnetName, gatewayName, connectionEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
             /// </summary>
@@ -11961,35 +6766,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
-            /// </summary>
-            /// <remarks>
-            /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='vnetName'>
-            /// Name of the Virtual Network.
-            /// </param>
-            /// <param name='gatewayName'>
-            /// Name of the gateway. Currently, the only supported string is "primary".
-            /// </param>
-            /// <param name='connectionEnvelope'>
-            /// The properties to update this gateway with.
-            /// </param>
-            public static VnetGatewayInner UpdateVnetConnectionGateway(this IWebAppsOperations operations, string resourceGroupName, string name, string vnetName, string gatewayName, VnetGatewayInner connectionEnvelope)
-            {
-                return operations.UpdateVnetConnectionGatewayAsync(resourceGroupName, name, vnetName, gatewayName, connectionEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Adds a gateway to a connected Virtual Network (PUT) or updates it (PATCH).
             /// </summary>
@@ -12025,47 +6802,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new web, mobile, or API app in an existing resource group, or
-            /// updates an existing app.
-            /// </summary>
-            /// <remarks>
-            /// Creates a new web, mobile, or API app in an existing resource group, or
-            /// updates an existing app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Unique name of the app to create or update. To create or update a
-            /// deployment slot, use the {slot} parameter.
-            /// </param>
-            /// <param name='siteEnvelope'>
-            /// A JSON representation of the app properties. See example.
-            /// </param>
-            /// <param name='skipDnsRegistration'>
-            /// If true web app hostname is not registered with DNS on creation. This
-            /// parameter is
-            /// only used for app creation
-            /// </param>
-            /// <param name='skipCustomDomainVerification'>
-            /// If true, custom (non *.azurewebsites.net) domains associated with web app
-            /// are not verified.
-            /// </param>
-            /// <param name='forceDnsRegistration'>
-            /// If true, web app hostname is force registered with DNS
-            /// </param>
-            /// <param name='ttlInSeconds'>
-            /// Time to live in seconds for web app's default domain name
-            /// </param>
-            public static SiteInner BeginCreateOrUpdate(this IWebAppsOperations operations, string resourceGroupName, string name, SiteInner siteEnvelope, bool? skipDnsRegistration = default(bool?), bool? skipCustomDomainVerification = default(bool?), bool? forceDnsRegistration = default(bool?), string ttlInSeconds = default(string))
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, name, siteEnvelope, skipDnsRegistration, skipCustomDomainVerification, forceDnsRegistration, ttlInSeconds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new web, mobile, or API app in an existing resource group, or
             /// updates an existing app.
@@ -12113,34 +6850,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restores a specific backup to another app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Restores a specific backup to another app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='backupId'>
-            /// ID of the backup.
-            /// </param>
-            /// <param name='request'>
-            /// Information on restore request
-            /// </param>
-            public static RestoreResponseInner BeginRestore(this IWebAppsOperations operations, string resourceGroupName, string name, string backupId, RestoreRequestInner request)
-            {
-                return operations.BeginRestoreAsync(resourceGroupName, name, backupId, request).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restores a specific backup to another app (or deployment slot, if
             /// specified).
@@ -12175,26 +6885,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the Git/FTP publishing credentials of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the Git/FTP publishing credentials of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            public static UserInner BeginListPublishingCredentials(this IWebAppsOperations operations, string resourceGroupName, string name)
-            {
-                return operations.BeginListPublishingCredentialsAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the Git/FTP publishing credentials of an app.
             /// </summary>
@@ -12221,32 +6912,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restores a web app.
-            /// </summary>
-            /// <remarks>
-            /// Restores a web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='subscriptionName'>
-            /// Azure subscription
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='migrationOptions'>
-            /// Migration migrationOptions
-            /// </param>
-            public static StorageMigrationResponseInner BeginMigrateStorage(this IWebAppsOperations operations, string subscriptionName, string resourceGroupName, string name, StorageMigrationOptionsInner migrationOptions)
-            {
-                return operations.BeginMigrateStorageAsync(subscriptionName, resourceGroupName, name, migrationOptions).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restores a web app.
             /// </summary>
@@ -12279,29 +6945,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Migrates a local (in-app) MySql database to a remote MySql database.
-            /// </summary>
-            /// <remarks>
-            /// Migrates a local (in-app) MySql database to a remote MySql database.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='migrationRequestEnvelope'>
-            /// MySql migration options
-            /// </param>
-            public static OperationInner BeginMigrateMySql(this IWebAppsOperations operations, string resourceGroupName, string name, MigrateMySqlRequestInner migrationRequestEnvelope)
-            {
-                return operations.BeginMigrateMySqlAsync(resourceGroupName, name, migrationRequestEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Migrates a local (in-app) MySql database to a remote MySql database.
             /// </summary>
@@ -12331,30 +6975,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Recovers a deleted web app.
-            /// </summary>
-            /// <remarks>
-            /// Recovers a deleted web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='recoveryEntity'>
-            /// Snapshot data used for web app recovery. Snapshot information can be
-            /// obtained by calling GetDeletedSites or GetSiteSnapshots API.
-            /// </param>
-            public static RecoverResponseInner BeginRecover(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSiteRecoveryEntityInner recoveryEntity)
-            {
-                return operations.BeginRecoverAsync(resourceGroupName, name, recoveryEntity).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Recovers a deleted web app.
             /// </summary>
@@ -12385,51 +7006,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new web, mobile, or API app in an existing resource group, or
-            /// updates an existing app.
-            /// </summary>
-            /// <remarks>
-            /// Creates a new web, mobile, or API app in an existing resource group, or
-            /// updates an existing app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Unique name of the app to create or update. To create or update a
-            /// deployment slot, use the {slot} parameter.
-            /// </param>
-            /// <param name='siteEnvelope'>
-            /// A JSON representation of the app properties. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot to create or update. By default, this API
-            /// attempts to create or modify the production slot.
-            /// </param>
-            /// <param name='skipDnsRegistration'>
-            /// If true web app hostname is not registered with DNS on creation. This
-            /// parameter is
-            /// only used for app creation
-            /// </param>
-            /// <param name='skipCustomDomainVerification'>
-            /// If true, custom (non *.azurewebsites.net) domains associated with web app
-            /// are not verified.
-            /// </param>
-            /// <param name='forceDnsRegistration'>
-            /// If true, web app hostname is force registered with DNS
-            /// </param>
-            /// <param name='ttlInSeconds'>
-            /// Time to live in seconds for web app's default domain name
-            /// </param>
-            public static SiteInner BeginCreateOrUpdateSlot(this IWebAppsOperations operations, string resourceGroupName, string name, SiteInner siteEnvelope, string slot, bool? skipDnsRegistration = default(bool?), bool? skipCustomDomainVerification = default(bool?), bool? forceDnsRegistration = default(bool?), string ttlInSeconds = default(string))
-            {
-                return operations.BeginCreateOrUpdateSlotAsync(resourceGroupName, name, siteEnvelope, slot, skipDnsRegistration, skipCustomDomainVerification, forceDnsRegistration, ttlInSeconds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new web, mobile, or API app in an existing resource group, or
             /// updates an existing app.
@@ -12481,38 +7058,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restores a specific backup to another app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Restores a specific backup to another app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='backupId'>
-            /// ID of the backup.
-            /// </param>
-            /// <param name='request'>
-            /// Information on restore request
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// restore a backup of the production slot.
-            /// </param>
-            public static RestoreResponseInner BeginRestoreSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string backupId, RestoreRequestInner request, string slot)
-            {
-                return operations.BeginRestoreSlotAsync(resourceGroupName, name, backupId, request, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restores a specific backup to another app (or deployment slot, if
             /// specified).
@@ -12551,30 +7097,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the Git/FTP publishing credentials of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets the Git/FTP publishing credentials of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will get
-            /// the publishing credentials for the production slot.
-            /// </param>
-            public static UserInner BeginListPublishingCredentialsSlot(this IWebAppsOperations operations, string resourceGroupName, string name, string slot)
-            {
-                return operations.BeginListPublishingCredentialsSlotAsync(resourceGroupName, name, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the Git/FTP publishing credentials of an app.
             /// </summary>
@@ -12605,34 +7128,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Recovers a deleted web app.
-            /// </summary>
-            /// <remarks>
-            /// Recovers a deleted web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of web app
-            /// </param>
-            /// <param name='recoveryEntity'>
-            /// Snapshot data used for web app recovery. Snapshot information can be
-            /// obtained by calling GetDeletedSites or GetSiteSnapshots API.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of web app slot. If not specified then will default to production
-            /// slot.
-            /// </param>
-            public static RecoverResponseInner BeginRecoverSlot(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSiteRecoveryEntityInner recoveryEntity, string slot)
-            {
-                return operations.BeginRecoverSlotAsync(resourceGroupName, name, recoveryEntity, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Recovers a deleted web app.
             /// </summary>
@@ -12667,33 +7163,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Swaps two deployment slots of an app.
-            /// </summary>
-            /// <remarks>
-            /// Swaps two deployment slots of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slotSwapEntity'>
-            /// JSON object that contains the target slot name. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the source slot. If a slot is not specified, the production slot is
-            /// used as the source slot.
-            /// </param>
-            public static void BeginSwapSlotSlot(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSlotEntityInner slotSwapEntity, string slot)
-            {
-                operations.BeginSwapSlotSlotAsync(resourceGroupName, name, slotSwapEntity, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Swaps two deployment slots of an app.
             /// </summary>
@@ -12724,33 +7194,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.BeginSwapSlotSlotWithHttpMessagesAsync(resourceGroupName, name, slotSwapEntity, slot, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Updates the source control configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the source control configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='siteSourceControl'>
-            /// JSON representation of a SiteSourceControl object. See example.
-            /// </param>
-            /// <param name='slot'>
-            /// Name of the deployment slot. If a slot is not specified, the API will
-            /// update the source control configuration for the production slot.
-            /// </param>
-            public static SiteSourceControlInner BeginCreateOrUpdateSourceControlSlot(this IWebAppsOperations operations, string resourceGroupName, string name, SiteSourceControlInner siteSourceControl, string slot)
-            {
-                return operations.BeginCreateOrUpdateSourceControlSlotAsync(resourceGroupName, name, siteSourceControl, slot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the source control configuration of an app.
             /// </summary>
@@ -12784,29 +7228,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Swaps two deployment slots of an app.
-            /// </summary>
-            /// <remarks>
-            /// Swaps two deployment slots of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='slotSwapEntity'>
-            /// JSON object that contains the target slot name. See example.
-            /// </param>
-            public static void BeginSwapSlotWithProduction(this IWebAppsOperations operations, string resourceGroupName, string name, CsmSlotEntityInner slotSwapEntity)
-            {
-                operations.BeginSwapSlotWithProductionAsync(resourceGroupName, name, slotSwapEntity).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Swaps two deployment slots of an app.
             /// </summary>
@@ -12833,29 +7255,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.BeginSwapSlotWithProductionWithHttpMessagesAsync(resourceGroupName, name, slotSwapEntity, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Updates the source control configuration of an app.
-            /// </summary>
-            /// <remarks>
-            /// Updates the source control configuration of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='name'>
-            /// Name of the app.
-            /// </param>
-            /// <param name='siteSourceControl'>
-            /// JSON representation of a SiteSourceControl object. See example.
-            /// </param>
-            public static SiteSourceControlInner BeginCreateOrUpdateSourceControl(this IWebAppsOperations operations, string resourceGroupName, string name, SiteSourceControlInner siteSourceControl)
-            {
-                return operations.BeginCreateOrUpdateSourceControlAsync(resourceGroupName, name, siteSourceControl).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the source control configuration of an app.
             /// </summary>
@@ -12885,23 +7285,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all apps for a subscription.
-            /// </summary>
-            /// <remarks>
-            /// Get all apps for a subscription.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteInner> ListNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all apps for a subscription.
             /// </summary>
@@ -12925,23 +7309,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all web, mobile, and API apps in the specified resource group.
-            /// </summary>
-            /// <remarks>
-            /// Gets all web, mobile, and API apps in the specified resource group.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteInner> ListByResourceGroupNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all web, mobile, and API apps in the specified resource group.
             /// </summary>
@@ -12965,23 +7333,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets existing backups of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets existing backups of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<BackupItemInner> ListBackupsNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListBackupsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets existing backups of an app.
             /// </summary>
@@ -13005,23 +7357,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List the configurations of an app
-            /// </summary>
-            /// <remarks>
-            /// List the configurations of an app
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteConfigResourceInner> ListConfigurationsNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListConfigurationsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List the configurations of an app
             /// </summary>
@@ -13045,25 +7381,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </summary>
-            /// <remarks>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DeploymentInner> ListDeploymentsNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListDeploymentsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List deployments for an app, or a deployment slot, or for an instance of a
             /// scaled-out app.
@@ -13089,23 +7407,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists ownership identifiers for domain associated with web app.
-            /// </summary>
-            /// <remarks>
-            /// Lists ownership identifiers for domain associated with web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<IdentifierInner> ListDomainOwnershipIdentifiersNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListDomainOwnershipIdentifiersNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists ownership identifiers for domain associated with web app.
             /// </summary>
@@ -13129,23 +7431,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get hostname bindings for an app or a deployment slot.
-            /// </summary>
-            /// <remarks>
-            /// Get hostname bindings for an app or a deployment slot.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<HostNameBindingInner> ListHostNameBindingsNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListHostNameBindingsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get hostname bindings for an app or a deployment slot.
             /// </summary>
@@ -13169,23 +7455,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all scale-out instances of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets all scale-out instances of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteInstanceInner> ListInstanceIdentifiersNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListInstanceIdentifiersNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all scale-out instances of an app.
             /// </summary>
@@ -13209,25 +7479,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </summary>
-            /// <remarks>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DeploymentInner> ListInstanceDeploymentsNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListInstanceDeploymentsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List deployments for an app, or a deployment slot, or for an instance of a
             /// scaled-out app.
@@ -13253,23 +7505,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all metric definitions of an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets all metric definitions of an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListMetricDefinitionsNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListMetricDefinitionsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all metric definitions of an app (or deployment slot, if specified).
             /// </summary>
@@ -13293,23 +7529,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets performance metrics of an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets performance metrics of an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetric> ListMetricsNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListMetricsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets performance metrics of an app (or deployment slot, if specified).
             /// </summary>
@@ -13333,23 +7553,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets perfmon counters for web app.
-            /// </summary>
-            /// <remarks>
-            /// Gets perfmon counters for web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<PerfMonResponse> ListPerfMonCountersNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListPerfMonCountersNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets perfmon counters for web app.
             /// </summary>
@@ -13373,23 +7577,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets an app's deployment slots.
-            /// </summary>
-            /// <remarks>
-            /// Gets an app's deployment slots.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteInner> ListSlotsNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListSlotsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets an app's deployment slots.
             /// </summary>
@@ -13413,23 +7601,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets existing backups of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets existing backups of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<BackupItemInner> ListBackupsSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListBackupsSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets existing backups of an app.
             /// </summary>
@@ -13453,23 +7625,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List the configurations of an app
-            /// </summary>
-            /// <remarks>
-            /// List the configurations of an app
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteConfigResourceInner> ListConfigurationsSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListConfigurationsSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List the configurations of an app
             /// </summary>
@@ -13493,25 +7649,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </summary>
-            /// <remarks>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DeploymentInner> ListDeploymentsSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListDeploymentsSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List deployments for an app, or a deployment slot, or for an instance of a
             /// scaled-out app.
@@ -13537,23 +7675,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists ownership identifiers for domain associated with web app.
-            /// </summary>
-            /// <remarks>
-            /// Lists ownership identifiers for domain associated with web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<IdentifierInner> ListDomainOwnershipIdentifiersSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListDomainOwnershipIdentifiersSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists ownership identifiers for domain associated with web app.
             /// </summary>
@@ -13577,23 +7699,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get hostname bindings for an app or a deployment slot.
-            /// </summary>
-            /// <remarks>
-            /// Get hostname bindings for an app or a deployment slot.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<HostNameBindingInner> ListHostNameBindingsSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListHostNameBindingsSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get hostname bindings for an app or a deployment slot.
             /// </summary>
@@ -13617,23 +7723,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all scale-out instances of an app.
-            /// </summary>
-            /// <remarks>
-            /// Gets all scale-out instances of an app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SiteInstanceInner> ListInstanceIdentifiersSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListInstanceIdentifiersSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all scale-out instances of an app.
             /// </summary>
@@ -13657,25 +7747,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </summary>
-            /// <remarks>
-            /// List deployments for an app, or a deployment slot, or for an instance of a
-            /// scaled-out app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DeploymentInner> ListInstanceDeploymentsSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListInstanceDeploymentsSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List deployments for an app, or a deployment slot, or for an instance of a
             /// scaled-out app.
@@ -13701,23 +7773,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all metric definitions of an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets all metric definitions of an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetricDefinitionInner> ListMetricDefinitionsSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListMetricDefinitionsSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all metric definitions of an app (or deployment slot, if specified).
             /// </summary>
@@ -13741,23 +7797,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets performance metrics of an app (or deployment slot, if specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets performance metrics of an app (or deployment slot, if specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceMetric> ListMetricsSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListMetricsSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets performance metrics of an app (or deployment slot, if specified).
             /// </summary>
@@ -13781,23 +7821,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets perfmon counters for web app.
-            /// </summary>
-            /// <remarks>
-            /// Gets perfmon counters for web app.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<PerfMonResponse> ListPerfMonCountersSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListPerfMonCountersSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets perfmon counters for web app.
             /// </summary>
@@ -13821,23 +7845,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the difference in configuration settings between two web app slots.
-            /// </summary>
-            /// <remarks>
-            /// Get the difference in configuration settings between two web app slots.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SlotDifferenceInner> ListSlotDifferencesSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListSlotDifferencesSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the difference in configuration settings between two web app slots.
             /// </summary>
@@ -13861,23 +7869,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns all Snapshots to the user.
-            /// </summary>
-            /// <remarks>
-            /// Returns all Snapshots to the user.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SnapshotInner> ListSnapshotsSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListSnapshotsSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns all Snapshots to the user.
             /// </summary>
@@ -13901,25 +7893,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the quota usage information of an app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets the quota usage information of an app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<CsmUsageQuota> ListUsagesSlotNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListUsagesSlotNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the quota usage information of an app (or deployment slot, if
             /// specified).
@@ -13945,23 +7919,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the difference in configuration settings between two web app slots.
-            /// </summary>
-            /// <remarks>
-            /// Get the difference in configuration settings between two web app slots.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SlotDifferenceInner> ListSlotDifferencesFromProductionNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListSlotDifferencesFromProductionNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the difference in configuration settings between two web app slots.
             /// </summary>
@@ -13985,23 +7943,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns all Snapshots to the user.
-            /// </summary>
-            /// <remarks>
-            /// Returns all Snapshots to the user.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SnapshotInner> ListSnapshotsNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListSnapshotsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns all Snapshots to the user.
             /// </summary>
@@ -14025,25 +7967,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the quota usage information of an app (or deployment slot, if
-            /// specified).
-            /// </summary>
-            /// <remarks>
-            /// Gets the quota usage information of an app (or deployment slot, if
-            /// specified).
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<CsmUsageQuota> ListUsagesNext(this IWebAppsOperations operations, string nextPageLink)
-            {
-                return operations.ListUsagesNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the quota usage information of an app (or deployment slot, if
             /// specified).

--- a/src/ResourceManagement/AppService/Generated/WebSiteManagementClientExtensions.cs
+++ b/src/ResourceManagement/AppService/Generated/WebSiteManagementClientExtensions.cs
@@ -22,20 +22,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
     /// </summary>
     public static partial class WebSiteManagementClientExtensions
     {
-            /// <summary>
-            /// Gets publishing user
-            /// </summary>
-            /// <remarks>
-            /// Gets publishing user
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static UserInner GetPublishingUser(this IWebSiteManagementClient operations)
-            {
-                return operations.GetPublishingUserAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets publishing user
             /// </summary>
@@ -56,23 +43,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates publishing user
-            /// </summary>
-            /// <remarks>
-            /// Updates publishing user
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='userDetails'>
-            /// Details of publishing user
-            /// </param>
-            public static UserInner UpdatePublishingUser(this IWebSiteManagementClient operations, UserInner userDetails)
-            {
-                return operations.UpdatePublishingUserAsync(userDetails).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates publishing user
             /// </summary>
@@ -96,20 +67,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the source controls available for Azure websites.
-            /// </summary>
-            /// <remarks>
-            /// Gets the source controls available for Azure websites.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<SourceControlInner> ListSourceControls(this IWebSiteManagementClient operations)
-            {
-                return operations.ListSourceControlsAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the source controls available for Azure websites.
             /// </summary>
@@ -130,26 +88,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates source control token
-            /// </summary>
-            /// <remarks>
-            /// Updates source control token
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='sourceControlType'>
-            /// Type of source control
-            /// </param>
-            /// <param name='requestMessage'>
-            /// Source control token information
-            /// </param>
-            public static SourceControlInner UpdateSourceControl(this IWebSiteManagementClient operations, string sourceControlType, SourceControlInner requestMessage)
-            {
-                return operations.UpdateSourceControlAsync(sourceControlType, requestMessage).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates source control token
             /// </summary>
@@ -176,30 +115,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Check if a resource name is available.
-            /// </summary>
-            /// <remarks>
-            /// Check if a resource name is available.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='name'>
-            /// Resource name to verify.
-            /// </param>
-            /// <param name='type'>
-            /// Resource type used for verification. Possible values include: 'Site',
-            /// 'Slot', 'HostingEnvironment'
-            /// </param>
-            /// <param name='isFqdn'>
-            /// Is fully qualified domain name.
-            /// </param>
-            public static ResourceNameAvailabilityInner CheckNameAvailability(this IWebSiteManagementClient operations, string name, string type, bool? isFqdn = default(bool?))
-            {
-                return operations.CheckNameAvailabilityAsync(name, type, isFqdn).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Check if a resource name is available.
             /// </summary>
@@ -230,28 +146,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a list of available geographical regions.
-            /// </summary>
-            /// <remarks>
-            /// Get a list of available geographical regions.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='sku'>
-            /// Name of SKU used to filter the regions. Possible values include: 'Free',
-            /// 'Shared', 'Basic', 'Standard', 'Premium', 'Dynamic', 'Isolated'
-            /// </param>
-            /// <param name='linuxWorkersEnabled'>
-            /// Specify &lt;code&gt;true&lt;/code&gt; if you want to filter to only regions
-            /// that support Linux workers.
-            /// </param>
-            public static IPage<GeoRegionInner> ListGeoRegions(this IWebSiteManagementClient operations, string sku = default(string), bool? linuxWorkersEnabled = default(bool?))
-            {
-                return operations.ListGeoRegionsAsync(sku, linuxWorkersEnabled).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a list of available geographical regions.
             /// </summary>
@@ -280,20 +175,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List all premier add-on offers.
-            /// </summary>
-            /// <remarks>
-            /// List all premier add-on offers.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<PremierAddOnOfferInner> ListPremierAddOnOffers(this IWebSiteManagementClient operations)
-            {
-                return operations.ListPremierAddOnOffersAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List all premier add-on offers.
             /// </summary>
@@ -314,20 +196,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List all SKUs.
-            /// </summary>
-            /// <remarks>
-            /// List all SKUs.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static SkuInfosInner ListSkus(this IWebSiteManagementClient operations)
-            {
-                return operations.ListSkusAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List all SKUs.
             /// </summary>
@@ -348,26 +217,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Move resources between resource groups.
-            /// </summary>
-            /// <remarks>
-            /// Move resources between resource groups.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='moveResourceEnvelope'>
-            /// Object that represents the resource to move.
-            /// </param>
-            public static void Move(this IWebSiteManagementClient operations, string resourceGroupName, CsmMoveResourceEnvelopeInner moveResourceEnvelope)
-            {
-                operations.MoveAsync(resourceGroupName, moveResourceEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Move resources between resource groups.
             /// </summary>
@@ -391,26 +241,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.MoveWithHttpMessagesAsync(resourceGroupName, moveResourceEnvelope, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Validate if a resource can be created.
-            /// </summary>
-            /// <remarks>
-            /// Validate if a resource can be created.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='validateRequest'>
-            /// Request with the resources to validate.
-            /// </param>
-            public static ValidateResponseInner Validate(this IWebSiteManagementClient operations, string resourceGroupName, ValidateRequestInner validateRequest)
-            {
-                return operations.ValidateAsync(resourceGroupName, validateRequest).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Validate if a resource can be created.
             /// </summary>
@@ -437,26 +268,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Validate whether a resource can be moved.
-            /// </summary>
-            /// <remarks>
-            /// Validate whether a resource can be moved.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the resource group to which the resource belongs.
-            /// </param>
-            /// <param name='moveResourceEnvelope'>
-            /// Object that represents the resource to move.
-            /// </param>
-            public static void ValidateMove(this IWebSiteManagementClient operations, string resourceGroupName, CsmMoveResourceEnvelopeInner moveResourceEnvelope)
-            {
-                operations.ValidateMoveAsync(resourceGroupName, moveResourceEnvelope).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Validate whether a resource can be moved.
             /// </summary>
@@ -480,23 +292,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 (await operations.ValidateMoveWithHttpMessagesAsync(resourceGroupName, moveResourceEnvelope, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the source controls available for Azure websites.
-            /// </summary>
-            /// <remarks>
-            /// Gets the source controls available for Azure websites.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SourceControlInner> ListSourceControlsNext(this IWebSiteManagementClient operations, string nextPageLink)
-            {
-                return operations.ListSourceControlsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the source controls available for Azure websites.
             /// </summary>
@@ -520,23 +316,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a list of available geographical regions.
-            /// </summary>
-            /// <remarks>
-            /// Get a list of available geographical regions.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<GeoRegionInner> ListGeoRegionsNext(this IWebSiteManagementClient operations, string nextPageLink)
-            {
-                return operations.ListGeoRegionsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a list of available geographical regions.
             /// </summary>
@@ -560,23 +340,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 }
             }
 
-            /// <summary>
-            /// List all premier add-on offers.
-            /// </summary>
-            /// <remarks>
-            /// List all premier add-on offers.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<PremierAddOnOfferInner> ListPremierAddOnOffersNext(this IWebSiteManagementClient operations, string nextPageLink)
-            {
-                return operations.ListPremierAddOnOffersNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List all premier add-on offers.
             /// </summary>

--- a/src/ResourceManagement/AppService/HostNameBindingImpl.cs
+++ b/src/ResourceManagement/AppService/HostNameBindingImpl.cs
@@ -247,11 +247,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         {
             if (parent is IDeploymentSlot)
             {
-                SetInner(parent.Manager.Inner.WebApps.GetHostNameBindingSlot(Parent.ResourceGroupName, ((IDeploymentSlot)parent).Parent.Name, parent.Name, name));
+                SetInner(Extensions.Synchronize(() => parent.Manager.Inner.WebApps.GetHostNameBindingSlotAsync(Parent.ResourceGroupName, ((IDeploymentSlot)parent).Parent.Name, parent.Name, name)));
             }
             else
             {
-                SetInner(parent.Manager.Inner.WebApps.GetHostNameBinding(parent.ResourceGroupName, parent.Name, name));
+                SetInner(Extensions.Synchronize(() => parent.Manager.Inner.WebApps.GetHostNameBindingAsync(parent.ResourceGroupName, parent.Name, name)));
             }
 
             return this;
@@ -262,11 +262,11 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         {
             if (parent is IWebApp)
             {
-                SetInner(parent.Manager.Inner.WebApps.GetHostNameBinding(parent.ResourceGroupName, parent.Name, Name()));
+                SetInner(Extensions.Synchronize(() => parent.Manager.Inner.WebApps.GetHostNameBindingAsync(parent.ResourceGroupName, parent.Name, Name())));
             }
             else
             {
-                SetInner(parent.Manager.Inner.WebApps.GetHostNameBindingSlot(parent.ResourceGroupName, ((IDeploymentSlot)parent).Parent.Name, parent.Name, Name()));
+                SetInner(Extensions.Synchronize(() => parent.Manager.Inner.WebApps.GetHostNameBindingSlotAsync(parent.ResourceGroupName, ((IDeploymentSlot)parent).Parent.Name, parent.Name, Name())));
             }
             return this;
         }

--- a/src/ResourceManagement/AppService/HostNameBindingImpl.cs
+++ b/src/ResourceManagement/AppService/HostNameBindingImpl.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:5E4C278C0FA45BB98AA6EAEE080D4953:FC16212D06A7CCEE646CE7693B370B6F
         public IHostNameBinding Create()
         {
-            return CreateAsync().Result;
+            return Extensions.Synchronize(() => CreateAsync());
         }
 
         ///GENMHASH:1AF7DCAA563064BE5F57020487ABA63B:9EB989BD7CA88C88EBCC64DAB83581CD

--- a/src/ResourceManagement/AppService/WebAppsImpl.cs
+++ b/src/ResourceManagement/AppService/WebAppsImpl.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         {
             Func<SiteInner, IWebApp> converter = inner =>
             {
-                return PopulateModelAsync(inner).ConfigureAwait(false).GetAwaiter().GetResult();
+                return Extensions.Synchronize(() => PopulateModelAsync(inner));
             };
 
             return Inner.ListByResourceGroup(resourceGroupName)

--- a/src/ResourceManagement/AppService/WebAppsImpl.cs
+++ b/src/ResourceManagement/AppService/WebAppsImpl.cs
@@ -40,8 +40,8 @@ namespace Microsoft.Azure.Management.AppService.Fluent
                 return Extensions.Synchronize(() => PopulateModelAsync(inner));
             };
 
-            return Inner.ListByResourceGroup(resourceGroupName)
-                        .AsContinuousCollection(link => Inner.ListByResourceGroupNext(link))
+            return Extensions.Synchronize(() => Inner.ListByResourceGroupAsync(resourceGroupName))
+                        .AsContinuousCollection(link => Extensions.Synchronize(() => Inner.ListByResourceGroupNextAsync(link)))
                         .Select(inner => converter(inner));
         }
 

--- a/src/ResourceManagement/Batch/ApplicationPackageImpl.cs
+++ b/src/ResourceManagement/Batch/ApplicationPackageImpl.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         ///GENMHASH:65E6085BB9054A86F6A84772E3F5A9EC:B194B6D94E13B7450F78AF5DC15946BE
         public void Delete()
         {
-            DeleteAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => DeleteAsync());
         }
 
         ///GENMHASH:0FEDA307DAD2022B36843E8905D26EAD:9B272804AD473CBF3C5DEE818D16023C

--- a/src/ResourceManagement/Batch/ApplicationsImpl.cs
+++ b/src/ResourceManagement/Batch/ApplicationsImpl.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 return childResources;
             }
 
-            var applicationList = Parent.Manager.Inner.Application.List(Parent.ResourceGroupName, Parent.Name);
+            var applicationList = Extensions.Synchronize(() => Parent.Manager.Inner.Application.ListAsync(Parent.ResourceGroupName, Parent.Name));
 
             foreach (var application in applicationList)
             {

--- a/src/ResourceManagement/Batch/BatchAccountsImpl.cs
+++ b/src/ResourceManagement/Batch/BatchAccountsImpl.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
 
         public void Delete(string groupName, string name)
         {
-            Inner.Delete(groupName, name);
+            Extensions.Synchronize(() => Inner.DeleteAsync(groupName, name));
         }
 
         ///GENMHASH:2FE8C4C2D5EAD7E37787838DE0B47D92:0EB96B74B82C153C18B62BE83EB415B1
@@ -114,7 +114,8 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         ///GENMHASH:F8EF648D033A93895EA3A4E4EB60B9B2:F0DC62FB7F617AF3C57F4F01580CC827
         internal int GetBatchAccountQuotaByLocation(Region region)
         {
-            return Manager.Inner.Location.GetQuotas(region.Name).AccountQuota.GetValueOrDefault();
+            return Extensions.Synchronize(() => Manager.Inner.Location.GetQuotasAsync(region.Name))
+                        .AccountQuota.GetValueOrDefault();
         }
     }
 }

--- a/src/ResourceManagement/Batch/Domain/InterfaceImpl/ApplicationPackageImpl.cs
+++ b/src/ResourceManagement/Batch/Domain/InterfaceImpl/ApplicationPackageImpl.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         /// <param name="format">The format of the uploaded Batch application package, either "zip" or "tar".</param>
         void Microsoft.Azure.Management.Batch.Fluent.IApplicationPackageBeta.Activate(string format)
         {
-
-            this.ActivateAsync(format).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => this.ActivateAsync(format));
         }
 
         /// <summary>

--- a/src/ResourceManagement/Batch/Domain/InterfaceImpl/BatchAccountImpl.cs
+++ b/src/ResourceManagement/Batch/Domain/InterfaceImpl/BatchAccountImpl.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
     using Microsoft.Azure.Management.Storage.Fluent;
     using System.Collections.Generic;
     using Models;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     internal partial class BatchAccountImpl 
     {
@@ -70,7 +71,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         /// <return>The access keys for this Batch account.</return>
         Microsoft.Azure.Management.Batch.Fluent.BatchAccountKeys Microsoft.Azure.Management.Batch.Fluent.IBatchAccount.GetKeys()
         {
-            return this.GetKeysAsync().GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.GetKeysAsync());
         }
 
         /// <summary>
@@ -133,7 +134,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         /// </summary>
         void Microsoft.Azure.Management.Batch.Fluent.IBatchAccount.SynchronizeAutoStorageKeys()
         {
-            this.SynchronizeAutoStorageKeysAsync().GetAwaiter().GetResult(); ;
+            Extensions.Synchronize(() => this.SynchronizeAutoStorageKeysAsync()); ;
         }
 
         /// <summary>
@@ -143,7 +144,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
         /// <return>Regenerated access keys for this Batch account.</return>
         Microsoft.Azure.Management.Batch.Fluent.BatchAccountKeys Microsoft.Azure.Management.Batch.Fluent.IBatchAccount.RegenerateKeys(AccountKeyType keyType)
         {
-            return this.RegenerateKeysAsync(keyType).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.RegenerateKeysAsync(keyType));
         }
 
         /// <summary>

--- a/src/ResourceManagement/Batch/Generated/ApplicationOperationsExtensions.cs
+++ b/src/ResourceManagement/Batch/Generated/ApplicationOperationsExtensions.cs
@@ -22,29 +22,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
     /// </summary>
     public static partial class ApplicationOperationsExtensions
     {
-            /// <summary>
-            /// Adds an application to the specified Batch account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            /// <param name='applicationId'>
-            /// The ID of the application.
-            /// </param>
-            /// <param name='parameters'>
-            /// The parameters for the request.
-            /// </param>
-            public static ApplicationInner Create(this IApplicationOperations operations, string resourceGroupName, string accountName, string applicationId, ApplicationCreateParametersInner parameters = default(ApplicationCreateParametersInner))
-            {
-                return operations.CreateAsync(resourceGroupName, accountName, applicationId, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Adds an application to the specified Batch account.
             /// </summary>
@@ -74,26 +52,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an application.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            /// <param name='applicationId'>
-            /// The ID of the application.
-            /// </param>
-            public static void Delete(this IApplicationOperations operations, string resourceGroupName, string accountName, string applicationId)
-            {
-                operations.DeleteAsync(resourceGroupName, accountName, applicationId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an application.
             /// </summary>
@@ -117,26 +76,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, accountName, applicationId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets information about the specified application.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            /// <param name='applicationId'>
-            /// The ID of the application.
-            /// </param>
-            public static ApplicationInner Get(this IApplicationOperations operations, string resourceGroupName, string accountName, string applicationId)
-            {
-                return operations.GetAsync(resourceGroupName, accountName, applicationId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about the specified application.
             /// </summary>
@@ -163,29 +103,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates settings for the specified application.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            /// <param name='applicationId'>
-            /// The ID of the application.
-            /// </param>
-            /// <param name='parameters'>
-            /// The parameters for the request.
-            /// </param>
-            public static void Update(this IApplicationOperations operations, string resourceGroupName, string accountName, string applicationId, ApplicationUpdateParametersInner parameters)
-            {
-                operations.UpdateAsync(resourceGroupName, accountName, applicationId, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates settings for the specified application.
             /// </summary>
@@ -212,26 +130,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 (await operations.UpdateWithHttpMessagesAsync(resourceGroupName, accountName, applicationId, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Lists all of the applications in the specified account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            /// <param name='maxresults'>
-            /// The maximum number of items to return in the response.
-            /// </param>
-            public static IPage<ApplicationInner> List(this IApplicationOperations operations, string resourceGroupName, string accountName, int? maxresults = default(int?))
-            {
-                return operations.ListAsync(resourceGroupName, accountName, maxresults).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the applications in the specified account.
             /// </summary>
@@ -258,20 +157,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the applications in the specified account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ApplicationInner> ListNext(this IApplicationOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the applications in the specified account.
             /// </summary>

--- a/src/ResourceManagement/Batch/Generated/ApplicationPackageOperationsExtensions.cs
+++ b/src/ResourceManagement/Batch/Generated/ApplicationPackageOperationsExtensions.cs
@@ -22,32 +22,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
     /// </summary>
     public static partial class ApplicationPackageOperationsExtensions
     {
-            /// <summary>
-            /// Activates the specified application package.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            /// <param name='applicationId'>
-            /// The ID of the application.
-            /// </param>
-            /// <param name='version'>
-            /// The version of the application to activate.
-            /// </param>
-            /// <param name='parameters'>
-            /// The parameters for the request.
-            /// </param>
-            public static void Activate(this IApplicationPackageOperations operations, string resourceGroupName, string accountName, string applicationId, string version, ActivateApplicationPackageParametersInner parameters)
-            {
-                operations.ActivateAsync(resourceGroupName, accountName, applicationId, version, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Activates the specified application package.
             /// </summary>
@@ -77,29 +52,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 (await operations.ActivateWithHttpMessagesAsync(resourceGroupName, accountName, applicationId, version, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates an application package record.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            /// <param name='applicationId'>
-            /// The ID of the application.
-            /// </param>
-            /// <param name='version'>
-            /// The version of the application.
-            /// </param>
-            public static ApplicationPackageInner Create(this IApplicationPackageOperations operations, string resourceGroupName, string accountName, string applicationId, string version)
-            {
-                return operations.CreateAsync(resourceGroupName, accountName, applicationId, version).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates an application package record.
             /// </summary>
@@ -129,29 +82,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an application package record and its associated binary file.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            /// <param name='applicationId'>
-            /// The ID of the application.
-            /// </param>
-            /// <param name='version'>
-            /// The version of the application to delete.
-            /// </param>
-            public static void Delete(this IApplicationPackageOperations operations, string resourceGroupName, string accountName, string applicationId, string version)
-            {
-                operations.DeleteAsync(resourceGroupName, accountName, applicationId, version).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an application package record and its associated binary file.
             /// </summary>
@@ -178,29 +109,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, accountName, applicationId, version, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets information about the specified application package.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            /// <param name='applicationId'>
-            /// The ID of the application.
-            /// </param>
-            /// <param name='version'>
-            /// The version of the application.
-            /// </param>
-            public static ApplicationPackageInner Get(this IApplicationPackageOperations operations, string resourceGroupName, string accountName, string applicationId, string version)
-            {
-                return operations.GetAsync(resourceGroupName, accountName, applicationId, version).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about the specified application package.
             /// </summary>

--- a/src/ResourceManagement/Batch/Generated/BatchAccountOperationsExtensions.cs
+++ b/src/ResourceManagement/Batch/Generated/BatchAccountOperationsExtensions.cs
@@ -22,33 +22,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
     /// </summary>
     public static partial class BatchAccountOperationsExtensions
     {
-            /// <summary>
-            /// Creates a new Batch account with the specified parameters. Existing
-            /// accounts cannot be updated with this API and should instead be updated with
-            /// the Update Batch Account API.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// A name for the Batch account which must be unique within the region. Batch
-            /// account names must be between 3 and 24 characters in length and must use
-            /// only numbers and lowercase letters. This name is used as part of the DNS
-            /// name that is used to access the Batch service in the region in which the
-            /// account is created. For example:
-            /// http://accountname.region.batch.azure.com/.
-            /// </param>
-            /// <param name='parameters'>
-            /// Additional parameters for account creation.
-            /// </param>
-            public static BatchAccountInner Create(this IBatchAccountOperations operations, string resourceGroupName, string accountName, BatchAccountCreateParametersInner parameters)
-            {
-                return operations.CreateAsync(resourceGroupName, accountName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new Batch account with the specified parameters. Existing
             /// accounts cannot be updated with this API and should instead be updated with
@@ -82,26 +56,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the properties of an existing Batch account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            /// <param name='parameters'>
-            /// Additional parameters for account update.
-            /// </param>
-            public static BatchAccountInner Update(this IBatchAccountOperations operations, string resourceGroupName, string accountName, BatchAccountUpdateParametersInner parameters)
-            {
-                return operations.UpdateAsync(resourceGroupName, accountName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the properties of an existing Batch account.
             /// </summary>
@@ -128,23 +83,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified Batch account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            public static BatchAccountDeleteHeadersInner Delete(this IBatchAccountOperations operations, string resourceGroupName, string accountName)
-            {
-                return operations.DeleteAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified Batch account.
             /// </summary>
@@ -168,23 +107,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about the specified Batch account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            public static BatchAccountInner Get(this IBatchAccountOperations operations, string resourceGroupName, string accountName)
-            {
-                return operations.GetAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about the specified Batch account.
             /// </summary>
@@ -208,17 +131,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about the Batch accounts associated with the subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<BatchAccountInner> List(this IBatchAccountOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about the Batch accounts associated with the subscription.
             /// </summary>
@@ -236,21 +149,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about the Batch accounts associated with the specified
-            /// resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            public static IPage<BatchAccountInner> ListByResourceGroup(this IBatchAccountOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about the Batch accounts associated with the specified
             /// resource group.
@@ -272,24 +171,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Synchronizes access keys for the auto-storage account configured for the
-            /// specified Batch account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            public static void SynchronizeAutoStorageKeys(this IBatchAccountOperations operations, string resourceGroupName, string accountName)
-            {
-                operations.SynchronizeAutoStorageKeysAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Synchronizes access keys for the auto-storage account configured for the
             /// specified Batch account.
@@ -311,26 +193,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 (await operations.SynchronizeAutoStorageKeysWithHttpMessagesAsync(resourceGroupName, accountName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Regenerates the specified account key for the Batch account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            /// <param name='parameters'>
-            /// The type of key to regenerate.
-            /// </param>
-            public static BatchAccountKeysInner RegenerateKey(this IBatchAccountOperations operations, string resourceGroupName, string accountName, BatchAccountRegenerateKeyParametersInner parameters)
-            {
-                return operations.RegenerateKeyAsync(resourceGroupName, accountName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Regenerates the specified account key for the Batch account.
             /// </summary>
@@ -357,30 +220,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the account keys for the specified Batch account.
-            /// </summary>
-            /// <remarks>
-            /// This operation applies only to Batch accounts created with a
-            /// poolAllocationMode of 'BatchService'. If the Batch account was created with
-            /// a poolAllocationMode of 'UserSubscription', clients cannot use access to
-            /// keys to authenticate, and must use Azure Active Directory instead. In this
-            /// case, getting the keys will fail.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            public static BatchAccountKeysInner GetKeys(this IBatchAccountOperations operations, string resourceGroupName, string accountName)
-            {
-                return operations.GetKeysAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the account keys for the specified Batch account.
             /// </summary>
@@ -411,33 +251,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new Batch account with the specified parameters. Existing
-            /// accounts cannot be updated with this API and should instead be updated with
-            /// the Update Batch Account API.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// A name for the Batch account which must be unique within the region. Batch
-            /// account names must be between 3 and 24 characters in length and must use
-            /// only numbers and lowercase letters. This name is used as part of the DNS
-            /// name that is used to access the Batch service in the region in which the
-            /// account is created. For example:
-            /// http://accountname.region.batch.azure.com/.
-            /// </param>
-            /// <param name='parameters'>
-            /// Additional parameters for account creation.
-            /// </param>
-            public static BatchAccountInner BeginCreate(this IBatchAccountOperations operations, string resourceGroupName, string accountName, BatchAccountCreateParametersInner parameters)
-            {
-                return operations.BeginCreateAsync(resourceGroupName, accountName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new Batch account with the specified parameters. Existing
             /// accounts cannot be updated with this API and should instead be updated with
@@ -471,23 +285,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified Batch account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the Batch account.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the Batch account.
-            /// </param>
-            public static BatchAccountDeleteHeadersInner BeginDelete(this IBatchAccountOperations operations, string resourceGroupName, string accountName)
-            {
-                return operations.BeginDeleteAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified Batch account.
             /// </summary>
@@ -511,20 +309,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about the Batch accounts associated with the subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<BatchAccountInner> ListNext(this IBatchAccountOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about the Batch accounts associated with the subscription.
             /// </summary>
@@ -545,21 +330,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about the Batch accounts associated with the specified
-            /// resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<BatchAccountInner> ListByResourceGroupNext(this IBatchAccountOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about the Batch accounts associated with the specified
             /// resource group.

--- a/src/ResourceManagement/Batch/Generated/LocationOperationsExtensions.cs
+++ b/src/ResourceManagement/Batch/Generated/LocationOperationsExtensions.cs
@@ -22,21 +22,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
     /// </summary>
     public static partial class LocationOperationsExtensions
     {
-            /// <summary>
-            /// Gets the Batch service quotas for the specified subscription at the given
-            /// location.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='locationName'>
-            /// The region for which to retrieve Batch service quotas.
-            /// </param>
-            public static BatchLocationQuotaInner GetQuotas(this ILocationOperations operations, string locationName)
-            {
-                return operations.GetQuotasAsync(locationName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the Batch service quotas for the specified subscription at the given
             /// location.

--- a/src/ResourceManagement/Batch/Generated/OperationsExtensions.cs
+++ b/src/ResourceManagement/Batch/Generated/OperationsExtensions.cs
@@ -22,17 +22,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
     /// </summary>
     public static partial class OperationsExtensions
     {
-            /// <summary>
-            /// Lists available operations for the Microsoft.Batch provider
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<Operation> List(this IOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists available operations for the Microsoft.Batch provider
             /// </summary>
@@ -50,20 +40,7 @@ namespace Microsoft.Azure.Management.Batch.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists available operations for the Microsoft.Batch provider
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<Operation> ListNext(this IOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists available operations for the Microsoft.Batch provider
             /// </summary>

--- a/src/ResourceManagement/Cdn/CdnEndpointImpl.cs
+++ b/src/ResourceManagement/Cdn/CdnEndpointImpl.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         ///GENMHASH:AD2E24D9DFB738D4BF1A5F65CE996552:03764A67ECF90331193C59D0D3F1DA4D
         public CustomDomainValidationResult ValidateCustomDomain(string hostName)
         {
-            return ValidateCustomDomainAsync(hostName).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => ValidateCustomDomainAsync(hostName));
         }
 
         ///GENMHASH:0F38250A3837DF9C2C345D4A038B654B:A5F7C81073BA64AE03AC5C595EE8B6E5

--- a/src/ResourceManagement/Cdn/CdnEndpointImpl.cs
+++ b/src/ResourceManagement/Cdn/CdnEndpointImpl.cs
@@ -516,10 +516,10 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
             customDomainList.Clear();
             deletedCustomDomainList.Clear();
             customDomainList.AddRange(
-                Parent.Manager.Inner.CustomDomains.ListByEndpoint(
+                Extensions.Synchronize(() => Parent.Manager.Inner.CustomDomains.ListByEndpointAsync(
                     Parent.ResourceGroupName,
                     Parent.Name,
-                    Name()));
+                    Name())));
             return this;
         }
 
@@ -635,11 +635,11 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         ///GENMHASH:89CD44AA5060CAB16CB0AF1FB046BC64:0A693DB1A3AF2F29E579F4E675DE54E9
         public IEnumerable<ResourceUsage> ListResourceUsage()
         {
-            return Parent.Manager.Inner.Endpoints.ListResourceUsage(
+            return Extensions.Synchronize(() => Parent.Manager.Inner.Endpoints.ListResourceUsageAsync(
                                             Parent.ResourceGroupName,
                                             Parent.Name,
-                                            Name())
-                     .AsContinuousCollection(link => Parent.Manager.Inner.Endpoints.ListResourceUsageNext(link))
+                                            Name()))
+                     .AsContinuousCollection(link => Extensions.Synchronize(() => Parent.Manager.Inner.Endpoints.ListResourceUsageNextAsync(link)))
                      .Select(inner => new ResourceUsage(inner));
         }
 

--- a/src/ResourceManagement/Cdn/CdnEndpointsImpl.cs
+++ b/src/ResourceManagement/Cdn/CdnEndpointsImpl.cs
@@ -20,14 +20,15 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         {
             List<CdnEndpointImpl> childResources = new List<CdnEndpointImpl>();
 
-            foreach(var innerEndpoint in Parent.Manager.Inner.Endpoints.ListByProfile(Parent.ResourceGroupName, Parent.Name))
+            foreach(var innerEndpoint in Extensions.Synchronize(() => Parent.Manager.Inner.Endpoints.ListByProfileAsync(Parent.ResourceGroupName, Parent.Name)))
             {
                 var endpoint = new CdnEndpointImpl(innerEndpoint.Name, Parent, innerEndpoint);
 
-                foreach (var customDomain in Parent.Manager.Inner.CustomDomains.ListByEndpoint(
-                    Parent.ResourceGroupName, 
-                    Parent.Name, 
-                    innerEndpoint.Name))
+                foreach (var customDomain in 
+                    Extensions.Synchronize(() => Parent.Manager.Inner.CustomDomains.ListByEndpointAsync(
+                        Parent.ResourceGroupName, 
+                        Parent.Name, 
+                        innerEndpoint.Name)))
                 {
                     endpoint.WithCustomDomain(customDomain.HostName);
                 }

--- a/src/ResourceManagement/Cdn/CdnProfileImpl.cs
+++ b/src/ResourceManagement/Cdn/CdnProfileImpl.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         ///GENMHASH:1D5C24C8FDD38263C467FE7510F78581:F289006A354128A889CBDDA7CC12862C
         public string GenerateSsoUri()
         {
-            SsoUriInner ssoUri = Manager.Inner.Profiles.GenerateSsoUri(ResourceGroupName, Name);
+            SsoUriInner ssoUri = Extensions.Synchronize(() => Manager.Inner.Profiles.GenerateSsoUriAsync(ResourceGroupName, Name));
             if (ssoUri != null)
             {
                 return ssoUri.SsoUriValue;
@@ -240,8 +240,8 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         ///GENMHASH:89CD44AA5060CAB16CB0AF1FB046BC64:38BC374AC5D46ED852675FD772CAFDAD
         public IEnumerable<ResourceUsage> ListResourceUsage()
         {
-            return Manager.Inner.Profiles.ListResourceUsage(ResourceGroupName, Name)
-                .AsContinuousCollection(link => Manager.Inner.Profiles.ListResourceUsageNext(link))
+            return Extensions.Synchronize(() => Manager.Inner.Profiles.ListResourceUsageAsync(ResourceGroupName, Name))
+                .AsContinuousCollection(link => Extensions.Synchronize(() => Manager.Inner.Profiles.ListResourceUsageNextAsync(link)))
                 .Select(inner => new ResourceUsage(inner));
         }
 

--- a/src/ResourceManagement/Cdn/CdnProfileImpl.cs
+++ b/src/ResourceManagement/Cdn/CdnProfileImpl.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         ///GENMHASH:0B8B56A49D49CB3A5F0D927E7BE72FB6:15D778FA14DCB4E885FC219DB1E89EB7
         public CustomDomainValidationResult ValidateEndpointCustomDomain(string endpointName, string hostName)
         {
-            return ValidateEndpointCustomDomainAsync(endpointName, hostName).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => ValidateEndpointCustomDomainAsync(endpointName, hostName));
         }
 
         ///GENMHASH:3100428FE3EA33121B09FE78BAEAFA03:C9621675455EC620B9844FE8A5939DF2

--- a/src/ResourceManagement/Cdn/CdnProfilesImpl.cs
+++ b/src/ResourceManagement/Cdn/CdnProfilesImpl.cs
@@ -28,16 +28,16 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         ///GENMHASH:2CEB6E35574F5C7F1D19ADAC97C93D65:1B5FDD33003D9073F97F1C9831CA2660
         public IEnumerable<Operation> ListOperations()
         {
-            return Manager.Inner.ListOperations()
-                                .AsContinuousCollection(link => Manager.Inner.ListOperationsNext(link))
+            return Extensions.Synchronize(() => Manager.Inner.ListOperationsAsync())
+                                .AsContinuousCollection(link => Extensions.Synchronize(() => Manager.Inner.ListOperationsNextAsync(link)))
                                 .Select(inner=> new Operation(inner));
         }
 
         ///GENMHASH:89CD44AA5060CAB16CB0AF1FB046BC64:416FABEC3862B2A47FF2F9DD56AFEFF6
         public IEnumerable<ResourceUsage> ListResourceUsage()
         {
-            return Manager.Inner.ListResourceUsage()
-                                .AsContinuousCollection(link => Manager.Inner.ListResourceUsageNext(link))
+            return Extensions.Synchronize(() => Manager.Inner.ListResourceUsageAsync())
+                                .AsContinuousCollection(link => Extensions.Synchronize(() => Manager.Inner.ListResourceUsageNextAsync(link)))
                                 .Select(inner => new ResourceUsage(inner));
 
         }
@@ -45,8 +45,8 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         ///GENMHASH:6F0D776A3FBBF84EE0312C9E28F2D855:EC99713AFF94DCD8E902241A49011E4B
         public IEnumerable<EdgeNode> ListEdgeNodes()
         {
-            return Manager.Inner.EdgeNodes.List()
-                                .AsContinuousCollection(link => Manager.Inner.EdgeNodes.ListNext(link))
+            return Extensions.Synchronize(() => Manager.Inner.EdgeNodes.ListAsync())
+                                .AsContinuousCollection(link => Extensions.Synchronize(() => Manager.Inner.EdgeNodes.ListNextAsync(link)))
                                 .Select(inner => new EdgeNode(inner));
         }
 

--- a/src/ResourceManagement/Cdn/CdnProfilesImpl.cs
+++ b/src/ResourceManagement/Cdn/CdnProfilesImpl.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         ///GENMHASH:8B3976582303B73AC81C5220073E2D55:A4104491D327BA3667E857CA7A2EC15D
         public CheckNameAvailabilityResult CheckEndpointNameAvailability(string name)
         {
-            return CheckEndpointNameAvailabilityAsync(name).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => CheckEndpointNameAvailabilityAsync(name));
         }
 
         ///GENMHASH:2CEB6E35574F5C7F1D19ADAC97C93D65:1B5FDD33003D9073F97F1C9831CA2660
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
 
         public string GenerateSsoUri(string resourceGroupName, string profileName)
         {
-            return GenerateSsoUriAsync(resourceGroupName, profileName).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GenerateSsoUriAsync(resourceGroupName, profileName));
         }
 
         ///GENMHASH:2404C5CA15B0D5D6226D2C7D01E79303:FA381ABED6F4688FD47A380CF0F41845

--- a/src/ResourceManagement/Cdn/Generated/CdnManagementClientExtensions.cs
+++ b/src/ResourceManagement/Cdn/Generated/CdnManagementClientExtensions.cs
@@ -22,21 +22,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
     /// </summary>
     public static partial class CdnManagementClientExtensions
     {
-            /// <summary>
-            /// Check the availability of a resource name. This is needed for resources
-            /// where name is globally unique, such as a CDN endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='name'>
-            /// The resource name to validate.
-            /// </param>
-            public static CheckNameAvailabilityOutputInner CheckNameAvailability(this ICdnManagementClient operations, string name)
-            {
-                return operations.CheckNameAvailabilityAsync(name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Check the availability of a resource name. This is needed for resources
             /// where name is globally unique, such as a CDN endpoint.
@@ -58,18 +44,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Check the quota and actual usage of the CDN profiles under the given
-            /// subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<ResourceUsageInner> ListResourceUsage(this ICdnManagementClient operations)
-            {
-                return operations.ListResourceUsageAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Check the quota and actual usage of the CDN profiles under the given
             /// subscription.
@@ -88,17 +63,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the available CDN REST API operations.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<OperationInner> ListOperations(this ICdnManagementClient operations)
-            {
-                return operations.ListOperationsAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the available CDN REST API operations.
             /// </summary>
@@ -116,21 +81,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Check the quota and actual usage of the CDN profiles under the given
-            /// subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceUsageInner> ListResourceUsageNext(this ICdnManagementClient operations, string nextPageLink)
-            {
-                return operations.ListResourceUsageNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Check the quota and actual usage of the CDN profiles under the given
             /// subscription.
@@ -152,20 +103,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the available CDN REST API operations.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<OperationInner> ListOperationsNext(this ICdnManagementClient operations, string nextPageLink)
-            {
-                return operations.ListOperationsNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the available CDN REST API operations.
             /// </summary>

--- a/src/ResourceManagement/Cdn/Generated/CustomDomainsOperationsExtensions.cs
+++ b/src/ResourceManagement/Cdn/Generated/CustomDomainsOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
     /// </summary>
     public static partial class CustomDomainsOperationsExtensions
     {
-            /// <summary>
-            /// Lists all of the existing custom domains within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            public static IPage<CustomDomainInner> ListByEndpoint(this ICustomDomainsOperations operations, string resourceGroupName, string profileName, string endpointName)
-            {
-                return operations.ListByEndpointAsync(resourceGroupName, profileName, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the existing custom domains within an endpoint.
             /// </summary>
@@ -68,29 +49,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets an exisitng custom domain within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='customDomainName'>
-            /// Name of the custom domain within an endpoint.
-            /// </param>
-            public static CustomDomainInner Get(this ICustomDomainsOperations operations, string resourceGroupName, string profileName, string endpointName, string customDomainName)
-            {
-                return operations.GetAsync(resourceGroupName, profileName, endpointName, customDomainName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets an exisitng custom domain within an endpoint.
             /// </summary>
@@ -120,32 +79,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new custom domain within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='customDomainName'>
-            /// Name of the custom domain within an endpoint.
-            /// </param>
-            /// <param name='hostName'>
-            /// The host name of the custom domain. Must be a domain name.
-            /// </param>
-            public static CustomDomainInner Create(this ICustomDomainsOperations operations, string resourceGroupName, string profileName, string endpointName, string customDomainName, string hostName)
-            {
-                return operations.CreateAsync(resourceGroupName, profileName, endpointName, customDomainName, hostName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new custom domain within an endpoint.
             /// </summary>
@@ -178,29 +112,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an existing custom domain within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='customDomainName'>
-            /// Name of the custom domain within an endpoint.
-            /// </param>
-            public static CustomDomainInner Delete(this ICustomDomainsOperations operations, string resourceGroupName, string profileName, string endpointName, string customDomainName)
-            {
-                return operations.DeleteAsync(resourceGroupName, profileName, endpointName, customDomainName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an existing custom domain within an endpoint.
             /// </summary>
@@ -230,29 +142,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Disable https delivery of the custom domain.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='customDomainName'>
-            /// Name of the custom domain within an endpoint.
-            /// </param>
-            public static CustomDomainInner DisableCustomHttps(this ICustomDomainsOperations operations, string resourceGroupName, string profileName, string endpointName, string customDomainName)
-            {
-                return operations.DisableCustomHttpsAsync(resourceGroupName, profileName, endpointName, customDomainName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Disable https delivery of the custom domain.
             /// </summary>
@@ -282,29 +172,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Enable https delivery of the custom domain.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='customDomainName'>
-            /// Name of the custom domain within an endpoint.
-            /// </param>
-            public static CustomDomainInner EnableCustomHttps(this ICustomDomainsOperations operations, string resourceGroupName, string profileName, string endpointName, string customDomainName)
-            {
-                return operations.EnableCustomHttpsAsync(resourceGroupName, profileName, endpointName, customDomainName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Enable https delivery of the custom domain.
             /// </summary>
@@ -334,32 +202,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new custom domain within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='customDomainName'>
-            /// Name of the custom domain within an endpoint.
-            /// </param>
-            /// <param name='hostName'>
-            /// The host name of the custom domain. Must be a domain name.
-            /// </param>
-            public static CustomDomainInner BeginCreate(this ICustomDomainsOperations operations, string resourceGroupName, string profileName, string endpointName, string customDomainName, string hostName)
-            {
-                return operations.BeginCreateAsync(resourceGroupName, profileName, endpointName, customDomainName, hostName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new custom domain within an endpoint.
             /// </summary>
@@ -392,29 +235,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an existing custom domain within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='customDomainName'>
-            /// Name of the custom domain within an endpoint.
-            /// </param>
-            public static CustomDomainInner BeginDelete(this ICustomDomainsOperations operations, string resourceGroupName, string profileName, string endpointName, string customDomainName)
-            {
-                return operations.BeginDeleteAsync(resourceGroupName, profileName, endpointName, customDomainName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an existing custom domain within an endpoint.
             /// </summary>
@@ -444,20 +265,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the existing custom domains within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<CustomDomainInner> ListByEndpointNext(this ICustomDomainsOperations operations, string nextPageLink)
-            {
-                return operations.ListByEndpointNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the existing custom domains within an endpoint.
             /// </summary>

--- a/src/ResourceManagement/Cdn/Generated/EdgeNodesOperationsExtensions.cs
+++ b/src/ResourceManagement/Cdn/Generated/EdgeNodesOperationsExtensions.cs
@@ -22,17 +22,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
     /// </summary>
     public static partial class EdgeNodesOperationsExtensions
     {
-            /// <summary>
-            /// Lists all the edge nodes of a CDN service.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<EdgeNodeInner> List(this IEdgeNodesOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the edge nodes of a CDN service.
             /// </summary>
@@ -50,20 +40,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the edge nodes of a CDN service.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<EdgeNodeInner> ListNext(this IEdgeNodesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the edge nodes of a CDN service.
             /// </summary>

--- a/src/ResourceManagement/Cdn/Generated/EndpointsOperationsExtensions.cs
+++ b/src/ResourceManagement/Cdn/Generated/EndpointsOperationsExtensions.cs
@@ -24,23 +24,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
     /// </summary>
     public static partial class EndpointsOperationsExtensions
     {
-            /// <summary>
-            /// Lists existing CDN endpoints.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            public static IPage<EndpointInner> ListByProfile(this IEndpointsOperations operations, string resourceGroupName, string profileName)
-            {
-                return operations.ListByProfileAsync(resourceGroupName, profileName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists existing CDN endpoints.
             /// </summary>
@@ -64,27 +48,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets an existing CDN endpoint with the specified endpoint name under the
-            /// specified subscription, resource group and profile.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            public static EndpointInner Get(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName)
-            {
-                return operations.GetAsync(resourceGroupName, profileName, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets an existing CDN endpoint with the specified endpoint name under the
             /// specified subscription, resource group and profile.
@@ -112,30 +76,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new CDN endpoint with the specified endpoint name under the
-            /// specified subscription, resource group and profile.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='endpoint'>
-            /// Endpoint properties
-            /// </param>
-            public static EndpointInner Create(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName, EndpointInner endpoint)
-            {
-                return operations.CreateAsync(resourceGroupName, profileName, endpointName, endpoint).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new CDN endpoint with the specified endpoint name under the
             /// specified subscription, resource group and profile.
@@ -166,33 +107,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates an existing CDN endpoint with the specified endpoint name under the
-            /// specified subscription, resource group and profile. Only tags and Origin
-            /// HostHeader can be updated after creating an endpoint. To update origins,
-            /// use the Update Origin operation. To update custom domains, use the Update
-            /// Custom Domain operation.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='endpointUpdateProperties'>
-            /// Endpoint update properties
-            /// </param>
-            public static EndpointInner Update(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName, EndpointUpdateParametersInner endpointUpdateProperties)
-            {
-                return operations.UpdateAsync(resourceGroupName, profileName, endpointName, endpointUpdateProperties).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates an existing CDN endpoint with the specified endpoint name under the
             /// specified subscription, resource group and profile. Only tags and Origin
@@ -226,27 +141,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an existing CDN endpoint with the specified endpoint name under the
-            /// specified subscription, resource group and profile.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            public static void Delete(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName)
-            {
-                operations.DeleteAsync(resourceGroupName, profileName, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an existing CDN endpoint with the specified endpoint name under the
             /// specified subscription, resource group and profile.
@@ -271,26 +166,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, profileName, endpointName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Starts an existing CDN endpoint that is on a stopped state.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            public static EndpointInner Start(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName)
-            {
-                return operations.StartAsync(resourceGroupName, profileName, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Starts an existing CDN endpoint that is on a stopped state.
             /// </summary>
@@ -317,26 +193,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Stops an existing running CDN endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            public static EndpointInner Stop(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName)
-            {
-                return operations.StopAsync(resourceGroupName, profileName, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Stops an existing running CDN endpoint.
             /// </summary>
@@ -363,30 +220,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Removes a content from CDN.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='contentPaths'>
-            /// The path to the content to be purged. Can describe a file path or a wild
-            /// card directory.
-            /// </param>
-            public static void PurgeContent(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName, IList<string> contentPaths)
-            {
-                operations.PurgeContentAsync(resourceGroupName, profileName, endpointName, contentPaths).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Removes a content from CDN.
             /// </summary>
@@ -414,30 +248,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 (await operations.PurgeContentWithHttpMessagesAsync(resourceGroupName, profileName, endpointName, contentPaths, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Pre-loads a content to CDN. Available for Verizon Profiles.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='contentPaths'>
-            /// The path to the content to be loaded. Path should be a relative file URL of
-            /// the origin.
-            /// </param>
-            public static void LoadContent(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName, IList<string> contentPaths)
-            {
-                operations.LoadContentAsync(resourceGroupName, profileName, endpointName, contentPaths).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Pre-loads a content to CDN. Available for Verizon Profiles.
             /// </summary>
@@ -465,30 +276,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 (await operations.LoadContentWithHttpMessagesAsync(resourceGroupName, profileName, endpointName, contentPaths, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Validates the custom domain mapping to ensure it maps to the correct CDN
-            /// endpoint in DNS.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='hostName'>
-            /// The host name of the custom domain. Must be a domain name.
-            /// </param>
-            public static ValidateCustomDomainOutputInner ValidateCustomDomain(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName, string hostName)
-            {
-                return operations.ValidateCustomDomainAsync(resourceGroupName, profileName, endpointName, hostName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Validates the custom domain mapping to ensure it maps to the correct CDN
             /// endpoint in DNS.
@@ -519,27 +307,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Checks the quota and usage of geo filters and custom domains under the
-            /// given endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            public static IPage<ResourceUsageInner> ListResourceUsage(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName)
-            {
-                return operations.ListResourceUsageAsync(resourceGroupName, profileName, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks the quota and usage of geo filters and custom domains under the
             /// given endpoint.
@@ -567,30 +335,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new CDN endpoint with the specified endpoint name under the
-            /// specified subscription, resource group and profile.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='endpoint'>
-            /// Endpoint properties
-            /// </param>
-            public static EndpointInner BeginCreate(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName, EndpointInner endpoint)
-            {
-                return operations.BeginCreateAsync(resourceGroupName, profileName, endpointName, endpoint).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new CDN endpoint with the specified endpoint name under the
             /// specified subscription, resource group and profile.
@@ -621,33 +366,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates an existing CDN endpoint with the specified endpoint name under the
-            /// specified subscription, resource group and profile. Only tags and Origin
-            /// HostHeader can be updated after creating an endpoint. To update origins,
-            /// use the Update Origin operation. To update custom domains, use the Update
-            /// Custom Domain operation.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='endpointUpdateProperties'>
-            /// Endpoint update properties
-            /// </param>
-            public static EndpointInner BeginUpdate(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName, EndpointUpdateParametersInner endpointUpdateProperties)
-            {
-                return operations.BeginUpdateAsync(resourceGroupName, profileName, endpointName, endpointUpdateProperties).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates an existing CDN endpoint with the specified endpoint name under the
             /// specified subscription, resource group and profile. Only tags and Origin
@@ -681,27 +400,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an existing CDN endpoint with the specified endpoint name under the
-            /// specified subscription, resource group and profile.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            public static void BeginDelete(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, profileName, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an existing CDN endpoint with the specified endpoint name under the
             /// specified subscription, resource group and profile.
@@ -726,26 +425,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, profileName, endpointName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Starts an existing CDN endpoint that is on a stopped state.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            public static EndpointInner BeginStart(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName)
-            {
-                return operations.BeginStartAsync(resourceGroupName, profileName, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Starts an existing CDN endpoint that is on a stopped state.
             /// </summary>
@@ -772,26 +452,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Stops an existing running CDN endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            public static EndpointInner BeginStop(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName)
-            {
-                return operations.BeginStopAsync(resourceGroupName, profileName, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Stops an existing running CDN endpoint.
             /// </summary>
@@ -818,30 +479,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Removes a content from CDN.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='contentPaths'>
-            /// The path to the content to be purged. Can describe a file path or a wild
-            /// card directory.
-            /// </param>
-            public static void BeginPurgeContent(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName, IList<string> contentPaths)
-            {
-                operations.BeginPurgeContentAsync(resourceGroupName, profileName, endpointName, contentPaths).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Removes a content from CDN.
             /// </summary>
@@ -869,30 +507,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 (await operations.BeginPurgeContentWithHttpMessagesAsync(resourceGroupName, profileName, endpointName, contentPaths, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Pre-loads a content to CDN. Available for Verizon Profiles.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='contentPaths'>
-            /// The path to the content to be loaded. Path should be a relative file URL of
-            /// the origin.
-            /// </param>
-            public static void BeginLoadContent(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointName, IList<string> contentPaths)
-            {
-                operations.BeginLoadContentAsync(resourceGroupName, profileName, endpointName, contentPaths).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Pre-loads a content to CDN. Available for Verizon Profiles.
             /// </summary>
@@ -920,20 +535,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 (await operations.BeginLoadContentWithHttpMessagesAsync(resourceGroupName, profileName, endpointName, contentPaths, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Lists existing CDN endpoints.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<EndpointInner> ListByProfileNext(this IEndpointsOperations operations, string nextPageLink)
-            {
-                return operations.ListByProfileNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists existing CDN endpoints.
             /// </summary>
@@ -954,21 +556,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Checks the quota and usage of geo filters and custom domains under the
-            /// given endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceUsageInner> ListResourceUsageNext(this IEndpointsOperations operations, string nextPageLink)
-            {
-                return operations.ListResourceUsageNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks the quota and usage of geo filters and custom domains under the
             /// given endpoint.

--- a/src/ResourceManagement/Cdn/Generated/OriginsOperationsExtensions.cs
+++ b/src/ResourceManagement/Cdn/Generated/OriginsOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
     /// </summary>
     public static partial class OriginsOperationsExtensions
     {
-            /// <summary>
-            /// Lists all of the existing origins within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            public static IPage<OriginInner> ListByEndpoint(this IOriginsOperations operations, string resourceGroupName, string profileName, string endpointName)
-            {
-                return operations.ListByEndpointAsync(resourceGroupName, profileName, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the existing origins within an endpoint.
             /// </summary>
@@ -68,29 +49,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets an existing origin within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='originName'>
-            /// Name of the origin which is unique within the endpoint.
-            /// </param>
-            public static OriginInner Get(this IOriginsOperations operations, string resourceGroupName, string profileName, string endpointName, string originName)
-            {
-                return operations.GetAsync(resourceGroupName, profileName, endpointName, originName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets an existing origin within an endpoint.
             /// </summary>
@@ -120,32 +79,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates an existing origin within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='originName'>
-            /// Name of the origin which is unique within the endpoint.
-            /// </param>
-            /// <param name='originUpdateProperties'>
-            /// Origin properties
-            /// </param>
-            public static OriginInner Update(this IOriginsOperations operations, string resourceGroupName, string profileName, string endpointName, string originName, OriginUpdateParametersInner originUpdateProperties)
-            {
-                return operations.UpdateAsync(resourceGroupName, profileName, endpointName, originName, originUpdateProperties).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates an existing origin within an endpoint.
             /// </summary>
@@ -178,32 +112,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates an existing origin within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='endpointName'>
-            /// Name of the endpoint under the profile which is unique globally.
-            /// </param>
-            /// <param name='originName'>
-            /// Name of the origin which is unique within the endpoint.
-            /// </param>
-            /// <param name='originUpdateProperties'>
-            /// Origin properties
-            /// </param>
-            public static OriginInner BeginUpdate(this IOriginsOperations operations, string resourceGroupName, string profileName, string endpointName, string originName, OriginUpdateParametersInner originUpdateProperties)
-            {
-                return operations.BeginUpdateAsync(resourceGroupName, profileName, endpointName, originName, originUpdateProperties).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates an existing origin within an endpoint.
             /// </summary>
@@ -236,20 +145,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the existing origins within an endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<OriginInner> ListByEndpointNext(this IOriginsOperations operations, string nextPageLink)
-            {
-                return operations.ListByEndpointNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the existing origins within an endpoint.
             /// </summary>

--- a/src/ResourceManagement/Cdn/Generated/ProfilesOperationsExtensions.cs
+++ b/src/ResourceManagement/Cdn/Generated/ProfilesOperationsExtensions.cs
@@ -24,17 +24,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
     /// </summary>
     public static partial class ProfilesOperationsExtensions
     {
-            /// <summary>
-            /// Lists all of the CDN profiles within an Azure subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<ProfileInner> List(this IProfilesOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the CDN profiles within an Azure subscription.
             /// </summary>
@@ -52,20 +42,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the CDN profiles within a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            public static IPage<ProfileInner> ListByResourceGroup(this IProfilesOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the CDN profiles within a resource group.
             /// </summary>
@@ -86,24 +63,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a CDN profile with the specified profile name under the specified
-            /// subscription and resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            public static ProfileInner Get(this IProfilesOperations operations, string resourceGroupName, string profileName)
-            {
-                return operations.GetAsync(resourceGroupName, profileName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a CDN profile with the specified profile name under the specified
             /// subscription and resource group.
@@ -128,27 +88,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new CDN profile with a profile name under the specified
-            /// subscription and resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='profile'>
-            /// Profile properties needed to create a new profile.
-            /// </param>
-            public static ProfileInner Create(this IProfilesOperations operations, string resourceGroupName, string profileName, ProfileInner profile)
-            {
-                return operations.CreateAsync(resourceGroupName, profileName, profile).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new CDN profile with a profile name under the specified
             /// subscription and resource group.
@@ -176,27 +116,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates an existing CDN profile with the specified profile name under the
-            /// specified subscription and resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='tags'>
-            /// Profile tags
-            /// </param>
-            public static ProfileInner Update(this IProfilesOperations operations, string resourceGroupName, string profileName, IDictionary<string, string> tags)
-            {
-                return operations.UpdateAsync(resourceGroupName, profileName, tags).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates an existing CDN profile with the specified profile name under the
             /// specified subscription and resource group.
@@ -224,25 +144,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an existing CDN profile with the specified parameters. Deleting a
-            /// profile will result in the deletion of all of the sub-resources including
-            /// endpoints, origins and custom domains.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            public static void Delete(this IProfilesOperations operations, string resourceGroupName, string profileName)
-            {
-                operations.DeleteAsync(resourceGroupName, profileName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an existing CDN profile with the specified parameters. Deleting a
             /// profile will result in the deletion of all of the sub-resources including
@@ -265,28 +167,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, profileName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Generates a dynamic SSO URI used to sign in to the CDN supplemental portal.
-            /// Supplemnetal portal is used to configure advanced feature capabilities that
-            /// are not yet available in the Azure portal, such as core reports in a
-            /// standard profile; rules engine, advanced HTTP reports, and real-time stats
-            /// and alerts in a premium profile. The SSO URI changes approximately every 10
-            /// minutes.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            public static SsoUriInner GenerateSsoUri(this IProfilesOperations operations, string resourceGroupName, string profileName)
-            {
-                return operations.GenerateSsoUriAsync(resourceGroupName, profileName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Generates a dynamic SSO URI used to sign in to the CDN supplemental portal.
             /// Supplemnetal portal is used to configure advanced feature capabilities that
@@ -315,23 +196,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Checks the quota and actual usage of endpoints under the given CDN profile.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            public static IPage<ResourceUsageInner> ListResourceUsage(this IProfilesOperations operations, string resourceGroupName, string profileName)
-            {
-                return operations.ListResourceUsageAsync(resourceGroupName, profileName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks the quota and actual usage of endpoints under the given CDN profile.
             /// </summary>
@@ -355,27 +220,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new CDN profile with a profile name under the specified
-            /// subscription and resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='profile'>
-            /// Profile properties needed to create a new profile.
-            /// </param>
-            public static ProfileInner BeginCreate(this IProfilesOperations operations, string resourceGroupName, string profileName, ProfileInner profile)
-            {
-                return operations.BeginCreateAsync(resourceGroupName, profileName, profile).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new CDN profile with a profile name under the specified
             /// subscription and resource group.
@@ -403,27 +248,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates an existing CDN profile with the specified profile name under the
-            /// specified subscription and resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            /// <param name='tags'>
-            /// Profile tags
-            /// </param>
-            public static ProfileInner BeginUpdate(this IProfilesOperations operations, string resourceGroupName, string profileName, IDictionary<string, string> tags)
-            {
-                return operations.BeginUpdateAsync(resourceGroupName, profileName, tags).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates an existing CDN profile with the specified profile name under the
             /// specified subscription and resource group.
@@ -451,25 +276,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an existing CDN profile with the specified parameters. Deleting a
-            /// profile will result in the deletion of all of the sub-resources including
-            /// endpoints, origins and custom domains.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='profileName'>
-            /// Name of the CDN profile which is unique within the resource group.
-            /// </param>
-            public static void BeginDelete(this IProfilesOperations operations, string resourceGroupName, string profileName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, profileName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an existing CDN profile with the specified parameters. Deleting a
             /// profile will result in the deletion of all of the sub-resources including
@@ -492,20 +299,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, profileName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Lists all of the CDN profiles within an Azure subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ProfileInner> ListNext(this IProfilesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the CDN profiles within an Azure subscription.
             /// </summary>
@@ -526,20 +320,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the CDN profiles within a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ProfileInner> ListByResourceGroupNext(this IProfilesOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the CDN profiles within a resource group.
             /// </summary>
@@ -560,20 +341,7 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
                 }
             }
 
-            /// <summary>
-            /// Checks the quota and actual usage of endpoints under the given CDN profile.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceUsageInner> ListResourceUsageNext(this IProfilesOperations operations, string nextPageLink)
-            {
-                return operations.ListResourceUsageNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks the quota and actual usage of endpoints under the given CDN profile.
             /// </summary>

--- a/src/ResourceManagement/Compute/AvailabilitySetImpl.cs
+++ b/src/ResourceManagement/Compute/AvailabilitySetImpl.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:8FCDE9292B4D0AE6B0FA60BC84DD60E5:0ADB8EF84E7C5EBD42CD3DED6C7CDC38
         public IEnumerable<IVirtualMachineSize> ListVirtualMachineSizes()
         {
-            return this.Manager.Inner.AvailabilitySets.ListAvailableSizes(this.ResourceGroupName, this.Name)
+            return Extensions.Synchronize(() => this.Manager.Inner.AvailabilitySets.ListAvailableSizesAsync(this.ResourceGroupName, this.Name))
                 .Select(inner => new VirtualMachineSizeImpl(inner));
         }
     }

--- a/src/ResourceManagement/Compute/ComputeUsagesImpl.cs
+++ b/src/ResourceManagement/Compute/ComputeUsagesImpl.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:360BB74037893879A730ED7ED0A3938A:34BF45703D53DEAC832C7449858B69FC
         public IEnumerable<IComputeUsage> ListByRegion(string regionName)
         {
-            return WrapList(client.Usage.List(regionName)
-                .AsContinuousCollection(link => client.Usage.ListNext(link)));
+            return WrapList(Extensions.Synchronize(() => client.Usage.ListAsync(regionName))
+                .AsContinuousCollection(link => Extensions.Synchronize(() => client.Usage.ListNextAsync(link))));
         }
 
         ///GENMHASH:271CC39CE723B6FD3D7CCA7471D4B201:039795D842B96323D94D260F3FF83299

--- a/src/ResourceManagement/Compute/DiskImpl.cs
+++ b/src/ResourceManagement/Compute/DiskImpl.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using System.Threading.Tasks;
     using Models;
     using ResourceManager.Fluent;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     /// <summary>
     /// The implementation for Disk and its create and update interfaces.
@@ -128,7 +129,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:C14080365CC6F93E30BB51B78DED7084:769384CE5F12D8DA31D146E04DAD108F
         public void RevokeAccess()
         {
-            this.RevokeAccessAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => this.RevokeAccessAsync());
         }
 
         ///GENMHASH:920045A2761D4D5D5F5E2E52D43917D0:28B657BB52464897349F96AD3FEE7B7C
@@ -189,7 +190,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:DAC486F08AF23F259E630032FC20FAF1:3FE53F300A729DFBC3C1F55BBB117CA1
         public string GrantAccess(int accessDurationInSeconds)
         {
-            return this.GrantAccessAsync(accessDurationInSeconds).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.GrantAccessAsync(accessDurationInSeconds));
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:AACFFB1D9582E4E00031423DDDD4036A

--- a/src/ResourceManagement/Compute/DisksImpl.cs
+++ b/src/ResourceManagement/Compute/DisksImpl.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:1BCE81BDD651175D2AF64E39F4F2C420:F211289A9C0637B5973069548F05CECE
         public void RevokeAccess(string resourceGroupName, string diskName)
         {
-            this.Inner.RevokeAccess(resourceGroupName, diskName);
+            Extensions.Synchronize(() => this.Inner.RevokeAccessAsync(resourceGroupName, diskName));
         }
 
         ///GENMHASH:C2E2A5650639245BC0993A33DCAA5D61:AB53C4E88693DA816105A74AACCB3115

--- a/src/ResourceManagement/Compute/DisksImpl.cs
+++ b/src/ResourceManagement/Compute/DisksImpl.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:C2E2A5650639245BC0993A33DCAA5D61:AB53C4E88693DA816105A74AACCB3115
         public string GrantAccess(string resourceGroupName, string diskName, AccessLevel accessLevel, int accessDuration)
         {
-            return this.GrantAccessAsync(resourceGroupName, diskName, accessLevel, accessDuration).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.GrantAccessAsync(resourceGroupName, diskName, accessLevel, accessDuration));
         }
 
         ///GENMHASH:CAAAC294CEC4F5465B5368FDC3327C5D:2F567929AA028332A657F78A9A7C3964

--- a/src/ResourceManagement/Compute/Generated/AvailabilitySetsOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/AvailabilitySetsOperationsExtensions.cs
@@ -24,26 +24,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class AvailabilitySetsOperationsExtensions
     {
-            /// <summary>
-            /// Create or update an availability set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the availability set.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Create Availability Set operation.
-            /// </param>
-            public static AvailabilitySetInner CreateOrUpdate(this IAvailabilitySetsOperations operations, string resourceGroupName, string name, AvailabilitySetInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, name, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update an availability set.
             /// </summary>
@@ -70,23 +51,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete an availability set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='availabilitySetName'>
-            /// The name of the availability set.
-            /// </param>
-            public static OperationStatusResponseInner Delete(this IAvailabilitySetsOperations operations, string resourceGroupName, string availabilitySetName)
-            {
-                return operations.DeleteAsync(resourceGroupName, availabilitySetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete an availability set.
             /// </summary>
@@ -110,23 +75,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Retrieves information about an availability set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='availabilitySetName'>
-            /// The name of the availability set.
-            /// </param>
-            public static AvailabilitySetInner Get(this IAvailabilitySetsOperations operations, string resourceGroupName, string availabilitySetName)
-            {
-                return operations.GetAsync(resourceGroupName, availabilitySetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Retrieves information about an availability set.
             /// </summary>
@@ -150,20 +99,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all availability sets in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IEnumerable<AvailabilitySetInner> List(this IAvailabilitySetsOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all availability sets in a resource group.
             /// </summary>
@@ -184,24 +120,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all available virtual machine sizes that can be used to create a new
-            /// virtual machine in an existing availability set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='availabilitySetName'>
-            /// The name of the availability set.
-            /// </param>
-            public static IEnumerable<VirtualMachineSize> ListAvailableSizes(this IAvailabilitySetsOperations operations, string resourceGroupName, string availabilitySetName)
-            {
-                return operations.ListAvailableSizesAsync(resourceGroupName, availabilitySetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all available virtual machine sizes that can be used to create a new
             /// virtual machine in an existing availability set.

--- a/src/ResourceManagement/Compute/Generated/ContainerServicesOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/ContainerServicesOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class ContainerServicesOperationsExtensions
     {
-            /// <summary>
-            /// Gets a list of container services in the specified subscription.
-            /// </summary>
-            /// <remarks>
-            /// Gets a list of container services in the specified subscription. The
-            /// operation returns properties of each container service including state,
-            /// orchestrator, number of masters and agents, and FQDNs of masters and
-            /// agents.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<ContainerServiceInner> List(this IContainerServicesOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of container services in the specified subscription.
             /// </summary>
@@ -62,31 +46,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a container service.
-            /// </summary>
-            /// <remarks>
-            /// Creates or updates a container service with the specified configuration of
-            /// orchestrator, masters, and agents.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='containerServiceName'>
-            /// The name of the container service in the specified subscription and
-            /// resource group.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Create or Update a Container Service operation.
-            /// </param>
-            public static ContainerServiceInner CreateOrUpdate(this IContainerServicesOperations operations, string resourceGroupName, string containerServiceName, ContainerServiceInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, containerServiceName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a container service.
             /// </summary>
@@ -118,30 +78,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the properties of the specified container service.
-            /// </summary>
-            /// <remarks>
-            /// Gets the properties of the specified container service in the specified
-            /// subscription and resource group. The operation returns the properties
-            /// including state, orchestrator, number of masters and agents, and FQDNs of
-            /// masters and agents.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='containerServiceName'>
-            /// The name of the container service in the specified subscription and
-            /// resource group.
-            /// </param>
-            public static ContainerServiceInner Get(this IContainerServicesOperations operations, string resourceGroupName, string containerServiceName)
-            {
-                return operations.GetAsync(resourceGroupName, containerServiceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the properties of the specified container service.
             /// </summary>
@@ -172,32 +109,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified container service.
-            /// </summary>
-            /// <remarks>
-            /// Deletes the specified container service in the specified subscription and
-            /// resource group. The operation does not delete other resources created as
-            /// part of creating a container service, including storage accounts, VMs, and
-            /// availability sets. All the other resources created with the container
-            /// service are part of the same resource group and can be deleted
-            /// individually.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='containerServiceName'>
-            /// The name of the container service in the specified subscription and
-            /// resource group.
-            /// </param>
-            public static void Delete(this IContainerServicesOperations operations, string resourceGroupName, string containerServiceName)
-            {
-                operations.DeleteAsync(resourceGroupName, containerServiceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified container service.
             /// </summary>
@@ -227,26 +139,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, containerServiceName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets a list of container services in the specified resource group.
-            /// </summary>
-            /// <remarks>
-            /// Gets a list of container services in the specified subscription and
-            /// resource group. The operation returns properties of each container service
-            /// including state, orchestrator, number of masters and agents, and FQDNs of
-            /// masters and agents.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<ContainerServiceInner> ListByResourceGroup(this IContainerServicesOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of container services in the specified resource group.
             /// </summary>
@@ -273,31 +166,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a container service.
-            /// </summary>
-            /// <remarks>
-            /// Creates or updates a container service with the specified configuration of
-            /// orchestrator, masters, and agents.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='containerServiceName'>
-            /// The name of the container service in the specified subscription and
-            /// resource group.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Create or Update a Container Service operation.
-            /// </param>
-            public static ContainerServiceInner BeginCreateOrUpdate(this IContainerServicesOperations operations, string resourceGroupName, string containerServiceName, ContainerServiceInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, containerServiceName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a container service.
             /// </summary>
@@ -329,32 +198,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified container service.
-            /// </summary>
-            /// <remarks>
-            /// Deletes the specified container service in the specified subscription and
-            /// resource group. The operation does not delete other resources created as
-            /// part of creating a container service, including storage accounts, VMs, and
-            /// availability sets. All the other resources created with the container
-            /// service are part of the same resource group and can be deleted
-            /// individually.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='containerServiceName'>
-            /// The name of the container service in the specified subscription and
-            /// resource group.
-            /// </param>
-            public static void BeginDelete(this IContainerServicesOperations operations, string resourceGroupName, string containerServiceName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, containerServiceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified container service.
             /// </summary>
@@ -384,26 +228,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, containerServiceName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets a list of container services in the specified subscription.
-            /// </summary>
-            /// <remarks>
-            /// Gets a list of container services in the specified subscription. The
-            /// operation returns properties of each container service including state,
-            /// orchestrator, number of masters and agents, and FQDNs of masters and
-            /// agents.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ContainerServiceInner> ListNext(this IContainerServicesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of container services in the specified subscription.
             /// </summary>
@@ -430,26 +255,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of container services in the specified resource group.
-            /// </summary>
-            /// <remarks>
-            /// Gets a list of container services in the specified subscription and
-            /// resource group. The operation returns properties of each container service
-            /// including state, orchestrator, number of masters and agents, and FQDNs of
-            /// masters and agents.
-            /// </remarks>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ContainerServiceInner> ListByResourceGroupNext(this IContainerServicesOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of container services in the specified resource group.
             /// </summary>

--- a/src/ResourceManagement/Compute/Generated/DisksOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/DisksOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class DisksOperationsExtensions
     {
-            /// <summary>
-            /// Creates or updates a disk.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='diskName'>
-            /// The name of the disk within the given subscription and resource group.
-            /// </param>
-            /// <param name='disk'>
-            /// Disk object supplied in the body of the Put disk operation.
-            /// </param>
-            public static DiskInner CreateOrUpdate(this IDisksOperations operations, string resourceGroupName, string diskName, DiskInner disk)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, diskName, disk).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a disk.
             /// </summary>
@@ -68,26 +49,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates (patches) a disk.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='diskName'>
-            /// The name of the disk within the given subscription and resource group.
-            /// </param>
-            /// <param name='disk'>
-            /// Disk object supplied in the body of the Patch disk operation.
-            /// </param>
-            public static DiskInner Update(this IDisksOperations operations, string resourceGroupName, string diskName, DiskUpdateInner disk)
-            {
-                return operations.UpdateAsync(resourceGroupName, diskName, disk).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates (patches) a disk.
             /// </summary>
@@ -114,23 +76,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about a disk.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='diskName'>
-            /// The name of the disk within the given subscription and resource group.
-            /// </param>
-            public static DiskInner Get(this IDisksOperations operations, string resourceGroupName, string diskName)
-            {
-                return operations.GetAsync(resourceGroupName, diskName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about a disk.
             /// </summary>
@@ -154,23 +100,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a disk.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='diskName'>
-            /// The name of the disk within the given subscription and resource group.
-            /// </param>
-            public static OperationStatusResponseInner Delete(this IDisksOperations operations, string resourceGroupName, string diskName)
-            {
-                return operations.DeleteAsync(resourceGroupName, diskName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a disk.
             /// </summary>
@@ -194,20 +124,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the disks under a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<DiskInner> ListByResourceGroup(this IDisksOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the disks under a resource group.
             /// </summary>
@@ -228,17 +145,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the disks under a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<DiskInner> List(this IDisksOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the disks under a subscription.
             /// </summary>
@@ -256,26 +163,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Grants access to a disk.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='diskName'>
-            /// The name of the disk within the given subscription and resource group.
-            /// </param>
-            /// <param name='grantAccessData'>
-            /// Access data object supplied in the body of the get disk access operation.
-            /// </param>
-            public static AccessUriInner GrantAccess(this IDisksOperations operations, string resourceGroupName, string diskName, GrantAccessDataInner grantAccessData)
-            {
-                return operations.GrantAccessAsync(resourceGroupName, diskName, grantAccessData).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Grants access to a disk.
             /// </summary>
@@ -302,23 +190,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Revokes access to a disk.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='diskName'>
-            /// The name of the disk within the given subscription and resource group.
-            /// </param>
-            public static OperationStatusResponseInner RevokeAccess(this IDisksOperations operations, string resourceGroupName, string diskName)
-            {
-                return operations.RevokeAccessAsync(resourceGroupName, diskName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Revokes access to a disk.
             /// </summary>
@@ -342,26 +214,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a disk.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='diskName'>
-            /// The name of the disk within the given subscription and resource group.
-            /// </param>
-            /// <param name='disk'>
-            /// Disk object supplied in the body of the Put disk operation.
-            /// </param>
-            public static DiskInner BeginCreateOrUpdate(this IDisksOperations operations, string resourceGroupName, string diskName, DiskInner disk)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, diskName, disk).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a disk.
             /// </summary>
@@ -388,26 +241,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates (patches) a disk.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='diskName'>
-            /// The name of the disk within the given subscription and resource group.
-            /// </param>
-            /// <param name='disk'>
-            /// Disk object supplied in the body of the Patch disk operation.
-            /// </param>
-            public static DiskInner BeginUpdate(this IDisksOperations operations, string resourceGroupName, string diskName, DiskUpdateInner disk)
-            {
-                return operations.BeginUpdateAsync(resourceGroupName, diskName, disk).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates (patches) a disk.
             /// </summary>
@@ -434,23 +268,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a disk.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='diskName'>
-            /// The name of the disk within the given subscription and resource group.
-            /// </param>
-            public static OperationStatusResponseInner BeginDelete(this IDisksOperations operations, string resourceGroupName, string diskName)
-            {
-                return operations.BeginDeleteAsync(resourceGroupName, diskName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a disk.
             /// </summary>
@@ -474,26 +292,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Grants access to a disk.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='diskName'>
-            /// The name of the disk within the given subscription and resource group.
-            /// </param>
-            /// <param name='grantAccessData'>
-            /// Access data object supplied in the body of the get disk access operation.
-            /// </param>
-            public static AccessUriInner BeginGrantAccess(this IDisksOperations operations, string resourceGroupName, string diskName, GrantAccessDataInner grantAccessData)
-            {
-                return operations.BeginGrantAccessAsync(resourceGroupName, diskName, grantAccessData).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Grants access to a disk.
             /// </summary>
@@ -520,23 +319,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Revokes access to a disk.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='diskName'>
-            /// The name of the disk within the given subscription and resource group.
-            /// </param>
-            public static OperationStatusResponseInner BeginRevokeAccess(this IDisksOperations operations, string resourceGroupName, string diskName)
-            {
-                return operations.BeginRevokeAccessAsync(resourceGroupName, diskName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Revokes access to a disk.
             /// </summary>
@@ -560,20 +343,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the disks under a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DiskInner> ListByResourceGroupNext(this IDisksOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the disks under a resource group.
             /// </summary>
@@ -594,20 +364,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the disks under a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DiskInner> ListNext(this IDisksOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the disks under a subscription.
             /// </summary>

--- a/src/ResourceManagement/Compute/Generated/ImagesOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/ImagesOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class ImagesOperationsExtensions
     {
-            /// <summary>
-            /// Create or update an image.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='imageName'>
-            /// The name of the image.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Create Image operation.
-            /// </param>
-            public static ImageInner CreateOrUpdate(this IImagesOperations operations, string resourceGroupName, string imageName, ImageInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, imageName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update an image.
             /// </summary>
@@ -68,23 +49,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an Image.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='imageName'>
-            /// The name of the image.
-            /// </param>
-            public static OperationStatusResponseInner Delete(this IImagesOperations operations, string resourceGroupName, string imageName)
-            {
-                return operations.DeleteAsync(resourceGroupName, imageName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an Image.
             /// </summary>
@@ -108,26 +73,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets an image.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='imageName'>
-            /// The name of the image.
-            /// </param>
-            /// <param name='expand'>
-            /// The expand expression to apply on the operation.
-            /// </param>
-            public static ImageInner Get(this IImagesOperations operations, string resourceGroupName, string imageName, string expand = default(string))
-            {
-                return operations.GetAsync(resourceGroupName, imageName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets an image.
             /// </summary>
@@ -154,20 +100,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the list of images under a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<ImageInner> ListByResourceGroup(this IImagesOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the list of images under a resource group.
             /// </summary>
@@ -188,19 +121,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the list of Images in the subscription. Use nextLink property in the
-            /// response to get the next page of Images. Do this till nextLink is not null
-            /// to fetch all the Images.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<ImageInner> List(this IImagesOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the list of Images in the subscription. Use nextLink property in the
             /// response to get the next page of Images. Do this till nextLink is not null
@@ -220,26 +141,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or update an image.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='imageName'>
-            /// The name of the image.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Create Image operation.
-            /// </param>
-            public static ImageInner BeginCreateOrUpdate(this IImagesOperations operations, string resourceGroupName, string imageName, ImageInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, imageName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update an image.
             /// </summary>
@@ -266,23 +168,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an Image.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='imageName'>
-            /// The name of the image.
-            /// </param>
-            public static OperationStatusResponseInner BeginDelete(this IImagesOperations operations, string resourceGroupName, string imageName)
-            {
-                return operations.BeginDeleteAsync(resourceGroupName, imageName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an Image.
             /// </summary>
@@ -306,20 +192,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the list of images under a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ImageInner> ListByResourceGroupNext(this IImagesOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the list of images under a resource group.
             /// </summary>
@@ -340,22 +213,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the list of Images in the subscription. Use nextLink property in the
-            /// response to get the next page of Images. Do this till nextLink is not null
-            /// to fetch all the Images.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ImageInner> ListNext(this IImagesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the list of Images in the subscription. Use nextLink property in the
             /// response to get the next page of Images. Do this till nextLink is not null

--- a/src/ResourceManagement/Compute/Generated/SnapshotsOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/SnapshotsOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class SnapshotsOperationsExtensions
     {
-            /// <summary>
-            /// Creates or updates a snapshot.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='snapshotName'>
-            /// The name of the snapshot within the given subscription and resource group.
-            /// </param>
-            /// <param name='snapshot'>
-            /// Snapshot object supplied in the body of the Put disk operation.
-            /// </param>
-            public static SnapshotInner CreateOrUpdate(this ISnapshotsOperations operations, string resourceGroupName, string snapshotName, SnapshotInner snapshot)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, snapshotName, snapshot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a snapshot.
             /// </summary>
@@ -68,26 +49,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates (patches) a snapshot.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='snapshotName'>
-            /// The name of the snapshot within the given subscription and resource group.
-            /// </param>
-            /// <param name='snapshot'>
-            /// Snapshot object supplied in the body of the Patch snapshot operation.
-            /// </param>
-            public static SnapshotInner Update(this ISnapshotsOperations operations, string resourceGroupName, string snapshotName, SnapshotUpdateInner snapshot)
-            {
-                return operations.UpdateAsync(resourceGroupName, snapshotName, snapshot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates (patches) a snapshot.
             /// </summary>
@@ -114,23 +76,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about a snapshot.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='snapshotName'>
-            /// The name of the snapshot within the given subscription and resource group.
-            /// </param>
-            public static SnapshotInner Get(this ISnapshotsOperations operations, string resourceGroupName, string snapshotName)
-            {
-                return operations.GetAsync(resourceGroupName, snapshotName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about a snapshot.
             /// </summary>
@@ -154,23 +100,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a snapshot.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='snapshotName'>
-            /// The name of the snapshot within the given subscription and resource group.
-            /// </param>
-            public static OperationStatusResponseInner Delete(this ISnapshotsOperations operations, string resourceGroupName, string snapshotName)
-            {
-                return operations.DeleteAsync(resourceGroupName, snapshotName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a snapshot.
             /// </summary>
@@ -194,20 +124,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists snapshots under a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<SnapshotInner> ListByResourceGroup(this ISnapshotsOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists snapshots under a resource group.
             /// </summary>
@@ -228,17 +145,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists snapshots under a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<SnapshotInner> List(this ISnapshotsOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists snapshots under a subscription.
             /// </summary>
@@ -256,27 +163,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Grants access to a snapshot.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='snapshotName'>
-            /// The name of the snapshot within the given subscription and resource group.
-            /// </param>
-            /// <param name='grantAccessData'>
-            /// Access data object supplied in the body of the get snapshot access
-            /// operation.
-            /// </param>
-            public static AccessUriInner GrantAccess(this ISnapshotsOperations operations, string resourceGroupName, string snapshotName, GrantAccessDataInner grantAccessData)
-            {
-                return operations.GrantAccessAsync(resourceGroupName, snapshotName, grantAccessData).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Grants access to a snapshot.
             /// </summary>
@@ -304,23 +191,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Revokes access to a snapshot.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='snapshotName'>
-            /// The name of the snapshot within the given subscription and resource group.
-            /// </param>
-            public static OperationStatusResponseInner RevokeAccess(this ISnapshotsOperations operations, string resourceGroupName, string snapshotName)
-            {
-                return operations.RevokeAccessAsync(resourceGroupName, snapshotName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Revokes access to a snapshot.
             /// </summary>
@@ -344,26 +215,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a snapshot.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='snapshotName'>
-            /// The name of the snapshot within the given subscription and resource group.
-            /// </param>
-            /// <param name='snapshot'>
-            /// Snapshot object supplied in the body of the Put disk operation.
-            /// </param>
-            public static SnapshotInner BeginCreateOrUpdate(this ISnapshotsOperations operations, string resourceGroupName, string snapshotName, SnapshotInner snapshot)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, snapshotName, snapshot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a snapshot.
             /// </summary>
@@ -390,26 +242,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates (patches) a snapshot.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='snapshotName'>
-            /// The name of the snapshot within the given subscription and resource group.
-            /// </param>
-            /// <param name='snapshot'>
-            /// Snapshot object supplied in the body of the Patch snapshot operation.
-            /// </param>
-            public static SnapshotInner BeginUpdate(this ISnapshotsOperations operations, string resourceGroupName, string snapshotName, SnapshotUpdateInner snapshot)
-            {
-                return operations.BeginUpdateAsync(resourceGroupName, snapshotName, snapshot).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates (patches) a snapshot.
             /// </summary>
@@ -436,23 +269,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a snapshot.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='snapshotName'>
-            /// The name of the snapshot within the given subscription and resource group.
-            /// </param>
-            public static OperationStatusResponseInner BeginDelete(this ISnapshotsOperations operations, string resourceGroupName, string snapshotName)
-            {
-                return operations.BeginDeleteAsync(resourceGroupName, snapshotName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a snapshot.
             /// </summary>
@@ -476,27 +293,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Grants access to a snapshot.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='snapshotName'>
-            /// The name of the snapshot within the given subscription and resource group.
-            /// </param>
-            /// <param name='grantAccessData'>
-            /// Access data object supplied in the body of the get snapshot access
-            /// operation.
-            /// </param>
-            public static AccessUriInner BeginGrantAccess(this ISnapshotsOperations operations, string resourceGroupName, string snapshotName, GrantAccessDataInner grantAccessData)
-            {
-                return operations.BeginGrantAccessAsync(resourceGroupName, snapshotName, grantAccessData).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Grants access to a snapshot.
             /// </summary>
@@ -524,23 +321,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Revokes access to a snapshot.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='snapshotName'>
-            /// The name of the snapshot within the given subscription and resource group.
-            /// </param>
-            public static OperationStatusResponseInner BeginRevokeAccess(this ISnapshotsOperations operations, string resourceGroupName, string snapshotName)
-            {
-                return operations.BeginRevokeAccessAsync(resourceGroupName, snapshotName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Revokes access to a snapshot.
             /// </summary>
@@ -564,20 +345,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists snapshots under a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SnapshotInner> ListByResourceGroupNext(this ISnapshotsOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists snapshots under a resource group.
             /// </summary>
@@ -598,20 +366,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists snapshots under a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SnapshotInner> ListNext(this ISnapshotsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists snapshots under a subscription.
             /// </summary>

--- a/src/ResourceManagement/Compute/Generated/UsageOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/UsageOperationsExtensions.cs
@@ -22,22 +22,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class UsageOperationsExtensions
     {
-            /// <summary>
-            /// Gets, for the specified location, the current compute resource usage
-            /// information as well as the limits for compute resources under the
-            /// subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// The location for which resource usage is queried.
-            /// </param>
-            public static IPage<Usage> List(this IUsageOperations operations, string location)
-            {
-                return operations.ListAsync(location).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets, for the specified location, the current compute resource usage
             /// information as well as the limits for compute resources under the
@@ -60,22 +45,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets, for the specified location, the current compute resource usage
-            /// information as well as the limits for compute resources under the
-            /// subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<Usage> ListNext(this IUsageOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets, for the specified location, the current compute resource usage
             /// information as well as the limits for compute resources under the

--- a/src/ResourceManagement/Compute/Generated/VirtualMachineExtensionImagesOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/VirtualMachineExtensionImagesOperationsExtensions.cs
@@ -25,25 +25,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class VirtualMachineExtensionImagesOperationsExtensions
     {
-            /// <summary>
-            /// Gets a virtual machine extension image.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// </param>
-            /// <param name='publisherName'>
-            /// </param>
-            /// <param name='type'>
-            /// </param>
-            /// <param name='version'>
-            /// </param>
-            public static VirtualMachineExtensionImageInner Get(this IVirtualMachineExtensionImagesOperations operations, string location, string publisherName, string type, string version)
-            {
-                return operations.GetAsync(location, publisherName, type, version).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a virtual machine extension image.
             /// </summary>
@@ -69,21 +51,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of virtual machine extension image types.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// </param>
-            /// <param name='publisherName'>
-            /// </param>
-            public static IList<VirtualMachineExtensionImageInner> ListTypes(this IVirtualMachineExtensionImagesOperations operations, string location, string publisherName)
-            {
-                return operations.ListTypesAsync(location, publisherName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of virtual machine extension image types.
             /// </summary>
@@ -105,26 +73,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of virtual machine extension image versions.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// </param>
-            /// <param name='publisherName'>
-            /// </param>
-            /// <param name='type'>
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IList<VirtualMachineExtensionImageInner> ListVersions(this IVirtualMachineExtensionImagesOperations operations, string location, string publisherName, string type, ODataQuery<VirtualMachineExtensionImageInner> odataQuery = default(ODataQuery<VirtualMachineExtensionImageInner>))
-            {
-                return operations.ListVersionsAsync(location, publisherName, type, odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of virtual machine extension image versions.
             /// </summary>

--- a/src/ResourceManagement/Compute/Generated/VirtualMachineExtensionsOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/VirtualMachineExtensionsOperationsExtensions.cs
@@ -22,30 +22,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class VirtualMachineExtensionsOperationsExtensions
     {
-            /// <summary>
-            /// The operation to create or update the extension.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine where the extension should be create or
-            /// updated.
-            /// </param>
-            /// <param name='vmExtensionName'>
-            /// The name of the virtual machine extension.
-            /// </param>
-            /// <param name='extensionParameters'>
-            /// Parameters supplied to the Create Virtual Machine Extension operation.
-            /// </param>
-            public static VirtualMachineExtensionInner CreateOrUpdate(this IVirtualMachineExtensionsOperations operations, string resourceGroupName, string vmName, string vmExtensionName, VirtualMachineExtensionInner extensionParameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, vmName, vmExtensionName, extensionParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to create or update the extension.
             /// </summary>
@@ -76,26 +53,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to delete the extension.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine where the extension should be deleted.
-            /// </param>
-            /// <param name='vmExtensionName'>
-            /// The name of the virtual machine extension.
-            /// </param>
-            public static OperationStatusResponseInner Delete(this IVirtualMachineExtensionsOperations operations, string resourceGroupName, string vmName, string vmExtensionName)
-            {
-                return operations.DeleteAsync(resourceGroupName, vmName, vmExtensionName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to delete the extension.
             /// </summary>
@@ -122,29 +80,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to get the extension.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine containing the extension.
-            /// </param>
-            /// <param name='vmExtensionName'>
-            /// The name of the virtual machine extension.
-            /// </param>
-            /// <param name='expand'>
-            /// The expand expression to apply on the operation.
-            /// </param>
-            public static VirtualMachineExtensionInner Get(this IVirtualMachineExtensionsOperations operations, string resourceGroupName, string vmName, string vmExtensionName, string expand = default(string))
-            {
-                return operations.GetAsync(resourceGroupName, vmName, vmExtensionName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to get the extension.
             /// </summary>
@@ -174,30 +110,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to create or update the extension.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine where the extension should be create or
-            /// updated.
-            /// </param>
-            /// <param name='vmExtensionName'>
-            /// The name of the virtual machine extension.
-            /// </param>
-            /// <param name='extensionParameters'>
-            /// Parameters supplied to the Create Virtual Machine Extension operation.
-            /// </param>
-            public static VirtualMachineExtensionInner BeginCreateOrUpdate(this IVirtualMachineExtensionsOperations operations, string resourceGroupName, string vmName, string vmExtensionName, VirtualMachineExtensionInner extensionParameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, vmName, vmExtensionName, extensionParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to create or update the extension.
             /// </summary>
@@ -228,26 +141,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to delete the extension.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine where the extension should be deleted.
-            /// </param>
-            /// <param name='vmExtensionName'>
-            /// The name of the virtual machine extension.
-            /// </param>
-            public static OperationStatusResponseInner BeginDelete(this IVirtualMachineExtensionsOperations operations, string resourceGroupName, string vmName, string vmExtensionName)
-            {
-                return operations.BeginDeleteAsync(resourceGroupName, vmName, vmExtensionName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to delete the extension.
             /// </summary>

--- a/src/ResourceManagement/Compute/Generated/VirtualMachineImagesOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/VirtualMachineImagesOperationsExtensions.cs
@@ -25,32 +25,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class VirtualMachineImagesOperationsExtensions
     {
-            /// <summary>
-            /// Gets a virtual machine image.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// The name of a supported Azure region.
-            /// </param>
-            /// <param name='publisherName'>
-            /// A valid image publisher.
-            /// </param>
-            /// <param name='offer'>
-            /// A valid image publisher offer.
-            /// </param>
-            /// <param name='skus'>
-            /// A valid image SKU.
-            /// </param>
-            /// <param name='version'>
-            /// A valid image SKU version.
-            /// </param>
-            public static VirtualMachineImageInner Get(this IVirtualMachineImagesOperations operations, string location, string publisherName, string offer, string skus, string version)
-            {
-                return operations.GetAsync(location, publisherName, offer, skus, version).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a virtual machine image.
             /// </summary>
@@ -83,33 +58,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of all virtual machine image versions for the specified
-            /// location, publisher, offer, and SKU.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// The name of a supported Azure region.
-            /// </param>
-            /// <param name='publisherName'>
-            /// A valid image publisher.
-            /// </param>
-            /// <param name='offer'>
-            /// A valid image publisher offer.
-            /// </param>
-            /// <param name='skus'>
-            /// A valid image SKU.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IList<VirtualMachineImageResourceInner> List(this IVirtualMachineImagesOperations operations, string location, string publisherName, string offer, string skus, ODataQuery<VirtualMachineImageResourceInner> odataQuery = default(ODataQuery<VirtualMachineImageResourceInner>))
-            {
-                return ((IVirtualMachineImagesOperations)operations).ListAsync(location, publisherName, offer, skus, odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of all virtual machine image versions for the specified
             /// location, publisher, offer, and SKU.
@@ -143,24 +92,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of virtual machine image offers for the specified location and
-            /// publisher.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// The name of a supported Azure region.
-            /// </param>
-            /// <param name='publisherName'>
-            /// A valid image publisher.
-            /// </param>
-            public static IList<VirtualMachineImageResourceInner> ListOffers(this IVirtualMachineImagesOperations operations, string location, string publisherName)
-            {
-                return operations.ListOffersAsync(location, publisherName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of virtual machine image offers for the specified location and
             /// publisher.
@@ -185,21 +117,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of virtual machine image publishers for the specified Azure
-            /// location.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// The name of a supported Azure region.
-            /// </param>
-            public static IList<VirtualMachineImageResourceInner> ListPublishers(this IVirtualMachineImagesOperations operations, string location)
-            {
-                return operations.ListPublishersAsync(location).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of virtual machine image publishers for the specified Azure
             /// location.
@@ -221,27 +139,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of virtual machine image SKUs for the specified location,
-            /// publisher, and offer.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// The name of a supported Azure region.
-            /// </param>
-            /// <param name='publisherName'>
-            /// A valid image publisher.
-            /// </param>
-            /// <param name='offer'>
-            /// A valid image publisher offer.
-            /// </param>
-            public static IList<VirtualMachineImageResourceInner> ListSkus(this IVirtualMachineImagesOperations operations, string location, string publisherName, string offer)
-            {
-                return operations.ListSkusAsync(location, publisherName, offer).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of virtual machine image SKUs for the specified location,
             /// publisher, and offer.

--- a/src/ResourceManagement/Compute/Generated/VirtualMachineScaleSetVMsOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/VirtualMachineScaleSetVMsOperationsExtensions.cs
@@ -23,27 +23,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class VirtualMachineScaleSetVMsOperationsExtensions
     {
-            /// <summary>
-            /// Reimages (upgrade the operating system) a specific virtual machine in a VM
-            /// scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner Reimage(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.ReimageAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reimages (upgrade the operating system) a specific virtual machine in a VM
             /// scale set.
@@ -71,28 +51,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Allows you to re-image all the disks ( including data disks ) in the a
-            /// virtual machine scale set instance. This operation is only supported for
-            /// managed disks.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner ReimageAll(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.ReimageAllAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Allows you to re-image all the disks ( including data disks ) in the a
             /// virtual machine scale set instance. This operation is only supported for
@@ -121,29 +80,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deallocates a specific virtual machine in a VM scale set. Shuts down the
-            /// virtual machine and releases the compute resources it uses. You are not
-            /// billed for the compute resources of this virtual machine once it is
-            /// deallocated.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner Deallocate(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.DeallocateAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deallocates a specific virtual machine in a VM scale set. Shuts down the
             /// virtual machine and releases the compute resources it uses. You are not
@@ -173,26 +110,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a virtual machine from a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner Delete(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.DeleteAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a virtual machine from a VM scale set.
             /// </summary>
@@ -219,26 +137,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a virtual machine from a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static VirtualMachineScaleSetVMInner Get(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.GetAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a virtual machine from a VM scale set.
             /// </summary>
@@ -265,26 +164,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the status of a virtual machine from a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static VirtualMachineScaleSetVMInstanceViewInner GetInstanceView(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.GetInstanceViewAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the status of a virtual machine from a VM scale set.
             /// </summary>
@@ -311,29 +191,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of all virtual machines in a VM scale sets.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualMachineScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            /// <param name='select'>
-            /// The list parameters.
-            /// </param>
-            public static IPage<VirtualMachineScaleSetVMInner> List(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string virtualMachineScaleSetName, ODataQuery<VirtualMachineScaleSetVMInner> odataQuery = default(ODataQuery<VirtualMachineScaleSetVMInner>), string select = default(string))
-            {
-                return ((IVirtualMachineScaleSetVMsOperations)operations).ListAsync(resourceGroupName, virtualMachineScaleSetName, odataQuery, select).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of all virtual machines in a VM scale sets.
             /// </summary>
@@ -363,28 +221,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Power off (stop) a virtual machine in a VM scale set. Note that resources
-            /// are still attached and you are getting charged for the resources. Instead,
-            /// use deallocate to release resources and avoid charges.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner PowerOff(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.PowerOffAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Power off (stop) a virtual machine in a VM scale set. Note that resources
             /// are still attached and you are getting charged for the resources. Instead,
@@ -413,26 +250,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restarts a virtual machine in a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner Restart(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.RestartAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restarts a virtual machine in a VM scale set.
             /// </summary>
@@ -459,26 +277,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Starts a virtual machine in a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner Start(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.StartAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Starts a virtual machine in a VM scale set.
             /// </summary>
@@ -505,27 +304,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Reimages (upgrade the operating system) a specific virtual machine in a VM
-            /// scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginReimage(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.BeginReimageAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reimages (upgrade the operating system) a specific virtual machine in a VM
             /// scale set.
@@ -553,28 +332,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Allows you to re-image all the disks ( including data disks ) in the a
-            /// virtual machine scale set instance. This operation is only supported for
-            /// managed disks.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginReimageAll(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.BeginReimageAllAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Allows you to re-image all the disks ( including data disks ) in the a
             /// virtual machine scale set instance. This operation is only supported for
@@ -603,29 +361,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deallocates a specific virtual machine in a VM scale set. Shuts down the
-            /// virtual machine and releases the compute resources it uses. You are not
-            /// billed for the compute resources of this virtual machine once it is
-            /// deallocated.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginDeallocate(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.BeginDeallocateAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deallocates a specific virtual machine in a VM scale set. Shuts down the
             /// virtual machine and releases the compute resources it uses. You are not
@@ -655,26 +391,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a virtual machine from a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginDelete(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.BeginDeleteAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a virtual machine from a VM scale set.
             /// </summary>
@@ -701,28 +418,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Power off (stop) a virtual machine in a VM scale set. Note that resources
-            /// are still attached and you are getting charged for the resources. Instead,
-            /// use deallocate to release resources and avoid charges.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginPowerOff(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.BeginPowerOffAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Power off (stop) a virtual machine in a VM scale set. Note that resources
             /// are still attached and you are getting charged for the resources. Instead,
@@ -751,26 +447,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restarts a virtual machine in a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginRestart(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.BeginRestartAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restarts a virtual machine in a VM scale set.
             /// </summary>
@@ -797,26 +474,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Starts a virtual machine in a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceId'>
-            /// The instance ID of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginStart(this IVirtualMachineScaleSetVMsOperations operations, string resourceGroupName, string vmScaleSetName, string instanceId)
-            {
-                return operations.BeginStartAsync(resourceGroupName, vmScaleSetName, instanceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Starts a virtual machine in a VM scale set.
             /// </summary>
@@ -843,20 +501,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of all virtual machines in a VM scale sets.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VirtualMachineScaleSetVMInner> ListNext(this IVirtualMachineScaleSetVMsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of all virtual machines in a VM scale sets.
             /// </summary>

--- a/src/ResourceManagement/Compute/Generated/VirtualMachineScaleSetsOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/VirtualMachineScaleSetsOperationsExtensions.cs
@@ -24,26 +24,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class VirtualMachineScaleSetsOperationsExtensions
     {
-            /// <summary>
-            /// Create or update a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the VM scale set to create or update.
-            /// </param>
-            /// <param name='parameters'>
-            /// The scale set object.
-            /// </param>
-            public static VirtualMachineScaleSetInner CreateOrUpdate(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string name, VirtualMachineScaleSetInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, name, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a VM scale set.
             /// </summary>
@@ -70,28 +51,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deallocates specific virtual machines in a VM scale set. Shuts down the
-            /// virtual machines and releases the compute resources. You are not billed for
-            /// the compute resources that this virtual machine scale set deallocates.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner Deallocate(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds = default(IList<string>))
-            {
-                return operations.DeallocateAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deallocates specific virtual machines in a VM scale set. Shuts down the
             /// virtual machines and releases the compute resources. You are not billed for
@@ -120,23 +80,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            public static OperationStatusResponseInner Delete(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName)
-            {
-                return operations.DeleteAsync(resourceGroupName, vmScaleSetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a VM scale set.
             /// </summary>
@@ -160,23 +104,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Display information about a virtual machine scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            public static VirtualMachineScaleSetInner Get(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName)
-            {
-                return operations.GetAsync(resourceGroupName, vmScaleSetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Display information about a virtual machine scale set.
             /// </summary>
@@ -200,26 +128,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes virtual machines in a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner DeleteInstances(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds)
-            {
-                return operations.DeleteInstancesAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes virtual machines in a VM scale set.
             /// </summary>
@@ -246,23 +155,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the status of a VM scale set instance.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            public static VirtualMachineScaleSetInstanceViewInner GetInstanceView(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName)
-            {
-                return operations.GetInstanceViewAsync(resourceGroupName, vmScaleSetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the status of a VM scale set instance.
             /// </summary>
@@ -286,20 +179,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of all VM scale sets under a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<VirtualMachineScaleSetInner> List(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of all VM scale sets under a resource group.
             /// </summary>
@@ -320,20 +200,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of all VM Scale Sets in the subscription, regardless of the
-            /// associated resource group. Use nextLink property in the response to get the
-            /// next page of VM Scale Sets. Do this till nextLink is not null to fetch all
-            /// the VM Scale Sets.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<VirtualMachineScaleSetInner> ListAll(this IVirtualMachineScaleSetsOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of all VM Scale Sets in the subscription, regardless of the
             /// associated resource group. Use nextLink property in the response to get the
@@ -354,24 +221,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of SKUs available for your VM scale set, including the minimum
-            /// and maximum VM instances allowed for each SKU.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            public static IPage<VirtualMachineScaleSetSku> ListSkus(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName)
-            {
-                return operations.ListSkusAsync(resourceGroupName, vmScaleSetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of SKUs available for your VM scale set, including the minimum
             /// and maximum VM instances allowed for each SKU.
@@ -396,28 +246,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Power off (stop) one or more virtual machines in a VM scale set. Note that
-            /// resources are still attached and you are getting charged for the resources.
-            /// Instead, use deallocate to release resources and avoid charges.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner PowerOff(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds = default(IList<string>))
-            {
-                return operations.PowerOffAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Power off (stop) one or more virtual machines in a VM scale set. Note that
             /// resources are still attached and you are getting charged for the resources.
@@ -446,26 +275,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restarts one or more virtual machines in a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner Restart(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds = default(IList<string>))
-            {
-                return operations.RestartAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restarts one or more virtual machines in a VM scale set.
             /// </summary>
@@ -492,26 +302,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Starts one or more virtual machines in a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner Start(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds = default(IList<string>))
-            {
-                return operations.StartAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Starts one or more virtual machines in a VM scale set.
             /// </summary>
@@ -538,27 +329,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Upgrades one or more virtual machines to the latest SKU set in the VM scale
-            /// set model.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner UpdateInstances(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds)
-            {
-                return operations.UpdateInstancesAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Upgrades one or more virtual machines to the latest SKU set in the VM scale
             /// set model.
@@ -586,24 +357,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Reimages (upgrade the operating system) one or more virtual machines in a
-            /// VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            public static OperationStatusResponseInner Reimage(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName)
-            {
-                return operations.ReimageAsync(resourceGroupName, vmScaleSetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reimages (upgrade the operating system) one or more virtual machines in a
             /// VM scale set.
@@ -628,25 +382,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Reimages all the disks ( including data disks ) in the virtual machines in
-            /// a virtual machine scale set. This operation is only supported for managed
-            /// disks.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            public static OperationStatusResponseInner ReimageAll(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName)
-            {
-                return operations.ReimageAllAsync(resourceGroupName, vmScaleSetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reimages all the disks ( including data disks ) in the virtual machines in
             /// a virtual machine scale set. This operation is only supported for managed
@@ -672,26 +408,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or update a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the VM scale set to create or update.
-            /// </param>
-            /// <param name='parameters'>
-            /// The scale set object.
-            /// </param>
-            public static VirtualMachineScaleSetInner BeginCreateOrUpdate(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string name, VirtualMachineScaleSetInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, name, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a VM scale set.
             /// </summary>
@@ -718,28 +435,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deallocates specific virtual machines in a VM scale set. Shuts down the
-            /// virtual machines and releases the compute resources. You are not billed for
-            /// the compute resources that this virtual machine scale set deallocates.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner BeginDeallocate(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds = default(IList<string>))
-            {
-                return operations.BeginDeallocateAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deallocates specific virtual machines in a VM scale set. Shuts down the
             /// virtual machines and releases the compute resources. You are not billed for
@@ -768,23 +464,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            public static OperationStatusResponseInner BeginDelete(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName)
-            {
-                return operations.BeginDeleteAsync(resourceGroupName, vmScaleSetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a VM scale set.
             /// </summary>
@@ -808,26 +488,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes virtual machines in a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner BeginDeleteInstances(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds)
-            {
-                return operations.BeginDeleteInstancesAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes virtual machines in a VM scale set.
             /// </summary>
@@ -854,28 +515,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Power off (stop) one or more virtual machines in a VM scale set. Note that
-            /// resources are still attached and you are getting charged for the resources.
-            /// Instead, use deallocate to release resources and avoid charges.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner BeginPowerOff(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds = default(IList<string>))
-            {
-                return operations.BeginPowerOffAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Power off (stop) one or more virtual machines in a VM scale set. Note that
             /// resources are still attached and you are getting charged for the resources.
@@ -904,26 +544,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Restarts one or more virtual machines in a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner BeginRestart(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds = default(IList<string>))
-            {
-                return operations.BeginRestartAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Restarts one or more virtual machines in a VM scale set.
             /// </summary>
@@ -950,26 +571,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Starts one or more virtual machines in a VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner BeginStart(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds = default(IList<string>))
-            {
-                return operations.BeginStartAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Starts one or more virtual machines in a VM scale set.
             /// </summary>
@@ -996,27 +598,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Upgrades one or more virtual machines to the latest SKU set in the VM scale
-            /// set model.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            /// <param name='instanceIds'>
-            /// The virtual machine scale set instance ids.
-            /// </param>
-            public static OperationStatusResponseInner BeginUpdateInstances(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName, IList<string> instanceIds)
-            {
-                return operations.BeginUpdateInstancesAsync(resourceGroupName, vmScaleSetName, instanceIds).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Upgrades one or more virtual machines to the latest SKU set in the VM scale
             /// set model.
@@ -1044,24 +626,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Reimages (upgrade the operating system) one or more virtual machines in a
-            /// VM scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            public static OperationStatusResponseInner BeginReimage(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName)
-            {
-                return operations.BeginReimageAsync(resourceGroupName, vmScaleSetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reimages (upgrade the operating system) one or more virtual machines in a
             /// VM scale set.
@@ -1086,25 +651,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Reimages all the disks ( including data disks ) in the virtual machines in
-            /// a virtual machine scale set. This operation is only supported for managed
-            /// disks.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmScaleSetName'>
-            /// The name of the VM scale set.
-            /// </param>
-            public static OperationStatusResponseInner BeginReimageAll(this IVirtualMachineScaleSetsOperations operations, string resourceGroupName, string vmScaleSetName)
-            {
-                return operations.BeginReimageAllAsync(resourceGroupName, vmScaleSetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reimages all the disks ( including data disks ) in the virtual machines in
             /// a virtual machine scale set. This operation is only supported for managed
@@ -1130,20 +677,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of all VM scale sets under a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VirtualMachineScaleSetInner> ListNext(this IVirtualMachineScaleSetsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of all VM scale sets under a resource group.
             /// </summary>
@@ -1164,23 +698,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of all VM Scale Sets in the subscription, regardless of the
-            /// associated resource group. Use nextLink property in the response to get the
-            /// next page of VM Scale Sets. Do this till nextLink is not null to fetch all
-            /// the VM Scale Sets.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VirtualMachineScaleSetInner> ListAllNext(this IVirtualMachineScaleSetsOperations operations, string nextPageLink)
-            {
-                return operations.ListAllNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of all VM Scale Sets in the subscription, regardless of the
             /// associated resource group. Use nextLink property in the response to get the
@@ -1204,21 +722,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of SKUs available for your VM scale set, including the minimum
-            /// and maximum VM instances allowed for each SKU.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VirtualMachineScaleSetSku> ListSkusNext(this IVirtualMachineScaleSetsOperations operations, string nextPageLink)
-            {
-                return operations.ListSkusNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of SKUs available for your VM scale set, including the minimum
             /// and maximum VM instances allowed for each SKU.

--- a/src/ResourceManagement/Compute/Generated/VirtualMachineSizesOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/VirtualMachineSizesOperationsExtensions.cs
@@ -24,20 +24,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class VirtualMachineSizesOperationsExtensions
     {
-            /// <summary>
-            /// Lists all available virtual machine sizes for a subscription in a location.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// The location upon which virtual-machine-sizes is queried.
-            /// </param>
-            public static IEnumerable<VirtualMachineSize> List(this IVirtualMachineSizesOperations operations, string location)
-            {
-                return operations.ListAsync(location).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all available virtual machine sizes for a subscription in a location.
             /// </summary>

--- a/src/ResourceManagement/Compute/Generated/VirtualMachinesOperationsExtensions.cs
+++ b/src/ResourceManagement/Compute/Generated/VirtualMachinesOperationsExtensions.cs
@@ -24,27 +24,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     /// </summary>
     public static partial class VirtualMachinesOperationsExtensions
     {
-            /// <summary>
-            /// Captures the VM by copying virtual hard disks of the VM and outputs a
-            /// template that can be used to create similar VMs.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Capture Virtual Machine operation.
-            /// </param>
-            public static VirtualMachineCaptureResultInner Capture(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName, VirtualMachineCaptureParametersInner parameters)
-            {
-                return operations.CaptureAsync(resourceGroupName, vmName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Captures the VM by copying virtual hard disks of the VM and outputs a
             /// template that can be used to create similar VMs.
@@ -72,26 +52,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to create or update a virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Create Virtual Machine operation.
-            /// </param>
-            public static VirtualMachineInner CreateOrUpdate(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName, VirtualMachineInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, vmName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to create or update a virtual machine.
             /// </summary>
@@ -118,23 +79,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to delete a virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner Delete(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.DeleteAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to delete a virtual machine.
             /// </summary>
@@ -158,28 +103,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Retrieves information about the model view or the instance view of a
-            /// virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            /// <param name='expand'>
-            /// The expand expression to apply on the operation. Possible values include:
-            /// 'instanceView'
-            /// </param>
-            public static VirtualMachineInner Get(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName, InstanceViewTypes? expand = default(InstanceViewTypes?))
-            {
-                return operations.GetAsync(resourceGroupName, vmName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Retrieves information about the model view or the instance view of a
             /// virtual machine.
@@ -208,24 +132,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Converts virtual machine disks from blob-based to managed disks. Virtual
-            /// machine must be stop-deallocated before invoking this operation.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner ConvertToManagedDisks(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.ConvertToManagedDisksAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Converts virtual machine disks from blob-based to managed disks. Virtual
             /// machine must be stop-deallocated before invoking this operation.
@@ -250,24 +157,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Shuts down the virtual machine and releases the compute resources. You are
-            /// not billed for the compute resources that this virtual machine uses.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner Deallocate(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.DeallocateAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Shuts down the virtual machine and releases the compute resources. You are
             /// not billed for the compute resources that this virtual machine uses.
@@ -292,23 +182,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Sets the state of the virtual machine to generalized.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner Generalize(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.GeneralizeAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Sets the state of the virtual machine to generalized.
             /// </summary>
@@ -332,21 +206,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the virtual machines in the specified resource group. Use the
-            /// nextLink property in the response to get the next page of virtual machines.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<VirtualMachineInner> List(this IVirtualMachinesOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the virtual machines in the specified resource group. Use the
             /// nextLink property in the response to get the next page of virtual machines.
@@ -368,18 +228,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the virtual machines in the specified subscription. Use the
-            /// nextLink property in the response to get the next page of virtual machines.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<VirtualMachineInner> ListAll(this IVirtualMachinesOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the virtual machines in the specified subscription. Use the
             /// nextLink property in the response to get the next page of virtual machines.
@@ -398,24 +247,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all available virtual machine sizes to which the specified virtual
-            /// machine can be resized.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static IEnumerable<VirtualMachineSize> ListAvailableSizes(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.ListAvailableSizesAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all available virtual machine sizes to which the specified virtual
             /// machine can be resized.
@@ -440,25 +272,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to power off (stop) a virtual machine. The virtual machine
-            /// can be restarted with the same provisioned resources. You are still charged
-            /// for this virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner PowerOff(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.PowerOffAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to power off (stop) a virtual machine. The virtual machine
             /// can be restarted with the same provisioned resources. You are still charged
@@ -484,23 +298,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to restart a virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner Restart(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.RestartAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to restart a virtual machine.
             /// </summary>
@@ -524,23 +322,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to start a virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner Start(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.StartAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to start a virtual machine.
             /// </summary>
@@ -564,23 +346,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to redeploy a virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner Redeploy(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.RedeployAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to redeploy a virtual machine.
             /// </summary>
@@ -604,27 +370,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Captures the VM by copying virtual hard disks of the VM and outputs a
-            /// template that can be used to create similar VMs.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Capture Virtual Machine operation.
-            /// </param>
-            public static VirtualMachineCaptureResultInner BeginCapture(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName, VirtualMachineCaptureParametersInner parameters)
-            {
-                return operations.BeginCaptureAsync(resourceGroupName, vmName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Captures the VM by copying virtual hard disks of the VM and outputs a
             /// template that can be used to create similar VMs.
@@ -652,26 +398,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to create or update a virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Create Virtual Machine operation.
-            /// </param>
-            public static VirtualMachineInner BeginCreateOrUpdate(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName, VirtualMachineInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, vmName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to create or update a virtual machine.
             /// </summary>
@@ -698,23 +425,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to delete a virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginDelete(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.BeginDeleteAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to delete a virtual machine.
             /// </summary>
@@ -738,24 +449,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Converts virtual machine disks from blob-based to managed disks. Virtual
-            /// machine must be stop-deallocated before invoking this operation.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginConvertToManagedDisks(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.BeginConvertToManagedDisksAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Converts virtual machine disks from blob-based to managed disks. Virtual
             /// machine must be stop-deallocated before invoking this operation.
@@ -780,24 +474,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Shuts down the virtual machine and releases the compute resources. You are
-            /// not billed for the compute resources that this virtual machine uses.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginDeallocate(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.BeginDeallocateAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Shuts down the virtual machine and releases the compute resources. You are
             /// not billed for the compute resources that this virtual machine uses.
@@ -822,25 +499,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to power off (stop) a virtual machine. The virtual machine
-            /// can be restarted with the same provisioned resources. You are still charged
-            /// for this virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginPowerOff(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.BeginPowerOffAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to power off (stop) a virtual machine. The virtual machine
             /// can be restarted with the same provisioned resources. You are still charged
@@ -866,23 +525,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to restart a virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginRestart(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.BeginRestartAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to restart a virtual machine.
             /// </summary>
@@ -906,23 +549,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to start a virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginStart(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.BeginStartAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to start a virtual machine.
             /// </summary>
@@ -946,23 +573,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// The operation to redeploy a virtual machine.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='vmName'>
-            /// The name of the virtual machine.
-            /// </param>
-            public static OperationStatusResponseInner BeginRedeploy(this IVirtualMachinesOperations operations, string resourceGroupName, string vmName)
-            {
-                return operations.BeginRedeployAsync(resourceGroupName, vmName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The operation to redeploy a virtual machine.
             /// </summary>
@@ -986,21 +597,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the virtual machines in the specified resource group. Use the
-            /// nextLink property in the response to get the next page of virtual machines.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VirtualMachineInner> ListNext(this IVirtualMachinesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the virtual machines in the specified resource group. Use the
             /// nextLink property in the response to get the next page of virtual machines.
@@ -1022,21 +619,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the virtual machines in the specified subscription. Use the
-            /// nextLink property in the response to get the next page of virtual machines.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VirtualMachineInner> ListAllNext(this IVirtualMachinesOperations operations, string nextPageLink)
-            {
-                return operations.ListAllNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the virtual machines in the specified subscription. Use the
             /// nextLink property in the response to get the next page of virtual machines.

--- a/src/ResourceManagement/Compute/LinuxDiskVolumeEncryptionMonitorImpl.cs
+++ b/src/ResourceManagement/Compute/LinuxDiskVolumeEncryptionMonitorImpl.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:FF7924BFEF46CE7F250D6F5B1A727744
         public IDiskVolumeEncryptionMonitor Refresh()
         {
-            return RefreshAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return ResourceManager.Fluent.Core.Extensions.Synchronize(() => RefreshAsync());
         }
 
         /// <return>The instance view status collection associated with the encryption extension.</return>

--- a/src/ResourceManagement/Compute/SnapshotImpl.cs
+++ b/src/ResourceManagement/Compute/SnapshotImpl.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using System.Threading.Tasks;
     using Models;
     using ResourceManager.Fluent;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     /// <summary>
     /// The implementation for Snapshot and its create and update interfaces.
@@ -107,7 +108,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:DAC486F08AF23F259E630032FC20FAF1:3FE53F300A729DFBC3C1F55BBB117CA1
         public string GrantAccess(int accessDurationInSeconds)
         {
-            return this.GrantAccessAsync(accessDurationInSeconds).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.GrantAccessAsync(accessDurationInSeconds));
         }
 
         ///GENMHASH:0305227D84160F6D01FAC3F90C4D3B17:B17E3BD9F6452F930B5081BFB28B816E
@@ -236,7 +237,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:C14080365CC6F93E30BB51B78DED7084:769384CE5F12D8DA31D146E04DAD108F
         public void RevokeAccess()
         {
-            RevokeAccessAsync().GetAwaiter().GetResult();
+            Extensions.Synchronize(() => RevokeAccessAsync());
         }
 
         ///GENMHASH:920045A2761D4D5D5F5E2E52D43917D0:28B657BB52464897349F96AD3FEE7B7C

--- a/src/ResourceManagement/Compute/SnapshotsImpl.cs
+++ b/src/ResourceManagement/Compute/SnapshotsImpl.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:C2E2A5650639245BC0993A33DCAA5D61:4AB1078BF23153C40209095ABAF6C89C
         public string GrantAccess(string resourceGroupName, string snapshotName, AccessLevel accessLevel, int accessDuration)
         {
-            return this.GrantAccessAsync(resourceGroupName, snapshotName, accessLevel, accessDuration).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.GrantAccessAsync(resourceGroupName, snapshotName, accessLevel, accessDuration));
         }
 
         ///GENMHASH:C2E2A5650639245BC0993A33DCAA5D61:7697FA7DB7AB14465F345F0D9BFABB88

--- a/src/ResourceManagement/Compute/SnapshotsImpl.cs
+++ b/src/ResourceManagement/Compute/SnapshotsImpl.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:1BCE81BDD651175D2AF64E39F4F2C420:E28682D27CF6E0619DBC893BDB64CB37
         public void RevokeAccess(string resourceGroupName, string snapName)
         {
-            this.Inner.RevokeAccess(resourceGroupName, snapName);
+            Extensions.Synchronize(() => this.Inner.RevokeAccessAsync(resourceGroupName, snapName));
         }
 
         ///GENMHASH:1BCE81BDD651175D2AF64E39F4F2C420:BFFE56CE1D59C3CA9284FED6EC0BD4DE

--- a/src/ResourceManagement/Compute/VirtualMachineEncryptionImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineEncryptionImpl.cs
@@ -5,11 +5,12 @@ namespace Microsoft.Azure.Management.Compute.Fluent
     using System.Threading;
     using System.Threading.Tasks;
     using Models;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     /// <summary>
     /// Implementation of VirtualMachineEncryption.
     /// </summary>
-///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmNvbXB1dGUuaW1wbGVtZW50YXRpb24uVmlydHVhbE1hY2hpbmVFbmNyeXB0aW9uSW1wbA==
+    ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LmNvbXB1dGUuaW1wbGVtZW50YXRpb24uVmlydHVhbE1hY2hpbmVFbmNyeXB0aW9uSW1wbA==
     internal partial class VirtualMachineEncryptionImpl  :
         IVirtualMachineEncryption
     {
@@ -51,25 +52,25 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:E41DD646C1F7D0458D57765D5AA21BD2:1A8F2584537929C0B602DAC8BEA90F0A
         public IDiskVolumeEncryptionMonitor Enable(string keyVaultId, string aadClientId, string aadSecret)
         {
-            return EnableAsync(keyVaultId, aadClientId, aadSecret).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => EnableAsync(keyVaultId, aadClientId, aadSecret));
         }
 
         ///GENMHASH:9D6DD1865EFFEE09432AB8D009095748:DC1C703A2CBB98499CF5B5775B6772AA
         public IDiskVolumeEncryptionMonitor Enable(WindowsVMDiskEncryptionConfiguration encryptionSettings)
         {
-            return EnableAsync(encryptionSettings).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => EnableAsync(encryptionSettings));
         }
 
         ///GENMHASH:B90504B6DA9457416BB33BED5A9AA699:DC1C703A2CBB98499CF5B5775B6772AA
         public IDiskVolumeEncryptionMonitor Enable(LinuxVMDiskEncryptionConfiguration encryptionSettings)
         {
-            return EnableAsync(encryptionSettings).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => EnableAsync(encryptionSettings));
         }
 
         ///GENMHASH:111E7E7282F1AF5C0D13E925EE81F501:FBB9648A0907B504CC31792F37E4880E
         public IDiskVolumeEncryptionMonitor Disable(DiskVolumeType volumeType)
         {
-            return DisableAsync(volumeType).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => DisableAsync(volumeType));
         }
 
         ///GENMHASH:63180E26DE0748370CBF1E688F400DA7:5A16D5F74FDBF1874F9D0EA507F123B3
@@ -100,7 +101,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:C6ABD3D452DBDFE8506CA443FC27C3BF:D1A986AAA62E86256065FD08F6B69054
         public IDiskVolumeEncryptionMonitor GetMonitor()
         {
-            return GetMonitorAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetMonitorAsync());
         }
     }
 }

--- a/src/ResourceManagement/Compute/VirtualMachineExtensionImageTypesImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineExtensionImageTypesImpl.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:59EB64D540FD3901775AB588B47D36A4
         public IEnumerable<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineExtensionImageType> List()
         {
-            return WrapList(this.client.ListTypes(this.publisher.Region.Name, this.publisher.Name));
+            return WrapList(Extensions.Synchronize(() => this.client.ListTypesAsync(this.publisher.Region.Name, this.publisher.Name)));
         }
 
         public async Task<IPagedCollection<IVirtualMachineExtensionImageType>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/Compute/VirtualMachineExtensionImageVersionImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineExtensionImageVersionImpl.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:CAE7C5956C89A3353EA5E0FC6E8AD675:39D1FBA4A37519D7E29877939A31F436
         public IVirtualMachineExtensionImage GetImage()
         {
-            VirtualMachineExtensionImageInner inner = this.client.Get(this.RegionName(),
+            VirtualMachineExtensionImageInner inner = Extensions.Synchronize(() => this.client.GetAsync(this.RegionName(),
                 this.Type().Publisher.Name,
                 this.Type().Name,
-                this.Name());
+                this.Name()));
             return new VirtualMachineExtensionImageImpl(this, inner);
         }
 

--- a/src/ResourceManagement/Compute/VirtualMachineExtensionImageVersionsImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineExtensionImageVersionsImpl.cs
@@ -29,10 +29,10 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:DE7A9E25A3A0DA8C686B167840FC2C68
         public IEnumerable<IVirtualMachineExtensionImageVersion> List()
         {
-            return WrapList(this.client.ListVersions(
+            return WrapList(Extensions.Synchronize(() => this.client.ListVersionsAsync(
                 type.RegionName,
                 type.Publisher.Name,
-                type.Name));
+                type.Name)));
         }
 
         public async Task<IPagedCollection<IVirtualMachineExtensionImageVersion>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/Compute/VirtualMachineExtensionImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineExtensionImpl.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:955D294F6E1F6B9054F1EABE1AE05EA2:3B40334C37474720957E6C6B24FC2D63
         public VirtualMachineExtensionInstanceView GetInstanceView()
         {
-            return GetInstanceViewAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return ResourceManager.Fluent.Core.Extensions.Synchronize(() => GetInstanceViewAsync());
         }
     }
 }

--- a/src/ResourceManagement/Compute/VirtualMachineExtensionsImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineExtensionsImpl.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:310B2185D2F2431DF2BBDBC06E585C74:F003E4397C7BD6AC051C07C6076BF2D5
         public IReadOnlyDictionary<string, IVirtualMachineExtension> AsMap()
         {
-            return this.AsMapAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.AsMapAsync());
         }
 
         /// <summary>

--- a/src/ResourceManagement/Compute/VirtualMachineImagesImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineImagesImpl.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:A5C3605D6EBCBFB12152B28DBA2D191F:78A0104FC3E1707F4CA255D832A69FFD
         public IVirtualMachineImage GetImage(Region region, string publisherName, string offerName, string skuName, string version)
         {
-            VirtualMachineImageInner innerImage = this.client.Get(region.Name,
-                publisherName, offerName, skuName, version);
+            VirtualMachineImageInner innerImage = Extensions.Synchronize(() => this.client.GetAsync(
+                region.Name, publisherName, offerName, skuName, version));
             if (innerImage == null)
             {
                 return null;
@@ -42,8 +42,8 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:A5C3605D6EBCBFB12152B28DBA2D191F:78A0104FC3E1707F4CA255D832A69FFD
         public IVirtualMachineImage GetImage(string region, string publisherName, string offerName, string skuName, string version)
         {
-            VirtualMachineImageInner innerImage = this.client.Get(region,
-                publisherName, offerName, skuName, version);
+            VirtualMachineImageInner innerImage = Extensions.Synchronize(() => this.client.GetAsync(region,
+                publisherName, offerName, skuName, version));
             if (innerImage == null)
             {
                 return null;

--- a/src/ResourceManagement/Compute/VirtualMachineImagesInSkuImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineImagesInSkuImpl.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         public IEnumerable<IVirtualMachineImage> List()
         {
             List<IVirtualMachineImage> firstPage = new List<IVirtualMachineImage>();
-            var innerImages = innerCollection.List(sku.Region.Name, sku.Publisher.Name, sku.Offer.Name, sku.Name);
+            var innerImages = Extensions.Synchronize(() => innerCollection.ListAsync(sku.Region.Name, sku.Publisher.Name, sku.Offer.Name, sku.Name));
 
             foreach(var innerImage in innerImages)
             {
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                     sku.Offer.Name,
                     sku.Name,
                     version,
-                    innerCollection.Get(sku.Region.Name, sku.Publisher.Name, sku.Offer.Name, sku.Name, version)));
+                    Extensions.Synchronize(() => innerCollection.GetAsync(sku.Region.Name, sku.Publisher.Name, sku.Offer.Name, sku.Name, version))));
             }
             return firstPage;
         }

--- a/src/ResourceManagement/Compute/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineImpl.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:F5949CB4AFA8DD0B8DED0F369B12A8F6:6AC69BE8BE090CDE9822C84DD5F906F3
         public VirtualMachineInstanceView RefreshInstanceView()
         {
-            return RefreshInstanceViewAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => RefreshInstanceViewAsync());
         }
 
         ///GENMHASH:D97B6272C7E7717C00D4F9B818A713C0:8DD09B90F0555BB3E1AEF7B9AF044379
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:1F383B6B989059B78D6ECB949E789CD4:D3D812C91301FB29508197FA8534CDDC
         public string Capture(string containerName, string vhdPrefix, bool overwriteVhd)
         {
-            return this.CaptureAsync(containerName, vhdPrefix, overwriteVhd).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.CaptureAsync(containerName, vhdPrefix, overwriteVhd));
         }
 
         ///GENMHASH:C345130B595C0FF585A57651EFDC3A0F:E97CAC99D13041F7FEAACC7E4508DC7B

--- a/src/ResourceManagement/Compute/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineImpl.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:667E734583F577A898C6389A3D9F4C09:B1A3725E3B60B26D7F37CA7ABFE371B0
         public void Deallocate()
         {
-            Manager.Inner.VirtualMachines.Deallocate(this.ResourceGroupName, this.Name);
+            Extensions.Synchronize(() => Manager.Inner.VirtualMachines.DeallocateAsync(this.ResourceGroupName, this.Name));
             Refresh();
         }
 
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:0745971EF3F2CE7276C7E535722C5E6C:F7A7B3A36B61441CF0850BDE432A2805
         public void Generalize()
         {
-            Manager.Inner.VirtualMachines.Generalize(this.ResourceGroupName, this.Name);
+            Extensions.Synchronize(() => Manager.Inner.VirtualMachines.GeneralizeAsync(this.ResourceGroupName, this.Name));
         }
 
         public async Task GeneralizeAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:8761D0D225B7C49A7A5025186E94B263:21AAF0008CE6CF3F9846F2DFE1CBEBCB
         public void PowerOff()
         {
-            Manager.Inner.VirtualMachines.PowerOff(this.ResourceGroupName, this.Name);
+            Extensions.Synchronize(() => Manager.Inner.VirtualMachines.PowerOffAsync(this.ResourceGroupName, this.Name));
         }
 
         public async Task PowerOffAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:08CFC096AC6388D1C0E041ECDF099E3D:4479808A1E2B2A23538E662AD3F721EE
         public void Restart()
         {
-            Manager.Inner.VirtualMachines.Restart(this.ResourceGroupName, this.Name);
+            Extensions.Synchronize(() => Manager.Inner.VirtualMachines.RestartAsync(this.ResourceGroupName, this.Name));
         }
 
         public async Task RestartAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:0F38250A3837DF9C2C345D4A038B654B:5723E041D4826DFBE50B8B49C31EAF08
         public void Start()
         {
-            Manager.Inner.VirtualMachines.Start(this.ResourceGroupName, this.Name);
+            Extensions.Synchronize(() => Manager.Inner.VirtualMachines.StartAsync(this.ResourceGroupName, this.Name));
         }
 
         public async Task StartAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -191,8 +191,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:D9EB75AF88B1A07EDC0965B26A7F7C04:E30F1E083D68AA7A68C7128405BA3741
         public void Redeploy()
         {
-            Manager.Inner.VirtualMachines.Redeploy(this.ResourceGroupName, this.Name);
-
+            Extensions.Synchronize(() => Manager.Inner.VirtualMachines.RedeployAsync(this.ResourceGroupName, this.Name));
         }
 
         public async Task RedeployAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -217,7 +216,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:842FBE4DCB8BFE1B50632DBBE157AEA8:B5262187B60CE486998F800E9A96B659
         public IEnumerable<Microsoft.Azure.Management.Compute.Fluent.IVirtualMachineSize> AvailableSizes()
         {
-            return Manager.Inner.VirtualMachines.ListAvailableSizes(this.ResourceGroupName,this.Name)
+            return Extensions.Synchronize(() => Manager.Inner.VirtualMachines.ListAvailableSizesAsync(this.ResourceGroupName,this.Name))
                 .Select(inner => new VirtualMachineSizeImpl(inner));
         }
 

--- a/src/ResourceManagement/Compute/VirtualMachineOffersImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineOffersImpl.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:CF6916AB824B8B57D0C4089778CE6C55
         public IEnumerable<IVirtualMachineOffer> List()
         {
-            return WrapList(innerCollection.ListOffers(publisher.Region.Name, publisher.Name));
+            return WrapList(Extensions.Synchronize(() => innerCollection.ListOffersAsync(publisher.Region.Name, publisher.Name)));
         }
 
         public async Task<IPagedCollection<IVirtualMachineOffer>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/Compute/VirtualMachinePublishersImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachinePublishersImpl.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:360BB74037893879A730ED7ED0A3938A:0812389C333714A6DDA6CD76F7B8FEFC
         public IEnumerable<IVirtualMachinePublisher> ListByRegion(string regionName)
         {
-            return WrapList(innerCollection.ListPublishers(regionName));
+            return WrapList(Extensions.Synchronize(() => innerCollection.ListPublishersAsync(regionName)));
         }
 
         ///GENMHASH:2ED29FF482F2137640A1CA66925828A8:FDF416505062C8F51CBE651942F05701

--- a/src/ResourceManagement/Compute/VirtualMachineScaleSetImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineScaleSetImpl.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:8761D0D225B7C49A7A5025186E94B263:21AAF0008CE6CF3F9846F2DFE1CBEBCB
         public void PowerOff()
         {
-            Manager.Inner.VirtualMachineScaleSets.PowerOff(ResourceGroupName, Name);
+            Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => Manager.Inner.VirtualMachineScaleSets.PowerOffAsync(ResourceGroupName, Name));
         }
 
         public async Task PowerOffAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:667E734583F577A898C6389A3D9F4C09:B1A3725E3B60B26D7F37CA7ABFE371B0
         public void Deallocate()
         {
-            Manager.Inner.VirtualMachineScaleSets.Deallocate(this.ResourceGroupName, this.Name);
+            Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => Manager.Inner.VirtualMachineScaleSets.DeallocateAsync(this.ResourceGroupName, this.Name));
             Refresh();
         }
 
@@ -703,7 +703,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:08CFC096AC6388D1C0E041ECDF099E3D:4479808A1E2B2A23538E662AD3F721EE
         public void Restart()
         {
-            Manager.Inner.VirtualMachineScaleSets.Restart(this.ResourceGroupName, this.Name);
+            Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => Manager.Inner.VirtualMachineScaleSets.RestartAsync(this.ResourceGroupName, this.Name));
         }
 
         public async Task RestartAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -1355,8 +1355,8 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:CAFE3044E63DB355E0097F6FD22A0282:600739A4DD068DBA0CF85CC076E9111F
         public IEnumerable<IVirtualMachineScaleSetSku> ListAvailableSkus()
         {
-            return Manager.Inner.VirtualMachineScaleSets.ListSkus(ResourceGroupName, Name)
-                   .AsContinuousCollection(link => Manager.Inner.VirtualMachineScaleSets.ListSkusNext(link))
+            return Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => Manager.Inner.VirtualMachineScaleSets.ListSkusAsync(ResourceGroupName, Name))
+                   .AsContinuousCollection(link => Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => Manager.Inner.VirtualMachineScaleSets.ListSkusNextAsync(link)))
                    .Select(inner => new VirtualMachineScaleSetSkuImpl(inner));
         }
 
@@ -1669,7 +1669,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:DB561BC9EF939094412065B65EB3D2EA:323D5930D438D7B746B03A2AB231B061
         public void Reimage()
         {
-            Manager.Inner.VirtualMachineScaleSets.Reimage(ResourceGroupName, Name);
+            Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => Manager.Inner.VirtualMachineScaleSets.ReimageAsync(ResourceGroupName, Name));
         }
         public async Task ReimageAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -1943,7 +1943,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:0F38250A3837DF9C2C345D4A038B654B:5723E041D4826DFBE50B8B49C31EAF08
         public void Start()
         {
-            Manager.Inner.VirtualMachineScaleSets.Start(ResourceGroupName, Name);
+            Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => Manager.Inner.VirtualMachineScaleSets.StartAsync(ResourceGroupName, Name));
         }
 
         public async Task StartAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/Compute/VirtualMachineScaleSetVMImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineScaleSetVMImpl.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:8761D0D225B7C49A7A5025186E94B263:BA170CE7D8B4381095CF80F0B121B545
         public void PowerOff()
         {
-            this.PowerOffAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            ResourceManager.Fluent.Core.Extensions.Synchronize(() => this.PowerOffAsync());
         }
 
         ///GENMHASH:F5949CB4AFA8DD0B8DED0F369B12A8F6:E8FB723EB69B1FF154465213A3298460
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:667E734583F577A898C6389A3D9F4C09:E31C3E6AAB81275E957AEE7FFC644CBF
         public void Deallocate()
         {
-            this.DeallocateAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            ResourceManager.Fluent.Core.Extensions.Synchronize(() => this.DeallocateAsync());
         }
 
         ///GENMHASH:C6D786A0345B2C4ADB349E573A0BF6C7:424FABAED1A1FB32529BDB97BA59F68B
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:65E6085BB9054A86F6A84772E3F5A9EC:3AF56414924A2B5C8018E43635C23E6D
         public void Delete()
         {
-            DeleteAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            ResourceManager.Fluent.Core.Extensions.Synchronize(() => DeleteAsync());
         }
 
         ///GENMHASH:84A1C38F299C7713046CF6F1527D8F63:1B67F25B1C5584321081FAB1AF143179
@@ -409,7 +409,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:DB561BC9EF939094412065B65EB3D2EA:EE9FAF4FEA996048F4927C08CF0BBB9F
         public void Reimage()
         {
-            this.ReimageAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            ResourceManager.Fluent.Core.Extensions.Synchronize(() => this.ReimageAsync());
         }
 
         ///GENMHASH:8DDA5FB2E9E6E0697D0969997C1BE9C4:9DD8966D7074391F9512E63BBEB93FA9
@@ -483,13 +483,13 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:08CFC096AC6388D1C0E041ECDF099E3D:8DC054450782B914522C4E063E233AAE
         public void Restart()
         {
-            this.RestartAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            ResourceManager.Fluent.Core.Extensions.Synchronize(() => this.RestartAsync());
         }
 
         ///GENMHASH:0F38250A3837DF9C2C345D4A038B654B:0E335374306A3050322A5D1E4C468CF8
         public void Start()
         {
-            this.StartAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            ResourceManager.Fluent.Core.Extensions.Synchronize(() => this.StartAsync());
         }
 
         ///GENMHASH:882F1CC2224D95370B7A4269ED87EC4F:FA558C03B2F8DB0C8883E9CE9D380464
@@ -504,7 +504,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:44ACDDF0B04148CC3F9347EA7C0643B4
         public IVirtualMachineScaleSetVM Refresh()
         {
-            return RefreshAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return ResourceManager.Fluent.Core.Extensions.Synchronize(() => RefreshAsync());
         }
         public async Task<IVirtualMachineScaleSetVM> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/src/ResourceManagement/Compute/VirtualMachineScaleSetVMImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineScaleSetVMImpl.cs
@@ -54,10 +54,10 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:F5949CB4AFA8DD0B8DED0F369B12A8F6:E8FB723EB69B1FF154465213A3298460
         public VirtualMachineInstanceView RefreshInstanceView()
         {
-            VirtualMachineScaleSetVMInstanceViewInner instanceViewInner = Parent.Manager.Inner.VirtualMachineScaleSetVMs.GetInstanceView(
+            VirtualMachineScaleSetVMInstanceViewInner instanceViewInner = Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => Parent.Manager.Inner.VirtualMachineScaleSetVMs.GetInstanceViewAsync(
                 Parent.ResourceGroupName,
                 Parent.Name,
-                InstanceId());
+                InstanceId()));
 
             if (instanceViewInner != null) {
                 this.virtualMachineInstanceView = new VirtualMachineInstanceView()

--- a/src/ResourceManagement/Compute/VirtualMachineScaleSetVMsImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineScaleSetVMsImpl.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:1AA7BDC7AB6868AA92F095AC7974525B
         public IEnumerable<IVirtualMachineScaleSetVM> List()
         {
-            return WrapList(Inner.List(scaleSet.ResourceGroupName,this.scaleSet.Name)
-                .AsContinuousCollection(link => Inner.ListNext(link)));
+            return WrapList(Extensions.Synchronize(() => Inner.ListAsync(scaleSet.ResourceGroupName,this.scaleSet.Name))
+                .AsContinuousCollection(link => Extensions.Synchronize(() => Inner.ListNextAsync(link))));
         }
 
         ///GENMHASH:3231F2649B87EC1E21076533D17E37D1:3FD352500A8609B35E39BD6C990FFB4D

--- a/src/ResourceManagement/Compute/VirtualMachineScaleSetsImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineScaleSetsImpl.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:2048E8AC80AC022225C462CE7FD14A6F:AB513A3D7E5B1192B76F853CB23CBB12
         public void Deallocate(string groupName, string name)
         {
-            this.Inner.Deallocate(groupName, name);
+            Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => this.Inner.DeallocateAsync(groupName, name));
         }
 
         ///GENMHASH:9F1310A4445A183902C9AF672DA34354:F32BEF843CE33ABB858763CFD92B9A36
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:9F1310A4445A183902C9AF672DA34354:F32BEF843CE33ABB858763CFD92B9A36
         public void PowerOff(string groupName, string name)
         {
-            this.Inner.PowerOff(groupName, name);
+            Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => this.Inner.PowerOffAsync(groupName, name));
         }
 
         ///GENMHASH:CD0E967F30C27C522C0DE3E4523C6CDD:8C9B139D9CD48BE89CACA8348E2E8469
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:CD0E967F30C27C522C0DE3E4523C6CDD:8C9B139D9CD48BE89CACA8348E2E8469
         public void Restart(string groupName, string name)
         {
-            this.Inner.Restart(groupName, name);
+            Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => this.Inner.RestartAsync(groupName, name));
         }
 
         ///GENMHASH:F5C1D0B90DEED77EE54F7CEB164C727E:4E2B451086A707DC66F26388A688071E
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:F5C1D0B90DEED77EE54F7CEB164C727E:4E2B451086A707DC66F26388A688071E
         public void Start(string groupName, string name)
         {
-            this.Inner.Start(groupName, name);
+            Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => this.Inner.StartAsync(groupName, name));
         }
 
         ///GENMHASH:4DBD1302C1BE61E6004FB18DA868020B:A8445E32081DE89D5D3DAD2DAAFEFB2F
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:4DBD1302C1BE61E6004FB18DA868020B:A8445E32081DE89D5D3DAD2DAAFEFB2F
         public void Reimage(string groupName, string name)
         {
-            this.Inner.Reimage(groupName, name);
+            Management.ResourceManager.Fluent.Core.Extensions.Synchronize(() => this.Inner.ReimageAsync(groupName, name));
         }
 
         ///GENMHASH:8ACFB0E23F5F24AD384313679B65F404:AD7C28D26EC1F237B93E54AD31899691

--- a/src/ResourceManagement/Compute/VirtualMachineSizesImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineSizesImpl.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:360BB74037893879A730ED7ED0A3938A:1B63D16EAADAEBB8A17A72652C7477D7
         public IEnumerable<IVirtualMachineSize> ListByRegion(string regionName)
         {
-            return WrapList(innerCollection.List(regionName));
+            return WrapList(Extensions.Synchronize(() => innerCollection.ListAsync(regionName)));
         }
 
         ///GENMHASH:271CC39CE723B6FD3D7CCA7471D4B201:039795D842B96323D94D260F3FF83299

--- a/src/ResourceManagement/Compute/VirtualMachineSkusImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineSkusImpl.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:F06F4A28DDFE89624259B7BA06AB2A0E
         public IEnumerable<IVirtualMachineSku> List()
         {
-            return WrapList(innerCollection.ListSkus(offer.Region.Name, offer.Publisher.Name, offer.Name));
+            return WrapList(Extensions.Synchronize(() => innerCollection.ListSkusAsync(offer.Region.Name, offer.Publisher.Name, offer.Name)));
         }
 
         public async Task<IPagedCollection<IVirtualMachineSku>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/Compute/VirtualMachinesImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachinesImpl.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:E5D7B16A7B6C705114CC71E8BB2B20E1:3352FEB5932DA51CF51CFE2F1E02A3C7
         public string Capture(string groupName, string name, string containerName, string vhdPrefix, bool overwriteVhd)
         {
-            return this.CaptureAsync(groupName, name, containerName, vhdPrefix, overwriteVhd).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.CaptureAsync(groupName, name, containerName, vhdPrefix, overwriteVhd));
         }
 
         ///GENMHASH:56C0F52C716CCBD879A6E9E8D44C3FA8:971714229723AE4B74BC25F6C0AF31AE

--- a/src/ResourceManagement/Compute/VirtualMachinesImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachinesImpl.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:2048E8AC80AC022225C462CE7FD14A6F:5B568A74BA34923154B4D31492B0C92D
         public void Deallocate(string groupName, string name)
         {
-            this.Inner.Deallocate(groupName, name);
+            Extensions.Synchronize(() => this.Inner.DeallocateAsync(groupName, name));
         }
 
         ///GENMHASH:00E88CFB1570D8A0A8E9FDE81CE27B2D:41D46BEAFAD59BFEA295012F3A5791B5
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:00E88CFB1570D8A0A8E9FDE81CE27B2D:504A7551D91B09781F4903910609216C
         public void Generalize(string groupName, string name)
         {
-            this.Inner.Generalize(groupName, name);
+            Extensions.Synchronize(() => this.Inner.GeneralizeAsync(groupName, name));
         }
 
         ///GENMHASH:9F1310A4445A183902C9AF672DA34354:F32BEF843CE33ABB858763CFD92B9A36
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:9F1310A4445A183902C9AF672DA34354:83A472D7E09E0673F32CBA699DC15325
         public void PowerOff(string groupName, string name)
         {
-            this.Inner.PowerOff(groupName, name);
+            Extensions.Synchronize(() => this.Inner.PowerOffAsync(groupName, name));
         }
 
         ///GENMHASH:CD0E967F30C27C522C0DE3E4523C6CDD:8C9B139D9CD48BE89CACA8348E2E8469
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:CD0E967F30C27C522C0DE3E4523C6CDD:A8F52D851502AC1A4DED0213F947A99D
         public void Restart(string groupName, string name)
         {
-            this.Inner.Restart(groupName, name);
+            Extensions.Synchronize(() => this.Inner.RestartAsync(groupName, name));
         }
 
         ///GENMHASH:F5C1D0B90DEED77EE54F7CEB164C727E:4E2B451086A707DC66F26388A688071E
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:F5C1D0B90DEED77EE54F7CEB164C727E:C9C91090340AC7B92658ED0FECEB6F8F
         public void Start(string groupName, string name)
         {
-            this.Inner.Start(groupName, name);
+            Extensions.Synchronize(() => this.Inner.StartAsync(groupName, name));
         }
 
         ///GENMHASH:5BA0ADF7CF4FCFD811B372F59A1C376E:0961DB2042C5E898ED8D9586E90E4F33
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:5BA0ADF7CF4FCFD811B372F59A1C376E:4FE4D054ADD4EAF10A50571AB9FC3FD0
         public void Redeploy(string groupName, string name)
         {
-            this.Inner.Redeploy(groupName, name);
+            Extensions.Synchronize(() => this.Inner.RedeployAsync(groupName, name));
         }
 
         ///GENMHASH:7DBF1DD4080EA265532035CF9FB8D313:1A99BFC30D31869BE5E39DD7E4E0639D
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:7DBF1DD4080EA265532035CF9FB8D313:C9EA85EF9B4A5425DA3BF761D0D65796
         public void MigrateToManaged(string groupName, string name)
         {
-            this.Inner.ConvertToManagedDisks(groupName, name);
+            Extensions.Synchronize(() => this.Inner.ConvertToManagedDisksAsync(groupName, name));
         }
 
         ///GENMHASH:E5D7B16A7B6C705114CC71E8BB2B20E1:6975A84E6594FF8DEA88E6C992B0B500

--- a/src/ResourceManagement/Compute/WindowsVolumeEncryptionMonitorImpl.cs
+++ b/src/ResourceManagement/Compute/WindowsVolumeEncryptionMonitorImpl.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:FF7924BFEF46CE7F250D6F5B1A727744
         public IDiskVolumeEncryptionMonitor Refresh()
         {
-            return RefreshAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => RefreshAsync());
         }
 
         ///GENMHASH:5A2D79502EDA81E37A36694062AEDC65:061A846F0F7CA8B3F2DF8CA79A8D8B5A

--- a/src/ResourceManagement/ContainerRegistry/Generated/OperationsExtensions.cs
+++ b/src/ResourceManagement/ContainerRegistry/Generated/OperationsExtensions.cs
@@ -22,17 +22,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
     /// </summary>
     public static partial class OperationsExtensions
     {
-            /// <summary>
-            /// Lists all of the available Azure Container Registry REST API operations.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<OperationDefinition> List(this IOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the available Azure Container Registry REST API operations.
             /// </summary>
@@ -50,20 +40,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the available Azure Container Registry REST API operations.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<OperationDefinition> ListNext(this IOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the available Azure Container Registry REST API operations.
             /// </summary>

--- a/src/ResourceManagement/ContainerRegistry/Generated/RegistriesOperationsExtensions.cs
+++ b/src/ResourceManagement/ContainerRegistry/Generated/RegistriesOperationsExtensions.cs
@@ -22,22 +22,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
     /// </summary>
     public static partial class RegistriesOperationsExtensions
     {
-            /// <summary>
-            /// Checks whether the container registry name is available for use. The name
-            /// must contain only alphanumeric characters, be globally unique, and between
-            /// 5 and 60 characters in length.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the container registry.
-            /// </param>
-            public static RegistryNameStatusInner CheckNameAvailability(this IRegistriesOperations operations, string name)
-            {
-                return operations.CheckNameAvailabilityAsync(name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks whether the container registry name is available for use. The name
             /// must contain only alphanumeric characters, be globally unique, and between
@@ -60,23 +45,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the properties of the specified container registry.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to which the container registry belongs.
-            /// </param>
-            /// <param name='registryName'>
-            /// The name of the container registry.
-            /// </param>
-            public static RegistryInner Get(this IRegistriesOperations operations, string resourceGroupName, string registryName)
-            {
-                return operations.GetAsync(resourceGroupName, registryName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the properties of the specified container registry.
             /// </summary>
@@ -100,26 +69,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a container registry with the specified parameters.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to which the container registry belongs.
-            /// </param>
-            /// <param name='registryName'>
-            /// The name of the container registry.
-            /// </param>
-            /// <param name='registryCreateParameters'>
-            /// The parameters for creating a container registry.
-            /// </param>
-            public static RegistryInner Create(this IRegistriesOperations operations, string resourceGroupName, string registryName, RegistryCreateParametersInner registryCreateParameters)
-            {
-                return operations.CreateAsync(resourceGroupName, registryName, registryCreateParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a container registry with the specified parameters.
             /// </summary>
@@ -146,23 +96,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a container registry.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to which the container registry belongs.
-            /// </param>
-            /// <param name='registryName'>
-            /// The name of the container registry.
-            /// </param>
-            public static void Delete(this IRegistriesOperations operations, string resourceGroupName, string registryName)
-            {
-                operations.DeleteAsync(resourceGroupName, registryName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a container registry.
             /// </summary>
@@ -183,26 +117,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, registryName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Updates a container registry with the specified parameters.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to which the container registry belongs.
-            /// </param>
-            /// <param name='registryName'>
-            /// The name of the container registry.
-            /// </param>
-            /// <param name='registryUpdateParameters'>
-            /// The parameters for updating a container registry.
-            /// </param>
-            public static RegistryInner Update(this IRegistriesOperations operations, string resourceGroupName, string registryName, RegistryUpdateParametersInner registryUpdateParameters)
-            {
-                return operations.UpdateAsync(resourceGroupName, registryName, registryUpdateParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates a container registry with the specified parameters.
             /// </summary>
@@ -229,20 +144,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the container registries under the specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to which the container registry belongs.
-            /// </param>
-            public static IPage<RegistryInner> ListByResourceGroup(this IRegistriesOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the container registries under the specified resource group.
             /// </summary>
@@ -263,17 +165,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the container registries under the specified subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<RegistryInner> List(this IRegistriesOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the container registries under the specified subscription.
             /// </summary>
@@ -291,23 +183,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists the login credentials for the specified container registry.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to which the container registry belongs.
-            /// </param>
-            /// <param name='registryName'>
-            /// The name of the container registry.
-            /// </param>
-            public static RegistryListCredentials ListCredentials(this IRegistriesOperations operations, string resourceGroupName, string registryName)
-            {
-                return operations.ListCredentialsAsync(resourceGroupName, registryName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists the login credentials for the specified container registry.
             /// </summary>
@@ -331,28 +207,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 }
             }
 
-            /// <summary>
-            /// Regenerates one of the login credentials for the specified container
-            /// registry.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to which the container registry belongs.
-            /// </param>
-            /// <param name='registryName'>
-            /// The name of the container registry.
-            /// </param>
-            /// <param name='name'>
-            /// Specifies name of the password which should be regenerated -- password or
-            /// password2. Possible values include: 'password', 'password2'
-            /// </param>
-            public static RegistryListCredentials RegenerateCredential(this IRegistriesOperations operations, string resourceGroupName, string registryName, PasswordName name)
-            {
-                return operations.RegenerateCredentialAsync(resourceGroupName, registryName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Regenerates one of the login credentials for the specified container
             /// registry.
@@ -381,26 +236,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a container registry with the specified parameters.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to which the container registry belongs.
-            /// </param>
-            /// <param name='registryName'>
-            /// The name of the container registry.
-            /// </param>
-            /// <param name='registryCreateParameters'>
-            /// The parameters for creating a container registry.
-            /// </param>
-            public static RegistryInner BeginCreate(this IRegistriesOperations operations, string resourceGroupName, string registryName, RegistryCreateParametersInner registryCreateParameters)
-            {
-                return operations.BeginCreateAsync(resourceGroupName, registryName, registryCreateParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a container registry with the specified parameters.
             /// </summary>
@@ -427,20 +263,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the container registries under the specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RegistryInner> ListByResourceGroupNext(this IRegistriesOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the container registries under the specified resource group.
             /// </summary>
@@ -461,20 +284,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the container registries under the specified subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RegistryInner> ListNext(this IRegistriesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the container registries under the specified subscription.
             /// </summary>

--- a/src/ResourceManagement/ContainerRegistry/RegistriesImpl.cs
+++ b/src/ResourceManagement/ContainerRegistry/RegistriesImpl.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
 
         public RegistryListCredentials ListCredentials(string groupName, string registryName)
         {
-            return this.Inner.ListCredentialsAsync(groupName, registryName).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.Inner.ListCredentialsAsync(groupName, registryName));
         }
 
         public async Task<RegistryListCredentials> RegenerateCredentialAsync(string groupName, string registryName, PasswordName passwordName, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ContainerRegistry/RegistryImpl.cs
+++ b/src/ResourceManagement/ContainerRegistry/RegistryImpl.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
 
         public RegistryListCredentials RegenerateCredential(PasswordName passwordName)
         {
-            return this.RegenerateCredentialAsync(passwordName).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.RegenerateCredentialAsync(passwordName));
         }
 
         public override IUpdate Update()
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
 
         public RegistryListCredentials ListCredentials()
         {
-            return this.ListCredentialsAsync().GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.ListCredentialsAsync());
         }
 
         public RegistryImpl WithExistingStorageAccount(IStorageAccount storageAccount)

--- a/src/ResourceManagement/Dns/ARecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/ARecordSetsImpl.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ///GENMHASH:B94D04B9D91F75559A6D8E405D4A72FD:14206AD3A35D0E04558660C133F8DA1D
         protected override IEnumerable<IARecordSet> ListIntern(string recordSetNameSuffix, int? pageSize)
         {
-            return WrapList(dnsZone.Manager.Inner.RecordSets.ListByType(dnsZone.ResourceGroupName,
+            return WrapList(Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName,
                                                                 dnsZone.Name,
                                                                 recordType,
                                                                 top: pageSize,
-                                                                recordsetnamesuffix: recordSetNameSuffix)
-                                                                .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
+                                                                recordsetnamesuffix: recordSetNameSuffix))
+                                                    .AsContinuousCollection(link => Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync(link))));
         }
 
         ///GENMHASH:A65D7F670CB73E56248FA5B252060BCD:29F76B986FA21FD2583D531C098AD879

--- a/src/ResourceManagement/Dns/AaaaRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/AaaaRecordSetsImpl.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ///GENMHASH:B94D04B9D91F75559A6D8E405D4A72FD:2D7A98BB2BCAD1ACBF5B8624AD621EE4
         protected override IEnumerable<IAaaaRecordSet> ListIntern(string recordSetNameSuffix, int? pageSize)
         {
-            return WrapList(dnsZone.Manager.Inner.RecordSets.ListByType(dnsZone.ResourceGroupName, 
-                                                                dnsZone.Name,
-                                                                recordType, 
-                                                                top: pageSize,
-                                                                recordsetnamesuffix: recordSetNameSuffix)
-                                                                .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
+            return WrapList(Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName, 
+                                                                    dnsZone.Name,
+                                                                    recordType, 
+                                                                    top: pageSize,
+                                                                    recordsetnamesuffix: recordSetNameSuffix))
+                                                                .AsContinuousCollection(link => Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync(link))));
         }
 
         ///GENMHASH:A65D7F670CB73E56248FA5B252060BCD:583D2C6D497AA58FD8B23595EF66DCF0

--- a/src/ResourceManagement/Dns/CnameRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/CnameRecordSetsImpl.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ///GENMHASH:B94D04B9D91F75559A6D8E405D4A72FD:D009704C171C4D453FCEC632203851C7
         protected override IEnumerable<ICNameRecordSet> ListIntern(string recordSetNameSuffix, int? pageSize)
         {
-            return WrapList(dnsZone.Manager.Inner.RecordSets.ListByType(dnsZone.ResourceGroupName,
+            return WrapList(Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName,
                                                                 dnsZone.Name,
                                                                 recordType,
                                                                 top: pageSize,
-                                                                recordsetnamesuffix: recordSetNameSuffix)
-                                                                .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
+                                                                recordsetnamesuffix: recordSetNameSuffix))
+                                                    .AsContinuousCollection(link => Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync(link))));
         }
 
         ///GENMHASH:A65D7F670CB73E56248FA5B252060BCD:DF02675D7363FC8D2194BA7296AC08B3

--- a/src/ResourceManagement/Dns/DnsRecordSetsBaseImpl.cs
+++ b/src/ResourceManagement/Dns/DnsRecordSetsBaseImpl.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
 
         public RecordSetT GetByName(string name)
         {
-            return GetByNameAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetByNameAsync(name));
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:8702BABF19DCC459AC95CE748259A3D1

--- a/src/ResourceManagement/Dns/DnsZoneImpl.cs
+++ b/src/ResourceManagement/Dns/DnsZoneImpl.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     using DnsZone.Definition;
     using Models;
     using System.Linq;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
     /// <summary>
     /// Implementation for DnsZone.
@@ -328,17 +329,19 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ///GENMHASH:3F0A6CC3DBBB3330F47E8737215D7ECE:89EB3CA649B988C6CE1268D1D2437E71
         public ISoaRecordSet GetSoaRecordSet()
         {
-            RecordSetInner inner = Manager.Inner.RecordSets.Get(ResourceGroupName, Name, "@", RecordType.SOA);
+            RecordSetInner inner = Extensions.Synchronize(() => Manager.Inner.RecordSets.GetAsync(ResourceGroupName, Name, "@", RecordType.SOA));
             return new SoaRecordSetImpl(this, inner);
         }
 
         ///GENMHASH:DAB4AD5D3ECB1C104BA24998D652F125:360292BEDD7386B9C66109E12C8F07EB
         private IEnumerable<Microsoft.Azure.Management.Dns.Fluent.IDnsRecordSet> ListRecordSetsIntern(string recordSetSuffix, int? pageSize)
         {
-            return Manager.Inner.RecordSets.ListByDnsZone(ResourceGroupName,
-                Name,
-                top: pageSize,
-                recordsetnamesuffix: recordSetSuffix).Select(inner =>
+            return Extensions.Synchronize(() => Manager.Inner.RecordSets.ListByDnsZoneAsync(
+                    ResourceGroupName,
+                    Name,
+                    top: pageSize,
+                    recordsetnamesuffix: recordSetSuffix))
+                .Select(inner =>
                 {
                     var recordSet = new DnsRecordSetImpl(this, inner);
                     switch(recordSet.RecordType())

--- a/src/ResourceManagement/Dns/DnsZonesImpl.cs
+++ b/src/ResourceManagement/Dns/DnsZonesImpl.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ///GENMHASH:39C3F7BAA4073DBF7D9C81AC4336F2D1:32FF50F6C08B8687F5130EDE8E5BA465
         public void DeleteByResourceGroupName(string resourceGroupName, string zoneName, string eTagValue)
         {
-            DeleteByResourceGroupNameAsync(resourceGroupName, zoneName, eTagValue).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => DeleteByResourceGroupNameAsync(resourceGroupName, zoneName, eTagValue));
         }
 
         ///GENMHASH:8ACFB0E23F5F24AD384313679B65F404:6A5AFD43FB6D60947DE42BF4153B3E35
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ///GENMHASH:A17E5445D2F99DCCB7C75768B0291EED:46771EA9A18C8A10AFFAEA5F5B47057F
         public void DeleteById(string id, string eTagValue)
         {
-            DeleteByIdAsync(id, eTagValue).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => DeleteByIdAsync(id, eTagValue));
         }
 
         ///GENMHASH:888AD5B0E0B6C157410F28C8D7AB0DD6:65F3733A4D17B7CA277164946BAE2A98

--- a/src/ResourceManagement/Dns/Generated/RecordSetsOperationsExtensions.cs
+++ b/src/ResourceManagement/Dns/Generated/RecordSetsOperationsExtensions.cs
@@ -22,38 +22,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     /// </summary>
     public static partial class RecordSetsOperationsExtensions
     {
-            /// <summary>
-            /// Updates a record set within a DNS zone.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='zoneName'>
-            /// The name of the DNS zone (without a terminating dot).
-            /// </param>
-            /// <param name='relativeRecordSetName'>
-            /// The name of the record set, relative to the name of the zone.
-            /// </param>
-            /// <param name='recordType'>
-            /// The type of DNS record in this record set. Possible values include: 'A',
-            /// 'AAAA', 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SRV', 'TXT'
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Update operation.
-            /// </param>
-            /// <param name='ifMatch'>
-            /// The etag of the record set. Omit this value to always overwrite the current
-            /// record set. Specify the last-seen etag value to prevent accidentally
-            /// overwritting concurrent changes.
-            /// </param>
-            public static RecordSetInner Update(this IRecordSetsOperations operations, string resourceGroupName, string zoneName, string relativeRecordSetName, RecordType recordType, RecordSetInner parameters, string ifMatch = default(string))
-            {
-                return operations.UpdateAsync(resourceGroupName, zoneName, relativeRecordSetName, recordType, parameters, ifMatch).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates a record set within a DNS zone.
             /// </summary>
@@ -92,44 +61,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a record set within a DNS zone.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='zoneName'>
-            /// The name of the DNS zone (without a terminating dot).
-            /// </param>
-            /// <param name='relativeRecordSetName'>
-            /// The name of the record set, relative to the name of the zone.
-            /// </param>
-            /// <param name='recordType'>
-            /// The type of DNS record in this record set. Record sets of type SOA can be
-            /// updated but not created (they are created when the DNS zone is created).
-            /// Possible values include: 'A', 'AAAA', 'CNAME', 'MX', 'NS', 'PTR', 'SOA',
-            /// 'SRV', 'TXT'
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the CreateOrUpdate operation.
-            /// </param>
-            /// <param name='ifMatch'>
-            /// The etag of the record set. Omit this value to always overwrite the current
-            /// record set. Specify the last-seen etag value to prevent accidentally
-            /// overwritting any concurrent changes.
-            /// </param>
-            /// <param name='ifNoneMatch'>
-            /// Set to '*' to allow a new record set to be created, but to prevent updating
-            /// an existing record set. Other values will be ignored.
-            /// </param>
-            public static RecordSetInner CreateOrUpdate(this IRecordSetsOperations operations, string resourceGroupName, string zoneName, string relativeRecordSetName, RecordType recordType, RecordSetInner parameters, string ifMatch = default(string), string ifNoneMatch = default(string))
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, zoneName, relativeRecordSetName, recordType, parameters, ifMatch, ifNoneMatch).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a record set within a DNS zone.
             /// </summary>
@@ -174,36 +106,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a record set from a DNS zone. This operation cannot be undone.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='zoneName'>
-            /// The name of the DNS zone (without a terminating dot).
-            /// </param>
-            /// <param name='relativeRecordSetName'>
-            /// The name of the record set, relative to the name of the zone.
-            /// </param>
-            /// <param name='recordType'>
-            /// The type of DNS record in this record set. Record sets of type SOA cannot
-            /// be deleted (they are deleted when the DNS zone is deleted). Possible values
-            /// include: 'A', 'AAAA', 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SRV', 'TXT'
-            /// </param>
-            /// <param name='ifMatch'>
-            /// The etag of the record set. Omit this value to always delete the current
-            /// record set. Specify the last-seen etag value to prevent accidentally
-            /// deleting any concurrent changes.
-            /// </param>
-            public static void Delete(this IRecordSetsOperations operations, string resourceGroupName, string zoneName, string relativeRecordSetName, RecordType recordType, string ifMatch = default(string))
-            {
-                operations.DeleteAsync(resourceGroupName, zoneName, relativeRecordSetName, recordType, ifMatch).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a record set from a DNS zone. This operation cannot be undone.
             /// </summary>
@@ -237,30 +140,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, zoneName, relativeRecordSetName, recordType, ifMatch, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets a record set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='zoneName'>
-            /// The name of the DNS zone (without a terminating dot).
-            /// </param>
-            /// <param name='relativeRecordSetName'>
-            /// The name of the record set, relative to the name of the zone.
-            /// </param>
-            /// <param name='recordType'>
-            /// The type of DNS record in this record set. Possible values include: 'A',
-            /// 'AAAA', 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SRV', 'TXT'
-            /// </param>
-            public static RecordSetInner Get(this IRecordSetsOperations operations, string resourceGroupName, string zoneName, string relativeRecordSetName, RecordType recordType)
-            {
-                return operations.GetAsync(resourceGroupName, zoneName, relativeRecordSetName, recordType).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a record set.
             /// </summary>
@@ -291,36 +171,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists the record sets of a specified type in a DNS zone.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='zoneName'>
-            /// The name of the DNS zone (without a terminating dot).
-            /// </param>
-            /// <param name='recordType'>
-            /// The type of record sets to enumerate. Possible values include: 'A', 'AAAA',
-            /// 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SRV', 'TXT'
-            /// </param>
-            /// <param name='top'>
-            /// The maximum number of record sets to return. If not specified, returns up
-            /// to 100 record sets.
-            /// </param>
-            /// <param name='recordsetnamesuffix'>
-            /// The suffix label of the record set name that has to be used to filter the
-            /// record set enumerations. If this parameter is specified, Enumeration will
-            /// return only records that end with .&lt;recordSetNameSuffix&gt;
-            /// </param>
-            public static IPage<RecordSetInner> ListByType(this IRecordSetsOperations operations, string resourceGroupName, string zoneName, RecordType recordType, int? top = default(int?), string recordsetnamesuffix = default(string))
-            {
-                return operations.ListByTypeAsync(resourceGroupName, zoneName, recordType, top, recordsetnamesuffix).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists the record sets of a specified type in a DNS zone.
             /// </summary>
@@ -357,32 +208,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all record sets in a DNS zone.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='zoneName'>
-            /// The name of the DNS zone (without a terminating dot).
-            /// </param>
-            /// <param name='top'>
-            /// The maximum number of record sets to return. If not specified, returns up
-            /// to 100 record sets.
-            /// </param>
-            /// <param name='recordsetnamesuffix'>
-            /// The suffix label of the record set name that has to be used to filter the
-            /// record set enumerations. If this parameter is specified, Enumeration will
-            /// return only records that end with .&lt;recordSetNameSuffix&gt;
-            /// </param>
-            public static IPage<RecordSetInner> ListByDnsZone(this IRecordSetsOperations operations, string resourceGroupName, string zoneName, int? top = default(int?), string recordsetnamesuffix = default(string))
-            {
-                return operations.ListByDnsZoneAsync(resourceGroupName, zoneName, top, recordsetnamesuffix).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all record sets in a DNS zone.
             /// </summary>
@@ -415,20 +241,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists the record sets of a specified type in a DNS zone.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RecordSetInner> ListByTypeNext(this IRecordSetsOperations operations, string nextPageLink)
-            {
-                return operations.ListByTypeNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists the record sets of a specified type in a DNS zone.
             /// </summary>
@@ -449,20 +262,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all record sets in a DNS zone.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RecordSetInner> ListByDnsZoneNext(this IRecordSetsOperations operations, string nextPageLink)
-            {
-                return operations.ListByDnsZoneNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all record sets in a DNS zone.
             /// </summary>

--- a/src/ResourceManagement/Dns/Generated/ZonesOperationsExtensions.cs
+++ b/src/ResourceManagement/Dns/Generated/ZonesOperationsExtensions.cs
@@ -22,35 +22,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
     /// </summary>
     public static partial class ZonesOperationsExtensions
     {
-            /// <summary>
-            /// Creates or updates a DNS zone. Does not modify DNS records within the zone.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='zoneName'>
-            /// The name of the DNS zone (without a terminating dot).
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the CreateOrUpdate operation.
-            /// </param>
-            /// <param name='ifMatch'>
-            /// The etag of the DNS zone. Omit this value to always overwrite the current
-            /// zone. Specify the last-seen etag value to prevent accidentally overwritting
-            /// any concurrent changes.
-            /// </param>
-            /// <param name='ifNoneMatch'>
-            /// Set to '*' to allow a new DNS zone to be created, but to prevent updating
-            /// an existing zone. Other values will be ignored.
-            /// </param>
-            public static ZoneInner CreateOrUpdate(this IZonesOperations operations, string resourceGroupName, string zoneName, ZoneInner parameters, string ifMatch = default(string), string ifNoneMatch = default(string))
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, zoneName, parameters, ifMatch, ifNoneMatch).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a DNS zone. Does not modify DNS records within the zone.
             /// </summary>
@@ -86,29 +58,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a DNS zone. WARNING: All DNS records in the zone will also be
-            /// deleted. This operation cannot be undone.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='zoneName'>
-            /// The name of the DNS zone (without a terminating dot).
-            /// </param>
-            /// <param name='ifMatch'>
-            /// The etag of the DNS zone. Omit this value to always delete the current
-            /// zone. Specify the last-seen etag value to prevent accidentally deleting any
-            /// concurrent changes.
-            /// </param>
-            public static ZoneDeleteResultInner Delete(this IZonesOperations operations, string resourceGroupName, string zoneName, string ifMatch = default(string))
-            {
-                return operations.DeleteAsync(resourceGroupName, zoneName, ifMatch).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a DNS zone. WARNING: All DNS records in the zone will also be
             /// deleted. This operation cannot be undone.
@@ -138,24 +88,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a DNS zone. Retrieves the zone properties, but not the record sets
-            /// within the zone.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='zoneName'>
-            /// The name of the DNS zone (without a terminating dot).
-            /// </param>
-            public static ZoneInner Get(this IZonesOperations operations, string resourceGroupName, string zoneName)
-            {
-                return operations.GetAsync(resourceGroupName, zoneName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a DNS zone. Retrieves the zone properties, but not the record sets
             /// within the zone.
@@ -180,24 +113,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists the DNS zones within a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='top'>
-            /// The maximum number of record sets to return. If not specified, returns up
-            /// to 100 record sets.
-            /// </param>
-            public static IPage<ZoneInner> ListByResourceGroup(this IZonesOperations operations, string resourceGroupName, int? top = default(int?))
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName, top).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists the DNS zones within a resource group.
             /// </summary>
@@ -222,21 +138,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists the DNS zones in all resource groups in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='top'>
-            /// The maximum number of DNS zones to return. If not specified, returns up to
-            /// 100 zones.
-            /// </param>
-            public static IPage<ZoneInner> List(this IZonesOperations operations, int? top = default(int?))
-            {
-                return operations.ListAsync(top).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists the DNS zones in all resource groups in a subscription.
             /// </summary>
@@ -258,29 +160,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a DNS zone. WARNING: All DNS records in the zone will also be
-            /// deleted. This operation cannot be undone.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='zoneName'>
-            /// The name of the DNS zone (without a terminating dot).
-            /// </param>
-            /// <param name='ifMatch'>
-            /// The etag of the DNS zone. Omit this value to always delete the current
-            /// zone. Specify the last-seen etag value to prevent accidentally deleting any
-            /// concurrent changes.
-            /// </param>
-            public static ZoneDeleteResultInner BeginDelete(this IZonesOperations operations, string resourceGroupName, string zoneName, string ifMatch = default(string))
-            {
-                return operations.BeginDeleteAsync(resourceGroupName, zoneName, ifMatch).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a DNS zone. WARNING: All DNS records in the zone will also be
             /// deleted. This operation cannot be undone.
@@ -310,20 +190,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists the DNS zones within a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ZoneInner> ListByResourceGroupNext(this IZonesOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists the DNS zones within a resource group.
             /// </summary>
@@ -344,20 +211,7 @@ namespace Microsoft.Azure.Management.Dns.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists the DNS zones in all resource groups in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ZoneInner> ListNext(this IZonesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists the DNS zones in all resource groups in a subscription.
             /// </summary>

--- a/src/ResourceManagement/Dns/MxRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/MxRecordSetsImpl.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:726C64E2292CCBC7CE184E032B06D829
         protected override IEnumerable<IMXRecordSet> ListIntern(string recordSetNameSuffix, int? pageSize)
         {
-            return WrapList(dnsZone.Manager.Inner.RecordSets.ListByType(dnsZone.ResourceGroupName,
+            return WrapList(Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName,
                                                                 dnsZone.Name,
                                                                 recordType,
                                                                 top: pageSize,
-                                                                recordsetnamesuffix: recordSetNameSuffix)
-                                                                .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
+                                                                recordsetnamesuffix: recordSetNameSuffix))
+                                                        .AsContinuousCollection(link => Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync(link))));
         }
 
         ///GENMHASH:A65D7F670CB73E56248FA5B252060BCD:DC4FF2A84773DB187EB6D9E5EEE7D21A

--- a/src/ResourceManagement/Dns/NsRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/NsRecordSetsImpl.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ///GENMHASH:B94D04B9D91F75559A6D8E405D4A72FD:89AFD60B8A5875A2B8CC4B9A343A49AE
         protected override IEnumerable<INSRecordSet> ListIntern(string recordSetNameSuffix, int? pageSize)
         {
-            return WrapList(dnsZone.Manager.Inner.RecordSets.ListByType(dnsZone.ResourceGroupName,
+            return WrapList(Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName,
                                                                 dnsZone.Name,
                                                                 recordType,
                                                                 top: pageSize,
-                                                                recordsetnamesuffix: recordSetNameSuffix)
-                                                                .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
+                                                                recordsetnamesuffix: recordSetNameSuffix))
+                                                                .AsContinuousCollection(link => Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync(link))));
         }
 
         ///GENMHASH:A65D7F670CB73E56248FA5B252060BCD:5F707291D14DA5598B0C79A53C240FCC

--- a/src/ResourceManagement/Dns/PtrRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/PtrRecordSetsImpl.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ///GENMHASH:B94D04B9D91F75559A6D8E405D4A72FD:469D7E8DEB6CC072406A22D0635C0EC8
         protected override IEnumerable<IPtrRecordSet> ListIntern(string recordSetNameSuffix, int? pageSize)
         {
-            return WrapList(dnsZone.Manager.Inner.RecordSets.ListByType(dnsZone.ResourceGroupName,
+            return WrapList(Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName,
                                                                 dnsZone.Name,
                                                                 recordType,
                                                                 top: pageSize,
-                                                                recordsetnamesuffix: recordSetNameSuffix)
-                                                                .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
+                                                                recordsetnamesuffix: recordSetNameSuffix))
+                                                    .AsContinuousCollection(link => Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync(link))));
         }
 
         ///GENMHASH:A65D7F670CB73E56248FA5B252060BCD:79EECA7CF25C8E535058201251FF3187

--- a/src/ResourceManagement/Dns/SrvRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/SrvRecordSetsImpl.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ///GENMHASH:B94D04B9D91F75559A6D8E405D4A72FD:01A172482B1E120E31032E5543713776
         protected override IEnumerable<ISrvRecordSet> ListIntern(string recordSetNameSuffix, int? pageSize)
         {
-            return WrapList(dnsZone.Manager.Inner.RecordSets.ListByType(dnsZone.ResourceGroupName,
+            return WrapList(Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName,
                                                                 dnsZone.Name,
                                                                 recordType,
                                                                 top: pageSize,
-                                                                recordsetnamesuffix: recordSetNameSuffix)
-                                                                .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
+                                                                recordsetnamesuffix: recordSetNameSuffix))
+                                                .AsContinuousCollection(link => Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync(link))));
         }
 
         ///GENMHASH:A65D7F670CB73E56248FA5B252060BCD:BAA4ACA3AC07B56B82C6B16D77059D51

--- a/src/ResourceManagement/Dns/TxtRecordSetsImpl.cs
+++ b/src/ResourceManagement/Dns/TxtRecordSetsImpl.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         ///GENMHASH:B94D04B9D91F75559A6D8E405D4A72FD:75EE3247B7E5B19C0139A9BD8ACE8C80
         protected override IEnumerable<ITxtRecordSet> ListIntern(string recordSetNameSuffix, int? pageSize)
         {
-            return WrapList(dnsZone.Manager.Inner.RecordSets.ListByType(dnsZone.ResourceGroupName,
+            return WrapList(Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeAsync(dnsZone.ResourceGroupName,
                                                                 dnsZone.Name,
                                                                 recordType,
                                                                 top: pageSize,
-                                                                recordsetnamesuffix: recordSetNameSuffix)
-                                                                .AsContinuousCollection(link => dnsZone.Manager.Inner.RecordSets.ListByTypeNext(link)));
+                                                                recordsetnamesuffix: recordSetNameSuffix))
+                                                    .AsContinuousCollection(link => Extensions.Synchronize(() => dnsZone.Manager.Inner.RecordSets.ListByTypeNextAsync(link))));
         }
 
         ///GENMHASH:A65D7F670CB73E56248FA5B252060BCD:F34D4050AF5DEA0333DEAB400CDEE5CB

--- a/src/ResourceManagement/DocumentDB/DocumentDBAccountImpl.cs
+++ b/src/ResourceManagement/DocumentDB/DocumentDBAccountImpl.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
 
         public Models.DatabaseAccountListKeysResultInner ListKeys()
         {
-            return this.ListKeysAsync().GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.ListKeysAsync());
         }
 
         public string IPRangeFilter()
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
 
         public Models.DatabaseAccountListConnectionStringsResultInner ListConnectionStrings()
         {
-            return this.ListConnectionStringsAsync().GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.ListConnectionStringsAsync());
         }
 
         internal DocumentDBAccountImpl(string name, Models.DatabaseAccountInner innerObject, IDocumentDBManager manager) :
@@ -334,8 +334,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
 
         public void RegenerateKey(string keyKind)
         {
-            this.RegenerateKeyAsync(keyKind).GetAwaiter().GetResult();
-
+            Extensions.Synchronize(() => this.RegenerateKeyAsync(keyKind));
         }
 
         private static string FixDBName(string name)

--- a/src/ResourceManagement/DocumentDB/DocumentDBAccountsImpl.cs
+++ b/src/ResourceManagement/DocumentDB/DocumentDBAccountsImpl.cs
@@ -111,12 +111,12 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
 
         public Models.DatabaseAccountListConnectionStringsResultInner ListConnectionStrings(string groupName, string accountName)
         {
-            return this.ListConnectionStringsAsync(groupName, accountName).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.ListConnectionStringsAsync(groupName, accountName));
         }
 
         public Models.DatabaseAccountListKeysResultInner ListKeys(string groupName, string accountName)
         {
-            return this.ListKeysAsync(groupName, accountName).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.ListKeysAsync(groupName, accountName));
         }
 
         public async Task<Models.DatabaseAccountListKeysResultInner> ListKeysAsync(string groupName, string accountName, CancellationToken cancellationToken = default(CancellationToken))
@@ -126,8 +126,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
 
         public void FailoverPriorityChange(string groupName, string accountName, IList<Microsoft.Azure.Management.DocumentDB.Fluent.Models.Location> failoverLocations)
         {
-            this.FailoverPriorityChangeAsync(groupName, accountName, failoverLocations).GetAwaiter().GetResult();
-
+            Extensions.Synchronize(() => this.FailoverPriorityChangeAsync(groupName, accountName, failoverLocations));
         }
 
         public async Task RegenerateKeyAsync(string groupName, string accountName, string keyKind, CancellationToken cancellationToken = default(CancellationToken))
@@ -142,8 +141,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
 
         public void RegenerateKey(string groupName, string accountName, string keyKind)
         {
-            this.RegenerateKeyAsync(groupName, accountName, keyKind).GetAwaiter().GetResult();
-
+            Extensions.Synchronize(() => this.RegenerateKeyAsync(groupName, accountName, keyKind));
         }
     }
 }

--- a/src/ResourceManagement/DocumentDB/Generated/DatabaseAccountsOperationsExtensions.cs
+++ b/src/ResourceManagement/DocumentDB/Generated/DatabaseAccountsOperationsExtensions.cs
@@ -24,23 +24,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
     /// </summary>
     public static partial class DatabaseAccountsOperationsExtensions
     {
-            /// <summary>
-            /// Retrieves the properties of an existing Azure DocumentDB database account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            public static DatabaseAccountInner Get(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName)
-            {
-                return operations.GetAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Retrieves the properties of an existing Azure DocumentDB database account.
             /// </summary>
@@ -64,25 +48,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 }
             }
 
-            /// <summary>
-            /// Patches the properties of an existing Azure DocumentDB database account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            /// <param name='tags'>
-            /// </param>
-            public static DatabaseAccountInner Patch(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName, IDictionary<string, string> tags)
-            {
-                return operations.PatchAsync(resourceGroupName, accountName, tags).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Patches the properties of an existing Azure DocumentDB database account.
             /// </summary>
@@ -108,26 +74,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates an Azure DocumentDB database account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            /// <param name='createUpdateParameters'>
-            /// The parameters to provide for the current database account.
-            /// </param>
-            public static DatabaseAccountInner CreateOrUpdate(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName, DatabaseAccountCreateUpdateParametersInner createUpdateParameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, accountName, createUpdateParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates an Azure DocumentDB database account.
             /// </summary>
@@ -154,23 +101,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an existing Azure DocumentDB database account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            public static void Delete(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName)
-            {
-                operations.DeleteAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an existing Azure DocumentDB database account.
             /// </summary>
@@ -191,30 +122,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, accountName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Changes the failover priority for the Azure DocumentDB database account. A
-            /// failover priority of 0 indicates a write region. The maximum value for a
-            /// failover priority = (total number of regions - 1). Failover priority values
-            /// must be unique for each of the regions in which the database account
-            /// exists.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            /// <param name='failoverPoliciesProperty'>
-            /// List of failover policies.
-            /// </param>
-            public static void FailoverPriorityChange(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName, IList<FailoverPolicyInner> failoverPoliciesProperty = default(IList<FailoverPolicyInner>))
-            {
-                operations.FailoverPriorityChangeAsync(resourceGroupName, accountName, failoverPoliciesProperty).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Changes the failover priority for the Azure DocumentDB database account. A
             /// failover priority of 0 indicates a write region. The maximum value for a
@@ -242,18 +150,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 (await operations.FailoverPriorityChangeWithHttpMessagesAsync(resourceGroupName, accountName, failoverPoliciesProperty, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Lists all the Azure DocumentDB database accounts available under the
-            /// subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IEnumerable<DatabaseAccountInner> List(this IDatabaseAccountsOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the Azure DocumentDB database accounts available under the
             /// subscription.
@@ -272,21 +169,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the Azure DocumentDB database accounts available under the given
-            /// resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            public static IEnumerable<DatabaseAccountInner> ListByResourceGroup(this IDatabaseAccountsOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the Azure DocumentDB database accounts available under the given
             /// resource group.
@@ -308,23 +191,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists the access keys for the specified Azure DocumentDB database account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            public static DatabaseAccountListKeysResultInner ListKeys(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName)
-            {
-                return operations.ListKeysAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists the access keys for the specified Azure DocumentDB database account.
             /// </summary>
@@ -348,24 +215,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists the connection strings for the specified Azure DocumentDB database
-            /// account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            public static DatabaseAccountListConnectionStringsResultInner ListConnectionStrings(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName)
-            {
-                return operations.ListConnectionStringsAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists the connection strings for the specified Azure DocumentDB database
             /// account.
@@ -390,24 +240,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists the read-only access keys for the specified Azure DocumentDB database
-            /// account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            public static DatabaseAccountListReadOnlyKeysResultInner ListReadOnlyKeys(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName)
-            {
-                return operations.ListReadOnlyKeysAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists the read-only access keys for the specified Azure DocumentDB database
             /// account.
@@ -432,28 +265,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 }
             }
 
-            /// <summary>
-            /// Regenerates an access key for the specified Azure DocumentDB database
-            /// account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            /// <param name='keyKind'>
-            /// The access key to regenerate. Possible values include: 'primary',
-            /// 'secondary', 'primaryReadonly', 'secondaryReadonly'
-            /// </param>
-            public static void RegenerateKey(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName, string keyKind)
-            {
-                operations.RegenerateKeyAsync(resourceGroupName, accountName, keyKind).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Regenerates an access key for the specified Azure DocumentDB database
             /// account.
@@ -479,22 +291,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 (await operations.RegenerateKeyWithHttpMessagesAsync(resourceGroupName, accountName, keyKind, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Checks that the Azure DocumentDB account name already exists. A valid
-            /// account name may contain only lowercase letters, numbers, and the '-'
-            /// character, and must be between 3 and 50 characters.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            public static bool CheckNameExists(this IDatabaseAccountsOperations operations, string accountName)
-            {
-                return operations.CheckNameExistsAsync(accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks that the Azure DocumentDB account name already exists. A valid
             /// account name may contain only lowercase letters, numbers, and the '-'
@@ -517,25 +314,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 }
             }
 
-            /// <summary>
-            /// Patches the properties of an existing Azure DocumentDB database account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            /// <param name='tags'>
-            /// </param>
-            public static DatabaseAccountInner BeginPatch(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName, IDictionary<string, string> tags)
-            {
-                return operations.BeginPatchAsync(resourceGroupName, accountName, tags).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Patches the properties of an existing Azure DocumentDB database account.
             /// </summary>
@@ -561,26 +340,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates an Azure DocumentDB database account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            /// <param name='createUpdateParameters'>
-            /// The parameters to provide for the current database account.
-            /// </param>
-            public static DatabaseAccountInner BeginCreateOrUpdate(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName, DatabaseAccountCreateUpdateParametersInner createUpdateParameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, accountName, createUpdateParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates an Azure DocumentDB database account.
             /// </summary>
@@ -607,23 +367,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an existing Azure DocumentDB database account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            public static void BeginDelete(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an existing Azure DocumentDB database account.
             /// </summary>
@@ -644,30 +388,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, accountName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Changes the failover priority for the Azure DocumentDB database account. A
-            /// failover priority of 0 indicates a write region. The maximum value for a
-            /// failover priority = (total number of regions - 1). Failover priority values
-            /// must be unique for each of the regions in which the database account
-            /// exists.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            /// <param name='failoverPoliciesProperty'>
-            /// List of failover policies.
-            /// </param>
-            public static void BeginFailoverPriorityChange(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName, IList<FailoverPolicyInner> failoverPoliciesProperty = default(IList<FailoverPolicyInner>))
-            {
-                operations.BeginFailoverPriorityChangeAsync(resourceGroupName, accountName, failoverPoliciesProperty).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Changes the failover priority for the Azure DocumentDB database account. A
             /// failover priority of 0 indicates a write region. The maximum value for a
@@ -695,28 +416,7 @@ namespace Microsoft.Azure.Management.DocumentDB.Fluent
                 (await operations.BeginFailoverPriorityChangeWithHttpMessagesAsync(resourceGroupName, accountName, failoverPoliciesProperty, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Regenerates an access key for the specified Azure DocumentDB database
-            /// account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of an Azure resource group.
-            /// </param>
-            /// <param name='accountName'>
-            /// DocumentDB database account name.
-            /// </param>
-            /// <param name='keyKind'>
-            /// The access key to regenerate. Possible values include: 'primary',
-            /// 'secondary', 'primaryReadonly', 'secondaryReadonly'
-            /// </param>
-            public static void BeginRegenerateKey(this IDatabaseAccountsOperations operations, string resourceGroupName, string accountName, string keyKind)
-            {
-                operations.BeginRegenerateKeyAsync(resourceGroupName, accountName, keyKind).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Regenerates an access key for the specified Azure DocumentDB database
             /// account.

--- a/src/ResourceManagement/Graph.RBAC/ActiveDirectoryApplicationsImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ActiveDirectoryApplicationsImpl.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 return Extensions.Synchronize(() => ((ActiveDirectoryApplicationImpl)WrapModel(inner)).RefreshCredentialsAsync());
             };
 
-            return Inner.List()
-                        .AsContinuousCollection(link => Inner.ListNext(link))
+            return Extensions.Synchronize(() => Inner.ListAsync())
+                        .AsContinuousCollection(link => Extensions.Synchronize(() => Inner.ListNextAsync(link)))
                         .Select(inner => converter(inner));
         }
 
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         public ActiveDirectoryApplicationImpl GetById(string id)
         {
-            return (ActiveDirectoryApplicationImpl) Extensions.Synchronize(() => ((ActiveDirectoryApplicationImpl)WrapModel(innerCollection.Get(id))).RefreshCredentialsAsync());
+            return (ActiveDirectoryApplicationImpl) Extensions.Synchronize(() => ((ActiveDirectoryApplicationImpl)WrapModel(Extensions.Synchronize(() => innerCollection.GetAsync(id)))).RefreshCredentialsAsync());
         }
 
         public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryApplication> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         public override void DeleteById(string id)
         {
-            innerCollection.Delete(id);
+            Extensions.Synchronize(() => innerCollection.DeleteAsync(id));
         }
     }
 }

--- a/src/ResourceManagement/Graph.RBAC/ActiveDirectoryApplicationsImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ActiveDirectoryApplicationsImpl.cs
@@ -15,32 +15,32 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// <summary>
     /// The implementation of Applications and its parent interfaces.
     /// </summary>
-    public partial class ActiveDirectoryApplicationsImpl  :
-        CreatableResources<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryApplication,Microsoft.Azure.Management.Graph.RBAC.Fluent.ActiveDirectoryApplicationImpl,Models.ApplicationInner>,
+    public partial class ActiveDirectoryApplicationsImpl :
+        CreatableResources<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryApplication, Microsoft.Azure.Management.Graph.RBAC.Fluent.ActiveDirectoryApplicationImpl, Models.ApplicationInner>,
         IActiveDirectoryApplications,
         IHasManager<Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManager>,
         IHasInner<Microsoft.Azure.Management.Graph.RBAC.Fluent.IApplicationsOperations>
     {
         private IApplicationsOperations innerCollection;
         private GraphRbacManager manager;
-                public GraphRbacManager Manager()
+        public GraphRbacManager Manager()
         {
             return this.manager;
         }
 
-                public override async Task DeleteByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task DeleteByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
             await innerCollection.DeleteAsync(id, cancellationToken);
         }
 
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryApplication> GetByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryApplication> GetByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             IEnumerable<ApplicationInner> inners = await manager.Inner.Applications.ListAsync(string.Format("displayName eq '{0}'", name), cancellationToken);
             if (inners == null || !inners.Any())
             {
                 inners = await manager.Inner.Applications.ListAsync(string.Format("appId eq '{0}'", name), cancellationToken);
             }
-            if (inners == null || ! inners.Any())
+            if (inners == null || !inners.Any())
             {
                 return null;
             }
@@ -50,11 +50,11 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             }
         }
 
-                public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryApplication> List()
+        public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryApplication> List()
         {
             Func<ApplicationInner, IActiveDirectoryApplication> converter = inner =>
             {
-                return ((ActiveDirectoryApplicationImpl) WrapModel(inner)).RefreshCredentialsAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+                return Extensions.Synchronize(() => ((ActiveDirectoryApplicationImpl)WrapModel(inner)).RefreshCredentialsAsync());
             };
 
             return Inner.List()
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                         .Select(inner => converter(inner));
         }
 
-                public IApplicationsOperations Inner
+        public IApplicationsOperations Inner
         {
             get
             {
@@ -70,34 +70,34 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             }
         }
 
-                public ActiveDirectoryApplicationImpl GetById(string id)
+        public ActiveDirectoryApplicationImpl GetById(string id)
         {
-            return (ActiveDirectoryApplicationImpl)((ActiveDirectoryApplicationImpl)WrapModel(innerCollection.Get(id))).RefreshCredentialsAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return (ActiveDirectoryApplicationImpl) Extensions.Synchronize(() => ((ActiveDirectoryApplicationImpl)WrapModel(innerCollection.Get(id))).RefreshCredentialsAsync());
         }
 
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryApplication> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryApplication> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await ((ActiveDirectoryApplicationImpl)WrapModel(await innerCollection.GetAsync(id, cancellationToken))).RefreshCredentialsAsync(cancellationToken);
         }
 
-                public IActiveDirectoryApplication GetByName(string spn)
+        public IActiveDirectoryApplication GetByName(string spn)
         {
-            return GetByNameAsync(spn).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetByNameAsync(spn));
         }
 
-                public ActiveDirectoryApplicationImpl Define(string name)
+        public ActiveDirectoryApplicationImpl Define(string name)
         {
             return WrapModel(name);
         }
 
-                internal  ActiveDirectoryApplicationsImpl(GraphRbacManager graphRbacManager)
+        internal ActiveDirectoryApplicationsImpl(GraphRbacManager graphRbacManager)
         {
             this.innerCollection = graphRbacManager.Inner.Applications;
             this.manager = graphRbacManager;
 
         }
 
-                public async Task<Microsoft.Azure.Management.ResourceManager.Fluent.Core.IPagedCollection<IActiveDirectoryApplication>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.ResourceManager.Fluent.Core.IPagedCollection<IActiveDirectoryApplication>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await PagedCollection<IActiveDirectoryApplication, ApplicationInner>.LoadPageWithWrapModelAsync(
                 async (cancellation) => await Inner.ListAsync(null, cancellation),
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 loadAllPages, cancellationToken);
         }
 
-                protected override IActiveDirectoryApplication WrapModel(ApplicationInner applicationInner)
+        protected override IActiveDirectoryApplication WrapModel(ApplicationInner applicationInner)
         {
             if (applicationInner == null)
             {
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             return new ActiveDirectoryApplicationImpl(applicationInner, manager);
         }
 
-                protected override ActiveDirectoryApplicationImpl WrapModel(string name)
+        protected override ActiveDirectoryApplicationImpl WrapModel(string name)
         {
             return new ActiveDirectoryApplicationImpl(new ApplicationInner
             {

--- a/src/ResourceManagement/Graph.RBAC/ActiveDirectoryGroupsImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ActiveDirectoryGroupsImpl.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryGroup> List()
         {
-            return WrapList(Inner.List());
+            return WrapList(Extensions.Synchronize(() => Inner.ListAsync()));
         }
 
         public async Task<Microsoft.Azure.Management.ResourceManager.Fluent.Core.IPagedCollection<IActiveDirectoryGroup>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/Graph.RBAC/ActiveDirectoryGroupsImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ActiveDirectoryGroupsImpl.cs
@@ -14,37 +14,37 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// <summary>
     /// The implementation of Users and its parent interfaces.
     /// </summary>
-    public partial class ActiveDirectoryGroupsImpl  :
-        ReadableWrappers<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryGroup,Microsoft.Azure.Management.Graph.RBAC.Fluent.ActiveDirectoryGroupImpl,Models.ADGroupInner>,
+    public partial class ActiveDirectoryGroupsImpl :
+        ReadableWrappers<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryGroup, Microsoft.Azure.Management.Graph.RBAC.Fluent.ActiveDirectoryGroupImpl, Models.ADGroupInner>,
         IActiveDirectoryGroups
     {
         private GraphRbacManager manager;
-                internal  ActiveDirectoryGroupsImpl(GraphRbacManager manager)
+        internal ActiveDirectoryGroupsImpl(GraphRbacManager manager)
         {
             this.manager = manager;
         }
 
-                public GraphRbacManager Manager()
+        public GraphRbacManager Manager()
         {
             return manager;
         }
 
-                public ActiveDirectoryGroupImpl GetById(string objectId)
+        public ActiveDirectoryGroupImpl GetById(string objectId)
         {
-            return (ActiveDirectoryGroupImpl) GetByIdAsync(objectId).ConfigureAwait(false).GetAwaiter().GetResult();
+            return (ActiveDirectoryGroupImpl) Extensions.Synchronize(() => GetByIdAsync(objectId));
         }
 
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryGroup> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryGroup> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
             return WrapModel(await Inner.GetAsync(id, cancellationToken));
         }
-        
-                public IActiveDirectoryGroup GetByName(string name)
+
+        public IActiveDirectoryGroup GetByName(string name)
         {
-            return GetByNameAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetByNameAsync(name));
         }
 
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryGroup> GetByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryGroup> GetByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             IEnumerable<ADGroupInner> inners = await Inner.ListAsync(string.Format("displayName eq '{0}'", name), cancellationToken);
             if (inners == null || !inners.Any())
@@ -54,12 +54,12 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             return WrapModel(inners.First());
         }
 
-                public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryGroup> List()
+        public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryGroup> List()
         {
             return WrapList(Inner.List());
         }
 
-                public async Task<Microsoft.Azure.Management.ResourceManager.Fluent.Core.IPagedCollection<IActiveDirectoryGroup>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.ResourceManager.Fluent.Core.IPagedCollection<IActiveDirectoryGroup>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await PagedCollection<IActiveDirectoryGroup, ADGroupInner>.LoadPage(
                 async (cancellation) => await Inner.ListAsync(null, cancellation),
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (inner) => WrapModel(inner), loadAllPages, cancellationToken);
         }
 
-                public IGroupsOperations Inner
+        public IGroupsOperations Inner
         {
             get
             {
@@ -75,11 +75,11 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             }
         }
 
-                protected override IActiveDirectoryGroup WrapModel(ADGroupInner groupInner)
+        protected override IActiveDirectoryGroup WrapModel(ADGroupInner groupInner)
         {
             if (groupInner == null)
             {
-                return null;    
+                return null;
             }
             return new ActiveDirectoryGroupImpl(groupInner, manager);
         }

--- a/src/ResourceManagement/Graph.RBAC/ActiveDirectoryUsersImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ActiveDirectoryUsersImpl.cs
@@ -16,38 +16,38 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// <summary>
     /// The implementation of Users and its parent interfaces.
     /// </summary>
-    public partial class ActiveDirectoryUsersImpl  :
-        ReadableWrappers<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryUser,Microsoft.Azure.Management.Graph.RBAC.Fluent.ActiveDirectoryUserImpl,Models.UserInner>,
+    public partial class ActiveDirectoryUsersImpl :
+        ReadableWrappers<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryUser, Microsoft.Azure.Management.Graph.RBAC.Fluent.ActiveDirectoryUserImpl, Models.UserInner>,
         IActiveDirectoryUsers,
         IHasInner<Microsoft.Azure.Management.Graph.RBAC.Fluent.IUsersOperations>
     {
         private GraphRbacManager manager;
-                public GraphRbacManager Manager()
+        public GraphRbacManager Manager()
         {
             return manager;
         }
 
-                public ActiveDirectoryUserImpl GetById(string objectId)
+        public ActiveDirectoryUserImpl GetById(string objectId)
         {
-            return (ActiveDirectoryUserImpl) GetByIdAsync(objectId).ConfigureAwait(false).GetAwaiter().GetResult();
+            return (ActiveDirectoryUserImpl) Extensions.Synchronize(() => GetByIdAsync(objectId));
         }
 
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryUser> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryUser> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
             return WrapModel(await Inner.GetAsync(id, cancellationToken));
         }
-        
-                internal  ActiveDirectoryUsersImpl(GraphRbacManager manager)
+
+        internal ActiveDirectoryUsersImpl(GraphRbacManager manager)
         {
             this.manager = manager;
         }
 
-                public ActiveDirectoryUserImpl GetByName(string upn)
+        public ActiveDirectoryUserImpl GetByName(string upn)
         {
-            return (ActiveDirectoryUserImpl) GetByNameAsync(upn).ConfigureAwait(false).GetAwaiter().GetResult();
+            return (ActiveDirectoryUserImpl) Extensions.Synchronize(() => GetByNameAsync(upn));
         }
 
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryUser> GetByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryUser> GetByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             UserInner inner = null;
             try
@@ -84,12 +84,12 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             return null;
         }
 
-                public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryUser> List()
+        public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryUser> List()
         {
             return WrapList(this.manager.Inner.Users.List());
         }
 
-                public IUsersOperations Inner
+        public IUsersOperations Inner
         {
             get
             {
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             }
         }
 
-                public async Task<Microsoft.Azure.Management.ResourceManager.Fluent.Core.IPagedCollection<IActiveDirectoryUser>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.ResourceManager.Fluent.Core.IPagedCollection<IActiveDirectoryUser>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await PagedCollection<IActiveDirectoryUser, UserInner>.LoadPage(
                 async (cancellation) => await Inner.ListAsync(null, cancellation),
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 WrapModel, loadAllPages, cancellationToken);
         }
 
-                protected override IActiveDirectoryUser WrapModel(UserInner userInner)
+        protected override IActiveDirectoryUser WrapModel(UserInner userInner)
         {
             if (userInner == null)
             {

--- a/src/ResourceManagement/Graph.RBAC/ActiveDirectoryUsersImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ActiveDirectoryUsersImpl.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IActiveDirectoryUser> List()
         {
-            return WrapList(this.manager.Inner.Users.List());
+            return WrapList(Extensions.Synchronize(() => this.manager.Inner.Users.ListAsync()));
         }
 
         public IUsersOperations Inner

--- a/src/ResourceManagement/Graph.RBAC/Generated/ApplicationsOperationsExtensions.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/ApplicationsOperationsExtensions.cs
@@ -26,20 +26,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// </summary>
     public static partial class ApplicationsOperationsExtensions
     {
-            /// <summary>
-            /// Create a new application.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='parameters'>
-            /// The parameters for creating an application.
-            /// </param>
-            public static ApplicationInner Create(this IApplicationsOperations operations, ApplicationCreateParametersInner parameters)
-            {
-                return operations.CreateAsync(parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a new application.
             /// </summary>
@@ -60,20 +47,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists applications by filter parameters.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<ApplicationInner> List(this IApplicationsOperations operations, ODataQuery<ApplicationInner> odataQuery = default(ODataQuery<ApplicationInner>))
-            {
-                return ((IApplicationsOperations)operations).ListAsync(odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists applications by filter parameters.
             /// </summary>
@@ -94,20 +68,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete an application.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='applicationObjectId'>
-            /// Application object ID.
-            /// </param>
-            public static void Delete(this IApplicationsOperations operations, string applicationObjectId)
-            {
-                operations.DeleteAsync(applicationObjectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete an application.
             /// </summary>
@@ -125,20 +86,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(applicationObjectId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get an application by object ID.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='applicationObjectId'>
-            /// Application object ID.
-            /// </param>
-            public static ApplicationInner Get(this IApplicationsOperations operations, string applicationObjectId)
-            {
-                return operations.GetAsync(applicationObjectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get an application by object ID.
             /// </summary>
@@ -159,23 +107,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Update an existing application.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='applicationObjectId'>
-            /// Application object ID.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters to update an existing application.
-            /// </param>
-            public static void Patch(this IApplicationsOperations operations, string applicationObjectId, ApplicationUpdateParametersInner parameters)
-            {
-                operations.PatchAsync(applicationObjectId, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Update an existing application.
             /// </summary>
@@ -196,20 +128,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.PatchWithHttpMessagesAsync(applicationObjectId, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get the keyCredentials associated with an application.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='applicationObjectId'>
-            /// Application object ID.
-            /// </param>
-            public static IEnumerable<KeyCredential> ListKeyCredentials(this IApplicationsOperations operations, string applicationObjectId)
-            {
-                return operations.ListKeyCredentialsAsync(applicationObjectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the keyCredentials associated with an application.
             /// </summary>
@@ -230,23 +149,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Update the keyCredentials associated with an application.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='applicationObjectId'>
-            /// Application object ID.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters to update the keyCredentials of an existing application.
-            /// </param>
-            public static void UpdateKeyCredentials(this IApplicationsOperations operations, string applicationObjectId, KeyCredentialsUpdateParametersInner parameters)
-            {
-                operations.UpdateKeyCredentialsAsync(applicationObjectId, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Update the keyCredentials associated with an application.
             /// </summary>
@@ -267,20 +170,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.UpdateKeyCredentialsWithHttpMessagesAsync(applicationObjectId, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get the passwordCredentials associated with an application.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='applicationObjectId'>
-            /// Application object ID.
-            /// </param>
-            public static IEnumerable<Models.PasswordCredential> ListPasswordCredentials(this IApplicationsOperations operations, string applicationObjectId)
-            {
-                return operations.ListPasswordCredentialsAsync(applicationObjectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the passwordCredentials associated with an application.
             /// </summary>
@@ -301,23 +191,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Update passwordCredentials associated with an application.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='applicationObjectId'>
-            /// Application object ID.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters to update passwordCredentials of an existing application.
-            /// </param>
-            public static void UpdatePasswordCredentials(this IApplicationsOperations operations, string applicationObjectId, PasswordCredentialsUpdateParametersInner parameters)
-            {
-                operations.UpdatePasswordCredentialsAsync(applicationObjectId, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Update passwordCredentials associated with an application.
             /// </summary>
@@ -338,20 +212,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.UpdatePasswordCredentialsWithHttpMessagesAsync(applicationObjectId, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets a list of applications from the current tenant.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextLink'>
-            /// Next link for the list operation.
-            /// </param>
-            public static IPage<ApplicationInner> ListNext(this IApplicationsOperations operations, string nextLink)
-            {
-                return operations.ListNextAsync(nextLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of applications from the current tenant.
             /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/Generated/ClassicAdministratorsOperationsExtensions.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/ClassicAdministratorsOperationsExtensions.cs
@@ -23,21 +23,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// </summary>
     public static partial class ClassicAdministratorsOperationsExtensions
     {
-            /// <summary>
-            /// Gets service administrator, account administrator, and co-administrators
-            /// for the subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='apiVersion'>
-            /// The API version to use for this operation.
-            /// </param>
-            public static IPage<ClassicAdministrator> List(this IClassicAdministratorsOperations operations, string apiVersion)
-            {
-                return operations.ListAsync(apiVersion).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets service administrator, account administrator, and co-administrators
             /// for the subscription.
@@ -59,21 +45,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets service administrator, account administrator, and co-administrators
-            /// for the subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ClassicAdministrator> ListNext(this IClassicAdministratorsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets service administrator, account administrator, and co-administrators
             /// for the subscription.

--- a/src/ResourceManagement/Graph.RBAC/Generated/GroupsOperationsExtensions.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/GroupsOperationsExtensions.cs
@@ -26,21 +26,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// </summary>
     public static partial class GroupsOperationsExtensions
     {
-            /// <summary>
-            /// Checks whether the specified user, group, contact, or service principal is
-            /// a direct or transitive member of the specified group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='parameters'>
-            /// The check group membership parameters.
-            /// </param>
-            public static CheckGroupMembershipResultInner IsMemberOf(this IGroupsOperations operations, CheckGroupMembershipParametersInner parameters)
-            {
-                return operations.IsMemberOfAsync(parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks whether the specified user, group, contact, or service principal is
             /// a direct or transitive member of the specified group.
@@ -62,23 +48,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Remove a member from a group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='groupObjectId'>
-            /// The object ID of the group from which to remove the member.
-            /// </param>
-            /// <param name='memberObjectId'>
-            /// Member object id
-            /// </param>
-            public static void RemoveMember(this IGroupsOperations operations, string groupObjectId, string memberObjectId)
-            {
-                operations.RemoveMemberAsync(groupObjectId, memberObjectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Remove a member from a group.
             /// </summary>
@@ -99,24 +69,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.RemoveMemberWithHttpMessagesAsync(groupObjectId, memberObjectId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Add a member to a group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='groupObjectId'>
-            /// The object ID of the group to which to add the member.
-            /// </param>
-            /// <param name='parameters'>
-            /// The URL of the member object, such as
-            /// https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
-            /// </param>
-            public static void AddMember(this IGroupsOperations operations, string groupObjectId, GroupAddMemberParametersInner parameters)
-            {
-                operations.AddMemberAsync(groupObjectId, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Add a member to a group.
             /// </summary>
@@ -138,20 +91,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.AddMemberWithHttpMessagesAsync(groupObjectId, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Delete a group from the directory.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='groupObjectId'>
-            /// The object ID of the group to delete.
-            /// </param>
-            public static void Delete(this IGroupsOperations operations, string groupObjectId)
-            {
-                operations.DeleteAsync(groupObjectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a group from the directory.
             /// </summary>
@@ -169,20 +109,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(groupObjectId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Create a group in the directory.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='parameters'>
-            /// The parameters for the group to create.
-            /// </param>
-            public static ADGroupInner Create(this IGroupsOperations operations, GroupCreateParametersInner parameters)
-            {
-                return operations.CreateAsync(parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a group in the directory.
             /// </summary>
@@ -203,20 +130,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets list of groups for the current tenant.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<ADGroupInner> List(this IGroupsOperations operations, ODataQuery<ADGroupInner> odataQuery = default(ODataQuery<ADGroupInner>))
-            {
-                return ((IGroupsOperations)operations).ListAsync(odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets list of groups for the current tenant.
             /// </summary>
@@ -237,20 +151,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the members of a group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='objectId'>
-            /// The object ID of the group whose members should be retrieved.
-            /// </param>
-            public static IPage<AADObjectInner> GetGroupMembers(this IGroupsOperations operations, string objectId)
-            {
-                return operations.GetGroupMembersAsync(objectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the members of a group.
             /// </summary>
@@ -271,20 +172,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets group information from the directory.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='objectId'>
-            /// The object ID of the user for which to get group information.
-            /// </param>
-            public static ADGroupInner Get(this IGroupsOperations operations, string objectId)
-            {
-                return operations.GetAsync(objectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets group information from the directory.
             /// </summary>
@@ -305,24 +193,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a collection of object IDs of groups of which the specified group is a
-            /// member.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='objectId'>
-            /// The object ID of the group for which to get group membership.
-            /// </param>
-            /// <param name='parameters'>
-            /// Group filtering parameters.
-            /// </param>
-            public static IEnumerable<string> GetMemberGroups(this IGroupsOperations operations, string objectId, GroupGetMemberGroupsParametersInner parameters)
-            {
-                return operations.GetMemberGroupsAsync(objectId, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a collection of object IDs of groups of which the specified group is a
             /// member.
@@ -347,20 +218,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of groups for the current tenant.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextLink'>
-            /// Next link for the list operation.
-            /// </param>
-            public static IPage<ADGroupInner> ListNext(this IGroupsOperations operations, string nextLink)
-            {
-                return operations.ListNextAsync(nextLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of groups for the current tenant.
             /// </summary>
@@ -381,20 +239,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the members of a group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextLink'>
-            /// Next link for the list operation.
-            /// </param>
-            public static IPage<AADObjectInner> GetGroupMembersNext(this IGroupsOperations operations, string nextLink)
-            {
-                return operations.GetGroupMembersNextAsync(nextLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the members of a group.
             /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/Generated/ObjectsOperationsExtensions.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/ObjectsOperationsExtensions.cs
@@ -23,17 +23,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// </summary>
     public static partial class ObjectsOperationsExtensions
     {
-            /// <summary>
-            /// Gets the details for the currently logged-in user.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static AADObjectInner GetCurrentUser(this IObjectsOperations operations)
-            {
-                return operations.GetCurrentUserAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the details for the currently logged-in user.
             /// </summary>
@@ -51,20 +41,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets AD group membership for the specified AD object IDs.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='parameters'>
-            /// Objects filtering parameters.
-            /// </param>
-            public static IPage<AADObjectInner> GetObjectsByObjectIds(this IObjectsOperations operations, GetObjectsParametersInner parameters)
-            {
-                return operations.GetObjectsByObjectIdsAsync(parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets AD group membership for the specified AD object IDs.
             /// </summary>
@@ -85,20 +62,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets AD group membership for the specified AD object IDs.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextLink'>
-            /// Next link for the list operation.
-            /// </param>
-            public static IPage<AADObjectInner> GetObjectsByObjectIdsNext(this IObjectsOperations operations, string nextLink)
-            {
-                return operations.GetObjectsByObjectIdsNextAsync(nextLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets AD group membership for the specified AD object IDs.
             /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/Generated/PermissionsOperationsExtensions.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/PermissionsOperationsExtensions.cs
@@ -23,21 +23,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// </summary>
     public static partial class PermissionsOperationsExtensions
     {
-            /// <summary>
-            /// Gets all permissions the caller has for a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to get the permissions for. The name is case
-            /// insensitive.
-            /// </param>
-            public static IPage<Permission> ListForResourceGroup(this IPermissionsOperations operations, string resourceGroupName)
-            {
-                return operations.ListForResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all permissions the caller has for a resource group.
             /// </summary>
@@ -59,33 +45,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all permissions the caller has for a resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group containing the resource. The name is case
-            /// insensitive.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// The namespace of the resource provider.
-            /// </param>
-            /// <param name='parentResourcePath'>
-            /// The parent resource identity.
-            /// </param>
-            /// <param name='resourceType'>
-            /// The resource type of the resource.
-            /// </param>
-            /// <param name='resourceName'>
-            /// The name of the resource to get the permissions for.
-            /// </param>
-            public static IPage<Permission> ListForResource(this IPermissionsOperations operations, string resourceGroupName, string resourceProviderNamespace, string parentResourcePath, string resourceType, string resourceName)
-            {
-                return operations.ListForResourceAsync(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all permissions the caller has for a resource.
             /// </summary>
@@ -119,20 +79,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all permissions the caller has for a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<Permission> ListForResourceGroupNext(this IPermissionsOperations operations, string nextPageLink)
-            {
-                return operations.ListForResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all permissions the caller has for a resource group.
             /// </summary>
@@ -153,20 +100,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all permissions the caller has for a resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<Permission> ListForResourceNext(this IPermissionsOperations operations, string nextPageLink)
-            {
-                return operations.ListForResourceNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all permissions the caller has for a resource.
             /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/Generated/ProviderOperationsMetadataOperationsExtensions.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/ProviderOperationsMetadataOperationsExtensions.cs
@@ -23,26 +23,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// </summary>
     public static partial class ProviderOperationsMetadataOperationsExtensions
     {
-            /// <summary>
-            /// Gets provider operations metadata for the specified resource provider.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// The namespace of the resource provider.
-            /// </param>
-            /// <param name='apiVersion'>
-            /// The API version to use for the operation.
-            /// </param>
-            /// <param name='expand'>
-            /// Specifies whether to expand the values.
-            /// </param>
-            public static ProviderOperationsMetadataInner Get(this IProviderOperationsMetadataOperations operations, string resourceProviderNamespace, string apiVersion, string expand = "resourceTypes")
-            {
-                return operations.GetAsync(resourceProviderNamespace, apiVersion, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets provider operations metadata for the specified resource provider.
             /// </summary>
@@ -69,23 +50,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets provider operations metadata for all resource providers.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='apiVersion'>
-            /// The API version to use for this operation.
-            /// </param>
-            /// <param name='expand'>
-            /// Specifies whether to expand the values.
-            /// </param>
-            public static IPage<ProviderOperationsMetadataInner> List(this IProviderOperationsMetadataOperations operations, string apiVersion, string expand = "resourceTypes")
-            {
-                return operations.ListAsync(apiVersion, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets provider operations metadata for all resource providers.
             /// </summary>
@@ -109,20 +74,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets provider operations metadata for all resource providers.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ProviderOperationsMetadataInner> ListNext(this IProviderOperationsMetadataOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets provider operations metadata for all resource providers.
             /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/Generated/RoleAssignmentsOperationsExtensions.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/RoleAssignmentsOperationsExtensions.cs
@@ -24,35 +24,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// </summary>
     public static partial class RoleAssignmentsOperationsExtensions
     {
-            /// <summary>
-            /// Gets role assignments for a resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// The namespace of the resource provider.
-            /// </param>
-            /// <param name='parentResourcePath'>
-            /// The parent resource identity.
-            /// </param>
-            /// <param name='resourceType'>
-            /// The resource type of the resource.
-            /// </param>
-            /// <param name='resourceName'>
-            /// The name of the resource to get role assignments for.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<RoleAssignmentInner> ListForResource(this IRoleAssignmentsOperations operations, string resourceGroupName, string resourceProviderNamespace, string parentResourcePath, string resourceType, string resourceName, ODataQuery<RoleAssignmentFilterInner> odataQuery = default(ODataQuery<RoleAssignmentFilterInner>))
-            {
-                return ((IRoleAssignmentsOperations)operations).ListForResourceAsync(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets role assignments for a resource.
             /// </summary>
@@ -88,23 +60,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets role assignments for a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<RoleAssignmentInner> ListForResourceGroup(this IRoleAssignmentsOperations operations, string resourceGroupName, ODataQuery<RoleAssignmentFilterInner> odataQuery = default(ODataQuery<RoleAssignmentFilterInner>))
-            {
-                return ((IRoleAssignmentsOperations)operations).ListForResourceGroupAsync(resourceGroupName, odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets role assignments for a resource group.
             /// </summary>
@@ -128,23 +84,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a role assignment.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='scope'>
-            /// The scope of the role assignment to delete.
-            /// </param>
-            /// <param name='roleAssignmentName'>
-            /// The name of the role assignment to delete.
-            /// </param>
-            public static RoleAssignmentInner Delete(this IRoleAssignmentsOperations operations, string scope, string roleAssignmentName)
-            {
-                return operations.DeleteAsync(scope, roleAssignmentName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a role assignment.
             /// </summary>
@@ -168,32 +108,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a role assignment.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='scope'>
-            /// The scope of the role assignment to create. The scope can be any REST
-            /// resource instance. For example, use '/subscriptions/{subscription-id}/' for
-            /// a subscription,
-            /// '/subscriptions/{subscription-id}/resourceGroups/{resource-group-name}' for
-            /// a resource group, and
-            /// '/subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/providers/{resource-provider}/{resource-type}/{resource-name}'
-            /// for a resource.
-            /// </param>
-            /// <param name='roleAssignmentName'>
-            /// The name of the role assignment to create. It can be any valid GUID.
-            /// </param>
-            /// <param name='properties'>
-            /// Role assignment properties.
-            /// </param>
-            public static RoleAssignmentInner Create(this IRoleAssignmentsOperations operations, string scope, string roleAssignmentName, RoleAssignmentPropertiesInner properties = default(RoleAssignmentPropertiesInner))
-            {
-                return operations.CreateAsync(scope, roleAssignmentName, properties).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a role assignment.
             /// </summary>
@@ -226,23 +141,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the specified role assignment.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='scope'>
-            /// The scope of the role assignment.
-            /// </param>
-            /// <param name='roleAssignmentName'>
-            /// The name of the role assignment to get.
-            /// </param>
-            public static RoleAssignmentInner Get(this IRoleAssignmentsOperations operations, string scope, string roleAssignmentName)
-            {
-                return operations.GetAsync(scope, roleAssignmentName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the specified role assignment.
             /// </summary>
@@ -266,20 +165,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a role assignment.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='roleAssignmentId'>
-            /// The ID of the role assignment to delete.
-            /// </param>
-            public static RoleAssignmentInner DeleteById(this IRoleAssignmentsOperations operations, string roleAssignmentId)
-            {
-                return operations.DeleteByIdAsync(roleAssignmentId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a role assignment.
             /// </summary>
@@ -300,23 +186,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a role assignment by ID.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='roleAssignmentId'>
-            /// The ID of the role assignment to create.
-            /// </param>
-            /// <param name='properties'>
-            /// Role assignment properties.
-            /// </param>
-            public static RoleAssignmentInner CreateById(this IRoleAssignmentsOperations operations, string roleAssignmentId, RoleAssignmentPropertiesInner properties = default(RoleAssignmentPropertiesInner))
-            {
-                return operations.CreateByIdAsync(roleAssignmentId, properties).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a role assignment by ID.
             /// </summary>
@@ -340,20 +210,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a role assignment by ID.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='roleAssignmentId'>
-            /// The ID of the role assignment to get.
-            /// </param>
-            public static RoleAssignmentInner GetById(this IRoleAssignmentsOperations operations, string roleAssignmentId)
-            {
-                return operations.GetByIdAsync(roleAssignmentId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a role assignment by ID.
             /// </summary>
@@ -374,20 +231,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all role assignments for the subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<RoleAssignmentInner> List(this IRoleAssignmentsOperations operations, ODataQuery<RoleAssignmentFilterInner> odataQuery = default(ODataQuery<RoleAssignmentFilterInner>))
-            {
-                return ((IRoleAssignmentsOperations)operations).ListAsync(odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all role assignments for the subscription.
             /// </summary>
@@ -408,23 +252,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets role assignments for a scope.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='scope'>
-            /// The scope of the role assignments.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<RoleAssignmentInner> ListForScope(this IRoleAssignmentsOperations operations, string scope, ODataQuery<RoleAssignmentFilterInner> odataQuery = default(ODataQuery<RoleAssignmentFilterInner>))
-            {
-                return operations.ListForScopeAsync(scope, odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets role assignments for a scope.
             /// </summary>
@@ -448,20 +276,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets role assignments for a resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RoleAssignmentInner> ListForResourceNext(this IRoleAssignmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListForResourceNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets role assignments for a resource.
             /// </summary>
@@ -482,20 +297,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets role assignments for a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RoleAssignmentInner> ListForResourceGroupNext(this IRoleAssignmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListForResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets role assignments for a resource group.
             /// </summary>
@@ -516,20 +318,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all role assignments for the subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RoleAssignmentInner> ListNext(this IRoleAssignmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all role assignments for the subscription.
             /// </summary>
@@ -550,20 +339,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets role assignments for a scope.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RoleAssignmentInner> ListForScopeNext(this IRoleAssignmentsOperations operations, string nextPageLink)
-            {
-                return operations.ListForScopeNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets role assignments for a scope.
             /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/Generated/RoleDefinitionsOperationsExtensions.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/RoleDefinitionsOperationsExtensions.cs
@@ -24,23 +24,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// </summary>
     public static partial class RoleDefinitionsOperationsExtensions
     {
-            /// <summary>
-            /// Deletes a role definition.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='scope'>
-            /// The scope of the role definition.
-            /// </param>
-            /// <param name='roleDefinitionId'>
-            /// The ID of the role definition to delete.
-            /// </param>
-            public static RoleDefinitionInner Delete(this IRoleDefinitionsOperations operations, string scope, string roleDefinitionId)
-            {
-                return operations.DeleteAsync(scope, roleDefinitionId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a role definition.
             /// </summary>
@@ -64,23 +48,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get role definition by name (GUID).
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='scope'>
-            /// The scope of the role definition.
-            /// </param>
-            /// <param name='roleDefinitionId'>
-            /// The ID of the role definition.
-            /// </param>
-            public static RoleDefinitionInner Get(this IRoleDefinitionsOperations operations, string scope, string roleDefinitionId)
-            {
-                return operations.GetAsync(scope, roleDefinitionId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get role definition by name (GUID).
             /// </summary>
@@ -104,26 +72,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a role definition.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='scope'>
-            /// The scope of the role definition.
-            /// </param>
-            /// <param name='roleDefinitionId'>
-            /// The ID of the role definition.
-            /// </param>
-            /// <param name='roleDefinition'>
-            /// The values for the role definition.
-            /// </param>
-            public static RoleDefinitionInner CreateOrUpdate(this IRoleDefinitionsOperations operations, string scope, string roleDefinitionId, RoleDefinitionInner roleDefinition)
-            {
-                return operations.CreateOrUpdateAsync(scope, roleDefinitionId, roleDefinition).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a role definition.
             /// </summary>
@@ -150,20 +99,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a role definition by ID.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='roleDefinitionId'>
-            /// The fully qualified role definition ID to get.
-            /// </param>
-            public static RoleDefinitionInner GetById(this IRoleDefinitionsOperations operations, string roleDefinitionId)
-            {
-                return operations.GetByIdAsync(roleDefinitionId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a role definition by ID.
             /// </summary>
@@ -184,23 +120,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all role definitions that are applicable at scope and above.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='scope'>
-            /// The scope of the role definition.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<RoleDefinitionInner> List(this IRoleDefinitionsOperations operations, string scope, ODataQuery<RoleDefinitionFilterInner> odataQuery = default(ODataQuery<RoleDefinitionFilterInner>))
-            {
-                return ((IRoleDefinitionsOperations)operations).ListAsync(scope, odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all role definitions that are applicable at scope and above.
             /// </summary>
@@ -224,20 +144,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get all role definitions that are applicable at scope and above.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RoleDefinitionInner> ListNext(this IRoleDefinitionsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all role definitions that are applicable at scope and above.
             /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/Generated/ServicePrincipalsOperationsExtensions.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/ServicePrincipalsOperationsExtensions.cs
@@ -26,20 +26,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// </summary>
     public static partial class ServicePrincipalsOperationsExtensions
     {
-            /// <summary>
-            /// Creates a service principal in the directory.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters to create a service principal.
-            /// </param>
-            public static ServicePrincipalInner Create(this IServicePrincipalsOperations operations, ServicePrincipalCreateParametersInner parameters)
-            {
-                return operations.CreateAsync(parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a service principal in the directory.
             /// </summary>
@@ -60,20 +47,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of service principals from the current tenant.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<ServicePrincipalInner> List(this IServicePrincipalsOperations operations, ODataQuery<ServicePrincipalInner> odataQuery = default(ODataQuery<ServicePrincipalInner>))
-            {
-                return ((IServicePrincipalsOperations)operations).ListAsync(odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of service principals from the current tenant.
             /// </summary>
@@ -94,20 +68,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a service principal from the directory.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='objectId'>
-            /// The object ID of the service principal to delete.
-            /// </param>
-            public static void Delete(this IServicePrincipalsOperations operations, string objectId)
-            {
-                operations.DeleteAsync(objectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a service principal from the directory.
             /// </summary>
@@ -125,20 +86,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(objectId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets service principal information from the directory.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='objectId'>
-            /// The object ID of the service principal to get.
-            /// </param>
-            public static ServicePrincipalInner Get(this IServicePrincipalsOperations operations, string objectId)
-            {
-                return operations.GetAsync(objectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets service principal information from the directory.
             /// </summary>
@@ -159,20 +107,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the keyCredentials associated with the specified service principal.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='objectId'>
-            /// The object ID of the service principal for which to get keyCredentials.
-            /// </param>
-            public static IEnumerable<KeyCredential> ListKeyCredentials(this IServicePrincipalsOperations operations, string objectId)
-            {
-                return operations.ListKeyCredentialsAsync(objectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the keyCredentials associated with the specified service principal.
             /// </summary>
@@ -193,23 +128,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Update the keyCredentials associated with a service principal.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='objectId'>
-            /// The object ID for which to get service principal information.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters to update the keyCredentials of an existing service principal.
-            /// </param>
-            public static void UpdateKeyCredentials(this IServicePrincipalsOperations operations, string objectId, KeyCredentialsUpdateParametersInner parameters)
-            {
-                operations.UpdateKeyCredentialsAsync(objectId, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Update the keyCredentials associated with a service principal.
             /// </summary>
@@ -230,20 +149,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.UpdateKeyCredentialsWithHttpMessagesAsync(objectId, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the passwordCredentials associated with a service principal.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='objectId'>
-            /// The object ID of the service principal.
-            /// </param>
-            public static IEnumerable<Models.PasswordCredential> ListPasswordCredentials(this IServicePrincipalsOperations operations, string objectId)
-            {
-                return operations.ListPasswordCredentialsAsync(objectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the passwordCredentials associated with a service principal.
             /// </summary>
@@ -264,24 +170,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates the passwordCredentials associated with a service principal.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='objectId'>
-            /// The object ID of the service principal.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters to update the passwordCredentials of an existing service
-            /// principal.
-            /// </param>
-            public static void UpdatePasswordCredentials(this IServicePrincipalsOperations operations, string objectId, PasswordCredentialsUpdateParametersInner parameters)
-            {
-                operations.UpdatePasswordCredentialsAsync(objectId, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates the passwordCredentials associated with a service principal.
             /// </summary>
@@ -303,20 +192,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.UpdatePasswordCredentialsWithHttpMessagesAsync(objectId, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets a list of service principals from the current tenant.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextLink'>
-            /// Next link for the list operation.
-            /// </param>
-            public static IPage<ServicePrincipalInner> ListNext(this IServicePrincipalsOperations operations, string nextLink)
-            {
-                return operations.ListNextAsync(nextLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of service principals from the current tenant.
             /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/Generated/UsersOperationsExtensions.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/UsersOperationsExtensions.cs
@@ -26,20 +26,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// </summary>
     public static partial class UsersOperationsExtensions
     {
-            /// <summary>
-            /// Create a new user.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters to create a user.
-            /// </param>
-            public static UserInner Create(this IUsersOperations operations, UserCreateParametersInner parameters)
-            {
-                return operations.CreateAsync(parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a new user.
             /// </summary>
@@ -60,20 +47,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets list of users for the current tenant.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<UserInner> List(this IUsersOperations operations, ODataQuery<UserInner> odataQuery = default(ODataQuery<UserInner>))
-            {
-                return ((IUsersOperations)operations).ListAsync(odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets list of users for the current tenant.
             /// </summary>
@@ -94,20 +68,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets user information from the directory.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='upnOrObjectId'>
-            /// The object ID or principal name of the user for which to get information.
-            /// </param>
-            public static UserInner Get(this IUsersOperations operations, string upnOrObjectId)
-            {
-                return operations.GetAsync(upnOrObjectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets user information from the directory.
             /// </summary>
@@ -128,23 +89,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates a user.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='upnOrObjectId'>
-            /// The object ID or principal name of the user to update.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters to update an existing user.
-            /// </param>
-            public static void Update(this IUsersOperations operations, string upnOrObjectId, UserUpdateParametersInner parameters)
-            {
-                operations.UpdateAsync(upnOrObjectId, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates a user.
             /// </summary>
@@ -165,20 +110,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.UpdateWithHttpMessagesAsync(upnOrObjectId, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Delete a user.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='upnOrObjectId'>
-            /// The object ID or principal name of the user to delete.
-            /// </param>
-            public static void Delete(this IUsersOperations operations, string upnOrObjectId)
-            {
-                operations.DeleteAsync(upnOrObjectId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a user.
             /// </summary>
@@ -196,24 +128,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(upnOrObjectId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets a collection that contains the object IDs of the groups of which the
-            /// user is a member.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='objectId'>
-            /// The object ID of the user for which to get group membership.
-            /// </param>
-            /// <param name='parameters'>
-            /// User filtering parameters.
-            /// </param>
-            public static IEnumerable<string> GetMemberGroups(this IUsersOperations operations, string objectId, UserGetMemberGroupsParametersInner parameters)
-            {
-                return operations.GetMemberGroupsAsync(objectId, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a collection that contains the object IDs of the groups of which the
             /// user is a member.
@@ -238,20 +153,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of users for the current tenant.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextLink'>
-            /// Next link for the list operation.
-            /// </param>
-            public static IPage<UserInner> ListNext(this IUsersOperations operations, string nextLink)
-            {
-                return operations.ListNextAsync(nextLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of users for the current tenant.
             /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/RoleAssignmentsImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/RoleAssignmentsImpl.cs
@@ -14,38 +14,38 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// <summary>
     /// The implementation of RoleAssignments and its parent interfaces.
     /// </summary>
-    public partial class RoleAssignmentsImpl  :
-        CreatableResources<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleAssignment,Microsoft.Azure.Management.Graph.RBAC.Fluent.RoleAssignmentImpl,Models.RoleAssignmentInner>,
+    public partial class RoleAssignmentsImpl :
+        CreatableResources<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleAssignment, Microsoft.Azure.Management.Graph.RBAC.Fluent.RoleAssignmentImpl, Models.RoleAssignmentInner>,
         IRoleAssignments,
         IHasInner<IRoleAssignmentsOperations>
     {
         private GraphRbacManager manager;
-                public GraphRbacManager Manager()
+        public GraphRbacManager Manager()
         {
             return manager;
         }
 
-                public RoleAssignmentImpl GetById(string objectId)
+        public RoleAssignmentImpl GetById(string objectId)
         {
-            return (RoleAssignmentImpl) GetByIdAsync(objectId).ConfigureAwait(false).GetAwaiter().GetResult();
+            return (RoleAssignmentImpl) Extensions.Synchronize(() => GetByIdAsync(objectId));
         }
 
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleAssignment> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleAssignment> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
             return WrapModel(await manager.RoleInner.RoleAssignments.GetByIdAsync(id, cancellationToken));
         }
 
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleAssignment> GetByScopeAsync(string scope, string name, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleAssignment> GetByScopeAsync(string scope, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             return WrapModel(await manager.RoleInner.RoleAssignments.GetAsync(scope, name, cancellationToken));
         }
 
-                public RoleAssignmentImpl Define(string name)
+        public RoleAssignmentImpl Define(string name)
         {
             return WrapModel(name);
         }
 
-                public async Task<IPagedCollection<IRoleAssignment>> ListByScopeAsync(string scope, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IPagedCollection<IRoleAssignment>> ListByScopeAsync(string scope, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await PagedCollection<IRoleAssignment, RoleAssignmentInner>.LoadPage(
                 async (cancellation) => await manager.RoleInner.RoleAssignments.ListForScopeAsync(scope, null, cancellation),
@@ -53,22 +53,22 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 WrapModel, true, cancellationToken);
         }
 
-                public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleAssignment> ListByScope(string scope)
+        public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleAssignment> ListByScope(string scope)
         {
             return WrapList(manager.RoleInner.RoleAssignments.ListForScope(scope));
         }
 
-                public override async Task DeleteByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task DeleteByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
             await manager.RoleInner.RoleAssignments.DeleteByIdAsync(id, cancellationToken);
         }
 
-                public RoleAssignmentImpl GetByScope(string scope, string name)
+        public RoleAssignmentImpl GetByScope(string scope, string name)
         {
-            return (RoleAssignmentImpl) GetByScopeAsync(scope, name).ConfigureAwait(false).GetAwaiter().GetResult();
+            return (RoleAssignmentImpl) Extensions.Synchronize(() => GetByScopeAsync(scope, name));
         }
 
-                public IRoleAssignmentsOperations Inner
+        public IRoleAssignmentsOperations Inner
         {
             get
             {
@@ -76,12 +76,12 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             }
         }
 
-                internal  RoleAssignmentsImpl(GraphRbacManager manager)
+        internal RoleAssignmentsImpl(GraphRbacManager manager)
         {
             this.manager = manager;
         }
 
-                protected override IRoleAssignment WrapModel(RoleAssignmentInner roleAssignmentInner)
+        protected override IRoleAssignment WrapModel(RoleAssignmentInner roleAssignmentInner)
         {
             if (roleAssignmentInner == null)
             {
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             return new RoleAssignmentImpl(roleAssignmentInner, manager);
         }
 
-                protected override RoleAssignmentImpl WrapModel(string name)
+        protected override RoleAssignmentImpl WrapModel(string name)
         {
             return new RoleAssignmentImpl(new RoleAssignmentInner
             {

--- a/src/ResourceManagement/Graph.RBAC/RoleAssignmentsImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/RoleAssignmentsImpl.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleAssignment> ListByScope(string scope)
         {
-            return WrapList(manager.RoleInner.RoleAssignments.ListForScope(scope));
+            return WrapList(Extensions.Synchronize(() => manager.RoleInner.RoleAssignments.ListForScopeAsync(scope)));
         }
 
         public override async Task DeleteByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         public override void DeleteById(string id)
         {
-            manager.RoleInner.RoleAssignments.DeleteById(id);
+            Extensions.Synchronize(() => manager.RoleInner.RoleAssignments.DeleteByIdAsync(id));
         }
     }
 }

--- a/src/ResourceManagement/Graph.RBAC/RoleDefinitionsImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/RoleDefinitionsImpl.cs
@@ -14,38 +14,38 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// <summary>
     /// The implementation of RoleDefinitions and its parent interfaces.
     /// </summary>
-    public partial class RoleDefinitionsImpl  :
-        ReadableWrappers<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleDefinition,Microsoft.Azure.Management.Graph.RBAC.Fluent.RoleDefinitionImpl,Models.RoleDefinitionInner>,
+    public partial class RoleDefinitionsImpl :
+        ReadableWrappers<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleDefinition, Microsoft.Azure.Management.Graph.RBAC.Fluent.RoleDefinitionImpl, Models.RoleDefinitionInner>,
         IRoleDefinitions,
         IHasInner<IRoleDefinitionsOperations>
     {
         private GraphRbacManager manager;
-                public GraphRbacManager Manager()
+        public GraphRbacManager Manager()
         {
             return manager;
         }
 
-                public RoleDefinitionImpl GetById(string objectId)
+        public RoleDefinitionImpl GetById(string objectId)
         {
-            return (RoleDefinitionImpl) GetByIdAsync(objectId).ConfigureAwait(false).GetAwaiter().GetResult();
+            return (RoleDefinitionImpl) Extensions.Synchronize(() => GetByIdAsync(objectId));
         }
 
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleDefinition> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleDefinition> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
             return WrapModel(await manager.RoleInner.RoleDefinitions.GetByIdAsync(id, cancellationToken));
         }
-        
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleDefinition> GetByScopeAsync(string scope, string name, CancellationToken cancellationToken = default(CancellationToken))
+
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleDefinition> GetByScopeAsync(string scope, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             return WrapModel(await manager.RoleInner.RoleDefinitions.GetAsync(scope, name, cancellationToken));
         }
 
-                public RoleDefinitionImpl GetByScopeAndRoleName(string scope, string roleName)
+        public RoleDefinitionImpl GetByScopeAndRoleName(string scope, string roleName)
         {
-            return (RoleDefinitionImpl) GetByScopeAndRoleNameAsync(scope, roleName).ConfigureAwait(false).GetAwaiter().GetResult();
+            return (RoleDefinitionImpl) Extensions.Synchronize(() => GetByScopeAndRoleNameAsync(scope, roleName));
         }
 
-                public async Task<IPagedCollection<IRoleDefinition>> ListByScopeAsync(string scope, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IPagedCollection<IRoleDefinition>> ListByScopeAsync(string scope, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await PagedCollection<IRoleDefinition, RoleDefinitionInner>.LoadPage(
                 async (cancelltation) => await manager.RoleInner.RoleDefinitions.ListAsync(scope, null, cancelltation),
@@ -53,22 +53,22 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 WrapModel, true, cancellationToken);
         }
 
-                public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleDefinition> ListByScope(string scope)
+        public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleDefinition> ListByScope(string scope)
         {
             return WrapList(manager.RoleInner.RoleDefinitions.List(scope));
         }
 
-                internal  RoleDefinitionsImpl(GraphRbacManager manager)
+        internal RoleDefinitionsImpl(GraphRbacManager manager)
         {
             this.manager = manager;
         }
 
-                public RoleDefinitionImpl GetByScope(string scope, string name)
+        public RoleDefinitionImpl GetByScope(string scope, string name)
         {
-            return (RoleDefinitionImpl) GetByScopeAsync(scope, name).ConfigureAwait(false).GetAwaiter().GetResult();
+            return (RoleDefinitionImpl) Extensions.Synchronize(() => GetByScopeAsync(scope, name));
         }
 
-                public IRoleDefinitionsOperations Inner
+        public IRoleDefinitionsOperations Inner
         {
             get
             {
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             }
         }
 
-                protected override IRoleDefinition WrapModel(RoleDefinitionInner roleDefinitionInner)
+        protected override IRoleDefinition WrapModel(RoleDefinitionInner roleDefinitionInner)
         {
             if (roleDefinitionInner == null)
             {
@@ -84,8 +84,8 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             }
             return new RoleDefinitionImpl(roleDefinitionInner, manager);
         }
-        
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleDefinition> GetByScopeAndRoleNameAsync(string scope, string roleName, CancellationToken cancellationToken = default(CancellationToken))
+
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleDefinition> GetByScopeAndRoleNameAsync(string scope, string roleName, CancellationToken cancellationToken = default(CancellationToken))
         {
             var inners = await Inner.ListAsync(scope, string.Format("roleName eq '{0}'", roleName), cancellationToken);
             if (inners == null || !inners.Any())

--- a/src/ResourceManagement/Graph.RBAC/RoleDefinitionsImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/RoleDefinitionsImpl.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IRoleDefinition> ListByScope(string scope)
         {
-            return WrapList(manager.RoleInner.RoleDefinitions.List(scope));
+            return WrapList(Extensions.Synchronize(() => manager.RoleInner.RoleDefinitions.ListAsync(scope)));
         }
 
         internal RoleDefinitionsImpl(GraphRbacManager manager)

--- a/src/ResourceManagement/Graph.RBAC/ServicePrincipalsImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ServicePrincipalsImpl.cs
@@ -15,51 +15,51 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
     /// <summary>
     /// The implementation of ServicePrincipals and its parent interfaces.
     /// </summary>
-    public partial class ServicePrincipalsImpl  :
-        CreatableResources<Microsoft.Azure.Management.Graph.RBAC.Fluent.IServicePrincipal,Microsoft.Azure.Management.Graph.RBAC.Fluent.ServicePrincipalImpl,Models.ServicePrincipalInner>,
+    public partial class ServicePrincipalsImpl :
+        CreatableResources<Microsoft.Azure.Management.Graph.RBAC.Fluent.IServicePrincipal, Microsoft.Azure.Management.Graph.RBAC.Fluent.ServicePrincipalImpl, Models.ServicePrincipalInner>,
         IServicePrincipals,
         IHasManager<Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManager>,
         IHasInner<Microsoft.Azure.Management.Graph.RBAC.Fluent.IServicePrincipalsOperations>
     {
         private IServicePrincipalsOperations innerCollection;
         private GraphRbacManager manager;
-                internal  ServicePrincipalsImpl(GraphRbacManager graphRbacManager)
+        internal ServicePrincipalsImpl(GraphRbacManager graphRbacManager)
         {
             this.innerCollection = graphRbacManager.Inner.ServicePrincipals;
             this.manager = graphRbacManager;
         }
 
-                public GraphRbacManager Manager()
+        public GraphRbacManager Manager()
         {
             return this.manager;
         }
 
-                public ServicePrincipalImpl GetById(string id)
+        public ServicePrincipalImpl GetById(string id)
         {
-            return (ServicePrincipalImpl) GetByIdAsync(id).ConfigureAwait(false).GetAwaiter().GetResult();
+            return (ServicePrincipalImpl) Extensions.Synchronize(() => GetByIdAsync(id));
         }
 
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IServicePrincipal> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IServicePrincipal> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await ((ServicePrincipalImpl)WrapModel(await innerCollection.GetAsync(id, cancellationToken))).RefreshCredentialsAsync(cancellationToken);
         }
 
-                public IServicePrincipal GetByName(string spn)
+        public IServicePrincipal GetByName(string spn)
         {
-            return GetByNameAsync(spn).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetByNameAsync(spn));
         }
 
-                public ServicePrincipalImpl Define(string name)
+        public ServicePrincipalImpl Define(string name)
         {
             return WrapModel(name);
         }
 
-                public async override Task DeleteByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public async override Task DeleteByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
             await manager.Inner.ServicePrincipals.DeleteAsync(id, cancellationToken);
         }
 
-                public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IServicePrincipal> GetByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.Graph.RBAC.Fluent.IServicePrincipal> GetByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             IEnumerable<ServicePrincipalInner> inners = await manager.Inner.ServicePrincipals.ListAsync(string.Format("displayName eq '{0}'", name), cancellationToken);
             if (inners == null || !inners.Any())
@@ -76,11 +76,11 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             }
         }
 
-                public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IServicePrincipal> List()
+        public IEnumerable<Microsoft.Azure.Management.Graph.RBAC.Fluent.IServicePrincipal> List()
         {
             Func<ServicePrincipalInner, IServicePrincipal> converter = inner =>
             {
-                return ((ServicePrincipalImpl)WrapModel(inner)).RefreshCredentialsAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+                return Extensions.Synchronize(() => ((ServicePrincipalImpl)WrapModel(inner)).RefreshCredentialsAsync());
             };
 
             return Inner.List()
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                         .Select(inner => converter(inner));
         }
 
-                public async Task<Microsoft.Azure.Management.ResourceManager.Fluent.Core.IPagedCollection<IServicePrincipal>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Microsoft.Azure.Management.ResourceManager.Fluent.Core.IPagedCollection<IServicePrincipal>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))
         {
             return await PagedCollection<IServicePrincipal, ServicePrincipalInner>.LoadPageWithWrapModelAsync(
                 async (cancellation) => await innerCollection.ListAsync(null, cancellation),
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 loadAllPages, cancellationToken);
         }
 
-                public IServicePrincipalsOperations Inner
+        public IServicePrincipalsOperations Inner
         {
             get
             {
@@ -105,12 +105,12 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             }
         }
 
-                protected override IServicePrincipal WrapModel(ServicePrincipalInner servicePrincipalInner)
+        protected override IServicePrincipal WrapModel(ServicePrincipalInner servicePrincipalInner)
         {
             return servicePrincipalInner == null ? null : new ServicePrincipalImpl(servicePrincipalInner, manager);
         }
 
-                protected override ServicePrincipalImpl WrapModel(string name)
+        protected override ServicePrincipalImpl WrapModel(string name)
         {
             return new ServicePrincipalImpl(new ServicePrincipalInner
             {

--- a/src/ResourceManagement/Graph.RBAC/ServicePrincipalsImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ServicePrincipalsImpl.cs
@@ -83,8 +83,8 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 return Extensions.Synchronize(() => ((ServicePrincipalImpl)WrapModel(inner)).RefreshCredentialsAsync());
             };
 
-            return Inner.List()
-                        .AsContinuousCollection(link => Inner.ListNext(link))
+            return Extensions.Synchronize(() => Inner.ListAsync())
+                        .AsContinuousCollection(link => Extensions.Synchronize(() => Inner.ListNextAsync(link)))
                         .Select(inner => converter(inner));
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         public override void DeleteById(string id)
         {
-            Inner.Delete(id);
+            Extensions.Synchronize(() => Inner.DeleteAsync(id));
         }
     }
 }

--- a/src/ResourceManagement/KeyVault/Generated/VaultsOperationsExtensions.cs
+++ b/src/ResourceManagement/KeyVault/Generated/VaultsOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
     /// </summary>
     public static partial class VaultsOperationsExtensions
     {
-            /// <summary>
-            /// Create or update a key vault in the specified subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the Resource Group to which the server belongs.
-            /// </param>
-            /// <param name='vaultName'>
-            /// Name of the vault
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters to create or update the vault
-            /// </param>
-            public static VaultInner CreateOrUpdate(this IVaultsOperations operations, string resourceGroupName, string vaultName, VaultCreateOrUpdateParametersInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, vaultName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a key vault in the specified subscription.
             /// </summary>
@@ -68,23 +49,7 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified Azure key vault.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the Resource Group to which the vault belongs.
-            /// </param>
-            /// <param name='vaultName'>
-            /// The name of the vault to delete
-            /// </param>
-            public static void Delete(this IVaultsOperations operations, string resourceGroupName, string vaultName)
-            {
-                operations.DeleteAsync(resourceGroupName, vaultName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified Azure key vault.
             /// </summary>
@@ -105,23 +70,7 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, vaultName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified Azure key vault.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the Resource Group to which the vault belongs.
-            /// </param>
-            /// <param name='vaultName'>
-            /// The name of the vault.
-            /// </param>
-            public static VaultInner Get(this IVaultsOperations operations, string resourceGroupName, string vaultName)
-            {
-                return operations.GetAsync(resourceGroupName, vaultName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified Azure key vault.
             /// </summary>
@@ -145,24 +94,7 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
                 }
             }
 
-            /// <summary>
-            /// The List operation gets information about the vaults associated with the
-            /// subscription and within the specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the Resource Group to which the vault belongs.
-            /// </param>
-            /// <param name='top'>
-            /// Maximum number of results to return.
-            /// </param>
-            public static IPage<VaultInner> ListByResourceGroup(this IVaultsOperations operations, string resourceGroupName, int? top = default(int?))
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName, top).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The List operation gets information about the vaults associated with the
             /// subscription and within the specified resource group.
@@ -187,21 +119,7 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
                 }
             }
 
-            /// <summary>
-            /// The List operation gets information about the vaults associated with the
-            /// subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='top'>
-            /// Maximum number of results to return.
-            /// </param>
-            public static IPage<VaultInner> List(this IVaultsOperations operations, int? top = default(int?))
-            {
-                return operations.ListAsync(top).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The List operation gets information about the vaults associated with the
             /// subscription.
@@ -223,21 +141,7 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
                 }
             }
 
-            /// <summary>
-            /// The List operation gets information about the vaults associated with the
-            /// subscription and within the specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VaultInner> ListByResourceGroupNext(this IVaultsOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The List operation gets information about the vaults associated with the
             /// subscription and within the specified resource group.
@@ -259,21 +163,7 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
                 }
             }
 
-            /// <summary>
-            /// The List operation gets information about the vaults associated with the
-            /// subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VaultInner> ListNext(this IVaultsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The List operation gets information about the vaults associated with the
             /// subscription.

--- a/src/ResourceManagement/KeyVault/VaultImpl.cs
+++ b/src/ResourceManagement/KeyVault/VaultImpl.cs
@@ -251,12 +251,20 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
                     if (accessPolicy.UserPrincipalName != null)
                     {
                         tasks.Add(graphRbacManager.Users.GetByNameAsync(accessPolicy.UserPrincipalName, cancellationToken)
-                            .ContinueWith(user => accessPolicy.ForObjectId(Guid.Parse(user.Result.Id))));
+                            .ContinueWith(
+                                user => accessPolicy.ForObjectId(Guid.Parse(user.Result.Id)),
+                                cancellationToken,
+                                TaskContinuationOptions.ExecuteSynchronously,
+                                TaskScheduler.Default));
                     }
                     else if (accessPolicy.ServicePrincipalName != null)
                     {
                         tasks.Add(graphRbacManager.ServicePrincipals.GetByNameAsync(accessPolicy.ServicePrincipalName, cancellationToken)
-                            .ContinueWith(servicePrincipal => accessPolicy.ForObjectId(Guid.Parse(servicePrincipal.Result.Id))));
+                            .ContinueWith(
+                                servicePrincipal => accessPolicy.ForObjectId(Guid.Parse(servicePrincipal.Result.Id)),
+                                cancellationToken,
+                                TaskContinuationOptions.ExecuteSynchronously,
+                                TaskScheduler.Default));
                     }
                     else
                     {

--- a/src/ResourceManagement/Network/FlowLogSettingsImpl.cs
+++ b/src/ResourceManagement/Network/FlowLogSettingsImpl.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:7A26D184347EA91F532899FC93DA3E8B:8456BBCBBB11CEBC17C9ECE561F7920E
         public IFlowLogSettings Apply()
         {
-            return ApplyAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => ApplyAsync(CancellationToken.None));
         }
 
         ///GENMHASH:4A094106DADD6C15CD0CE10301E60136:8076B63FCD1974CC6F6FC168E61D2AE1

--- a/src/ResourceManagement/Network/Generated/ApplicationGatewaysOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/ApplicationGatewaysOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class ApplicationGatewaysOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified application gateway.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='applicationGatewayName'>
-            /// The name of the application gateway.
-            /// </param>
-            public static void Delete(this IApplicationGatewaysOperations operations, string resourceGroupName, string applicationGatewayName)
-            {
-                operations.DeleteAsync(resourceGroupName, applicationGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified application gateway.
             /// </summary>
@@ -59,23 +43,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, applicationGatewayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified application gateway.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='applicationGatewayName'>
-            /// The name of the application gateway.
-            /// </param>
-            public static ApplicationGatewayInner Get(this IApplicationGatewaysOperations operations, string resourceGroupName, string applicationGatewayName)
-            {
-                return operations.GetAsync(resourceGroupName, applicationGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified application gateway.
             /// </summary>
@@ -99,26 +67,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates the specified application gateway.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='applicationGatewayName'>
-            /// The name of the application gateway.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update application gateway operation.
-            /// </param>
-            public static ApplicationGatewayInner CreateOrUpdate(this IApplicationGatewaysOperations operations, string resourceGroupName, string applicationGatewayName, ApplicationGatewayInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, applicationGatewayName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates the specified application gateway.
             /// </summary>
@@ -145,20 +94,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all application gateways in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<ApplicationGatewayInner> List(this IApplicationGatewaysOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all application gateways in a resource group.
             /// </summary>
@@ -179,17 +115,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the application gateways in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<ApplicationGatewayInner> ListAll(this IApplicationGatewaysOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the application gateways in a subscription.
             /// </summary>
@@ -207,23 +133,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Starts the specified application gateway.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='applicationGatewayName'>
-            /// The name of the application gateway.
-            /// </param>
-            public static void Start(this IApplicationGatewaysOperations operations, string resourceGroupName, string applicationGatewayName)
-            {
-                operations.StartAsync(resourceGroupName, applicationGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Starts the specified application gateway.
             /// </summary>
@@ -244,23 +154,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.StartWithHttpMessagesAsync(resourceGroupName, applicationGatewayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Stops the specified application gateway in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='applicationGatewayName'>
-            /// The name of the application gateway.
-            /// </param>
-            public static void Stop(this IApplicationGatewaysOperations operations, string resourceGroupName, string applicationGatewayName)
-            {
-                operations.StopAsync(resourceGroupName, applicationGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Stops the specified application gateway in a resource group.
             /// </summary>
@@ -281,28 +175,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.StopWithHttpMessagesAsync(resourceGroupName, applicationGatewayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the backend health of the specified application gateway in a resource
-            /// group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='applicationGatewayName'>
-            /// The name of the application gateway.
-            /// </param>
-            /// <param name='expand'>
-            /// Expands BackendAddressPool and BackendHttpSettings referenced in backend
-            /// health.
-            /// </param>
-            public static ApplicationGatewayBackendHealthInner BackendHealth(this IApplicationGatewaysOperations operations, string resourceGroupName, string applicationGatewayName, string expand = default(string))
-            {
-                return operations.BackendHealthAsync(resourceGroupName, applicationGatewayName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the backend health of the specified application gateway in a resource
             /// group.
@@ -331,23 +204,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified application gateway.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='applicationGatewayName'>
-            /// The name of the application gateway.
-            /// </param>
-            public static void BeginDelete(this IApplicationGatewaysOperations operations, string resourceGroupName, string applicationGatewayName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, applicationGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified application gateway.
             /// </summary>
@@ -368,26 +225,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, applicationGatewayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates the specified application gateway.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='applicationGatewayName'>
-            /// The name of the application gateway.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update application gateway operation.
-            /// </param>
-            public static ApplicationGatewayInner BeginCreateOrUpdate(this IApplicationGatewaysOperations operations, string resourceGroupName, string applicationGatewayName, ApplicationGatewayInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, applicationGatewayName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates the specified application gateway.
             /// </summary>
@@ -414,23 +252,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Starts the specified application gateway.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='applicationGatewayName'>
-            /// The name of the application gateway.
-            /// </param>
-            public static void BeginStart(this IApplicationGatewaysOperations operations, string resourceGroupName, string applicationGatewayName)
-            {
-                operations.BeginStartAsync(resourceGroupName, applicationGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Starts the specified application gateway.
             /// </summary>
@@ -451,23 +273,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginStartWithHttpMessagesAsync(resourceGroupName, applicationGatewayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Stops the specified application gateway in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='applicationGatewayName'>
-            /// The name of the application gateway.
-            /// </param>
-            public static void BeginStop(this IApplicationGatewaysOperations operations, string resourceGroupName, string applicationGatewayName)
-            {
-                operations.BeginStopAsync(resourceGroupName, applicationGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Stops the specified application gateway in a resource group.
             /// </summary>
@@ -488,28 +294,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginStopWithHttpMessagesAsync(resourceGroupName, applicationGatewayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the backend health of the specified application gateway in a resource
-            /// group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='applicationGatewayName'>
-            /// The name of the application gateway.
-            /// </param>
-            /// <param name='expand'>
-            /// Expands BackendAddressPool and BackendHttpSettings referenced in backend
-            /// health.
-            /// </param>
-            public static ApplicationGatewayBackendHealthInner BeginBackendHealth(this IApplicationGatewaysOperations operations, string resourceGroupName, string applicationGatewayName, string expand = default(string))
-            {
-                return operations.BeginBackendHealthAsync(resourceGroupName, applicationGatewayName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the backend health of the specified application gateway in a resource
             /// group.
@@ -538,20 +323,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all application gateways in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ApplicationGatewayInner> ListNext(this IApplicationGatewaysOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all application gateways in a resource group.
             /// </summary>
@@ -572,20 +344,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the application gateways in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ApplicationGatewayInner> ListAllNext(this IApplicationGatewaysOperations operations, string nextPageLink)
-            {
-                return operations.ListAllNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the application gateways in a subscription.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/BgpServiceCommunitiesOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/BgpServiceCommunitiesOperationsExtensions.cs
@@ -22,17 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class BgpServiceCommunitiesOperationsExtensions
     {
-            /// <summary>
-            /// Gets all the available bgp service communities.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<BgpServiceCommunityInner> List(this IBgpServiceCommunitiesOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the available bgp service communities.
             /// </summary>
@@ -50,20 +40,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the available bgp service communities.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<BgpServiceCommunityInner> ListNext(this IBgpServiceCommunitiesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the available bgp service communities.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/ExpressRouteCircuitAuthorizationsOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/ExpressRouteCircuitAuthorizationsOperationsExtensions.cs
@@ -22,27 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class ExpressRouteCircuitAuthorizationsOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified authorization from the specified express route
-            /// circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='authorizationName'>
-            /// The name of the authorization.
-            /// </param>
-            public static void Delete(this IExpressRouteCircuitAuthorizationsOperations operations, string resourceGroupName, string circuitName, string authorizationName)
-            {
-                operations.DeleteAsync(resourceGroupName, circuitName, authorizationName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified authorization from the specified express route
             /// circuit.
@@ -67,26 +47,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, circuitName, authorizationName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified authorization from the specified express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='authorizationName'>
-            /// The name of the authorization.
-            /// </param>
-            public static ExpressRouteCircuitAuthorizationInner Get(this IExpressRouteCircuitAuthorizationsOperations operations, string resourceGroupName, string circuitName, string authorizationName)
-            {
-                return operations.GetAsync(resourceGroupName, circuitName, authorizationName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified authorization from the specified express route circuit.
             /// </summary>
@@ -113,30 +74,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates an authorization in the specified express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='authorizationName'>
-            /// The name of the authorization.
-            /// </param>
-            /// <param name='authorizationParameters'>
-            /// Parameters supplied to the create or update express route circuit
-            /// authorization operation.
-            /// </param>
-            public static ExpressRouteCircuitAuthorizationInner CreateOrUpdate(this IExpressRouteCircuitAuthorizationsOperations operations, string resourceGroupName, string circuitName, string authorizationName, ExpressRouteCircuitAuthorizationInner authorizationParameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, circuitName, authorizationName, authorizationParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates an authorization in the specified express route circuit.
             /// </summary>
@@ -167,23 +105,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all authorizations in an express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the circuit.
-            /// </param>
-            public static IPage<ExpressRouteCircuitAuthorizationInner> List(this IExpressRouteCircuitAuthorizationsOperations operations, string resourceGroupName, string circuitName)
-            {
-                return operations.ListAsync(resourceGroupName, circuitName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all authorizations in an express route circuit.
             /// </summary>
@@ -207,27 +129,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified authorization from the specified express route
-            /// circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='authorizationName'>
-            /// The name of the authorization.
-            /// </param>
-            public static void BeginDelete(this IExpressRouteCircuitAuthorizationsOperations operations, string resourceGroupName, string circuitName, string authorizationName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, circuitName, authorizationName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified authorization from the specified express route
             /// circuit.
@@ -252,30 +154,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, circuitName, authorizationName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates an authorization in the specified express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='authorizationName'>
-            /// The name of the authorization.
-            /// </param>
-            /// <param name='authorizationParameters'>
-            /// Parameters supplied to the create or update express route circuit
-            /// authorization operation.
-            /// </param>
-            public static ExpressRouteCircuitAuthorizationInner BeginCreateOrUpdate(this IExpressRouteCircuitAuthorizationsOperations operations, string resourceGroupName, string circuitName, string authorizationName, ExpressRouteCircuitAuthorizationInner authorizationParameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, circuitName, authorizationName, authorizationParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates an authorization in the specified express route circuit.
             /// </summary>
@@ -306,20 +185,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all authorizations in an express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ExpressRouteCircuitAuthorizationInner> ListNext(this IExpressRouteCircuitAuthorizationsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all authorizations in an express route circuit.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/ExpressRouteCircuitPeeringsOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/ExpressRouteCircuitPeeringsOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class ExpressRouteCircuitPeeringsOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified peering from the specified express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            public static void Delete(this IExpressRouteCircuitPeeringsOperations operations, string resourceGroupName, string circuitName, string peeringName)
-            {
-                operations.DeleteAsync(resourceGroupName, circuitName, peeringName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified peering from the specified express route circuit.
             /// </summary>
@@ -65,26 +46,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, circuitName, peeringName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified authorization from the specified express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            public static ExpressRouteCircuitPeeringInner Get(this IExpressRouteCircuitPeeringsOperations operations, string resourceGroupName, string circuitName, string peeringName)
-            {
-                return operations.GetAsync(resourceGroupName, circuitName, peeringName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified authorization from the specified express route circuit.
             /// </summary>
@@ -111,30 +73,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a peering in the specified express route circuits.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            /// <param name='peeringParameters'>
-            /// Parameters supplied to the create or update express route circuit peering
-            /// operation.
-            /// </param>
-            public static ExpressRouteCircuitPeeringInner CreateOrUpdate(this IExpressRouteCircuitPeeringsOperations operations, string resourceGroupName, string circuitName, string peeringName, ExpressRouteCircuitPeeringInner peeringParameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, circuitName, peeringName, peeringParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a peering in the specified express route circuits.
             /// </summary>
@@ -165,23 +104,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all peerings in a specified express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            public static IPage<ExpressRouteCircuitPeeringInner> List(this IExpressRouteCircuitPeeringsOperations operations, string resourceGroupName, string circuitName)
-            {
-                return operations.ListAsync(resourceGroupName, circuitName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all peerings in a specified express route circuit.
             /// </summary>
@@ -205,26 +128,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified peering from the specified express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            public static void BeginDelete(this IExpressRouteCircuitPeeringsOperations operations, string resourceGroupName, string circuitName, string peeringName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, circuitName, peeringName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified peering from the specified express route circuit.
             /// </summary>
@@ -248,30 +152,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, circuitName, peeringName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a peering in the specified express route circuits.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            /// <param name='peeringParameters'>
-            /// Parameters supplied to the create or update express route circuit peering
-            /// operation.
-            /// </param>
-            public static ExpressRouteCircuitPeeringInner BeginCreateOrUpdate(this IExpressRouteCircuitPeeringsOperations operations, string resourceGroupName, string circuitName, string peeringName, ExpressRouteCircuitPeeringInner peeringParameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, circuitName, peeringName, peeringParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a peering in the specified express route circuits.
             /// </summary>
@@ -302,20 +183,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all peerings in a specified express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ExpressRouteCircuitPeeringInner> ListNext(this IExpressRouteCircuitPeeringsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all peerings in a specified express route circuit.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/ExpressRouteCircuitsOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/ExpressRouteCircuitsOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class ExpressRouteCircuitsOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            public static void Delete(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName)
-            {
-                operations.DeleteAsync(resourceGroupName, circuitName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified express route circuit.
             /// </summary>
@@ -59,23 +43,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, circuitName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets information about the specified express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of express route circuit.
-            /// </param>
-            public static ExpressRouteCircuitInner Get(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName)
-            {
-                return operations.GetAsync(resourceGroupName, circuitName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about the specified express route circuit.
             /// </summary>
@@ -99,27 +67,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates an express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the circuit.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update express route circuit
-            /// operation.
-            /// </param>
-            public static ExpressRouteCircuitInner CreateOrUpdate(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName, ExpressRouteCircuitInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, circuitName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates an express route circuit.
             /// </summary>
@@ -147,30 +95,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the currently advertised ARP table associated with the express route
-            /// circuit in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            /// <param name='devicePath'>
-            /// The path of the device.
-            /// </param>
-            public static ExpressRouteCircuitsArpTableListResultInner ListArpTable(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName, string peeringName, string devicePath)
-            {
-                return operations.ListArpTableAsync(resourceGroupName, circuitName, peeringName, devicePath).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the currently advertised ARP table associated with the express route
             /// circuit in a resource group.
@@ -201,30 +126,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the currently advertised routes table associated with the express
-            /// route circuit in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            /// <param name='devicePath'>
-            /// The path of the device.
-            /// </param>
-            public static ExpressRouteCircuitsRoutesTableListResultInner ListRoutesTable(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName, string peeringName, string devicePath)
-            {
-                return operations.ListRoutesTableAsync(resourceGroupName, circuitName, peeringName, devicePath).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the currently advertised routes table associated with the express
             /// route circuit in a resource group.
@@ -255,30 +157,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the currently advertised routes table summary associated with the
-            /// express route circuit in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            /// <param name='devicePath'>
-            /// The path of the device.
-            /// </param>
-            public static ExpressRouteCircuitsRoutesTableSummaryListResultInner ListRoutesTableSummary(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName, string peeringName, string devicePath)
-            {
-                return operations.ListRoutesTableSummaryAsync(resourceGroupName, circuitName, peeringName, devicePath).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the currently advertised routes table summary associated with the
             /// express route circuit in a resource group.
@@ -309,23 +188,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the stats from an express route circuit in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            public static ExpressRouteCircuitStatsInner GetStats(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName)
-            {
-                return operations.GetStatsAsync(resourceGroupName, circuitName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the stats from an express route circuit in a resource group.
             /// </summary>
@@ -349,26 +212,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all stats from an express route circuit in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            public static ExpressRouteCircuitStatsInner GetPeeringStats(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName, string peeringName)
-            {
-                return operations.GetPeeringStatsAsync(resourceGroupName, circuitName, peeringName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all stats from an express route circuit in a resource group.
             /// </summary>
@@ -395,20 +239,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the express route circuits in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<ExpressRouteCircuitInner> List(this IExpressRouteCircuitsOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the express route circuits in a resource group.
             /// </summary>
@@ -429,17 +260,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the express route circuits in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<ExpressRouteCircuitInner> ListAll(this IExpressRouteCircuitsOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the express route circuits in a subscription.
             /// </summary>
@@ -457,23 +278,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            public static void BeginDelete(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, circuitName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified express route circuit.
             /// </summary>
@@ -494,27 +299,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, circuitName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates an express route circuit.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the circuit.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update express route circuit
-            /// operation.
-            /// </param>
-            public static ExpressRouteCircuitInner BeginCreateOrUpdate(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName, ExpressRouteCircuitInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, circuitName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates an express route circuit.
             /// </summary>
@@ -542,30 +327,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the currently advertised ARP table associated with the express route
-            /// circuit in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            /// <param name='devicePath'>
-            /// The path of the device.
-            /// </param>
-            public static ExpressRouteCircuitsArpTableListResultInner BeginListArpTable(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName, string peeringName, string devicePath)
-            {
-                return operations.BeginListArpTableAsync(resourceGroupName, circuitName, peeringName, devicePath).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the currently advertised ARP table associated with the express route
             /// circuit in a resource group.
@@ -596,30 +358,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the currently advertised routes table associated with the express
-            /// route circuit in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            /// <param name='devicePath'>
-            /// The path of the device.
-            /// </param>
-            public static ExpressRouteCircuitsRoutesTableListResultInner BeginListRoutesTable(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName, string peeringName, string devicePath)
-            {
-                return operations.BeginListRoutesTableAsync(resourceGroupName, circuitName, peeringName, devicePath).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the currently advertised routes table associated with the express
             /// route circuit in a resource group.
@@ -650,30 +389,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the currently advertised routes table summary associated with the
-            /// express route circuit in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='circuitName'>
-            /// The name of the express route circuit.
-            /// </param>
-            /// <param name='peeringName'>
-            /// The name of the peering.
-            /// </param>
-            /// <param name='devicePath'>
-            /// The path of the device.
-            /// </param>
-            public static ExpressRouteCircuitsRoutesTableSummaryListResultInner BeginListRoutesTableSummary(this IExpressRouteCircuitsOperations operations, string resourceGroupName, string circuitName, string peeringName, string devicePath)
-            {
-                return operations.BeginListRoutesTableSummaryAsync(resourceGroupName, circuitName, peeringName, devicePath).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the currently advertised routes table summary associated with the
             /// express route circuit in a resource group.
@@ -704,20 +420,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the express route circuits in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ExpressRouteCircuitInner> ListNext(this IExpressRouteCircuitsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the express route circuits in a resource group.
             /// </summary>
@@ -738,20 +441,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the express route circuits in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ExpressRouteCircuitInner> ListAllNext(this IExpressRouteCircuitsOperations operations, string nextPageLink)
-            {
-                return operations.ListAllNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the express route circuits in a subscription.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/ExpressRouteServiceProvidersOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/ExpressRouteServiceProvidersOperationsExtensions.cs
@@ -22,17 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class ExpressRouteServiceProvidersOperationsExtensions
     {
-            /// <summary>
-            /// Gets all the available express route service providers.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<ExpressRouteServiceProviderInner> List(this IExpressRouteServiceProvidersOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the available express route service providers.
             /// </summary>
@@ -50,20 +40,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the available express route service providers.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ExpressRouteServiceProviderInner> ListNext(this IExpressRouteServiceProvidersOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the available express route service providers.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/LoadBalancersOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/LoadBalancersOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class LoadBalancersOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified load balancer.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='loadBalancerName'>
-            /// The name of the load balancer.
-            /// </param>
-            public static void Delete(this ILoadBalancersOperations operations, string resourceGroupName, string loadBalancerName)
-            {
-                operations.DeleteAsync(resourceGroupName, loadBalancerName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified load balancer.
             /// </summary>
@@ -59,26 +43,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, loadBalancerName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified load balancer.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='loadBalancerName'>
-            /// The name of the load balancer.
-            /// </param>
-            /// <param name='expand'>
-            /// Expands referenced resources.
-            /// </param>
-            public static LoadBalancerInner Get(this ILoadBalancersOperations operations, string resourceGroupName, string loadBalancerName, string expand = default(string))
-            {
-                return operations.GetAsync(resourceGroupName, loadBalancerName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified load balancer.
             /// </summary>
@@ -105,26 +70,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a load balancer.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='loadBalancerName'>
-            /// The name of the load balancer.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update load balancer operation.
-            /// </param>
-            public static LoadBalancerInner CreateOrUpdate(this ILoadBalancersOperations operations, string resourceGroupName, string loadBalancerName, LoadBalancerInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, loadBalancerName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a load balancer.
             /// </summary>
@@ -151,17 +97,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the load balancers in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<LoadBalancerInner> ListAll(this ILoadBalancersOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the load balancers in a subscription.
             /// </summary>
@@ -179,20 +115,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the load balancers in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<LoadBalancerInner> List(this ILoadBalancersOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the load balancers in a resource group.
             /// </summary>
@@ -213,23 +136,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified load balancer.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='loadBalancerName'>
-            /// The name of the load balancer.
-            /// </param>
-            public static void BeginDelete(this ILoadBalancersOperations operations, string resourceGroupName, string loadBalancerName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, loadBalancerName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified load balancer.
             /// </summary>
@@ -250,26 +157,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, loadBalancerName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a load balancer.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='loadBalancerName'>
-            /// The name of the load balancer.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update load balancer operation.
-            /// </param>
-            public static LoadBalancerInner BeginCreateOrUpdate(this ILoadBalancersOperations operations, string resourceGroupName, string loadBalancerName, LoadBalancerInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, loadBalancerName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a load balancer.
             /// </summary>
@@ -296,20 +184,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the load balancers in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<LoadBalancerInner> ListAllNext(this ILoadBalancersOperations operations, string nextPageLink)
-            {
-                return operations.ListAllNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the load balancers in a subscription.
             /// </summary>
@@ -330,20 +205,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the load balancers in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<LoadBalancerInner> ListNext(this ILoadBalancersOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the load balancers in a resource group.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/LocalNetworkGatewaysOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/LocalNetworkGatewaysOperationsExtensions.cs
@@ -22,27 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class LocalNetworkGatewaysOperationsExtensions
     {
-            /// <summary>
-            /// Creates or updates a local network gateway in the specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='localNetworkGatewayName'>
-            /// The name of the local network gateway.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update local network gateway
-            /// operation.
-            /// </param>
-            public static LocalNetworkGatewayInner CreateOrUpdate(this ILocalNetworkGatewaysOperations operations, string resourceGroupName, string localNetworkGatewayName, LocalNetworkGatewayInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, localNetworkGatewayName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a local network gateway in the specified resource group.
             /// </summary>
@@ -70,23 +50,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the specified local network gateway in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='localNetworkGatewayName'>
-            /// The name of the local network gateway.
-            /// </param>
-            public static LocalNetworkGatewayInner Get(this ILocalNetworkGatewaysOperations operations, string resourceGroupName, string localNetworkGatewayName)
-            {
-                return operations.GetAsync(resourceGroupName, localNetworkGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified local network gateway in a resource group.
             /// </summary>
@@ -110,23 +74,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified local network gateway.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='localNetworkGatewayName'>
-            /// The name of the local network gateway.
-            /// </param>
-            public static void Delete(this ILocalNetworkGatewaysOperations operations, string resourceGroupName, string localNetworkGatewayName)
-            {
-                operations.DeleteAsync(resourceGroupName, localNetworkGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified local network gateway.
             /// </summary>
@@ -147,20 +95,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, localNetworkGatewayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets all the local network gateways in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<LocalNetworkGatewayInner> List(this ILocalNetworkGatewaysOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the local network gateways in a resource group.
             /// </summary>
@@ -181,27 +116,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a local network gateway in the specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='localNetworkGatewayName'>
-            /// The name of the local network gateway.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update local network gateway
-            /// operation.
-            /// </param>
-            public static LocalNetworkGatewayInner BeginCreateOrUpdate(this ILocalNetworkGatewaysOperations operations, string resourceGroupName, string localNetworkGatewayName, LocalNetworkGatewayInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, localNetworkGatewayName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a local network gateway in the specified resource group.
             /// </summary>
@@ -229,23 +144,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified local network gateway.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='localNetworkGatewayName'>
-            /// The name of the local network gateway.
-            /// </param>
-            public static void BeginDelete(this ILocalNetworkGatewaysOperations operations, string resourceGroupName, string localNetworkGatewayName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, localNetworkGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified local network gateway.
             /// </summary>
@@ -266,20 +165,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, localNetworkGatewayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets all the local network gateways in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<LocalNetworkGatewayInner> ListNext(this ILocalNetworkGatewaysOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the local network gateways in a resource group.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/NetworkInterfacesOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/NetworkInterfacesOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class NetworkInterfacesOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified network interface.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkInterfaceName'>
-            /// The name of the network interface.
-            /// </param>
-            public static void Delete(this INetworkInterfacesOperations operations, string resourceGroupName, string networkInterfaceName)
-            {
-                operations.DeleteAsync(resourceGroupName, networkInterfaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified network interface.
             /// </summary>
@@ -59,26 +43,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, networkInterfaceName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets information about the specified network interface.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkInterfaceName'>
-            /// The name of the network interface.
-            /// </param>
-            /// <param name='expand'>
-            /// Expands referenced resources.
-            /// </param>
-            public static NetworkInterfaceInner Get(this INetworkInterfacesOperations operations, string resourceGroupName, string networkInterfaceName, string expand = default(string))
-            {
-                return operations.GetAsync(resourceGroupName, networkInterfaceName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about the specified network interface.
             /// </summary>
@@ -105,26 +70,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a network interface.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkInterfaceName'>
-            /// The name of the network interface.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update network interface operation.
-            /// </param>
-            public static NetworkInterfaceInner CreateOrUpdate(this INetworkInterfacesOperations operations, string resourceGroupName, string networkInterfaceName, NetworkInterfaceInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, networkInterfaceName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a network interface.
             /// </summary>
@@ -151,17 +97,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network interfaces in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<NetworkInterfaceInner> ListAll(this INetworkInterfacesOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network interfaces in a subscription.
             /// </summary>
@@ -179,20 +115,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network interfaces in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<NetworkInterfaceInner> List(this INetworkInterfacesOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network interfaces in a resource group.
             /// </summary>
@@ -213,23 +136,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all route tables applied to a network interface.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkInterfaceName'>
-            /// The name of the network interface.
-            /// </param>
-            public static EffectiveRouteListResultInner GetEffectiveRouteTable(this INetworkInterfacesOperations operations, string resourceGroupName, string networkInterfaceName)
-            {
-                return operations.GetEffectiveRouteTableAsync(resourceGroupName, networkInterfaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all route tables applied to a network interface.
             /// </summary>
@@ -253,23 +160,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network security groups applied to a network interface.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkInterfaceName'>
-            /// The name of the network interface.
-            /// </param>
-            public static EffectiveNetworkSecurityGroupListResultInner ListEffectiveNetworkSecurityGroups(this INetworkInterfacesOperations operations, string resourceGroupName, string networkInterfaceName)
-            {
-                return operations.ListEffectiveNetworkSecurityGroupsAsync(resourceGroupName, networkInterfaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network security groups applied to a network interface.
             /// </summary>
@@ -293,27 +184,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about all network interfaces in a virtual machine in a
-            /// virtual machine scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualMachineScaleSetName'>
-            /// The name of the virtual machine scale set.
-            /// </param>
-            /// <param name='virtualmachineIndex'>
-            /// The virtual machine index.
-            /// </param>
-            public static IPage<NetworkInterfaceInner> ListVirtualMachineScaleSetVMNetworkInterfaces(this INetworkInterfacesOperations operations, string resourceGroupName, string virtualMachineScaleSetName, string virtualmachineIndex)
-            {
-                return operations.ListVirtualMachineScaleSetVMNetworkInterfacesAsync(resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about all network interfaces in a virtual machine in a
             /// virtual machine scale set.
@@ -341,23 +212,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network interfaces in a virtual machine scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualMachineScaleSetName'>
-            /// The name of the virtual machine scale set.
-            /// </param>
-            public static IPage<NetworkInterfaceInner> ListVirtualMachineScaleSetNetworkInterfaces(this INetworkInterfacesOperations operations, string resourceGroupName, string virtualMachineScaleSetName)
-            {
-                return operations.ListVirtualMachineScaleSetNetworkInterfacesAsync(resourceGroupName, virtualMachineScaleSetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network interfaces in a virtual machine scale set.
             /// </summary>
@@ -381,32 +236,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the specified network interface in a virtual machine scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualMachineScaleSetName'>
-            /// The name of the virtual machine scale set.
-            /// </param>
-            /// <param name='virtualmachineIndex'>
-            /// The virtual machine index.
-            /// </param>
-            /// <param name='networkInterfaceName'>
-            /// The name of the network interface.
-            /// </param>
-            /// <param name='expand'>
-            /// Expands referenced resources.
-            /// </param>
-            public static NetworkInterfaceInner GetVirtualMachineScaleSetNetworkInterface(this INetworkInterfacesOperations operations, string resourceGroupName, string virtualMachineScaleSetName, string virtualmachineIndex, string networkInterfaceName, string expand = default(string))
-            {
-                return operations.GetVirtualMachineScaleSetNetworkInterfaceAsync(resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the specified network interface in a virtual machine scale set.
             /// </summary>
@@ -439,23 +269,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified network interface.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkInterfaceName'>
-            /// The name of the network interface.
-            /// </param>
-            public static void BeginDelete(this INetworkInterfacesOperations operations, string resourceGroupName, string networkInterfaceName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, networkInterfaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified network interface.
             /// </summary>
@@ -476,26 +290,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, networkInterfaceName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a network interface.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkInterfaceName'>
-            /// The name of the network interface.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update network interface operation.
-            /// </param>
-            public static NetworkInterfaceInner BeginCreateOrUpdate(this INetworkInterfacesOperations operations, string resourceGroupName, string networkInterfaceName, NetworkInterfaceInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, networkInterfaceName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a network interface.
             /// </summary>
@@ -522,23 +317,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all route tables applied to a network interface.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkInterfaceName'>
-            /// The name of the network interface.
-            /// </param>
-            public static EffectiveRouteListResultInner BeginGetEffectiveRouteTable(this INetworkInterfacesOperations operations, string resourceGroupName, string networkInterfaceName)
-            {
-                return operations.BeginGetEffectiveRouteTableAsync(resourceGroupName, networkInterfaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all route tables applied to a network interface.
             /// </summary>
@@ -562,23 +341,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network security groups applied to a network interface.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkInterfaceName'>
-            /// The name of the network interface.
-            /// </param>
-            public static EffectiveNetworkSecurityGroupListResultInner BeginListEffectiveNetworkSecurityGroups(this INetworkInterfacesOperations operations, string resourceGroupName, string networkInterfaceName)
-            {
-                return operations.BeginListEffectiveNetworkSecurityGroupsAsync(resourceGroupName, networkInterfaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network security groups applied to a network interface.
             /// </summary>
@@ -602,20 +365,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network interfaces in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<NetworkInterfaceInner> ListAllNext(this INetworkInterfacesOperations operations, string nextPageLink)
-            {
-                return operations.ListAllNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network interfaces in a subscription.
             /// </summary>
@@ -636,20 +386,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network interfaces in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<NetworkInterfaceInner> ListNext(this INetworkInterfacesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network interfaces in a resource group.
             /// </summary>
@@ -670,21 +407,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about all network interfaces in a virtual machine in a
-            /// virtual machine scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<NetworkInterfaceInner> ListVirtualMachineScaleSetVMNetworkInterfacesNext(this INetworkInterfacesOperations operations, string nextPageLink)
-            {
-                return operations.ListVirtualMachineScaleSetVMNetworkInterfacesNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about all network interfaces in a virtual machine in a
             /// virtual machine scale set.
@@ -706,20 +429,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network interfaces in a virtual machine scale set.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<NetworkInterfaceInner> ListVirtualMachineScaleSetNetworkInterfacesNext(this INetworkInterfacesOperations operations, string nextPageLink)
-            {
-                return operations.ListVirtualMachineScaleSetNetworkInterfacesNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network interfaces in a virtual machine scale set.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/NetworkManagementClientExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/NetworkManagementClientExtensions.cs
@@ -22,24 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class NetworkManagementClientExtensions
     {
-            /// <summary>
-            /// Checks whether a domain name in the cloudapp.net zone is available for use.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// The location of the domain name.
-            /// </param>
-            /// <param name='domainNameLabel'>
-            /// The domain name to be verified. It must conform to the following regular
-            /// expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$.
-            /// </param>
-            public static DnsNameAvailabilityResultInner CheckDnsNameAvailability(this INetworkManagementClient operations, string location, string domainNameLabel = default(string))
-            {
-                return operations.CheckDnsNameAvailabilityAsync(location, domainNameLabel).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks whether a domain name in the cloudapp.net zone is available for use.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/NetworkSecurityGroupsOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/NetworkSecurityGroupsOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class NetworkSecurityGroupsOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified network security group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkSecurityGroupName'>
-            /// The name of the network security group.
-            /// </param>
-            public static void Delete(this INetworkSecurityGroupsOperations operations, string resourceGroupName, string networkSecurityGroupName)
-            {
-                operations.DeleteAsync(resourceGroupName, networkSecurityGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified network security group.
             /// </summary>
@@ -59,26 +43,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, networkSecurityGroupName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified network security group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkSecurityGroupName'>
-            /// The name of the network security group.
-            /// </param>
-            /// <param name='expand'>
-            /// Expands referenced resources.
-            /// </param>
-            public static NetworkSecurityGroupInner Get(this INetworkSecurityGroupsOperations operations, string resourceGroupName, string networkSecurityGroupName, string expand = default(string))
-            {
-                return operations.GetAsync(resourceGroupName, networkSecurityGroupName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified network security group.
             /// </summary>
@@ -105,28 +70,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a network security group in the specified resource
-            /// group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkSecurityGroupName'>
-            /// The name of the network security group.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update network security group
-            /// operation.
-            /// </param>
-            public static NetworkSecurityGroupInner CreateOrUpdate(this INetworkSecurityGroupsOperations operations, string resourceGroupName, string networkSecurityGroupName, NetworkSecurityGroupInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, networkSecurityGroupName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a network security group in the specified resource
             /// group.
@@ -155,17 +99,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network security groups in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<NetworkSecurityGroupInner> ListAll(this INetworkSecurityGroupsOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network security groups in a subscription.
             /// </summary>
@@ -183,20 +117,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network security groups in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<NetworkSecurityGroupInner> List(this INetworkSecurityGroupsOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network security groups in a resource group.
             /// </summary>
@@ -217,23 +138,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified network security group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkSecurityGroupName'>
-            /// The name of the network security group.
-            /// </param>
-            public static void BeginDelete(this INetworkSecurityGroupsOperations operations, string resourceGroupName, string networkSecurityGroupName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, networkSecurityGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified network security group.
             /// </summary>
@@ -254,28 +159,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, networkSecurityGroupName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a network security group in the specified resource
-            /// group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkSecurityGroupName'>
-            /// The name of the network security group.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update network security group
-            /// operation.
-            /// </param>
-            public static NetworkSecurityGroupInner BeginCreateOrUpdate(this INetworkSecurityGroupsOperations operations, string resourceGroupName, string networkSecurityGroupName, NetworkSecurityGroupInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, networkSecurityGroupName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a network security group in the specified resource
             /// group.
@@ -304,20 +188,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network security groups in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<NetworkSecurityGroupInner> ListAllNext(this INetworkSecurityGroupsOperations operations, string nextPageLink)
-            {
-                return operations.ListAllNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network security groups in a subscription.
             /// </summary>
@@ -338,20 +209,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network security groups in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<NetworkSecurityGroupInner> ListNext(this INetworkSecurityGroupsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network security groups in a resource group.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/NetworkWatchersOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/NetworkWatchersOperationsExtensions.cs
@@ -24,26 +24,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class NetworkWatchersOperationsExtensions
     {
-            /// <summary>
-            /// Creates or updates a network watcher in the specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters that define the network watcher resource.
-            /// </param>
-            public static NetworkWatcherInner CreateOrUpdate(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, NetworkWatcherInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, networkWatcherName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a network watcher in the specified resource group.
             /// </summary>
@@ -70,23 +51,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the specified network watcher by resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            public static NetworkWatcherInner Get(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName)
-            {
-                return operations.GetAsync(resourceGroupName, networkWatcherName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified network watcher by resource group.
             /// </summary>
@@ -110,23 +75,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified network watcher resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            public static void Delete(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName)
-            {
-                operations.DeleteAsync(resourceGroupName, networkWatcherName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified network watcher resource.
             /// </summary>
@@ -147,20 +96,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, networkWatcherName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets all network watchers by resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IEnumerable<NetworkWatcherInner> List(this INetworkWatchersOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network watchers by resource group.
             /// </summary>
@@ -181,17 +117,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all network watchers by subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IEnumerable<NetworkWatcherInner> ListAll(this INetworkWatchersOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all network watchers by subscription.
             /// </summary>
@@ -209,26 +135,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the current network topology by resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='targetResourceGroupName'>
-            /// The name of the target resource group to perform topology on.
-            /// </param>
-            public static TopologyInner GetTopology(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, string targetResourceGroupName)
-            {
-                return operations.GetTopologyAsync(resourceGroupName, networkWatcherName, targetResourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the current network topology by resource group.
             /// </summary>
@@ -255,27 +162,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Verify IP flow from the specified VM to a location given the currently
-            /// configured NSG rules.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters that define the IP flow to be verified.
-            /// </param>
-            public static VerificationIPFlowResultInner VerifyIPFlow(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, VerificationIPFlowParametersInner parameters)
-            {
-                return operations.VerifyIPFlowAsync(resourceGroupName, networkWatcherName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Verify IP flow from the specified VM to a location given the currently
             /// configured NSG rules.
@@ -303,26 +190,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the next hop from the specified VM.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters that define the source and destination endpoint.
-            /// </param>
-            public static NextHopResultInner GetNextHop(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, NextHopParametersInner parameters)
-            {
-                return operations.GetNextHopAsync(resourceGroupName, networkWatcherName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the next hop from the specified VM.
             /// </summary>
@@ -349,26 +217,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the configured and effective security group rules on the specified VM.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='targetResourceId'>
-            /// ID of the target VM.
-            /// </param>
-            public static SecurityGroupViewResultInner GetVMSecurityRules(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, string targetResourceId)
-            {
-                return operations.GetVMSecurityRulesAsync(resourceGroupName, networkWatcherName, targetResourceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the configured and effective security group rules on the specified VM.
             /// </summary>
@@ -395,26 +244,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Initiate troubleshooting on a specified resource
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher resource.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters that define the resource to troubleshoot.
-            /// </param>
-            public static TroubleshootingResultInner GetTroubleshooting(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, TroubleshootingParametersInner parameters)
-            {
-                return operations.GetTroubleshootingAsync(resourceGroupName, networkWatcherName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Initiate troubleshooting on a specified resource
             /// </summary>
@@ -441,26 +271,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the last completed troubleshooting result on a specified resource
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher resource.
-            /// </param>
-            /// <param name='targetResourceId'>
-            /// The target resource ID to query the troubleshooting result.
-            /// </param>
-            public static TroubleshootingResultInner GetTroubleshootingResult(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, string targetResourceId)
-            {
-                return operations.GetTroubleshootingResultAsync(resourceGroupName, networkWatcherName, targetResourceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the last completed troubleshooting result on a specified resource
             /// </summary>
@@ -487,26 +298,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Configures flow log on a specified resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the network watcher resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher resource.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters that define the configuration of flow log.
-            /// </param>
-            public static FlowLogInformationInner SetFlowLogConfiguration(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, FlowLogInformationInner parameters)
-            {
-                return operations.SetFlowLogConfigurationAsync(resourceGroupName, networkWatcherName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Configures flow log on a specified resource.
             /// </summary>
@@ -533,26 +325,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Queries status of flow log on a specified resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the network watcher resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher resource.
-            /// </param>
-            /// <param name='targetResourceId'>
-            /// The target resource where getting the flow logging status.
-            /// </param>
-            public static FlowLogInformationInner GetFlowLogStatus(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, string targetResourceId)
-            {
-                return operations.GetFlowLogStatusAsync(resourceGroupName, networkWatcherName, targetResourceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Queries status of flow log on a specified resource.
             /// </summary>
@@ -579,23 +352,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified network watcher resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            public static void BeginDelete(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, networkWatcherName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified network watcher resource.
             /// </summary>
@@ -616,27 +373,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, networkWatcherName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Verify IP flow from the specified VM to a location given the currently
-            /// configured NSG rules.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters that define the IP flow to be verified.
-            /// </param>
-            public static VerificationIPFlowResultInner BeginVerifyIPFlow(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, VerificationIPFlowParametersInner parameters)
-            {
-                return operations.BeginVerifyIPFlowAsync(resourceGroupName, networkWatcherName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Verify IP flow from the specified VM to a location given the currently
             /// configured NSG rules.
@@ -664,26 +401,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the next hop from the specified VM.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters that define the source and destination endpoint.
-            /// </param>
-            public static NextHopResultInner BeginGetNextHop(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, NextHopParametersInner parameters)
-            {
-                return operations.BeginGetNextHopAsync(resourceGroupName, networkWatcherName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the next hop from the specified VM.
             /// </summary>
@@ -710,26 +428,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the configured and effective security group rules on the specified VM.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='targetResourceId'>
-            /// ID of the target VM.
-            /// </param>
-            public static SecurityGroupViewResultInner BeginGetVMSecurityRules(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, string targetResourceId)
-            {
-                return operations.BeginGetVMSecurityRulesAsync(resourceGroupName, networkWatcherName, targetResourceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the configured and effective security group rules on the specified VM.
             /// </summary>
@@ -756,26 +455,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Initiate troubleshooting on a specified resource
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher resource.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters that define the resource to troubleshoot.
-            /// </param>
-            public static TroubleshootingResultInner BeginGetTroubleshooting(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, TroubleshootingParametersInner parameters)
-            {
-                return operations.BeginGetTroubleshootingAsync(resourceGroupName, networkWatcherName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Initiate troubleshooting on a specified resource
             /// </summary>
@@ -802,26 +482,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get the last completed troubleshooting result on a specified resource
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher resource.
-            /// </param>
-            /// <param name='targetResourceId'>
-            /// The target resource ID to query the troubleshooting result.
-            /// </param>
-            public static TroubleshootingResultInner BeginGetTroubleshootingResult(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, string targetResourceId)
-            {
-                return operations.BeginGetTroubleshootingResultAsync(resourceGroupName, networkWatcherName, targetResourceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the last completed troubleshooting result on a specified resource
             /// </summary>
@@ -848,26 +509,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Configures flow log on a specified resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the network watcher resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher resource.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters that define the configuration of flow log.
-            /// </param>
-            public static FlowLogInformationInner BeginSetFlowLogConfiguration(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, FlowLogInformationInner parameters)
-            {
-                return operations.BeginSetFlowLogConfigurationAsync(resourceGroupName, networkWatcherName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Configures flow log on a specified resource.
             /// </summary>
@@ -894,26 +536,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Queries status of flow log on a specified resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the network watcher resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher resource.
-            /// </param>
-            /// <param name='targetResourceId'>
-            /// The target resource where getting the flow logging status.
-            /// </param>
-            public static FlowLogInformationInner BeginGetFlowLogStatus(this INetworkWatchersOperations operations, string resourceGroupName, string networkWatcherName, string targetResourceId)
-            {
-                return operations.BeginGetFlowLogStatusAsync(resourceGroupName, networkWatcherName, targetResourceId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Queries status of flow log on a specified resource.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/PacketCapturesOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/PacketCapturesOperationsExtensions.cs
@@ -24,29 +24,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class PacketCapturesOperationsExtensions
     {
-            /// <summary>
-            /// Create and start a packet capture on the specified VM.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='packetCaptureName'>
-            /// The name of the packet capture session.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters that define the create packet capture operation.
-            /// </param>
-            public static PacketCaptureResultInner Create(this IPacketCapturesOperations operations, string resourceGroupName, string networkWatcherName, string packetCaptureName, PacketCaptureInner parameters)
-            {
-                return operations.CreateAsync(resourceGroupName, networkWatcherName, packetCaptureName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create and start a packet capture on the specified VM.
             /// </summary>
@@ -76,26 +54,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a packet capture session by name.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='packetCaptureName'>
-            /// The name of the packet capture session.
-            /// </param>
-            public static PacketCaptureResultInner Get(this IPacketCapturesOperations operations, string resourceGroupName, string networkWatcherName, string packetCaptureName)
-            {
-                return operations.GetAsync(resourceGroupName, networkWatcherName, packetCaptureName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a packet capture session by name.
             /// </summary>
@@ -122,26 +81,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified packet capture session.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='packetCaptureName'>
-            /// The name of the packet capture session.
-            /// </param>
-            public static void Delete(this IPacketCapturesOperations operations, string resourceGroupName, string networkWatcherName, string packetCaptureName)
-            {
-                operations.DeleteAsync(resourceGroupName, networkWatcherName, packetCaptureName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified packet capture session.
             /// </summary>
@@ -165,26 +105,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, networkWatcherName, packetCaptureName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Stops a specified packet capture session.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='packetCaptureName'>
-            /// The name of the packet capture session.
-            /// </param>
-            public static void Stop(this IPacketCapturesOperations operations, string resourceGroupName, string networkWatcherName, string packetCaptureName)
-            {
-                operations.StopAsync(resourceGroupName, networkWatcherName, packetCaptureName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Stops a specified packet capture session.
             /// </summary>
@@ -208,26 +129,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.StopWithHttpMessagesAsync(resourceGroupName, networkWatcherName, packetCaptureName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Query the status of a running packet capture session.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the Network Watcher resource.
-            /// </param>
-            /// <param name='packetCaptureName'>
-            /// The name given to the packet capture session.
-            /// </param>
-            public static PacketCaptureQueryStatusResultInner GetStatus(this IPacketCapturesOperations operations, string resourceGroupName, string networkWatcherName, string packetCaptureName)
-            {
-                return operations.GetStatusAsync(resourceGroupName, networkWatcherName, packetCaptureName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Query the status of a running packet capture session.
             /// </summary>
@@ -254,23 +156,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all packet capture sessions within the specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the Network Watcher resource.
-            /// </param>
-            public static IEnumerable<PacketCaptureResultInner> List(this IPacketCapturesOperations operations, string resourceGroupName, string networkWatcherName)
-            {
-                return operations.ListAsync(resourceGroupName, networkWatcherName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all packet capture sessions within the specified resource group.
             /// </summary>
@@ -294,29 +180,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create and start a packet capture on the specified VM.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='packetCaptureName'>
-            /// The name of the packet capture session.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters that define the create packet capture operation.
-            /// </param>
-            public static PacketCaptureResultInner BeginCreate(this IPacketCapturesOperations operations, string resourceGroupName, string networkWatcherName, string packetCaptureName, PacketCaptureInner parameters)
-            {
-                return operations.BeginCreateAsync(resourceGroupName, networkWatcherName, packetCaptureName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create and start a packet capture on the specified VM.
             /// </summary>
@@ -346,26 +210,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified packet capture session.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='packetCaptureName'>
-            /// The name of the packet capture session.
-            /// </param>
-            public static void BeginDelete(this IPacketCapturesOperations operations, string resourceGroupName, string networkWatcherName, string packetCaptureName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, networkWatcherName, packetCaptureName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified packet capture session.
             /// </summary>
@@ -389,26 +234,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, networkWatcherName, packetCaptureName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Stops a specified packet capture session.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the network watcher.
-            /// </param>
-            /// <param name='packetCaptureName'>
-            /// The name of the packet capture session.
-            /// </param>
-            public static void BeginStop(this IPacketCapturesOperations operations, string resourceGroupName, string networkWatcherName, string packetCaptureName)
-            {
-                operations.BeginStopAsync(resourceGroupName, networkWatcherName, packetCaptureName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Stops a specified packet capture session.
             /// </summary>
@@ -432,26 +258,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginStopWithHttpMessagesAsync(resourceGroupName, networkWatcherName, packetCaptureName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Query the status of a running packet capture session.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkWatcherName'>
-            /// The name of the Network Watcher resource.
-            /// </param>
-            /// <param name='packetCaptureName'>
-            /// The name given to the packet capture session.
-            /// </param>
-            public static PacketCaptureQueryStatusResultInner BeginGetStatus(this IPacketCapturesOperations operations, string resourceGroupName, string networkWatcherName, string packetCaptureName)
-            {
-                return operations.BeginGetStatusAsync(resourceGroupName, networkWatcherName, packetCaptureName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Query the status of a running packet capture session.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/PublicIPAddressesOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/PublicIPAddressesOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class PublicIPAddressesOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified public IP address.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='publicIpAddressName'>
-            /// The name of the subnet.
-            /// </param>
-            public static void Delete(this IPublicIPAddressesOperations operations, string resourceGroupName, string publicIpAddressName)
-            {
-                operations.DeleteAsync(resourceGroupName, publicIpAddressName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified public IP address.
             /// </summary>
@@ -59,26 +43,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, publicIpAddressName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified public IP address in a specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='publicIpAddressName'>
-            /// The name of the subnet.
-            /// </param>
-            /// <param name='expand'>
-            /// Expands referenced resources.
-            /// </param>
-            public static PublicIPAddressInner Get(this IPublicIPAddressesOperations operations, string resourceGroupName, string publicIpAddressName, string expand = default(string))
-            {
-                return operations.GetAsync(resourceGroupName, publicIpAddressName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified public IP address in a specified resource group.
             /// </summary>
@@ -105,26 +70,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a static or dynamic public IP address.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='publicIpAddressName'>
-            /// The name of the public IP address.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update public IP address operation.
-            /// </param>
-            public static PublicIPAddressInner CreateOrUpdate(this IPublicIPAddressesOperations operations, string resourceGroupName, string publicIpAddressName, PublicIPAddressInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, publicIpAddressName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a static or dynamic public IP address.
             /// </summary>
@@ -151,17 +97,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the public IP addresses in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<PublicIPAddressInner> ListAll(this IPublicIPAddressesOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the public IP addresses in a subscription.
             /// </summary>
@@ -179,20 +115,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all public IP addresses in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<PublicIPAddressInner> List(this IPublicIPAddressesOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all public IP addresses in a resource group.
             /// </summary>
@@ -213,23 +136,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified public IP address.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='publicIpAddressName'>
-            /// The name of the subnet.
-            /// </param>
-            public static void BeginDelete(this IPublicIPAddressesOperations operations, string resourceGroupName, string publicIpAddressName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, publicIpAddressName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified public IP address.
             /// </summary>
@@ -250,26 +157,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, publicIpAddressName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a static or dynamic public IP address.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='publicIpAddressName'>
-            /// The name of the public IP address.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update public IP address operation.
-            /// </param>
-            public static PublicIPAddressInner BeginCreateOrUpdate(this IPublicIPAddressesOperations operations, string resourceGroupName, string publicIpAddressName, PublicIPAddressInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, publicIpAddressName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a static or dynamic public IP address.
             /// </summary>
@@ -296,20 +184,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the public IP addresses in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<PublicIPAddressInner> ListAllNext(this IPublicIPAddressesOperations operations, string nextPageLink)
-            {
-                return operations.ListAllNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the public IP addresses in a subscription.
             /// </summary>
@@ -330,20 +205,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all public IP addresses in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<PublicIPAddressInner> ListNext(this IPublicIPAddressesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all public IP addresses in a resource group.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/RouteFilterRulesOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/RouteFilterRulesOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class RouteFilterRulesOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified rule from a route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='ruleName'>
-            /// The name of the rule.
-            /// </param>
-            public static void Delete(this IRouteFilterRulesOperations operations, string resourceGroupName, string routeFilterName, string ruleName)
-            {
-                operations.DeleteAsync(resourceGroupName, routeFilterName, ruleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified rule from a route filter.
             /// </summary>
@@ -65,26 +46,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, routeFilterName, ruleName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified rule from a route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='ruleName'>
-            /// The name of the rule.
-            /// </param>
-            public static RouteFilterRuleInner Get(this IRouteFilterRulesOperations operations, string resourceGroupName, string routeFilterName, string ruleName)
-            {
-                return operations.GetAsync(resourceGroupName, routeFilterName, ruleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified rule from a route filter.
             /// </summary>
@@ -111,29 +73,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a route in the specified route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='ruleName'>
-            /// The name of the route filter rule.
-            /// </param>
-            /// <param name='routeFilterRuleParameters'>
-            /// Parameters supplied to the create or update route filter rule operation.
-            /// </param>
-            public static RouteFilterRuleInner CreateOrUpdate(this IRouteFilterRulesOperations operations, string resourceGroupName, string routeFilterName, string ruleName, RouteFilterRuleInner routeFilterRuleParameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, routeFilterName, ruleName, routeFilterRuleParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a route in the specified route filter.
             /// </summary>
@@ -163,29 +103,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates a route in the specified route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='ruleName'>
-            /// The name of the route filter rule.
-            /// </param>
-            /// <param name='routeFilterRuleParameters'>
-            /// Parameters supplied to the update route filter rule operation.
-            /// </param>
-            public static RouteFilterRuleInner Update(this IRouteFilterRulesOperations operations, string resourceGroupName, string routeFilterName, string ruleName, PatchRouteFilterRuleInner routeFilterRuleParameters)
-            {
-                return operations.UpdateAsync(resourceGroupName, routeFilterName, ruleName, routeFilterRuleParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates a route in the specified route filter.
             /// </summary>
@@ -215,23 +133,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all RouteFilterRules in a route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            public static IPage<RouteFilterRuleInner> ListByRouteFilter(this IRouteFilterRulesOperations operations, string resourceGroupName, string routeFilterName)
-            {
-                return operations.ListByRouteFilterAsync(resourceGroupName, routeFilterName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all RouteFilterRules in a route filter.
             /// </summary>
@@ -255,26 +157,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified rule from a route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='ruleName'>
-            /// The name of the rule.
-            /// </param>
-            public static void BeginDelete(this IRouteFilterRulesOperations operations, string resourceGroupName, string routeFilterName, string ruleName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, routeFilterName, ruleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified rule from a route filter.
             /// </summary>
@@ -298,29 +181,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, routeFilterName, ruleName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a route in the specified route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='ruleName'>
-            /// The name of the route filter rule.
-            /// </param>
-            /// <param name='routeFilterRuleParameters'>
-            /// Parameters supplied to the create or update route filter rule operation.
-            /// </param>
-            public static RouteFilterRuleInner BeginCreateOrUpdate(this IRouteFilterRulesOperations operations, string resourceGroupName, string routeFilterName, string ruleName, RouteFilterRuleInner routeFilterRuleParameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, routeFilterName, ruleName, routeFilterRuleParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a route in the specified route filter.
             /// </summary>
@@ -350,29 +211,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates a route in the specified route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='ruleName'>
-            /// The name of the route filter rule.
-            /// </param>
-            /// <param name='routeFilterRuleParameters'>
-            /// Parameters supplied to the update route filter rule operation.
-            /// </param>
-            public static RouteFilterRuleInner BeginUpdate(this IRouteFilterRulesOperations operations, string resourceGroupName, string routeFilterName, string ruleName, PatchRouteFilterRuleInner routeFilterRuleParameters)
-            {
-                return operations.BeginUpdateAsync(resourceGroupName, routeFilterName, ruleName, routeFilterRuleParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates a route in the specified route filter.
             /// </summary>
@@ -402,20 +241,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all RouteFilterRules in a route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RouteFilterRuleInner> ListByRouteFilterNext(this IRouteFilterRulesOperations operations, string nextPageLink)
-            {
-                return operations.ListByRouteFilterNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all RouteFilterRules in a route filter.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/RouteFiltersOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/RouteFiltersOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class RouteFiltersOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            public static void Delete(this IRouteFiltersOperations operations, string resourceGroupName, string routeFilterName)
-            {
-                operations.DeleteAsync(resourceGroupName, routeFilterName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified route filter.
             /// </summary>
@@ -59,26 +43,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, routeFilterName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='expand'>
-            /// Expands referenced express route bgp peering resources.
-            /// </param>
-            public static RouteFilterInner Get(this IRouteFiltersOperations operations, string resourceGroupName, string routeFilterName, string expand = default(string))
-            {
-                return operations.GetAsync(resourceGroupName, routeFilterName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified route filter.
             /// </summary>
@@ -105,26 +70,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a route filter in a specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='routeFilterParameters'>
-            /// Parameters supplied to the create or update route filter operation.
-            /// </param>
-            public static RouteFilterInner CreateOrUpdate(this IRouteFiltersOperations operations, string resourceGroupName, string routeFilterName, RouteFilterInner routeFilterParameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, routeFilterName, routeFilterParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a route filter in a specified resource group.
             /// </summary>
@@ -151,26 +97,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates a route filter in a specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='routeFilterParameters'>
-            /// Parameters supplied to the update route filter operation.
-            /// </param>
-            public static RouteFilterInner Update(this IRouteFiltersOperations operations, string resourceGroupName, string routeFilterName, PatchRouteFilterInner routeFilterParameters)
-            {
-                return operations.UpdateAsync(resourceGroupName, routeFilterName, routeFilterParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates a route filter in a specified resource group.
             /// </summary>
@@ -197,20 +124,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all route filters in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<RouteFilterInner> ListByResourceGroup(this IRouteFiltersOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all route filters in a resource group.
             /// </summary>
@@ -231,17 +145,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all route filters in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<RouteFilterInner> List(this IRouteFiltersOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all route filters in a subscription.
             /// </summary>
@@ -259,23 +163,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified route filter.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            public static void BeginDelete(this IRouteFiltersOperations operations, string resourceGroupName, string routeFilterName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, routeFilterName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified route filter.
             /// </summary>
@@ -296,26 +184,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, routeFilterName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a route filter in a specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='routeFilterParameters'>
-            /// Parameters supplied to the create or update route filter operation.
-            /// </param>
-            public static RouteFilterInner BeginCreateOrUpdate(this IRouteFiltersOperations operations, string resourceGroupName, string routeFilterName, RouteFilterInner routeFilterParameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, routeFilterName, routeFilterParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a route filter in a specified resource group.
             /// </summary>
@@ -342,26 +211,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates a route filter in a specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeFilterName'>
-            /// The name of the route filter.
-            /// </param>
-            /// <param name='routeFilterParameters'>
-            /// Parameters supplied to the update route filter operation.
-            /// </param>
-            public static RouteFilterInner BeginUpdate(this IRouteFiltersOperations operations, string resourceGroupName, string routeFilterName, PatchRouteFilterInner routeFilterParameters)
-            {
-                return operations.BeginUpdateAsync(resourceGroupName, routeFilterName, routeFilterParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates a route filter in a specified resource group.
             /// </summary>
@@ -388,20 +238,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all route filters in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RouteFilterInner> ListByResourceGroupNext(this IRouteFiltersOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all route filters in a resource group.
             /// </summary>
@@ -422,20 +259,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all route filters in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RouteFilterInner> ListNext(this IRouteFiltersOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all route filters in a subscription.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/RouteTablesOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/RouteTablesOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class RouteTablesOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified route table.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeTableName'>
-            /// The name of the route table.
-            /// </param>
-            public static void Delete(this IRouteTablesOperations operations, string resourceGroupName, string routeTableName)
-            {
-                operations.DeleteAsync(resourceGroupName, routeTableName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified route table.
             /// </summary>
@@ -59,26 +43,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, routeTableName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified route table.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeTableName'>
-            /// The name of the route table.
-            /// </param>
-            /// <param name='expand'>
-            /// Expands referenced resources.
-            /// </param>
-            public static RouteTableInner Get(this IRouteTablesOperations operations, string resourceGroupName, string routeTableName, string expand = default(string))
-            {
-                return operations.GetAsync(resourceGroupName, routeTableName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified route table.
             /// </summary>
@@ -105,26 +70,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or updates a route table in a specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeTableName'>
-            /// The name of the route table.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update route table operation.
-            /// </param>
-            public static RouteTableInner CreateOrUpdate(this IRouteTablesOperations operations, string resourceGroupName, string routeTableName, RouteTableInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, routeTableName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or updates a route table in a specified resource group.
             /// </summary>
@@ -151,20 +97,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all route tables in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<RouteTableInner> List(this IRouteTablesOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all route tables in a resource group.
             /// </summary>
@@ -185,17 +118,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all route tables in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<RouteTableInner> ListAll(this IRouteTablesOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all route tables in a subscription.
             /// </summary>
@@ -213,23 +136,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified route table.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeTableName'>
-            /// The name of the route table.
-            /// </param>
-            public static void BeginDelete(this IRouteTablesOperations operations, string resourceGroupName, string routeTableName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, routeTableName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified route table.
             /// </summary>
@@ -250,26 +157,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, routeTableName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Create or updates a route table in a specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeTableName'>
-            /// The name of the route table.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update route table operation.
-            /// </param>
-            public static RouteTableInner BeginCreateOrUpdate(this IRouteTablesOperations operations, string resourceGroupName, string routeTableName, RouteTableInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, routeTableName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or updates a route table in a specified resource group.
             /// </summary>
@@ -296,20 +184,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all route tables in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RouteTableInner> ListNext(this IRouteTablesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all route tables in a resource group.
             /// </summary>
@@ -330,20 +205,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all route tables in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RouteTableInner> ListAllNext(this IRouteTablesOperations operations, string nextPageLink)
-            {
-                return operations.ListAllNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all route tables in a subscription.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/RoutesOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/RoutesOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class RoutesOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified route from a route table.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeTableName'>
-            /// The name of the route table.
-            /// </param>
-            /// <param name='routeName'>
-            /// The name of the route.
-            /// </param>
-            public static void Delete(this IRoutesOperations operations, string resourceGroupName, string routeTableName, string routeName)
-            {
-                operations.DeleteAsync(resourceGroupName, routeTableName, routeName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified route from a route table.
             /// </summary>
@@ -65,26 +46,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, routeTableName, routeName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified route from a route table.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeTableName'>
-            /// The name of the route table.
-            /// </param>
-            /// <param name='routeName'>
-            /// The name of the route.
-            /// </param>
-            public static RouteInner Get(this IRoutesOperations operations, string resourceGroupName, string routeTableName, string routeName)
-            {
-                return operations.GetAsync(resourceGroupName, routeTableName, routeName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified route from a route table.
             /// </summary>
@@ -111,29 +73,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a route in the specified route table.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeTableName'>
-            /// The name of the route table.
-            /// </param>
-            /// <param name='routeName'>
-            /// The name of the route.
-            /// </param>
-            /// <param name='routeParameters'>
-            /// Parameters supplied to the create or update route operation.
-            /// </param>
-            public static RouteInner CreateOrUpdate(this IRoutesOperations operations, string resourceGroupName, string routeTableName, string routeName, RouteInner routeParameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, routeTableName, routeName, routeParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a route in the specified route table.
             /// </summary>
@@ -163,23 +103,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all routes in a route table.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeTableName'>
-            /// The name of the route table.
-            /// </param>
-            public static IPage<RouteInner> List(this IRoutesOperations operations, string resourceGroupName, string routeTableName)
-            {
-                return operations.ListAsync(resourceGroupName, routeTableName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all routes in a route table.
             /// </summary>
@@ -203,26 +127,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified route from a route table.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeTableName'>
-            /// The name of the route table.
-            /// </param>
-            /// <param name='routeName'>
-            /// The name of the route.
-            /// </param>
-            public static void BeginDelete(this IRoutesOperations operations, string resourceGroupName, string routeTableName, string routeName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, routeTableName, routeName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified route from a route table.
             /// </summary>
@@ -246,29 +151,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, routeTableName, routeName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a route in the specified route table.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='routeTableName'>
-            /// The name of the route table.
-            /// </param>
-            /// <param name='routeName'>
-            /// The name of the route.
-            /// </param>
-            /// <param name='routeParameters'>
-            /// Parameters supplied to the create or update route operation.
-            /// </param>
-            public static RouteInner BeginCreateOrUpdate(this IRoutesOperations operations, string resourceGroupName, string routeTableName, string routeName, RouteInner routeParameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, routeTableName, routeName, routeParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a route in the specified route table.
             /// </summary>
@@ -298,20 +181,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all routes in a route table.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RouteInner> ListNext(this IRoutesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all routes in a route table.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/SecurityRulesOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/SecurityRulesOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class SecurityRulesOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified network security rule.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkSecurityGroupName'>
-            /// The name of the network security group.
-            /// </param>
-            /// <param name='securityRuleName'>
-            /// The name of the security rule.
-            /// </param>
-            public static void Delete(this ISecurityRulesOperations operations, string resourceGroupName, string networkSecurityGroupName, string securityRuleName)
-            {
-                operations.DeleteAsync(resourceGroupName, networkSecurityGroupName, securityRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified network security rule.
             /// </summary>
@@ -65,26 +46,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, networkSecurityGroupName, securityRuleName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get the specified network security rule.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkSecurityGroupName'>
-            /// The name of the network security group.
-            /// </param>
-            /// <param name='securityRuleName'>
-            /// The name of the security rule.
-            /// </param>
-            public static SecurityRuleInner Get(this ISecurityRulesOperations operations, string resourceGroupName, string networkSecurityGroupName, string securityRuleName)
-            {
-                return operations.GetAsync(resourceGroupName, networkSecurityGroupName, securityRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get the specified network security rule.
             /// </summary>
@@ -111,30 +73,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a security rule in the specified network security group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkSecurityGroupName'>
-            /// The name of the network security group.
-            /// </param>
-            /// <param name='securityRuleName'>
-            /// The name of the security rule.
-            /// </param>
-            /// <param name='securityRuleParameters'>
-            /// Parameters supplied to the create or update network security rule
-            /// operation.
-            /// </param>
-            public static SecurityRuleInner CreateOrUpdate(this ISecurityRulesOperations operations, string resourceGroupName, string networkSecurityGroupName, string securityRuleName, SecurityRuleInner securityRuleParameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, networkSecurityGroupName, securityRuleName, securityRuleParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a security rule in the specified network security group.
             /// </summary>
@@ -165,23 +104,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all security rules in a network security group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkSecurityGroupName'>
-            /// The name of the network security group.
-            /// </param>
-            public static IPage<SecurityRuleInner> List(this ISecurityRulesOperations operations, string resourceGroupName, string networkSecurityGroupName)
-            {
-                return operations.ListAsync(resourceGroupName, networkSecurityGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all security rules in a network security group.
             /// </summary>
@@ -205,26 +128,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified network security rule.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkSecurityGroupName'>
-            /// The name of the network security group.
-            /// </param>
-            /// <param name='securityRuleName'>
-            /// The name of the security rule.
-            /// </param>
-            public static void BeginDelete(this ISecurityRulesOperations operations, string resourceGroupName, string networkSecurityGroupName, string securityRuleName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, networkSecurityGroupName, securityRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified network security rule.
             /// </summary>
@@ -248,30 +152,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, networkSecurityGroupName, securityRuleName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a security rule in the specified network security group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='networkSecurityGroupName'>
-            /// The name of the network security group.
-            /// </param>
-            /// <param name='securityRuleName'>
-            /// The name of the security rule.
-            /// </param>
-            /// <param name='securityRuleParameters'>
-            /// Parameters supplied to the create or update network security rule
-            /// operation.
-            /// </param>
-            public static SecurityRuleInner BeginCreateOrUpdate(this ISecurityRulesOperations operations, string resourceGroupName, string networkSecurityGroupName, string securityRuleName, SecurityRuleInner securityRuleParameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, networkSecurityGroupName, securityRuleName, securityRuleParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a security rule in the specified network security group.
             /// </summary>
@@ -302,20 +183,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all security rules in a network security group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SecurityRuleInner> ListNext(this ISecurityRulesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all security rules in a network security group.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/SubnetsOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/SubnetsOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class SubnetsOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified subnet.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='subnetName'>
-            /// The name of the subnet.
-            /// </param>
-            public static void Delete(this ISubnetsOperations operations, string resourceGroupName, string virtualNetworkName, string subnetName)
-            {
-                operations.DeleteAsync(resourceGroupName, virtualNetworkName, subnetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified subnet.
             /// </summary>
@@ -65,29 +46,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, virtualNetworkName, subnetName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified subnet by virtual network and resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='subnetName'>
-            /// The name of the subnet.
-            /// </param>
-            /// <param name='expand'>
-            /// Expands referenced resources.
-            /// </param>
-            public static SubnetInner Get(this ISubnetsOperations operations, string resourceGroupName, string virtualNetworkName, string subnetName, string expand = default(string))
-            {
-                return operations.GetAsync(resourceGroupName, virtualNetworkName, subnetName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified subnet by virtual network and resource group.
             /// </summary>
@@ -117,29 +76,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a subnet in the specified virtual network.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='subnetName'>
-            /// The name of the subnet.
-            /// </param>
-            /// <param name='subnetParameters'>
-            /// Parameters supplied to the create or update subnet operation.
-            /// </param>
-            public static SubnetInner CreateOrUpdate(this ISubnetsOperations operations, string resourceGroupName, string virtualNetworkName, string subnetName, SubnetInner subnetParameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, virtualNetworkName, subnetName, subnetParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a subnet in the specified virtual network.
             /// </summary>
@@ -169,23 +106,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all subnets in a virtual network.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            public static IPage<SubnetInner> List(this ISubnetsOperations operations, string resourceGroupName, string virtualNetworkName)
-            {
-                return operations.ListAsync(resourceGroupName, virtualNetworkName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all subnets in a virtual network.
             /// </summary>
@@ -209,26 +130,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified subnet.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='subnetName'>
-            /// The name of the subnet.
-            /// </param>
-            public static void BeginDelete(this ISubnetsOperations operations, string resourceGroupName, string virtualNetworkName, string subnetName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, virtualNetworkName, subnetName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified subnet.
             /// </summary>
@@ -252,29 +154,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, virtualNetworkName, subnetName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a subnet in the specified virtual network.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='subnetName'>
-            /// The name of the subnet.
-            /// </param>
-            /// <param name='subnetParameters'>
-            /// Parameters supplied to the create or update subnet operation.
-            /// </param>
-            public static SubnetInner BeginCreateOrUpdate(this ISubnetsOperations operations, string resourceGroupName, string virtualNetworkName, string subnetName, SubnetInner subnetParameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, virtualNetworkName, subnetName, subnetParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a subnet in the specified virtual network.
             /// </summary>
@@ -304,20 +184,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all subnets in a virtual network.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SubnetInner> ListNext(this ISubnetsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all subnets in a virtual network.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/UsagesOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/UsagesOperationsExtensions.cs
@@ -22,20 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class UsagesOperationsExtensions
     {
-            /// <summary>
-            /// Lists compute usages for a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='location'>
-            /// The location where resource usage is queried.
-            /// </param>
-            public static IPage<Usage> List(this IUsagesOperations operations, string location)
-            {
-                return operations.ListAsync(location).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists compute usages for a subscription.
             /// </summary>
@@ -56,20 +43,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists compute usages for a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<Usage> ListNext(this IUsagesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists compute usages for a subscription.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/VirtualNetworkGatewayConnectionsOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/VirtualNetworkGatewayConnectionsOperationsExtensions.cs
@@ -22,28 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class VirtualNetworkGatewayConnectionsOperationsExtensions
     {
-            /// <summary>
-            /// Creates or updates a virtual network gateway connection in the specified
-            /// resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayConnectionName'>
-            /// The name of the virtual network gateway connection.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update virtual network gateway
-            /// connection operation.
-            /// </param>
-            public static VirtualNetworkGatewayConnectionInner CreateOrUpdate(this IVirtualNetworkGatewayConnectionsOperations operations, string resourceGroupName, string virtualNetworkGatewayConnectionName, VirtualNetworkGatewayConnectionInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, virtualNetworkGatewayConnectionName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a virtual network gateway connection in the specified
             /// resource group.
@@ -72,23 +51,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the specified virtual network gateway connection by resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayConnectionName'>
-            /// The name of the virtual network gateway connection.
-            /// </param>
-            public static VirtualNetworkGatewayConnectionInner Get(this IVirtualNetworkGatewayConnectionsOperations operations, string resourceGroupName, string virtualNetworkGatewayConnectionName)
-            {
-                return operations.GetAsync(resourceGroupName, virtualNetworkGatewayConnectionName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified virtual network gateway connection by resource group.
             /// </summary>
@@ -112,23 +75,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified virtual network Gateway connection.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayConnectionName'>
-            /// The name of the virtual network gateway connection.
-            /// </param>
-            public static void Delete(this IVirtualNetworkGatewayConnectionsOperations operations, string resourceGroupName, string virtualNetworkGatewayConnectionName)
-            {
-                operations.DeleteAsync(resourceGroupName, virtualNetworkGatewayConnectionName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified virtual network Gateway connection.
             /// </summary>
@@ -149,29 +96,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, virtualNetworkGatewayConnectionName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// The Put VirtualNetworkGatewayConnectionSharedKey operation sets the virtual
-            /// network gateway connection shared key for passed virtual network gateway
-            /// connection in the specified resource group through Network resource
-            /// provider.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayConnectionName'>
-            /// The virtual network gateway connection name.
-            /// </param>
-            /// <param name='value'>
-            /// The virtual network connection shared key value.
-            /// </param>
-            public static ConnectionSharedKeyInner SetSharedKey(this IVirtualNetworkGatewayConnectionsOperations operations, string resourceGroupName, string virtualNetworkGatewayConnectionName, string value)
-            {
-                return operations.SetSharedKeyAsync(resourceGroupName, virtualNetworkGatewayConnectionName, value).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The Put VirtualNetworkGatewayConnectionSharedKey operation sets the virtual
             /// network gateway connection shared key for passed virtual network gateway
@@ -201,25 +126,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// The Get VirtualNetworkGatewayConnectionSharedKey operation retrieves
-            /// information about the specified virtual network gateway connection shared
-            /// key through Network resource provider.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayConnectionName'>
-            /// The virtual network gateway connection shared key name.
-            /// </param>
-            public static ConnectionSharedKeyInner GetSharedKey(this IVirtualNetworkGatewayConnectionsOperations operations, string resourceGroupName, string virtualNetworkGatewayConnectionName)
-            {
-                return operations.GetSharedKeyAsync(resourceGroupName, virtualNetworkGatewayConnectionName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The Get VirtualNetworkGatewayConnectionSharedKey operation retrieves
             /// information about the specified virtual network gateway connection shared
@@ -245,21 +152,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// The List VirtualNetworkGatewayConnections operation retrieves all the
-            /// virtual network gateways connections created.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<VirtualNetworkGatewayConnectionInner> List(this IVirtualNetworkGatewayConnectionsOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The List VirtualNetworkGatewayConnections operation retrieves all the
             /// virtual network gateways connections created.
@@ -281,30 +174,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// The VirtualNetworkGatewayConnectionResetSharedKey operation resets the
-            /// virtual network gateway connection shared key for passed virtual network
-            /// gateway connection in the specified resource group through Network resource
-            /// provider.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayConnectionName'>
-            /// The virtual network gateway connection reset shared key Name.
-            /// </param>
-            /// <param name='keyLength'>
-            /// The virtual network connection reset shared key length, should between 1
-            /// and 128.
-            /// </param>
-            public static ConnectionResetSharedKeyInner ResetSharedKey(this IVirtualNetworkGatewayConnectionsOperations operations, string resourceGroupName, string virtualNetworkGatewayConnectionName, int keyLength)
-            {
-                return operations.ResetSharedKeyAsync(resourceGroupName, virtualNetworkGatewayConnectionName, keyLength).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The VirtualNetworkGatewayConnectionResetSharedKey operation resets the
             /// virtual network gateway connection shared key for passed virtual network
@@ -335,28 +205,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a virtual network gateway connection in the specified
-            /// resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayConnectionName'>
-            /// The name of the virtual network gateway connection.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update virtual network gateway
-            /// connection operation.
-            /// </param>
-            public static VirtualNetworkGatewayConnectionInner BeginCreateOrUpdate(this IVirtualNetworkGatewayConnectionsOperations operations, string resourceGroupName, string virtualNetworkGatewayConnectionName, VirtualNetworkGatewayConnectionInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, virtualNetworkGatewayConnectionName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a virtual network gateway connection in the specified
             /// resource group.
@@ -385,23 +234,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified virtual network Gateway connection.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayConnectionName'>
-            /// The name of the virtual network gateway connection.
-            /// </param>
-            public static void BeginDelete(this IVirtualNetworkGatewayConnectionsOperations operations, string resourceGroupName, string virtualNetworkGatewayConnectionName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, virtualNetworkGatewayConnectionName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified virtual network Gateway connection.
             /// </summary>
@@ -422,29 +255,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, virtualNetworkGatewayConnectionName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// The Put VirtualNetworkGatewayConnectionSharedKey operation sets the virtual
-            /// network gateway connection shared key for passed virtual network gateway
-            /// connection in the specified resource group through Network resource
-            /// provider.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayConnectionName'>
-            /// The virtual network gateway connection name.
-            /// </param>
-            /// <param name='value'>
-            /// The virtual network connection shared key value.
-            /// </param>
-            public static ConnectionSharedKeyInner BeginSetSharedKey(this IVirtualNetworkGatewayConnectionsOperations operations, string resourceGroupName, string virtualNetworkGatewayConnectionName, string value)
-            {
-                return operations.BeginSetSharedKeyAsync(resourceGroupName, virtualNetworkGatewayConnectionName, value).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The Put VirtualNetworkGatewayConnectionSharedKey operation sets the virtual
             /// network gateway connection shared key for passed virtual network gateway
@@ -474,30 +285,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// The VirtualNetworkGatewayConnectionResetSharedKey operation resets the
-            /// virtual network gateway connection shared key for passed virtual network
-            /// gateway connection in the specified resource group through Network resource
-            /// provider.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayConnectionName'>
-            /// The virtual network gateway connection reset shared key Name.
-            /// </param>
-            /// <param name='keyLength'>
-            /// The virtual network connection reset shared key length, should between 1
-            /// and 128.
-            /// </param>
-            public static ConnectionResetSharedKeyInner BeginResetSharedKey(this IVirtualNetworkGatewayConnectionsOperations operations, string resourceGroupName, string virtualNetworkGatewayConnectionName, int keyLength)
-            {
-                return operations.BeginResetSharedKeyAsync(resourceGroupName, virtualNetworkGatewayConnectionName, keyLength).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The VirtualNetworkGatewayConnectionResetSharedKey operation resets the
             /// virtual network gateway connection shared key for passed virtual network
@@ -528,21 +316,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// The List VirtualNetworkGatewayConnections operation retrieves all the
-            /// virtual network gateways connections created.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VirtualNetworkGatewayConnectionInner> ListNext(this IVirtualNetworkGatewayConnectionsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The List VirtualNetworkGatewayConnections operation retrieves all the
             /// virtual network gateways connections created.

--- a/src/ResourceManagement/Network/Generated/VirtualNetworkGatewaysOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/VirtualNetworkGatewaysOperationsExtensions.cs
@@ -22,27 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class VirtualNetworkGatewaysOperationsExtensions
     {
-            /// <summary>
-            /// Creates or updates a virtual network gateway in the specified resource
-            /// group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to create or update virtual network gateway operation.
-            /// </param>
-            public static VirtualNetworkGatewayInner CreateOrUpdate(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName, VirtualNetworkGatewayInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, virtualNetworkGatewayName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a virtual network gateway in the specified resource
             /// group.
@@ -70,23 +50,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the specified virtual network gateway by resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            public static VirtualNetworkGatewayInner Get(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName)
-            {
-                return operations.GetAsync(resourceGroupName, virtualNetworkGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified virtual network gateway by resource group.
             /// </summary>
@@ -110,23 +74,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified virtual network gateway.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            public static void Delete(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName)
-            {
-                operations.DeleteAsync(resourceGroupName, virtualNetworkGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified virtual network gateway.
             /// </summary>
@@ -147,20 +95,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, virtualNetworkGatewayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets all virtual network gateways by resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<VirtualNetworkGatewayInner> List(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all virtual network gateways by resource group.
             /// </summary>
@@ -181,28 +116,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Resets the primary of the virtual network gateway in the specified resource
-            /// group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            /// <param name='gatewayVip'>
-            /// Virtual network gateway vip address supplied to the begin reset of the
-            /// active-active feature enabled gateway.
-            /// </param>
-            public static VirtualNetworkGatewayInner Reset(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName, string gatewayVip = default(string))
-            {
-                return operations.ResetAsync(resourceGroupName, virtualNetworkGatewayName, gatewayVip).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Resets the primary of the virtual network gateway in the specified resource
             /// group.
@@ -231,28 +145,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Generates VPN client package for P2S client of the virtual network gateway
-            /// in the specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            /// <param name='processorArchitecture'>
-            /// VPN client Processor Architecture. Possible values are: 'AMD64' and 'X86'.
-            /// Possible values include: 'Amd64', 'X86'
-            /// </param>
-            public static string Generatevpnclientpackage(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName, string processorArchitecture)
-            {
-                return operations.GeneratevpnclientpackageAsync(resourceGroupName, virtualNetworkGatewayName, processorArchitecture).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Generates VPN client package for P2S client of the virtual network gateway
             /// in the specified resource group.
@@ -281,26 +174,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// The GetBgpPeerStatus operation retrieves the status of all BGP peers.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            /// <param name='peer'>
-            /// The IP address of the peer to retrieve the status of.
-            /// </param>
-            public static BgpPeerStatusListResultInner GetBgpPeerStatus(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName, string peer = default(string))
-            {
-                return operations.GetBgpPeerStatusAsync(resourceGroupName, virtualNetworkGatewayName, peer).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The GetBgpPeerStatus operation retrieves the status of all BGP peers.
             /// </summary>
@@ -327,24 +201,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// This operation retrieves a list of routes the virtual network gateway has
-            /// learned, including routes learned from BGP peers.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            public static GatewayRouteListResultInner GetLearnedRoutes(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName)
-            {
-                return operations.GetLearnedRoutesAsync(resourceGroupName, virtualNetworkGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// This operation retrieves a list of routes the virtual network gateway has
             /// learned, including routes learned from BGP peers.
@@ -369,27 +226,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// This operation retrieves a list of routes the virtual network gateway is
-            /// advertising to the specified peer.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            /// <param name='peer'>
-            /// The IP address of the peer
-            /// </param>
-            public static GatewayRouteListResultInner GetAdvertisedRoutes(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName, string peer)
-            {
-                return operations.GetAdvertisedRoutesAsync(resourceGroupName, virtualNetworkGatewayName, peer).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// This operation retrieves a list of routes the virtual network gateway is
             /// advertising to the specified peer.
@@ -417,27 +254,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a virtual network gateway in the specified resource
-            /// group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to create or update virtual network gateway operation.
-            /// </param>
-            public static VirtualNetworkGatewayInner BeginCreateOrUpdate(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName, VirtualNetworkGatewayInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, virtualNetworkGatewayName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a virtual network gateway in the specified resource
             /// group.
@@ -465,23 +282,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified virtual network gateway.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            public static void BeginDelete(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, virtualNetworkGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified virtual network gateway.
             /// </summary>
@@ -502,28 +303,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, virtualNetworkGatewayName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Resets the primary of the virtual network gateway in the specified resource
-            /// group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            /// <param name='gatewayVip'>
-            /// Virtual network gateway vip address supplied to the begin reset of the
-            /// active-active feature enabled gateway.
-            /// </param>
-            public static VirtualNetworkGatewayInner BeginReset(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName, string gatewayVip = default(string))
-            {
-                return operations.BeginResetAsync(resourceGroupName, virtualNetworkGatewayName, gatewayVip).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Resets the primary of the virtual network gateway in the specified resource
             /// group.
@@ -552,26 +332,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// The GetBgpPeerStatus operation retrieves the status of all BGP peers.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            /// <param name='peer'>
-            /// The IP address of the peer to retrieve the status of.
-            /// </param>
-            public static BgpPeerStatusListResultInner BeginGetBgpPeerStatus(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName, string peer = default(string))
-            {
-                return operations.BeginGetBgpPeerStatusAsync(resourceGroupName, virtualNetworkGatewayName, peer).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The GetBgpPeerStatus operation retrieves the status of all BGP peers.
             /// </summary>
@@ -598,24 +359,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// This operation retrieves a list of routes the virtual network gateway has
-            /// learned, including routes learned from BGP peers.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            public static GatewayRouteListResultInner BeginGetLearnedRoutes(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName)
-            {
-                return operations.BeginGetLearnedRoutesAsync(resourceGroupName, virtualNetworkGatewayName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// This operation retrieves a list of routes the virtual network gateway has
             /// learned, including routes learned from BGP peers.
@@ -640,27 +384,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// This operation retrieves a list of routes the virtual network gateway is
-            /// advertising to the specified peer.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkGatewayName'>
-            /// The name of the virtual network gateway.
-            /// </param>
-            /// <param name='peer'>
-            /// The IP address of the peer
-            /// </param>
-            public static GatewayRouteListResultInner BeginGetAdvertisedRoutes(this IVirtualNetworkGatewaysOperations operations, string resourceGroupName, string virtualNetworkGatewayName, string peer)
-            {
-                return operations.BeginGetAdvertisedRoutesAsync(resourceGroupName, virtualNetworkGatewayName, peer).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// This operation retrieves a list of routes the virtual network gateway is
             /// advertising to the specified peer.
@@ -688,20 +412,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all virtual network gateways by resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VirtualNetworkGatewayInner> ListNext(this IVirtualNetworkGatewaysOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all virtual network gateways by resource group.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/VirtualNetworkPeeringsOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/VirtualNetworkPeeringsOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class VirtualNetworkPeeringsOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified virtual network peering.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='virtualNetworkPeeringName'>
-            /// The name of the virtual network peering.
-            /// </param>
-            public static void Delete(this IVirtualNetworkPeeringsOperations operations, string resourceGroupName, string virtualNetworkName, string virtualNetworkPeeringName)
-            {
-                operations.DeleteAsync(resourceGroupName, virtualNetworkName, virtualNetworkPeeringName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified virtual network peering.
             /// </summary>
@@ -65,26 +46,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified virtual network peering.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='virtualNetworkPeeringName'>
-            /// The name of the virtual network peering.
-            /// </param>
-            public static VirtualNetworkPeeringInner Get(this IVirtualNetworkPeeringsOperations operations, string resourceGroupName, string virtualNetworkName, string virtualNetworkPeeringName)
-            {
-                return operations.GetAsync(resourceGroupName, virtualNetworkName, virtualNetworkPeeringName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified virtual network peering.
             /// </summary>
@@ -111,30 +73,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a peering in the specified virtual network.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='virtualNetworkPeeringName'>
-            /// The name of the peering.
-            /// </param>
-            /// <param name='virtualNetworkPeeringParameters'>
-            /// Parameters supplied to the create or update virtual network peering
-            /// operation.
-            /// </param>
-            public static VirtualNetworkPeeringInner CreateOrUpdate(this IVirtualNetworkPeeringsOperations operations, string resourceGroupName, string virtualNetworkName, string virtualNetworkPeeringName, VirtualNetworkPeeringInner virtualNetworkPeeringParameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, virtualNetworkPeeringParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a peering in the specified virtual network.
             /// </summary>
@@ -165,23 +104,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all virtual network peerings in a virtual network.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            public static IPage<VirtualNetworkPeeringInner> List(this IVirtualNetworkPeeringsOperations operations, string resourceGroupName, string virtualNetworkName)
-            {
-                return operations.ListAsync(resourceGroupName, virtualNetworkName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all virtual network peerings in a virtual network.
             /// </summary>
@@ -205,26 +128,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified virtual network peering.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='virtualNetworkPeeringName'>
-            /// The name of the virtual network peering.
-            /// </param>
-            public static void BeginDelete(this IVirtualNetworkPeeringsOperations operations, string resourceGroupName, string virtualNetworkName, string virtualNetworkPeeringName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, virtualNetworkName, virtualNetworkPeeringName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified virtual network peering.
             /// </summary>
@@ -248,30 +152,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a peering in the specified virtual network.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='virtualNetworkPeeringName'>
-            /// The name of the peering.
-            /// </param>
-            /// <param name='virtualNetworkPeeringParameters'>
-            /// Parameters supplied to the create or update virtual network peering
-            /// operation.
-            /// </param>
-            public static VirtualNetworkPeeringInner BeginCreateOrUpdate(this IVirtualNetworkPeeringsOperations operations, string resourceGroupName, string virtualNetworkName, string virtualNetworkPeeringName, VirtualNetworkPeeringInner virtualNetworkPeeringParameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, virtualNetworkPeeringParameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a peering in the specified virtual network.
             /// </summary>
@@ -302,20 +183,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all virtual network peerings in a virtual network.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VirtualNetworkPeeringInner> ListNext(this IVirtualNetworkPeeringsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all virtual network peerings in a virtual network.
             /// </summary>

--- a/src/ResourceManagement/Network/Generated/VirtualNetworksOperationsExtensions.cs
+++ b/src/ResourceManagement/Network/Generated/VirtualNetworksOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
     /// </summary>
     public static partial class VirtualNetworksOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the specified virtual network.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            public static void Delete(this IVirtualNetworksOperations operations, string resourceGroupName, string virtualNetworkName)
-            {
-                operations.DeleteAsync(resourceGroupName, virtualNetworkName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified virtual network.
             /// </summary>
@@ -59,26 +43,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, virtualNetworkName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the specified virtual network by resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='expand'>
-            /// Expands referenced resources.
-            /// </param>
-            public static VirtualNetworkInner Get(this IVirtualNetworksOperations operations, string resourceGroupName, string virtualNetworkName, string expand = default(string))
-            {
-                return operations.GetAsync(resourceGroupName, virtualNetworkName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the specified virtual network by resource group.
             /// </summary>
@@ -105,26 +70,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a virtual network in the specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update virtual network operation
-            /// </param>
-            public static VirtualNetworkInner CreateOrUpdate(this IVirtualNetworksOperations operations, string resourceGroupName, string virtualNetworkName, VirtualNetworkInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, virtualNetworkName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a virtual network in the specified resource group.
             /// </summary>
@@ -151,17 +97,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all virtual networks in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<VirtualNetworkInner> ListAll(this IVirtualNetworksOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all virtual networks in a subscription.
             /// </summary>
@@ -179,20 +115,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all virtual networks in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<VirtualNetworkInner> List(this IVirtualNetworksOperations operations, string resourceGroupName)
-            {
-                return operations.ListAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all virtual networks in a resource group.
             /// </summary>
@@ -213,26 +136,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Checks whether a private IP address is available for use.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='ipAddress'>
-            /// The private IP address to be verified.
-            /// </param>
-            public static IPAddressAvailabilityResultInner CheckIPAddressAvailability(this IVirtualNetworksOperations operations, string resourceGroupName, string virtualNetworkName, string ipAddress = default(string))
-            {
-                return operations.CheckIPAddressAvailabilityAsync(resourceGroupName, virtualNetworkName, ipAddress).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks whether a private IP address is available for use.
             /// </summary>
@@ -259,23 +163,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the specified virtual network.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            public static void BeginDelete(this IVirtualNetworksOperations operations, string resourceGroupName, string virtualNetworkName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, virtualNetworkName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the specified virtual network.
             /// </summary>
@@ -296,26 +184,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, virtualNetworkName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates or updates a virtual network in the specified resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='virtualNetworkName'>
-            /// The name of the virtual network.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update virtual network operation
-            /// </param>
-            public static VirtualNetworkInner BeginCreateOrUpdate(this IVirtualNetworksOperations operations, string resourceGroupName, string virtualNetworkName, VirtualNetworkInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, virtualNetworkName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a virtual network in the specified resource group.
             /// </summary>
@@ -342,20 +211,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all virtual networks in a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VirtualNetworkInner> ListAllNext(this IVirtualNetworksOperations operations, string nextPageLink)
-            {
-                return operations.ListAllNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all virtual networks in a subscription.
             /// </summary>
@@ -376,20 +232,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all virtual networks in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<VirtualNetworkInner> ListNext(this IVirtualNetworksOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all virtual networks in a resource group.
             /// </summary>

--- a/src/ResourceManagement/Network/LoadBalancersImpl.cs
+++ b/src/ResourceManagement/Network/LoadBalancersImpl.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
 
         public void Delete(string id)
         {
-            DeleteAsync(id).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => DeleteAsync(id));
         }
 
         public async Task DeleteAsync(string id, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/Network/NetworkUsagesImpl.cs
+++ b/src/ResourceManagement/Network/NetworkUsagesImpl.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Azure.Management.Network.Fluent
 
         public IEnumerable<INetworkUsage> ListByRegion(string regionName)
         {
-            return WrapList(client.Usages.List(regionName).AsContinuousCollection(link => client.Usages.ListNext(link)));
+            return WrapList(Extensions.Synchronize(() => client.Usages.ListAsync(regionName))
+                .AsContinuousCollection(link => Extensions.Synchronize(() => client.Usages.ListNextAsync(link))));
         }
 
         public IEnumerable<INetworkUsage> ListByRegion(Region region)

--- a/src/ResourceManagement/Network/NetworkWatcherImpl.cs
+++ b/src/ResourceManagement/Network/NetworkWatcherImpl.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Management.Network.Fluent
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Models;
     using NetworkWatcher.Definition;
     using NetworkWatcher.Update;
@@ -60,16 +61,16 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:E85C9E0FD0DD69D8054769E60F0023E7:08E9F33BF19AA5A33146856680A21489
         public TopologyImpl GetTopology(string targetResourceGroup)
         {
-            TopologyInner topologyInner = this.Manager.Inner.NetworkWatchers
-                .GetTopology(this.ResourceGroupName, this.Name, targetResourceGroup);
+            TopologyInner topologyInner = Extensions.Synchronize(() => this.Manager.Inner.NetworkWatchers
+                .GetTopologyAsync(this.ResourceGroupName, this.Name, targetResourceGroup));
             return new TopologyImpl(this, topologyInner, targetResourceGroup);
         }
 
         ///GENMHASH:F57C7696A3ED75E619C8E1A9DFE5EA61:9938198EE6EDB0DC20C3A7100AD87595
         public IFlowLogSettings GetFlowLogSettings(string nsgId)
         {
-            FlowLogInformationInner flowLogInformationInner = this.Manager.Inner.NetworkWatchers
-                .GetFlowLogStatus(this.ResourceGroupName, this.Name, nsgId);
+            FlowLogInformationInner flowLogInformationInner = Extensions.Synchronize(() => this.Manager.Inner.NetworkWatchers
+                .GetFlowLogStatusAsync(this.ResourceGroupName, this.Name, nsgId));
             return new FlowLogSettingsImpl(this, flowLogInformationInner, nsgId);
         }
 
@@ -91,8 +92,8 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:C71E107FA8B2DA3EDF8CE88700E11F09:960DE2BF69BF56B713EE1D6546783210
         public ISecurityGroupView GetSecurityGroupView(string vmId)
         {
-            SecurityGroupViewResultInner securityGroupViewResultInner = this.Manager.Inner.NetworkWatchers
-                .GetVMSecurityRules(this.ResourceGroupName, this.Name, vmId);
+            SecurityGroupViewResultInner securityGroupViewResultInner = Extensions.Synchronize(() => this.Manager.Inner.NetworkWatchers
+                .GetVMSecurityRulesAsync(this.ResourceGroupName, this.Name, vmId));
             return new SecurityGroupViewImpl(this, securityGroupViewResultInner, vmId);
         }
 

--- a/src/ResourceManagement/Network/NetworkWatchersImpl.cs
+++ b/src/ResourceManagement/Network/NetworkWatchersImpl.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
 
         public IEnumerable<INetworkWatcher> List()
         {
-            return WrapList(Inner.ListAll());
+            return WrapList(Extensions.Synchronize(() => Inner.ListAllAsync()));
         }
 
         public async Task<IPagedCollection<INetworkWatcher>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = new CancellationToken())
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
 
         public IEnumerable<INetworkWatcher> ListByResourceGroup(string resourceGroupName)
         {
-            return WrapList(Inner.List(resourceGroupName));
+            return WrapList(Extensions.Synchronize(() => Inner.ListAsync(resourceGroupName)));
         }
 
         public async Task<IPagedCollection<INetworkWatcher>> ListByResourceGroupAsync(string resourceGroupName, bool loadAllPages = true,

--- a/src/ResourceManagement/Network/PacketCaptureImpl.cs
+++ b/src/ResourceManagement/Network/PacketCaptureImpl.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:25941804086E52163BC33944A2FAC34F:B4CF07412D871BC54604665642E679CA
         public IPacketCaptureStatus GetStatus()
         {
-            return GetStatusAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetStatusAsync(CancellationToken.None));
         }
 
         ///GENMHASH:2357B38E494D9F10171A28E135CB1715:3961EA7B900ECE15CB8B6D76F00F665B
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:EB854F18026EDB6E01762FA4580BE789:42462B796F15B0EB6E603ACA753873C0
         public void Stop()
         {
-            StopAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => StopAsync(CancellationToken.None));
         }
     }
 }

--- a/src/ResourceManagement/Network/PacketCapturesImpl.cs
+++ b/src/ResourceManagement/Network/PacketCapturesImpl.cs
@@ -80,8 +80,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:C2DC9CFAB6C291D220DD4F29AFF1BBEC:7459D8B9F8BB0A1EBD2FC4702A86F2F5
         public void DeleteByName(string name)
         {
-            DeleteByNameAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
-
+            Extensions.Synchronize(() => DeleteByNameAsync(name));
         }
 
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:A848F2676FADFFFDD0FBF4834FC5D602

--- a/src/ResourceManagement/Network/PacketCapturesImpl.cs
+++ b/src/ResourceManagement/Network/PacketCapturesImpl.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
             {
                 return ((PacketCaptureImpl)WrapModel(inner));
             };
-            return Inner.List(parent.ResourceGroupName, parent.Name)
+            return Extensions.Synchronize(() => Inner.ListAsync(parent.ResourceGroupName, parent.Name))
                 .Select(inner => converter(inner));
         }
 

--- a/src/ResourceManagement/Network/PacketCapturesImpl.cs
+++ b/src/ResourceManagement/Network/PacketCapturesImpl.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         ///GENMHASH:5C58E472AE184041661005E7B2D7EE30:6B6D1D91AC2FCE3076EBD61D0DB099CF
         public IPacketCapture GetByName(string name)
         {
-            return GetByNameAsync(name).Result;
+            return Extensions.Synchronize(() => GetByNameAsync(name));
         }
 
         /// <summary>

--- a/src/ResourceManagement/Network/VirtualMachineScaleSetNetworkInterfacesImpl.cs
+++ b/src/ResourceManagement/Network/VirtualMachineScaleSetNetworkInterfacesImpl.cs
@@ -44,11 +44,11 @@ namespace Microsoft.Azure.Management.Network.Fluent
 
         public IVirtualMachineScaleSetNetworkInterface GetByVirtualMachineInstanceId(string instanceId, string name)
         {
-            NetworkInterfaceInner networkInterfaceInner = Manager().Inner.NetworkInterfaces.GetVirtualMachineScaleSetNetworkInterface(
+            NetworkInterfaceInner networkInterfaceInner = Extensions.Synchronize(() => Manager().Inner.NetworkInterfaces.GetVirtualMachineScaleSetNetworkInterfaceAsync(
                 resourceGroupName,
                 scaleSetName,
                 instanceId,
-                name);
+                name));
             if (networkInterfaceInner == null)
             {
                 return null;
@@ -58,16 +58,14 @@ namespace Microsoft.Azure.Management.Network.Fluent
 
         public IEnumerable<IVirtualMachineScaleSetNetworkInterface> List()
         {
-            return WrapList(Manager().Inner.NetworkInterfaces
-                .ListVirtualMachineScaleSetNetworkInterfaces(resourceGroupName, scaleSetName)
-                .AsContinuousCollection(link => Manager().Inner.NetworkInterfaces.ListVirtualMachineScaleSetNetworkInterfacesNext(link)));
+            return WrapList(Extensions.Synchronize(() => Manager().Inner.NetworkInterfaces.ListVirtualMachineScaleSetNetworkInterfacesAsync(resourceGroupName, scaleSetName))
+                .AsContinuousCollection(link => Extensions.Synchronize(() => Manager().Inner.NetworkInterfaces.ListVirtualMachineScaleSetNetworkInterfacesNextAsync(link))));
         }
 
         public IEnumerable<IVirtualMachineScaleSetNetworkInterface> ListByVirtualMachineInstanceId(string instanceId)
         {
-            return WrapList(Manager().Inner.NetworkInterfaces
-                .ListVirtualMachineScaleSetVMNetworkInterfaces(resourceGroupName, scaleSetName, instanceId)
-                .AsContinuousCollection(link => Manager().Inner.NetworkInterfaces.ListVirtualMachineScaleSetVMNetworkInterfacesNext(link)));
+            return WrapList(Extensions.Synchronize(() => Manager().Inner.NetworkInterfaces.ListVirtualMachineScaleSetVMNetworkInterfacesAsync(resourceGroupName, scaleSetName, instanceId))
+                .AsContinuousCollection(link => Extensions.Synchronize(() => Manager().Inner.NetworkInterfaces.ListVirtualMachineScaleSetVMNetworkInterfacesNextAsync(link))));
         }
 
         protected override IVirtualMachineScaleSetNetworkInterface WrapModel(NetworkInterfaceInner inner)

--- a/src/ResourceManagement/RedisCache/Generated/PatchSchedulesOperationsExtensions.cs
+++ b/src/ResourceManagement/RedisCache/Generated/PatchSchedulesOperationsExtensions.cs
@@ -24,27 +24,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
     /// </summary>
     public static partial class PatchSchedulesOperationsExtensions
     {
-            /// <summary>
-            /// Create or replace the patching schedule for Redis cache (requires Premium
-            /// SKU).
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            /// <param name='scheduleEntriesProperty'>
-            /// List of patch schedules for a Redis cache.
-            /// </param>
-            public static RedisPatchScheduleInner CreateOrUpdate(this IPatchSchedulesOperations operations, string resourceGroupName, string name, IList<ScheduleEntryInner> scheduleEntriesProperty)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, name, scheduleEntriesProperty).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or replace the patching schedule for Redis cache (requires Premium
             /// SKU).
@@ -72,23 +52,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the patching schedule of a redis cache (requires Premium SKU).
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the redis cache.
-            /// </param>
-            public static void Delete(this IPatchSchedulesOperations operations, string resourceGroupName, string name)
-            {
-                operations.DeleteAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the patching schedule of a redis cache (requires Premium SKU).
             /// </summary>
@@ -109,23 +73,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the patching schedule of a redis cache (requires Premium SKU).
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the redis cache.
-            /// </param>
-            public static RedisPatchScheduleInner Get(this IPatchSchedulesOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the patching schedule of a redis cache (requires Premium SKU).
             /// </summary>

--- a/src/ResourceManagement/RedisCache/Generated/RedisOperationsExtensions.cs
+++ b/src/ResourceManagement/RedisCache/Generated/RedisOperationsExtensions.cs
@@ -22,27 +22,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
     /// </summary>
     public static partial class RedisOperationsExtensions
     {
-            /// <summary>
-            /// Create or replace (overwrite/recreate, with potential downtime) an existing
-            /// Redis cache.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Create Redis operation.
-            /// </param>
-            public static RedisResourceInner Create(this IRedisOperations operations, string resourceGroupName, string name, RedisCreateParametersInner parameters)
-            {
-                return operations.CreateAsync(resourceGroupName, name, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or replace (overwrite/recreate, with potential downtime) an existing
             /// Redis cache.
@@ -70,26 +50,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 }
             }
 
-            /// <summary>
-            /// Update an existing Redis cache.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Update Redis operation.
-            /// </param>
-            public static RedisResourceInner Update(this IRedisOperations operations, string resourceGroupName, string name, RedisUpdateParametersInner parameters)
-            {
-                return operations.UpdateAsync(resourceGroupName, name, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Update an existing Redis cache.
             /// </summary>
@@ -116,23 +77,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a Redis cache.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            public static void Delete(this IRedisOperations operations, string resourceGroupName, string name)
-            {
-                operations.DeleteAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a Redis cache.
             /// </summary>
@@ -153,23 +98,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets a Redis cache (resource description).
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            public static RedisResourceInner Get(this IRedisOperations operations, string resourceGroupName, string name)
-            {
-                return operations.GetAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a Redis cache (resource description).
             /// </summary>
@@ -193,20 +122,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all Redis caches in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            public static IPage<RedisResourceInner> ListByResourceGroup(this IRedisOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all Redis caches in a resource group.
             /// </summary>
@@ -227,17 +143,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all Redis caches in the specified subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<RedisResourceInner> List(this IRedisOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all Redis caches in the specified subscription.
             /// </summary>
@@ -255,24 +161,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 }
             }
 
-            /// <summary>
-            /// Retrieve a Redis cache's access keys. This operation requires write
-            /// permission to the cache resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            public static RedisAccessKeysInner ListKeys(this IRedisOperations operations, string resourceGroupName, string name)
-            {
-                return operations.ListKeysAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Retrieve a Redis cache's access keys. This operation requires write
             /// permission to the cache resource.
@@ -297,28 +186,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 }
             }
 
-            /// <summary>
-            /// Regenerate Redis cache's access keys. This operation requires write
-            /// permission to the cache resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            /// <param name='keyType'>
-            /// The Redis access key to regenerate. Possible values include: 'Primary',
-            /// 'Secondary'
-            /// </param>
-            public static RedisAccessKeysInner RegenerateKey(this IRedisOperations operations, string resourceGroupName, string name, RedisKeyType keyType)
-            {
-                return operations.RegenerateKeyAsync(resourceGroupName, name, keyType).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Regenerate Redis cache's access keys. This operation requires write
             /// permission to the cache resource.
@@ -347,27 +215,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 }
             }
 
-            /// <summary>
-            /// Reboot specified Redis node(s). This operation requires write permission to
-            /// the cache resource. There can be potential data loss.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            /// <param name='parameters'>
-            /// Specifies which Redis node(s) to reboot.
-            /// </param>
-            public static RedisForceRebootResponseInner ForceReboot(this IRedisOperations operations, string resourceGroupName, string name, RedisRebootParametersInner parameters)
-            {
-                return operations.ForceRebootAsync(resourceGroupName, name, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Reboot specified Redis node(s). This operation requires write permission to
             /// the cache resource. There can be potential data loss.
@@ -395,26 +243,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 }
             }
 
-            /// <summary>
-            /// Import data into Redis cache.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters for Redis import operation.
-            /// </param>
-            public static void ImportData(this IRedisOperations operations, string resourceGroupName, string name, ImportRDBParametersInner parameters)
-            {
-                operations.ImportDataAsync(resourceGroupName, name, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Import data into Redis cache.
             /// </summary>
@@ -438,26 +267,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 (await operations.ImportDataWithHttpMessagesAsync(resourceGroupName, name, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Export data from the redis cache to blobs in a container.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters for Redis export operation.
-            /// </param>
-            public static void ExportData(this IRedisOperations operations, string resourceGroupName, string name, ExportRDBParametersInner parameters)
-            {
-                operations.ExportDataAsync(resourceGroupName, name, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Export data from the redis cache to blobs in a container.
             /// </summary>
@@ -481,27 +291,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 (await operations.ExportDataWithHttpMessagesAsync(resourceGroupName, name, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Create or replace (overwrite/recreate, with potential downtime) an existing
-            /// Redis cache.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the Create Redis operation.
-            /// </param>
-            public static RedisResourceInner BeginCreate(this IRedisOperations operations, string resourceGroupName, string name, RedisCreateParametersInner parameters)
-            {
-                return operations.BeginCreateAsync(resourceGroupName, name, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or replace (overwrite/recreate, with potential downtime) an existing
             /// Redis cache.
@@ -529,23 +319,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a Redis cache.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            public static void BeginDelete(this IRedisOperations operations, string resourceGroupName, string name)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a Redis cache.
             /// </summary>
@@ -566,26 +340,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, name, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Import data into Redis cache.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters for Redis import operation.
-            /// </param>
-            public static void BeginImportData(this IRedisOperations operations, string resourceGroupName, string name, ImportRDBParametersInner parameters)
-            {
-                operations.BeginImportDataAsync(resourceGroupName, name, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Import data into Redis cache.
             /// </summary>
@@ -609,26 +364,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 (await operations.BeginImportDataWithHttpMessagesAsync(resourceGroupName, name, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Export data from the redis cache to blobs in a container.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group.
-            /// </param>
-            /// <param name='name'>
-            /// The name of the Redis cache.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters for Redis export operation.
-            /// </param>
-            public static void BeginExportData(this IRedisOperations operations, string resourceGroupName, string name, ExportRDBParametersInner parameters)
-            {
-                operations.BeginExportDataAsync(resourceGroupName, name, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Export data from the redis cache to blobs in a container.
             /// </summary>
@@ -652,20 +388,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 (await operations.BeginExportDataWithHttpMessagesAsync(resourceGroupName, name, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Lists all Redis caches in a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RedisResourceInner> ListByResourceGroupNext(this IRedisOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all Redis caches in a resource group.
             /// </summary>
@@ -686,20 +409,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all Redis caches in the specified subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<RedisResourceInner> ListNext(this IRedisOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all Redis caches in the specified subscription.
             /// </summary>

--- a/src/ResourceManagement/RedisCache/RedisCacheImpl.cs
+++ b/src/ResourceManagement/RedisCache/RedisCacheImpl.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
         ///GENMHASH:3D7C4113A3F55E3E31A8AB77D2A98BC2:D096D794DD08C7A81CB4711B276ACAF0
         public void DeletePatchSchedule()
         {
-            Manager.Inner.PatchSchedules.Delete(ResourceGroupName, Name);
+            Extensions.Synchronize(() => Manager.Inner.PatchSchedules.DeleteAsync(ResourceGroupName, Name));
         }
 
         ///GENMHASH:E0A932BCE095834DF49296A5A1B250F3:9AB43882F1D20579E20CB41390D07940
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
             RedisPatchScheduleInner patchSchedules = null;
             try
             {
-                patchSchedules = Manager.Inner.PatchSchedules.Get(ResourceGroupName, Name);
+                patchSchedules = Extensions.Synchronize(() => Manager.Inner.PatchSchedules.GetAsync(ResourceGroupName, Name));
             }
             catch(CloudException ex)
             {

--- a/src/ResourceManagement/RedisCache/RedisCacheImpl.cs
+++ b/src/ResourceManagement/RedisCache/RedisCacheImpl.cs
@@ -93,12 +93,12 @@ namespace Microsoft.Azure.Management.Redis.Fluent
 
         internal IRedisAccessKeys Keys()
         {
-            return GetKeysAsync().GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetKeysAsync());
         }
 
         internal IRedisAccessKeys GetKeys()
         {
-            return GetKeysAsync().GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetKeysAsync());
         }
 
         ///GENMHASH:6EE61FA0DE4D0297160B059C5B56D12A:FCE23512A2C31EB7F68F7065799142F4
@@ -326,7 +326,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
 
         internal IRedisAccessKeys RegenerateKey(RedisKeyType keyType)
         {
-            return RegenerateKeyAsync(keyType).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => RegenerateKeyAsync(keyType));
         }
 
         ///GENMHASH:861E02F6BBA5773E9337D78B346B0D6B:1E017460FECC66E20EB360CE96692158
@@ -382,7 +382,7 @@ namespace Microsoft.Azure.Management.Redis.Fluent
 
         internal IRedisAccessKeys RefreshKeys()
         {
-            return RefreshKeysAsync().GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => RefreshKeysAsync());
         }
 
         ///GENMHASH:36C3CA891B448CCCA6D3BB4C29A31470:222A26931EAF5A1984B63F0B88A1D104

--- a/src/ResourceManagement/ResourceManager/Core/CreatableResources.cs
+++ b/src/ResourceManagement/ResourceManager/Core/CreatableResources.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         public ICreatedResources<IFluentResourceT> Create(IEnumerable<ICreatable<IFluentResourceT>> creatables)
         {
-            return CreateAsync(creatables).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => CreateAsync(creatables));
         }
 
         public async Task<ICreatedResources<IFluentResourceT>> CreateAsync(

--- a/src/ResourceManagement/ResourceManager/Core/Extensions.cs
+++ b/src/ResourceManagement/ResourceManager/Core/Extensions.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Collections.Generic;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Models;
 using System.Reflection;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 {
@@ -44,6 +46,18 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                 .SetValue(page, list.ToList());
 
             return page;
+        }
+
+        public static TResult Synchronize<TResult>(Func<object, Task<TResult>> function, object state)
+        {
+            return Task.Factory.StartNew(function, state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default)
+                .Unwrap().GetAwaiter().GetResult();
+        }
+
+        public static void Synchronize<TResult>(Func<object, Task<Task>> function, object state)
+        {
+            Task.Factory.StartNew(function, state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default)
+                .Unwrap().GetAwaiter().GetResult();
         }
     }
 }

--- a/src/ResourceManagement/ResourceManager/Core/Extensions.cs
+++ b/src/ResourceManagement/ResourceManager/Core/Extensions.cs
@@ -48,16 +48,15 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
             return page;
         }
 
-        public static TResult Synchronize<TResult>(Func<object, Task<TResult>> function, object state)
+        public static TResult Synchronize<TResult>(Func<Task<TResult>> function)
         {
-            return Task.Factory.StartNew(function, state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default)
+            return Task.Factory.StartNew(function, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default)
                 .Unwrap().GetAwaiter().GetResult();
         }
 
-        public static void Synchronize<TResult>(Func<object, Task<Task>> function, object state)
+        public static void Synchronize(Func<Task> function)
         {
-            Task.Factory.StartNew(function, state, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default)
-                .Unwrap().GetAwaiter().GetResult();
+            Task.Factory.StartNew(function, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
         }
     }
 }

--- a/src/ResourceManagement/ResourceManager/Core/ExternalChildResource.cs
+++ b/src/ResourceManagement/ResourceManager/Core/ExternalChildResource.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         public virtual FluentModelT Refresh()
         {
-            return RefreshAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => RefreshAsync());
         }
 
         public virtual async Task<FluentModelT> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ResourceManager/Core/GroupableResources.cs
+++ b/src/ResourceManagement/ResourceManager/Core/GroupableResources.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         public IFluentResourceT GetByResourceGroup(string groupName, string name)
         {
-            return GetByResourceGroupAsync(groupName, name, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetByResourceGroupAsync(groupName, name, CancellationToken.None));
         }
 
         #endregion
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         public IFluentResourceT GetById(string id)
         {
-            return GetByIdAsync(id, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetByIdAsync(id, CancellationToken.None));
         }
 
         #endregion
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         public void DeleteByResourceGroup(string groupName, string name)
         {
-            this.DeleteByResourceGroupAsync(groupName, name, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => this.DeleteByResourceGroupAsync(groupName, name, CancellationToken.None));
         }
 
         #endregion
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         public override void DeleteById(string id)
         {
-            this.DeleteByIdAsync(id).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => this.DeleteByIdAsync(id));
         }
 
         public async override Task DeleteByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ResourceManager/Core/ResourceActions/Creatable.cs
+++ b/src/ResourceManagement/ResourceManager/Core/ResourceActions/Creatable.cs
@@ -39,11 +39,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
 
         public IFluentResourceT Create()
         {
-            return Extensions.Synchronize((s) =>
-                    {
-                        return ((Creatable<IFluentResourceT, InnerResourceT, FluentResourceT, IResourceT>)s).CreateAsync(CancellationToken.None);
-                    },
-                    this);
+            return Extensions.Synchronize(() => this.CreateAsync(CancellationToken.None));
         }
 
         public virtual Task<IFluentResourceT> CreateAsync(CancellationToken cancellationToken, bool multiThreaded = true)
@@ -97,7 +93,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
 
         public virtual IFluentResourceT CreateResource()
         {
-            return this.CreateResourceAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.CreateResourceAsync(CancellationToken.None));
         }
 
         async Task<IResourceT> IResourceCreator<IResourceT>.CreateResourceAsync(CancellationToken cancellationToken)

--- a/src/ResourceManagement/ResourceManager/Core/ResourceActions/Creatable.cs
+++ b/src/ResourceManagement/ResourceManager/Core/ResourceActions/Creatable.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
             {
                 CreatorTaskGroup.Prepare();
                 CreatorTaskGroup.ExecuteAsync(cancellationToken, multiThreaded).ContinueWith(
-                    (task, state) =>
+                    (task) =>
                             {
                                 if (task.Exception != null)
                                 {
@@ -69,7 +69,6 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
                                     }
                                 }
                             }, 
-                    null,
                     cancellationToken,
                     TaskContinuationOptions.ExecuteSynchronously,
                     TaskScheduler.Default);

--- a/src/ResourceManagement/ResourceManager/Core/ResourceActions/CreatableUpdatable.cs
+++ b/src/ResourceManagement/ResourceManager/Core/ResourceActions/CreatableUpdatable.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
         
         public IFluentResourceT Apply()
         {
-            return ApplyAsync(CancellationToken.None, true).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() =>  ApplyAsync(CancellationToken.None, true));
         }
 
         public virtual async Task<IFluentResourceT> ApplyAsync(

--- a/src/ResourceManagement/ResourceManager/Core/ResourceActions/Executable.cs
+++ b/src/ResourceManagement/ResourceManager/Core/ResourceActions/Executable.cs
@@ -21,8 +21,9 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
 
         public abstract Task<IFluentResourceT> ExecuteAsync(CancellationToken cancellationToken = default(CancellationToken), bool multiThreaded = true);
 
-        public IFluentResourceT Execute() {
-            return ExecuteAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+        public IFluentResourceT Execute()
+        {
+            return Extensions.Synchronize(() => ExecuteAsync(CancellationToken.None));
         }
-   }
+    }
 }

--- a/src/ResourceManagement/ResourceManager/Core/ResourceActions/IndexableRefreshableWrapper.cs
+++ b/src/ResourceManagement/ResourceManager/Core/ResourceActions/IndexableRefreshableWrapper.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions
 
         public override IFluentResourceT Refresh()
         {
-            return RefreshAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => RefreshAsync(CancellationToken.None));
         }
 
         public override async Task<IFluentResourceT> RefreshAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ResourceManager/Core/TopLevelModifiableResources.cs
+++ b/src/ResourceManagement/ResourceManager/Core/TopLevelModifiableResources.cs
@@ -32,12 +32,15 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         public virtual IEnumerable<IFluentResourceT> List()
         {
-            return WrapList(this.ListInnerAsync(default(CancellationToken)).GetAwaiter().GetResult().AsContinuousCollection(link => ListInnerNextAsync(link, default(CancellationToken)).GetAwaiter().GetResult()));
+            
+            return WrapList(Extensions.Synchronize(() => this.ListInnerAsync(default(CancellationToken)))
+                .AsContinuousCollection(link => Extensions.Synchronize(() => ListInnerNextAsync(link, default(CancellationToken)))));
         }
 
         public virtual IEnumerable<IFluentResourceT> ListByResourceGroup(string resourceGroupName)
         {
-            return WrapList(this.ListInnerByGroupAsync(resourceGroupName, default(CancellationToken)).GetAwaiter().GetResult().AsContinuousCollection(link => ListInnerByGroupNextAsync(link, default(CancellationToken)).GetAwaiter().GetResult()));
+            return WrapList(Extensions.Synchronize(() => this.ListInnerByGroupAsync(resourceGroupName, default(CancellationToken)))
+                .AsContinuousCollection(link => Extensions.Synchronize(() => ListInnerByGroupNextAsync(link, default(CancellationToken)))));
         }
 
         public virtual async Task<IPagedCollection<IFluentResourceT>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ResourceManager/DelayProvider.cs
+++ b/src/ResourceManagement/ResourceManager/DelayProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,7 +16,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public void Delay(int milliseconds)
         {
-            this.DelayAsync(milliseconds, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => this.DelayAsync(milliseconds, CancellationToken.None));
         }
     }
 }

--- a/src/ResourceManagement/ResourceManager/Deployment/DeploymentImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Deployment/DeploymentImpl.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                     ParametersLink = ParametersLink
                 }
             };
-            Manager.Inner.Deployments.BeginCreateOrUpdate(resourceGroupName, Name, inner);
+            Extensions.Synchronize(() => Manager.Inner.Deployments.BeginCreateOrUpdateAsync(resourceGroupName, Name, inner));
             return this;
         }
 
@@ -471,7 +471,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                     ParametersLink = ParametersLink
                 }
             };
-            Manager.Inner.Deployments.CreateOrUpdate(ResourceGroupName, Name, inner);
+            Extensions.Synchronize(() => Manager.Inner.Deployments.CreateOrUpdateAsync(ResourceGroupName, Name, inner));
             return this;
         }
 

--- a/src/ResourceManagement/ResourceManager/Deployment/DeploymentImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Deployment/DeploymentImpl.cs
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public void Cancel()
         {
-            CancelAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => this.CancelAsync());
         }
 
         public async Task CancelAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -388,7 +388,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IDeploymentExportResult ExportTemplate()
         {
-            return ExportTemplateAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => ExportTemplateAsync());
         }
 
         public async Task<IDeploymentExportResult> ExportTemplateAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ResourceManager/Deployment/DeploymentOperationsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Deployment/DeploymentOperationsImpl.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IDeploymentOperation GetById(string operationId)
         {
-            return WrapModel(client.Get(deployment.ResourceGroupName, deployment.Name, operationId));
+            return WrapModel(Extensions.Synchronize(() => client.GetAsync(deployment.ResourceGroupName, deployment.Name, operationId)));
         }
 
         public async Task<IDeploymentOperation> GetByIdAsync(string operationId, CancellationToken cancellationToken = default(CancellationToken))
@@ -39,8 +39,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IEnumerable<IDeploymentOperation> List()
         {
-            return client.List(deployment.ResourceGroupName, deployment.Name)
-                         .AsContinuousCollection(link => client.ListNext(link))
+            return Extensions.Synchronize(() => client.ListAsync(deployment.ResourceGroupName, deployment.Name))
+                         .AsContinuousCollection(link => Extensions.Synchronize(() => client.ListNextAsync(link)))
                          .Select(inner => WrapModel(inner));
         }
 

--- a/src/ResourceManagement/ResourceManager/Deployment/DeploymentsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Deployment/DeploymentsImpl.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public void DeleteById(string id)
         {
-            DeleteByIdAsync(id).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => DeleteByIdAsync(id, CancellationToken.None));
         }
 
         public void DeleteByResourceGroup(string groupName, string name)
         {
-            DeleteByResourceGroupAsync(groupName, name).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() =>  DeleteByResourceGroupAsync(groupName, name, CancellationToken.None));
         }
 
         public async Task DeleteByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IDeployment GetByResourceGroup(string resourceGroupName, string name)
         {
-            return GetByResourceGroupAsync(resourceGroupName, name).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetByResourceGroupAsync(resourceGroupName, name, CancellationToken.None));
         }
 
         public async Task<IDeployment> GetByResourceGroupAsync(string resourceGroupName, string name, CancellationToken cancellationToken = default(CancellationToken))
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IDeployment GetById(string id)
         {
-            return GetByIdAsync(id).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetByIdAsync(id));
         }
 
         public async Task<IDeployment> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ResourceManager/Deployment/DeploymentsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Deployment/DeploymentsImpl.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public bool CheckExistence(string resourceGroupName, string deploymentName)
         {
-            return Manager.Inner.Deployments.CheckExistence(resourceGroupName, deploymentName);
+            return Extensions.Synchronize(() => Manager.Inner.Deployments.CheckExistenceAsync(resourceGroupName, deploymentName));
         }
 
         public IBlank Define(string name)
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
             {
                 try
                 {
-                    var deploymentExtendedInner = Manager.Inner.Deployments.Get(resourceGroup.Name, name);
+                    var deploymentExtendedInner = Extensions.Synchronize(() => Manager.Inner.Deployments.GetAsync(resourceGroup.Name, name));
                     if (deploymentExtendedInner != null)
                     {
                         return WrapModel(deploymentExtendedInner);
@@ -122,8 +122,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IEnumerable<IDeployment> ListByResourceGroup(string resourceGroupName)
         {
-            return Manager.Inner.Deployments.List(resourceGroupName)
-                                            .AsContinuousCollection(link => Manager.Inner.Deployments.ListNext(link))
+            return Extensions.Synchronize(() => Manager.Inner.Deployments.ListAsync(resourceGroupName))
+                                            .AsContinuousCollection(link => Extensions.Synchronize(() => Manager.Inner.Deployments.ListNextAsync(link)))
                                             .Select(inner => WrapModel(inner));
         }
 

--- a/src/ResourceManagement/ResourceManager/Feature/FeaturesImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Feature/FeaturesImpl.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IFeature Register(string resourceProviderNamespace, string featureName)
         {
-            return RegisterAsync(resourceProviderNamespace, featureName).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() =>  RegisterAsync(resourceProviderNamespace, featureName));
         }
 
         public async Task<IFeature> RegisterAsync(

--- a/src/ResourceManagement/ResourceManager/Feature/FeaturesImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Feature/FeaturesImpl.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IEnumerable<IFeature> List()
         {
-            return client.ListAll()
-                         .AsContinuousCollection(link => client.ListNext(link))
+            return Extensions.Synchronize(() => client.ListAllAsync())
+                         .AsContinuousCollection(link => Extensions.Synchronize(() => client.ListNextAsync(link)))
                          .Select(inner => WrapModel(inner));
         }
 

--- a/src/ResourceManagement/ResourceManager/Generated/DeploymentOperationsExtensions.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/DeploymentOperationsExtensions.cs
@@ -22,26 +22,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
     /// </summary>
     public static partial class DeploymentOperationsExtensions
     {
-            /// <summary>
-            /// Get a list of deployments operations.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='deploymentName'>
-            /// The name of the deployment.
-            /// </param>
-            /// <param name='operationId'>
-            /// Operation Id.
-            /// </param>
-            public static DeploymentOperationInner Get(this IDeploymentOperations operations, string resourceGroupName, string deploymentName, string operationId)
-            {
-                return operations.GetAsync(resourceGroupName, deploymentName, operationId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a list of deployments operations.
             /// </summary>
@@ -68,26 +49,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of deployments operations.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='deploymentName'>
-            /// The name of the deployment.
-            /// </param>
-            /// <param name='top'>
-            /// Query parameters.
-            /// </param>
-            public static IPage<DeploymentOperationInner> List(this IDeploymentOperations operations, string resourceGroupName, string deploymentName, int? top = default(int?))
-            {
-                return operations.ListAsync(resourceGroupName, deploymentName, top).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of deployments operations.
             /// </summary>
@@ -114,20 +76,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of deployments operations.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DeploymentOperationInner> ListNext(this IDeploymentOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of deployments operations.
             /// </summary>

--- a/src/ResourceManagement/ResourceManager/Generated/DeploymentsOperationsExtensions.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/DeploymentsOperationsExtensions.cs
@@ -23,23 +23,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
     /// </summary>
     public static partial class DeploymentsOperationsExtensions
     {
-            /// <summary>
-            /// Delete deployment.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='deploymentName'>
-            /// The name of the deployment to be deleted.
-            /// </param>
-            public static void Delete(this IDeploymentsOperations operations, string resourceGroupName, string deploymentName)
-            {
-                operations.DeleteAsync(resourceGroupName, deploymentName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete deployment.
             /// </summary>
@@ -60,23 +44,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, deploymentName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Checks whether deployment exists.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to check. The name is case insensitive.
-            /// </param>
-            /// <param name='deploymentName'>
-            /// The name of the deployment.
-            /// </param>
-            public static bool CheckExistence(this IDeploymentsOperations operations, string resourceGroupName, string deploymentName)
-            {
-                return operations.CheckExistenceAsync(resourceGroupName, deploymentName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks whether deployment exists.
             /// </summary>
@@ -100,26 +68,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create a named template deployment using a template.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='deploymentName'>
-            /// The name of the deployment.
-            /// </param>
-            /// <param name='parameters'>
-            /// Additional parameters supplied to the operation.
-            /// </param>
-            public static DeploymentExtendedInner CreateOrUpdate(this IDeploymentsOperations operations, string resourceGroupName, string deploymentName, DeploymentInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, deploymentName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a named template deployment using a template.
             /// </summary>
@@ -146,23 +95,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a deployment.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to get. The name is case insensitive.
-            /// </param>
-            /// <param name='deploymentName'>
-            /// The name of the deployment.
-            /// </param>
-            public static DeploymentExtendedInner Get(this IDeploymentsOperations operations, string resourceGroupName, string deploymentName)
-            {
-                return operations.GetAsync(resourceGroupName, deploymentName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a deployment.
             /// </summary>
@@ -186,23 +119,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Cancel a currently running template deployment.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='deploymentName'>
-            /// The name of the deployment.
-            /// </param>
-            public static void Cancel(this IDeploymentsOperations operations, string resourceGroupName, string deploymentName)
-            {
-                operations.CancelAsync(resourceGroupName, deploymentName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Cancel a currently running template deployment.
             /// </summary>
@@ -223,26 +140,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 (await operations.CancelWithHttpMessagesAsync(resourceGroupName, deploymentName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Validate a deployment template.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='deploymentName'>
-            /// The name of the deployment.
-            /// </param>
-            /// <param name='parameters'>
-            /// Deployment to validate.
-            /// </param>
-            public static DeploymentValidateResultInner Validate(this IDeploymentsOperations operations, string resourceGroupName, string deploymentName, DeploymentInner parameters)
-            {
-                return operations.ValidateAsync(resourceGroupName, deploymentName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Validate a deployment template.
             /// </summary>
@@ -269,23 +167,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Exports a deployment template.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='deploymentName'>
-            /// The name of the deployment.
-            /// </param>
-            public static DeploymentExportResultInner ExportTemplate(this IDeploymentsOperations operations, string resourceGroupName, string deploymentName)
-            {
-                return operations.ExportTemplateAsync(resourceGroupName, deploymentName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Exports a deployment template.
             /// </summary>
@@ -309,23 +191,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a list of deployments.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to filter by. The name is case insensitive.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<DeploymentExtendedInner> List(this IDeploymentsOperations operations, string resourceGroupName, ODataQuery<DeploymentExtendedFilterInner> odataQuery = default(ODataQuery<DeploymentExtendedFilterInner>))
-            {
-                return ((IDeploymentsOperations)operations).ListAsync(resourceGroupName, odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a list of deployments.
             /// </summary>
@@ -349,23 +215,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete deployment.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='deploymentName'>
-            /// The name of the deployment to be deleted.
-            /// </param>
-            public static void BeginDelete(this IDeploymentsOperations operations, string resourceGroupName, string deploymentName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, deploymentName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete deployment.
             /// </summary>
@@ -386,26 +236,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, deploymentName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Create a named template deployment using a template.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='deploymentName'>
-            /// The name of the deployment.
-            /// </param>
-            /// <param name='parameters'>
-            /// Additional parameters supplied to the operation.
-            /// </param>
-            public static DeploymentExtendedInner BeginCreateOrUpdate(this IDeploymentsOperations operations, string resourceGroupName, string deploymentName, DeploymentInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, deploymentName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a named template deployment using a template.
             /// </summary>
@@ -432,20 +263,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a list of deployments.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<DeploymentExtendedInner> ListNext(this IDeploymentsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a list of deployments.
             /// </summary>

--- a/src/ResourceManagement/ResourceManager/Generated/FeaturesOperationsExtensions.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/FeaturesOperationsExtensions.cs
@@ -22,18 +22,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
     /// </summary>
     public static partial class FeaturesOperationsExtensions
     {
-            /// <summary>
-            /// Gets all the preview features that are available through AFEC for the
-            /// subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<FeatureResultInner> ListAll(this IFeaturesOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the preview features that are available through AFEC for the
             /// subscription.
@@ -52,21 +41,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the preview features in a provider namespace that are available
-            /// through AFEC for the subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// The namespace of the resource provider for getting features.
-            /// </param>
-            public static IPage<FeatureResultInner> List(this IFeaturesOperations operations, string resourceProviderNamespace)
-            {
-                return operations.ListAsync(resourceProviderNamespace).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the preview features in a provider namespace that are available
             /// through AFEC for the subscription.
@@ -88,23 +63,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the preview feature with the specified name.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// The resource provider namespace for the feature.
-            /// </param>
-            /// <param name='featureName'>
-            /// The name of the feature to get.
-            /// </param>
-            public static FeatureResultInner Get(this IFeaturesOperations operations, string resourceProviderNamespace, string featureName)
-            {
-                return operations.GetAsync(resourceProviderNamespace, featureName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the preview feature with the specified name.
             /// </summary>
@@ -128,23 +87,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Registers the preview feature for the subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// The namespace of the resource provider.
-            /// </param>
-            /// <param name='featureName'>
-            /// The name of the feature to register.
-            /// </param>
-            public static FeatureResultInner Register(this IFeaturesOperations operations, string resourceProviderNamespace, string featureName)
-            {
-                return operations.RegisterAsync(resourceProviderNamespace, featureName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Registers the preview feature for the subscription.
             /// </summary>
@@ -168,21 +111,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the preview features that are available through AFEC for the
-            /// subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<FeatureResultInner> ListAllNext(this IFeaturesOperations operations, string nextPageLink)
-            {
-                return operations.ListAllNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the preview features that are available through AFEC for the
             /// subscription.
@@ -204,21 +133,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the preview features in a provider namespace that are available
-            /// through AFEC for the subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<FeatureResultInner> ListNext(this IFeaturesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the preview features in a provider namespace that are available
             /// through AFEC for the subscription.

--- a/src/ResourceManagement/ResourceManager/Generated/ProvidersOperationsExtensions.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/ProvidersOperationsExtensions.cs
@@ -22,20 +22,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
     /// </summary>
     public static partial class ProvidersOperationsExtensions
     {
-            /// <summary>
-            /// Unregisters provider from a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// Namespace of the resource provider.
-            /// </param>
-            public static ProviderInner Unregister(this IProvidersOperations operations, string resourceProviderNamespace)
-            {
-                return operations.UnregisterAsync(resourceProviderNamespace).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Unregisters provider from a subscription.
             /// </summary>
@@ -56,20 +43,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Registers provider to be used with a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// Namespace of the resource provider.
-            /// </param>
-            public static ProviderInner Register(this IProvidersOperations operations, string resourceProviderNamespace)
-            {
-                return operations.RegisterAsync(resourceProviderNamespace).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Registers provider to be used with a subscription.
             /// </summary>
@@ -90,24 +64,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of resource providers.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='top'>
-            /// Query parameters. If null is passed returns all deployments.
-            /// </param>
-            /// <param name='expand'>
-            /// The $expand query parameter. e.g. To include property aliases in response,
-            /// use $expand=resourceTypes/aliases.
-            /// </param>
-            public static IPage<ProviderInner> List(this IProvidersOperations operations, int? top = default(int?), string expand = default(string))
-            {
-                return operations.ListAsync(top, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of resource providers.
             /// </summary>
@@ -132,24 +89,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a resource provider.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// Namespace of the resource provider.
-            /// </param>
-            /// <param name='expand'>
-            /// The $expand query parameter. e.g. To include property aliases in response,
-            /// use $expand=resourceTypes/aliases.
-            /// </param>
-            public static ProviderInner Get(this IProvidersOperations operations, string resourceProviderNamespace, string expand = default(string))
-            {
-                return operations.GetAsync(resourceProviderNamespace, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a resource provider.
             /// </summary>
@@ -174,20 +114,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of resource providers.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ProviderInner> ListNext(this IProvidersOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of resource providers.
             /// </summary>

--- a/src/ResourceManagement/ResourceManager/Generated/ResourceGroupsOperationsExtensions.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/ResourceGroupsOperationsExtensions.cs
@@ -23,23 +23,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
     /// </summary>
     public static partial class ResourceGroupsOperationsExtensions
     {
-            /// <summary>
-            /// Get all of the resources under a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Query parameters. If null is passed returns all resource groups.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<GenericResourceInner> ListResources(this IResourceGroupsOperations operations, string resourceGroupName, ODataQuery<GenericResourceFilterInner> odataQuery = default(ODataQuery<GenericResourceFilterInner>))
-            {
-                return operations.ListResourcesAsync(resourceGroupName, odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all of the resources under a subscription.
             /// </summary>
@@ -63,20 +47,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Checks whether resource group exists.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to check. The name is case insensitive.
-            /// </param>
-            public static bool CheckExistence(this IResourceGroupsOperations operations, string resourceGroupName)
-            {
-                return operations.CheckExistenceAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks whether resource group exists.
             /// </summary>
@@ -97,24 +68,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to be created or updated.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the create or update resource group service
-            /// operation.
-            /// </param>
-            public static ResourceGroupInner CreateOrUpdate(this IResourceGroupsOperations operations, string resourceGroupName, ResourceGroupInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a resource group.
             /// </summary>
@@ -139,20 +93,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to be deleted. The name is case insensitive.
-            /// </param>
-            public static void Delete(this IResourceGroupsOperations operations, string resourceGroupName)
-            {
-                operations.DeleteAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete resource group.
             /// </summary>
@@ -170,20 +111,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to get. The name is case insensitive.
-            /// </param>
-            public static ResourceGroupInner Get(this IResourceGroupsOperations operations, string resourceGroupName)
-            {
-                return operations.GetAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a resource group.
             /// </summary>
@@ -204,27 +132,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Resource groups can be updated through a simple PATCH operation to a group
-            /// address. The format of the request is the same as that for creating a
-            /// resource groups, though if a field is unspecified current value will be
-            /// carried over.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to be created or updated. The name is case
-            /// insensitive.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the update state resource group service operation.
-            /// </param>
-            public static ResourceGroupInner Patch(this IResourceGroupsOperations operations, string resourceGroupName, ResourceGroupInner parameters)
-            {
-                return operations.PatchAsync(resourceGroupName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Resource groups can be updated through a simple PATCH operation to a group
             /// address. The format of the request is the same as that for creating a
@@ -252,23 +160,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Captures the specified resource group as a template.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to be created or updated.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to the export template resource group operation.
-            /// </param>
-            public static ResourceGroupExportResultInner ExportTemplate(this IResourceGroupsOperations operations, string resourceGroupName, ExportTemplateRequestInner parameters)
-            {
-                return operations.ExportTemplateAsync(resourceGroupName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Captures the specified resource group as a template.
             /// </summary>
@@ -292,20 +184,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a collection of resource groups.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<ResourceGroupInner> List(this IResourceGroupsOperations operations, ODataQuery<ResourceGroupFilterInner> odataQuery = default(ODataQuery<ResourceGroupFilterInner>))
-            {
-                return ((IResourceGroupsOperations)operations).ListAsync(odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a collection of resource groups.
             /// </summary>
@@ -326,20 +205,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group to be deleted. The name is case insensitive.
-            /// </param>
-            public static void BeginDelete(this IResourceGroupsOperations operations, string resourceGroupName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete resource group.
             /// </summary>
@@ -357,20 +223,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get all of the resources under a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<GenericResourceInner> ListResourcesNext(this IResourceGroupsOperations operations, string nextPageLink)
-            {
-                return operations.ListResourcesNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all of the resources under a subscription.
             /// </summary>
@@ -391,20 +244,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a collection of resource groups.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<ResourceGroupInner> ListNext(this IResourceGroupsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a collection of resource groups.
             /// </summary>

--- a/src/ResourceManagement/ResourceManager/Generated/ResourcesOperationsExtensions.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/ResourcesOperationsExtensions.cs
@@ -23,24 +23,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
     /// </summary>
     public static partial class ResourcesOperationsExtensions
     {
-            /// <summary>
-            /// Move resources from one resource group to another. The resources being
-            /// moved should all be in the same resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='sourceResourceGroupName'>
-            /// Source resource group name.
-            /// </param>
-            /// <param name='parameters'>
-            /// move resources' parameters.
-            /// </param>
-            public static void MoveResources(this IResourcesOperations operations, string sourceResourceGroupName, ResourcesMoveInfoInner parameters)
-            {
-                operations.MoveResourcesAsync(sourceResourceGroupName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Move resources from one resource group to another. The resources being
             /// moved should all be in the same resource group.
@@ -62,20 +45,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 (await operations.MoveResourcesWithHttpMessagesAsync(sourceResourceGroupName, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get all of the resources under a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IPage<GenericResourceInner> List(this IResourcesOperations operations, ODataQuery<GenericResourceFilterInner> odataQuery = default(ODataQuery<GenericResourceFilterInner>))
-            {
-                return ((IResourcesOperations)operations).ListAsync(odataQuery).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all of the resources under a subscription.
             /// </summary>
@@ -96,34 +66,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Checks whether resource exists.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='parentResourcePath'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='resourceType'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='resourceName'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='apiVersion'>
-            /// </param>
-            public static bool CheckExistence(this IResourcesOperations operations, string resourceGroupName, string resourceProviderNamespace, string parentResourcePath, string resourceType, string resourceName, string apiVersion)
-            {
-                return operations.CheckExistenceAsync(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks whether resource exists.
             /// </summary>
@@ -158,34 +101,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete resource and all of its resources.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='parentResourcePath'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='resourceType'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='resourceName'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='apiVersion'>
-            /// </param>
-            public static void Delete(this IResourcesOperations operations, string resourceGroupName, string resourceProviderNamespace, string parentResourcePath, string resourceType, string resourceName, string apiVersion)
-            {
-                operations.DeleteAsync(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete resource and all of its resources.
             /// </summary>
@@ -217,37 +133,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Create a resource.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='parentResourcePath'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='resourceType'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='resourceName'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='apiVersion'>
-            /// </param>
-            /// <param name='parameters'>
-            /// Create or update resource parameters.
-            /// </param>
-            public static GenericResourceInner CreateOrUpdate(this IResourcesOperations operations, string resourceGroupName, string resourceProviderNamespace, string parentResourcePath, string resourceType, string resourceName, string apiVersion, GenericResourceInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a resource.
             /// </summary>
@@ -285,34 +171,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns a resource belonging to a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group. The name is case insensitive.
-            /// </param>
-            /// <param name='resourceProviderNamespace'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='parentResourcePath'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='resourceType'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='resourceName'>
-            /// Resource identity.
-            /// </param>
-            /// <param name='apiVersion'>
-            /// </param>
-            public static GenericResourceInner Get(this IResourcesOperations operations, string resourceGroupName, string resourceProviderNamespace, string parentResourcePath, string resourceType, string resourceName, string apiVersion)
-            {
-                return operations.GetAsync(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns a resource belonging to a resource group.
             /// </summary>
@@ -347,24 +206,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Move resources from one resource group to another. The resources being
-            /// moved should all be in the same resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='sourceResourceGroupName'>
-            /// Source resource group name.
-            /// </param>
-            /// <param name='parameters'>
-            /// move resources' parameters.
-            /// </param>
-            public static void BeginMoveResources(this IResourcesOperations operations, string sourceResourceGroupName, ResourcesMoveInfoInner parameters)
-            {
-                operations.BeginMoveResourcesAsync(sourceResourceGroupName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Move resources from one resource group to another. The resources being
             /// moved should all be in the same resource group.
@@ -386,20 +228,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 (await operations.BeginMoveResourcesWithHttpMessagesAsync(sourceResourceGroupName, parameters, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get all of the resources under a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<GenericResourceInner> ListNext(this IResourcesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get all of the resources under a subscription.
             /// </summary>

--- a/src/ResourceManagement/ResourceManager/Generated/SubscriptionsOperationsExtensions.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/SubscriptionsOperationsExtensions.cs
@@ -24,20 +24,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
     /// </summary>
     public static partial class SubscriptionsOperationsExtensions
     {
-            /// <summary>
-            /// Gets a list of the subscription locations.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='subscriptionId'>
-            /// Id of the subscription
-            /// </param>
-            public static IEnumerable<Location> ListLocations(this ISubscriptionsOperations operations, string subscriptionId)
-            {
-                return operations.ListLocationsAsync(subscriptionId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of the subscription locations.
             /// </summary>
@@ -58,20 +45,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets details about particular subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='subscriptionId'>
-            /// Id of the subscription.
-            /// </param>
-            public static SubscriptionInner Get(this ISubscriptionsOperations operations, string subscriptionId)
-            {
-                return operations.GetAsync(subscriptionId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets details about particular subscription.
             /// </summary>
@@ -92,17 +66,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of the subscriptionIds.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<SubscriptionInner> List(this ISubscriptionsOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of the subscriptionIds.
             /// </summary>
@@ -120,20 +84,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of the subscriptionIds.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SubscriptionInner> ListNext(this ISubscriptionsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of the subscriptionIds.
             /// </summary>

--- a/src/ResourceManagement/ResourceManager/Generated/TagsOperationsExtensions.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/TagsOperationsExtensions.cs
@@ -22,23 +22,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
     /// </summary>
     public static partial class TagsOperationsExtensions
     {
-            /// <summary>
-            /// Delete a subscription resource tag value.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='tagName'>
-            /// The name of the tag.
-            /// </param>
-            /// <param name='tagValue'>
-            /// The value of the tag.
-            /// </param>
-            public static void DeleteValue(this ITagsOperations operations, string tagName, string tagValue)
-            {
-                operations.DeleteValueAsync(tagName, tagValue).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a subscription resource tag value.
             /// </summary>
@@ -59,23 +43,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 (await operations.DeleteValueWithHttpMessagesAsync(tagName, tagValue, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Create a subscription resource tag value.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='tagName'>
-            /// The name of the tag.
-            /// </param>
-            /// <param name='tagValue'>
-            /// The value of the tag.
-            /// </param>
-            public static TagValueInner CreateOrUpdateValue(this ITagsOperations operations, string tagName, string tagValue)
-            {
-                return operations.CreateOrUpdateValueAsync(tagName, tagValue).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a subscription resource tag value.
             /// </summary>
@@ -99,20 +67,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create a subscription resource tag.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='tagName'>
-            /// The name of the tag.
-            /// </param>
-            public static TagDetailsInner CreateOrUpdate(this ITagsOperations operations, string tagName)
-            {
-                return operations.CreateOrUpdateAsync(tagName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create a subscription resource tag.
             /// </summary>
@@ -133,20 +88,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Delete a subscription resource tag.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='tagName'>
-            /// The name of the tag.
-            /// </param>
-            public static void Delete(this ITagsOperations operations, string tagName)
-            {
-                operations.DeleteAsync(tagName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Delete a subscription resource tag.
             /// </summary>
@@ -164,17 +106,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(tagName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Get a list of subscription resource tags.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<TagDetailsInner> List(this ITagsOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a list of subscription resource tags.
             /// </summary>
@@ -192,20 +124,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Get a list of subscription resource tags.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<TagDetailsInner> ListNext(this ITagsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Get a list of subscription resource tags.
             /// </summary>

--- a/src/ResourceManagement/ResourceManager/Generated/TenantsOperationsExtensions.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/TenantsOperationsExtensions.cs
@@ -22,17 +22,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
     /// </summary>
     public static partial class TenantsOperationsExtensions
     {
-            /// <summary>
-            /// Gets a list of the tenantIds.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<TenantIdDescription> List(this ITenantsOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of the tenantIds.
             /// </summary>
@@ -50,20 +40,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a list of the tenantIds.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<TenantIdDescription> ListNext(this ITenantsOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a list of the tenantIds.
             /// </summary>

--- a/src/ResourceManagement/ResourceManager/GenericResource/GenericResourcesImpl.cs
+++ b/src/ResourceManagement/ResourceManager/GenericResource/GenericResourcesImpl.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public void Delete(string resourceGroupName, string resourceProviderNamespace, string parentResourcePath, string resourceType, string resourceName, string apiVersion)
         {
-            Inner.Delete(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion);
+            Extensions.Synchronize(() => Inner.DeleteAsync(resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, resourceName, apiVersion));
         }
 
         public async Task DeleteAsync(
@@ -88,13 +88,13 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 parentResourcePath = "";
             }
 
-            GenericResourceInner inner = Inner.Get(
+            GenericResourceInner inner = Extensions.Synchronize(() => Inner.GetAsync(
                     resourceGroupName,
                     resourceProviderNamespace,
                     parentResourcePath,
                     resourceType,
                     resourceName,
-                    apiVersion);
+                    apiVersion));
             GenericResourceImpl resource = new GenericResourceImpl(
                     resourceName,
                     inner,
@@ -189,9 +189,9 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IEnumerable<IGenericResource> ListByTag(string resourceGroupName, string tagName, string tagValue)
         {
-            return WrapList(Manager.Inner.ResourceGroups.ListResources(
-                    resourceGroupName, ResourceUtils.CreateODataFilterForTags(tagName, tagValue))
-                    .AsContinuousCollection((nextLink) => Manager.Inner.ResourceGroups.ListResourcesNext(nextLink)));
+            return WrapList(Extensions.Synchronize(() => Manager.Inner.ResourceGroups.ListResourcesAsync(
+                    resourceGroupName, ResourceUtils.CreateODataFilterForTags(tagName, tagValue)))
+                    .AsContinuousCollection((nextLink) => Extensions.Synchronize(() => Manager.Inner.ResourceGroups.ListResourcesNextAsync(nextLink))));
         }
 
         public async Task<IPagedCollection<IGenericResource>> ListByTagAsync(string resourceGroupName, string tagName, string tagValue, bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ResourceManager/GenericResource/GenericResourcesImpl.cs
+++ b/src/ResourceManagement/ResourceManager/GenericResource/GenericResourcesImpl.cs
@@ -23,13 +23,13 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public bool CheckExistence(string resourceGroupName, string resourceProviderNamespace, string parentResourcePath, string resourceType, string resourceName, string apiVersion)
         {
-            return CheckExistenceAsync(
+            return Extensions.Synchronize (() => CheckExistenceAsync(
                 resourceGroupName,
                 resourceProviderNamespace,
                 parentResourcePath,
                 resourceType,
                 resourceName,
-                apiVersion).ConfigureAwait(false).GetAwaiter().GetResult();
+                apiVersion));
         }
 
         public async Task<bool> CheckExistenceAsync(
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public void MoveResources(string sourceResourceGroupName, IResourceGroup targetResourceGroup, IList<string> resources)
         {
-            MoveResourcesAsync(sourceResourceGroupName, targetResourceGroup, resources).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => MoveResourcesAsync(sourceResourceGroupName, targetResourceGroup, resources));
         }
 
         public async Task MoveResourcesAsync(

--- a/src/ResourceManagement/ResourceManager/IndependentChildrenImpl.cs
+++ b/src/ResourceManagement/ResourceManager/IndependentChildrenImpl.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
         ///GENMHASH:5002116800CBAC02BBC1B4BF62BC4942:A2A025A9F2772D74D0B8615C6144E641
         public T GetById(string id)
         {
-            return GetByIdAsync(id).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetByIdAsync(id));
         }
 
         public async Task<T> GetByIdAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
         {
             try
             {
-                return GetByParentAsync(resourceGroup, parentName, name).ConfigureAwait(false).GetAwaiter().GetResult();
+                return Extensions.Synchronize(() => GetByParentAsync(resourceGroup, parentName, name));
             }
             catch (CloudException ex) when (ex.Response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         public IEnumerable<T> ListByParent(string resourceGroupName, string parentName)
         {
-            return ListByParentAsync(resourceGroupName, parentName).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => ListByParentAsync(resourceGroupName, parentName));
         }
 
         public async Task<IPagedCollection<T>> ListByParentAsync(ParentT parentResource, CancellationToken cancellationToken = default(CancellationToken))
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
         public override void DeleteById(string id)
         {
-            DeleteByIdAsync(id).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => DeleteByIdAsync(id));
         }
 
         ///GENMHASH:4D33A73A344E127F784620E76B686786:F75A1B8CEFE83AE0B483457A2928324B

--- a/src/ResourceManagement/ResourceManager/Provider/ProvidersImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Provider/ProvidersImpl.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IProvider GetByName(string resourceProviderNamespace)
         {
-            return new ProviderImpl(client.Get(resourceProviderNamespace));
+            return new ProviderImpl(Extensions.Synchronize(() => client.GetAsync(resourceProviderNamespace)));
         }
 
         public async Task<IProvider> GetByNameAsync(string resourceProviderNamespace, CancellationToken cancellationToken = default(CancellationToken))
@@ -34,8 +34,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IEnumerable<IProvider> List()
         {
-            return client.List()
-                         .AsContinuousCollection(link => client.ListNext(link))
+            return Extensions.Synchronize(() => client.ListAsync())
+                         .AsContinuousCollection(link => Extensions.Synchronize(() => client.ListNextAsync(link)))
                          .Select(inner => WrapModel(inner));
         }
 
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IProvider Register(string resourceProviderNamespace)
         {
-            return WrapModel(client.Register(resourceProviderNamespace));
+            return WrapModel(Extensions.Synchronize(() => client.RegisterAsync(resourceProviderNamespace)));
         }
 
         public async Task<IProvider> RegisterAsync(string resourceProviderNamespace, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ResourceManager/Provider/ProvidersImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Provider/ProvidersImpl.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IProvider Unregister(string resourceProviderNamespace)
         {
-            return UnregisterAsync(resourceProviderNamespace).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => UnregisterAsync(resourceProviderNamespace));
         }
 
         public async Task<IProvider> UnregisterAsync(string resourceProviderNamespace, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ResourceManager/ResourceGroup/ResourceGroupImpl.cs
+++ b/src/ResourceManagement/ResourceManager/ResourceGroup/ResourceGroupImpl.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IResourceGroupExportResult ExportTemplate(ResourceGroupExportTemplateOptions options)
         {
-            return ExportTemplateAsync(options).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => ExportTemplateAsync(options));
         }
 
         public async Task<IResourceGroupExportResult> ExportTemplateAsync(ResourceGroupExportTemplateOptions options, CancellationToken cancellationToken = default(CancellationToken))
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public override IResourceGroup CreateResource()
         {
-            return CreateResourceAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => CreateResourceAsync(CancellationToken.None));
         }
     }
 }

--- a/src/ResourceManagement/ResourceManager/ResourceGroup/ResourceGroupsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/ResourceGroup/ResourceGroupsImpl.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IEnumerable<IResourceGroup> List()
         {
-           return WrapList(Inner.List()
-                                .AsContinuousCollection(link => Inner.ListNext(link)));
+           return WrapList(Extensions.Synchronize(() => Inner.ListAsync())
+                                .AsContinuousCollection(link => Extensions.Synchronize(() => Inner.ListNextAsync(link))));
         }
 
         public bool CheckExistence(string name)
@@ -99,9 +99,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IEnumerable<IResourceGroup> ListByTag(string tagName, string tagValue)
         {
-            return WrapList(Inner.List(
-                    ResourceUtils.CreateODataFilterForTags(tagName, tagValue))
-                    .AsContinuousCollection((nextLink) => Inner.ListNext(nextLink)));
+            return WrapList(Extensions.Synchronize(() => Inner.ListAsync(ResourceUtils.CreateODataFilterForTags(tagName, tagValue)))
+                    .AsContinuousCollection((nextLink) => Extensions.Synchronize(() => Inner.ListNextAsync(nextLink))));
         }
 
         public async Task<IPagedCollection<IResourceGroup>> ListByTagAsync(string tagName, string tagValue, bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ResourceManager/ResourceGroup/ResourceGroupsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/ResourceGroup/ResourceGroupsImpl.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public bool CheckExistence(string name)
         {
-            return CheckExistenceAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => CheckExistenceAsync(name));
         }
         public async Task<bool> CheckExistenceAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public void DeleteByName(string name)
         {
-            DeleteByNameAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => DeleteByNameAsync(name));
         }
 
         public async Task DeleteByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IResourceGroup GetByName(string name)
         {
-            return GetByNameAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetByNameAsync(name));
         }
 
         public async Task<IResourceGroup> GetByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public void BeginDeleteByName(string name)
         {
-            BeginDeleteByNameAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => BeginDeleteByNameAsync(name));
         }
 
         public async Task BeginDeleteByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ResourceManager/Subscription/SubscriptionImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Subscription/SubscriptionImpl.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IEnumerable<ILocation> ListLocations()
         {
-            return innerCollection.ListLocations(SubscriptionId)
+            return Extensions.Synchronize(() => innerCollection.ListLocationsAsync(SubscriptionId))
                          .Select(inner => new LocationImpl(inner));
         }
     }

--- a/src/ResourceManagement/ResourceManager/Subscription/SubscriptionsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Subscription/SubscriptionsImpl.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         public IEnumerable<ISubscription> List()
         {
-            return innerCollection.List()
-                                  .AsContinuousCollection(link => innerCollection.ListNext(link))
+            return Extensions.Synchronize(() => innerCollection.ListAsync())
+                                  .AsContinuousCollection(link => Extensions.Synchronize(() => innerCollection.ListNextAsync(link)))
                                   .Select(inner => WrapModel(inner));
         }
 
         public ISubscription GetById(string id)
         {
-            var inner = innerCollection.Get(id);
+            var inner = Extensions.Synchronize(() => innerCollection.GetAsync(id));
             if (inner == null)
             {
                 return null;

--- a/src/ResourceManagement/ResourceManager/Tenant/TenantsImpl.cs
+++ b/src/ResourceManagement/ResourceManager/Tenant/TenantsImpl.cs
@@ -33,8 +33,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
 
         IEnumerable<ITenant> ISupportsListing<ITenant>.List()
         {
-            return innerCollection.List()
-                                  .AsContinuousCollection(link => innerCollection.ListNext(link))
+            return Extensions.Synchronize(() => innerCollection.ListAsync())
+                                  .AsContinuousCollection(link => Extensions.Synchronize(() => innerCollection.ListNextAsync(link)))
                                   .Select(inner => WrapModel(inner));
         }
 

--- a/src/ResourceManagement/ServiceBus/AuthorizationRuleBaseImpl.cs
+++ b/src/ResourceManagement/ServiceBus/AuthorizationRuleBaseImpl.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
         ///GENMHASH:E4DFA7EA15F8324FB60C810D0C96D2FF:F6AE67E7333EEB65ADB6D0D8BBE8B1A9
         protected IAuthorizationKeys GetKeys()
         {
-            return GetKeysAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetKeysAsync());
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
         ///GENMHASH:DF4D523C032086042E747B7880875BA8:FD18BE4C1993EC7B8551146DDA176FAC
         protected IAuthorizationKeys RegenerateKey(Policykey policykey)
         {
-            return RegenerateKeyAsync(policykey).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => RegenerateKeyAsync(policykey));
         }
 
         /// <summary>

--- a/src/ResourceManagement/ServiceBus/Generated/NamespacesOperationsExtensions.cs
+++ b/src/ResourceManagement/ServiceBus/Generated/NamespacesOperationsExtensions.cs
@@ -23,22 +23,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     /// </summary>
     public static partial class NamespacesOperationsExtensions
     {
-            /// <summary>
-            /// Check the give namespace name availability.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='name'>
-            /// The Name to check the namespce name availability and The namespace name can
-            /// contain only letters, numbers, and hyphens. The namespace must start with a
-            /// letter, and it must end with a letter or number.
-            /// </param>
-            public static CheckNameAvailabilityResultInner CheckNameAvailabilityMethod(this INamespacesOperations operations, string name)
-            {
-                return operations.CheckNameAvailabilityMethodAsync(name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Check the give namespace name availability.
             /// </summary>
@@ -61,19 +46,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the available namespaces within the subscription, irrespective of
-            /// the resource groups.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639412.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<NamespaceModelInner> List(this INamespacesOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the available namespaces within the subscription, irrespective of
             /// the resource groups.
@@ -93,21 +66,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the available namespaces within a resource group.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639412.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            public static IPage<NamespaceModelInner> ListByResourceGroup(this INamespacesOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the available namespaces within a resource group.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639412.aspx" />
@@ -129,28 +88,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a service namespace. Once created, this namespace's
-            /// resource manifest is immutable. This operation is idempotent.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639408.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to create a namespace resource.
-            /// </param>
-            public static NamespaceModelInner CreateOrUpdate(this INamespacesOperations operations, string resourceGroupName, string namespaceName, NamespaceModelInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, namespaceName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a service namespace. Once created, this namespace's
             /// resource manifest is immutable. This operation is idempotent.
@@ -179,25 +117,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an existing namespace. This operation also removes all associated
-            /// resources under the namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639389.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            public static void Delete(this INamespacesOperations operations, string resourceGroupName, string namespaceName)
-            {
-                operations.DeleteAsync(resourceGroupName, namespaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an existing namespace. This operation also removes all associated
             /// resources under the namespace.
@@ -220,24 +140,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, namespaceName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets a description for the specified namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639379.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            public static NamespaceModelInner Get(this INamespacesOperations operations, string resourceGroupName, string namespaceName)
-            {
-                return operations.GetAsync(resourceGroupName, namespaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a description for the specified namespace.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639379.aspx" />
@@ -262,27 +165,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Updates a service namespace. Once created, this namespace's resource
-            /// manifest is immutable. This operation is idempotent.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to update a namespace resource.
-            /// </param>
-            public static NamespaceModelInner Update(this INamespacesOperations operations, string resourceGroupName, string namespaceName, NamespaceUpdateParametersInner parameters)
-            {
-                return operations.UpdateAsync(resourceGroupName, namespaceName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Updates a service namespace. Once created, this namespace's resource
             /// manifest is immutable. This operation is idempotent.
@@ -310,24 +193,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the authorization rules for a namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639376.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            public static IPage<SharedAccessAuthorizationRuleInner> ListAuthorizationRules(this INamespacesOperations operations, string resourceGroupName, string namespaceName)
-            {
-                return operations.ListAuthorizationRulesAsync(resourceGroupName, namespaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the authorization rules for a namespace.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639376.aspx" />
@@ -352,30 +218,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates an authorization rule for a namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639410.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            /// <param name='rights'>
-            /// The rights associated with the rule.
-            /// </param>
-            public static SharedAccessAuthorizationRuleInner CreateOrUpdateAuthorizationRule(this INamespacesOperations operations, string resourceGroupName, string namespaceName, string authorizationRuleName, IList<AccessRights?> rights)
-            {
-                return operations.CreateOrUpdateAuthorizationRuleAsync(resourceGroupName, namespaceName, authorizationRuleName, rights).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates an authorization rule for a namespace.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639410.aspx" />
@@ -406,27 +249,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a namespace authorization rule.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639417.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            public static void DeleteAuthorizationRule(this INamespacesOperations operations, string resourceGroupName, string namespaceName, string authorizationRuleName)
-            {
-                operations.DeleteAuthorizationRuleAsync(resourceGroupName, namespaceName, authorizationRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a namespace authorization rule.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639417.aspx" />
@@ -451,27 +274,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 (await operations.DeleteAuthorizationRuleWithHttpMessagesAsync(resourceGroupName, namespaceName, authorizationRuleName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets an authorization rule for a namespace by rule name.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639392.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            public static SharedAccessAuthorizationRuleInner GetAuthorizationRule(this INamespacesOperations operations, string resourceGroupName, string namespaceName, string authorizationRuleName)
-            {
-                return operations.GetAuthorizationRuleAsync(resourceGroupName, namespaceName, authorizationRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets an authorization rule for a namespace by rule name.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639392.aspx" />
@@ -499,27 +302,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the primary and secondary connection strings for the namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639398.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            public static ResourceListKeysInner ListKeys(this INamespacesOperations operations, string resourceGroupName, string namespaceName, string authorizationRuleName)
-            {
-                return operations.ListKeysAsync(resourceGroupName, namespaceName, authorizationRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the primary and secondary connection strings for the namespace.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639398.aspx" />
@@ -547,31 +330,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Regenerates the primary or secondary connection strings for the namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt718977.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            /// <param name='policykey'>
-            /// Key that needs to be regenerated. Possible values include: 'PrimaryKey',
-            /// 'SecondaryKey'
-            /// </param>
-            public static ResourceListKeysInner RegenerateKeys(this INamespacesOperations operations, string resourceGroupName, string namespaceName, string authorizationRuleName, Policykey? policykey = default(Policykey?))
-            {
-                return operations.RegenerateKeysAsync(resourceGroupName, namespaceName, authorizationRuleName, policykey).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Regenerates the primary or secondary connection strings for the namespace.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt718977.aspx" />
@@ -603,28 +362,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a service namespace. Once created, this namespace's
-            /// resource manifest is immutable. This operation is idempotent.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639408.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to create a namespace resource.
-            /// </param>
-            public static NamespaceModelInner BeginCreateOrUpdate(this INamespacesOperations operations, string resourceGroupName, string namespaceName, NamespaceModelInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, namespaceName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a service namespace. Once created, this namespace's
             /// resource manifest is immutable. This operation is idempotent.
@@ -653,25 +391,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an existing namespace. This operation also removes all associated
-            /// resources under the namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639389.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            public static void BeginDelete(this INamespacesOperations operations, string resourceGroupName, string namespaceName)
-            {
-                operations.BeginDeleteAsync(resourceGroupName, namespaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an existing namespace. This operation also removes all associated
             /// resources under the namespace.
@@ -694,22 +414,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 (await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, namespaceName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets all the available namespaces within the subscription, irrespective of
-            /// the resource groups.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639412.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<NamespaceModelInner> ListNext(this INamespacesOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the available namespaces within the subscription, irrespective of
             /// the resource groups.
@@ -732,21 +437,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the available namespaces within a resource group.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639412.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<NamespaceModelInner> ListByResourceGroupNext(this INamespacesOperations operations, string nextPageLink)
-            {
-                return operations.ListByResourceGroupNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the available namespaces within a resource group.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639412.aspx" />
@@ -768,21 +459,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the authorization rules for a namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639376.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SharedAccessAuthorizationRuleInner> ListAuthorizationRulesNext(this INamespacesOperations operations, string nextPageLink)
-            {
-                return operations.ListAuthorizationRulesNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the authorization rules for a namespace.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639376.aspx" />

--- a/src/ResourceManagement/ServiceBus/Generated/OperationsExtensions.cs
+++ b/src/ResourceManagement/ServiceBus/Generated/OperationsExtensions.cs
@@ -20,17 +20,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     /// </summary>
     public static partial class OperationsExtensions
     {
-            /// <summary>
-            /// Lists all of the available ServiceBus REST API operations.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IPage<Operation> List(this IOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the available ServiceBus REST API operations.
             /// </summary>
@@ -48,20 +38,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all of the available ServiceBus REST API operations.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<Operation> ListNext(this IOperations operations, string nextPageLink)
-            {
-                return operations.ListNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all of the available ServiceBus REST API operations.
             /// </summary>

--- a/src/ResourceManagement/ServiceBus/Generated/QueuesOperationsExtensions.cs
+++ b/src/ResourceManagement/ServiceBus/Generated/QueuesOperationsExtensions.cs
@@ -23,24 +23,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     /// </summary>
     public static partial class QueuesOperationsExtensions
     {
-            /// <summary>
-            /// Gets the queues within a namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639415.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            public static IPage<QueueInner> ListByNamespace(this IQueuesOperations operations, string resourceGroupName, string namespaceName)
-            {
-                return operations.ListByNamespaceAsync(resourceGroupName, namespaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the queues within a namespace.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639415.aspx" />
@@ -65,30 +48,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates a Service Bus queue. This operation is idempotent.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639395.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='queueName'>
-            /// The queue name.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to create or update a queue resource.
-            /// </param>
-            public static QueueInner CreateOrUpdate(this IQueuesOperations operations, string resourceGroupName, string namespaceName, string queueName, QueueInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, namespaceName, queueName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates a Service Bus queue. This operation is idempotent.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639395.aspx" />
@@ -119,27 +79,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a queue from the specified namespace in a resource group.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639411.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='queueName'>
-            /// The queue name.
-            /// </param>
-            public static void Delete(this IQueuesOperations operations, string resourceGroupName, string namespaceName, string queueName)
-            {
-                operations.DeleteAsync(resourceGroupName, namespaceName, queueName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a queue from the specified namespace in a resource group.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639411.aspx" />
@@ -164,27 +104,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, namespaceName, queueName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Returns a description for the specified queue.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639380.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='queueName'>
-            /// The queue name.
-            /// </param>
-            public static QueueInner Get(this IQueuesOperations operations, string resourceGroupName, string namespaceName, string queueName)
-            {
-                return operations.GetAsync(resourceGroupName, namespaceName, queueName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns a description for the specified queue.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639380.aspx" />
@@ -212,27 +132,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all authorization rules for a queue.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705607.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='queueName'>
-            /// The queue name.
-            /// </param>
-            public static IPage<SharedAccessAuthorizationRuleInner> ListAuthorizationRules(this IQueuesOperations operations, string resourceGroupName, string namespaceName, string queueName)
-            {
-                return operations.ListAuthorizationRulesAsync(resourceGroupName, namespaceName, queueName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all authorization rules for a queue.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705607.aspx" />
@@ -260,32 +160,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates an authorization rule for a queue.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='queueName'>
-            /// The queue name.
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            /// <param name='rights'>
-            /// The rights associated with the rule.
-            /// </param>
-            public static SharedAccessAuthorizationRuleInner CreateOrUpdateAuthorizationRule(this IQueuesOperations operations, string resourceGroupName, string namespaceName, string queueName, string authorizationRuleName, IList<AccessRights?> rights)
-            {
-                return operations.CreateOrUpdateAuthorizationRuleAsync(resourceGroupName, namespaceName, queueName, authorizationRuleName, rights).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates an authorization rule for a queue.
             /// </summary>
@@ -318,30 +193,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a queue authorization rule.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705609.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='queueName'>
-            /// The queue name.
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            public static void DeleteAuthorizationRule(this IQueuesOperations operations, string resourceGroupName, string namespaceName, string queueName, string authorizationRuleName)
-            {
-                operations.DeleteAuthorizationRuleAsync(resourceGroupName, namespaceName, queueName, authorizationRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a queue authorization rule.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705609.aspx" />
@@ -369,30 +221,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 (await operations.DeleteAuthorizationRuleWithHttpMessagesAsync(resourceGroupName, namespaceName, queueName, authorizationRuleName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets an authorization rule for a queue by rule name.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705611.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='queueName'>
-            /// The queue name.
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            public static SharedAccessAuthorizationRuleInner GetAuthorizationRule(this IQueuesOperations operations, string resourceGroupName, string namespaceName, string queueName, string authorizationRuleName)
-            {
-                return operations.GetAuthorizationRuleAsync(resourceGroupName, namespaceName, queueName, authorizationRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets an authorization rule for a queue by rule name.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705611.aspx" />
@@ -423,30 +252,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Primary and secondary connection strings to the queue.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705608.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='queueName'>
-            /// The queue name.
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            public static ResourceListKeysInner ListKeys(this IQueuesOperations operations, string resourceGroupName, string namespaceName, string queueName, string authorizationRuleName)
-            {
-                return operations.ListKeysAsync(resourceGroupName, namespaceName, queueName, authorizationRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Primary and secondary connection strings to the queue.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705608.aspx" />
@@ -477,34 +283,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Regenerates the primary or secondary connection strings to the queue.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705606.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='queueName'>
-            /// The queue name.
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            /// <param name='policykey'>
-            /// Key that needs to be regenerated. Possible values include: 'PrimaryKey',
-            /// 'SecondaryKey'
-            /// </param>
-            public static ResourceListKeysInner RegenerateKeys(this IQueuesOperations operations, string resourceGroupName, string namespaceName, string queueName, string authorizationRuleName, Policykey? policykey = default(Policykey?))
-            {
-                return operations.RegenerateKeysAsync(resourceGroupName, namespaceName, queueName, authorizationRuleName, policykey).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Regenerates the primary or secondary connection strings to the queue.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705606.aspx" />
@@ -539,21 +318,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets the queues within a namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639415.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<QueueInner> ListByNamespaceNext(this IQueuesOperations operations, string nextPageLink)
-            {
-                return operations.ListByNamespaceNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the queues within a namespace.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639415.aspx" />
@@ -575,21 +340,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all authorization rules for a queue.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705607.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SharedAccessAuthorizationRuleInner> ListAuthorizationRulesNext(this IQueuesOperations operations, string nextPageLink)
-            {
-                return operations.ListAuthorizationRulesNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all authorization rules for a queue.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt705607.aspx" />

--- a/src/ResourceManagement/ServiceBus/Generated/SubscriptionsOperationsExtensions.cs
+++ b/src/ResourceManagement/ServiceBus/Generated/SubscriptionsOperationsExtensions.cs
@@ -21,27 +21,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     /// </summary>
     public static partial class SubscriptionsOperationsExtensions
     {
-            /// <summary>
-            /// List all the subscriptions under a specified topic.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639400.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            public static IPage<SubscriptionInner> ListByTopic(this ISubscriptionsOperations operations, string resourceGroupName, string namespaceName, string topicName)
-            {
-                return operations.ListByTopicAsync(resourceGroupName, namespaceName, topicName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List all the subscriptions under a specified topic.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639400.aspx" />
@@ -69,33 +49,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a topic subscription.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639385.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            /// <param name='subscriptionName'>
-            /// The subscription name.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to create a subscription resource.
-            /// </param>
-            public static SubscriptionInner CreateOrUpdate(this ISubscriptionsOperations operations, string resourceGroupName, string namespaceName, string topicName, string subscriptionName, SubscriptionInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, namespaceName, topicName, subscriptionName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a topic subscription.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639385.aspx" />
@@ -129,30 +83,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a subscription from the specified topic.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639381.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            /// <param name='subscriptionName'>
-            /// The subscription name.
-            /// </param>
-            public static void Delete(this ISubscriptionsOperations operations, string resourceGroupName, string namespaceName, string topicName, string subscriptionName)
-            {
-                operations.DeleteAsync(resourceGroupName, namespaceName, topicName, subscriptionName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a subscription from the specified topic.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639381.aspx" />
@@ -180,30 +111,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, namespaceName, topicName, subscriptionName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Returns a subscription description for the specified topic.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639402.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            /// <param name='subscriptionName'>
-            /// The subscription name.
-            /// </param>
-            public static SubscriptionInner Get(this ISubscriptionsOperations operations, string resourceGroupName, string namespaceName, string topicName, string subscriptionName)
-            {
-                return operations.GetAsync(resourceGroupName, namespaceName, topicName, subscriptionName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns a subscription description for the specified topic.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639402.aspx" />
@@ -234,21 +142,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// List all the subscriptions under a specified topic.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639400.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SubscriptionInner> ListByTopicNext(this ISubscriptionsOperations operations, string nextPageLink)
-            {
-                return operations.ListByTopicNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// List all the subscriptions under a specified topic.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639400.aspx" />

--- a/src/ResourceManagement/ServiceBus/Generated/TopicsOperationsExtensions.cs
+++ b/src/ResourceManagement/ServiceBus/Generated/TopicsOperationsExtensions.cs
@@ -23,24 +23,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     /// </summary>
     public static partial class TopicsOperationsExtensions
     {
-            /// <summary>
-            /// Gets all the topics in a namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639388.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            public static IPage<TopicInner> ListByNamespace(this ITopicsOperations operations, string resourceGroupName, string namespaceName)
-            {
-                return operations.ListByNamespaceAsync(resourceGroupName, namespaceName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the topics in a namespace.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639388.aspx" />
@@ -65,30 +48,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a topic in the specified namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639409.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            /// <param name='parameters'>
-            /// Parameters supplied to create a topic resource.
-            /// </param>
-            public static TopicInner CreateOrUpdate(this ITopicsOperations operations, string resourceGroupName, string namespaceName, string topicName, TopicInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, namespaceName, topicName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a topic in the specified namespace.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639409.aspx" />
@@ -119,27 +79,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a topic from the specified namespace and resource group.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639404.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            public static void Delete(this ITopicsOperations operations, string resourceGroupName, string namespaceName, string topicName)
-            {
-                operations.DeleteAsync(resourceGroupName, namespaceName, topicName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a topic from the specified namespace and resource group.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639404.aspx" />
@@ -164,27 +104,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, namespaceName, topicName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Returns a description for the specified topic.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639399.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            public static TopicInner Get(this ITopicsOperations operations, string resourceGroupName, string namespaceName, string topicName)
-            {
-                return operations.GetAsync(resourceGroupName, namespaceName, topicName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns a description for the specified topic.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639399.aspx" />
@@ -212,27 +132,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets authorization rules for a topic.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720681.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            public static IPage<SharedAccessAuthorizationRuleInner> ListAuthorizationRules(this ITopicsOperations operations, string resourceGroupName, string namespaceName, string topicName)
-            {
-                return operations.ListAuthorizationRulesAsync(resourceGroupName, namespaceName, topicName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets authorization rules for a topic.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720681.aspx" />
@@ -260,33 +160,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates an authorizatio rule for the specified topic.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720678.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            /// <param name='rights'>
-            /// The rights associated with the rule.
-            /// </param>
-            public static SharedAccessAuthorizationRuleInner CreateOrUpdateAuthorizationRule(this ITopicsOperations operations, string resourceGroupName, string namespaceName, string topicName, string authorizationRuleName, IList<AccessRights?> rights)
-            {
-                return operations.CreateOrUpdateAuthorizationRuleAsync(resourceGroupName, namespaceName, topicName, authorizationRuleName, rights).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates an authorizatio rule for the specified topic.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720678.aspx" />
@@ -320,30 +194,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns the specified authorization rule.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720676.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            public static SharedAccessAuthorizationRuleInner GetAuthorizationRule(this ITopicsOperations operations, string resourceGroupName, string namespaceName, string topicName, string authorizationRuleName)
-            {
-                return operations.GetAuthorizationRuleAsync(resourceGroupName, namespaceName, topicName, authorizationRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns the specified authorization rule.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720676.aspx" />
@@ -374,30 +225,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a topic authorization rule.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720681.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            public static void DeleteAuthorizationRule(this ITopicsOperations operations, string resourceGroupName, string namespaceName, string topicName, string authorizationRuleName)
-            {
-                operations.DeleteAuthorizationRuleAsync(resourceGroupName, namespaceName, topicName, authorizationRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a topic authorization rule.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720681.aspx" />
@@ -425,30 +253,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 (await operations.DeleteAuthorizationRuleWithHttpMessagesAsync(resourceGroupName, namespaceName, topicName, authorizationRuleName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets the primary and secondary connection strings for the topic.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720677.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            public static ResourceListKeysInner ListKeys(this ITopicsOperations operations, string resourceGroupName, string namespaceName, string topicName, string authorizationRuleName)
-            {
-                return operations.ListKeysAsync(resourceGroupName, namespaceName, topicName, authorizationRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the primary and secondary connection strings for the topic.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720677.aspx" />
@@ -479,34 +284,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Regenerates primary or secondary connection strings for the topic.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720679.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// Name of the Resource group within the Azure subscription.
-            /// </param>
-            /// <param name='namespaceName'>
-            /// The namespace name
-            /// </param>
-            /// <param name='topicName'>
-            /// The topic name.
-            /// </param>
-            /// <param name='authorizationRuleName'>
-            /// The authorizationrule name.
-            /// </param>
-            /// <param name='policykey'>
-            /// Key that needs to be regenerated. Possible values include: 'PrimaryKey',
-            /// 'SecondaryKey'
-            /// </param>
-            public static ResourceListKeysInner RegenerateKeys(this ITopicsOperations operations, string resourceGroupName, string namespaceName, string topicName, string authorizationRuleName, Policykey? policykey = default(Policykey?))
-            {
-                return operations.RegenerateKeysAsync(resourceGroupName, namespaceName, topicName, authorizationRuleName, policykey).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Regenerates primary or secondary connection strings for the topic.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720679.aspx" />
@@ -541,21 +319,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets all the topics in a namespace.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639388.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<TopicInner> ListByNamespaceNext(this ITopicsOperations operations, string nextPageLink)
-            {
-                return operations.ListByNamespaceNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets all the topics in a namespace.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt639388.aspx" />
@@ -577,21 +341,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets authorization rules for a topic.
-            /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720681.aspx" />
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nextPageLink'>
-            /// The NextLink from the previous successful call to List operation.
-            /// </param>
-            public static IPage<SharedAccessAuthorizationRuleInner> ListAuthorizationRulesNext(this ITopicsOperations operations, string nextPageLink)
-            {
-                return operations.ListAuthorizationRulesNextAsync(nextPageLink).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets authorization rules for a topic.
             /// <see href="https://msdn.microsoft.com/en-us/library/azure/mt720681.aspx" />

--- a/src/ResourceManagement/ServiceBus/ServiceBusChildResourcesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/ServiceBusChildResourcesImpl.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
         ///GENMHASH:5C58E472AE184041661005E7B2D7EE30:6B6D1D91AC2FCE3076EBD61D0DB099CF
         public T GetByName(string name)
         {
-            return GetByNameAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetByNameAsync(name));
         }
 
         public abstract Task DeleteByNameAsync(string name, CancellationToken cancellationToken = default(CancellationToken));
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
         ///GENMHASH:C2DC9CFAB6C291D220DD4F29AFF1BBEC:7459D8B9F8BB0A1EBD2FC4702A86F2F5
         public void DeleteByName(string name)
         {
-            DeleteByNameAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => DeleteByNameAsync(name));
         }
 
         ///GENMHASH:D3FBF3E757A0D33222555A7D439A3F12:A13124E7BC21C819368C8CFA9F3DBE5F
@@ -76,8 +76,8 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
         ///GENMHASH:7D6013E8B95E991005ED921F493EFCE4:874C7A8E3CDF988B4BDA901B0FE62ABD
         public IEnumerable<T> List()
         {
-            return WrapList(ListInnerFirstPageAsync(default(CancellationToken)).ConfigureAwait(false).GetAwaiter().GetResult()
-                            .AsContinuousCollection(link => ListInnerNextPageAsync(link, default(CancellationToken)).ConfigureAwait(false).GetAwaiter().GetResult()));
+            return WrapList(Extensions.Synchronize(() => ListInnerFirstPageAsync(default(CancellationToken)))
+                            .AsContinuousCollection(link => Extensions.Synchronize(() => ListInnerNextPageAsync(link, default(CancellationToken)))));
         }
 
         public async Task<IPagedCollection<T>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/ServiceBus/ServiceBusNamespacesImpl.cs
+++ b/src/ResourceManagement/ServiceBus/ServiceBusNamespacesImpl.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
         ///GENMHASH:C4C74C5CA23BE3B4CAFEFD0EF23149A0:B6DE3F3ADD30CF80937F7E47989E73C7
         public ICheckNameAvailabilityResult CheckNameAvailability(string name)
         {
-            return this.CheckNameAvailabilityAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => this.CheckNameAvailabilityAsync(name));
         }
 
         ///GENMHASH:8ACFB0E23F5F24AD384313679B65F404:AD7C28D26EC1F237B93E54AD31899691

--- a/src/ResourceManagement/Sql/Generated/DatabasesOperationsExtensions.cs
+++ b/src/ResourceManagement/Sql/Generated/DatabasesOperationsExtensions.cs
@@ -24,32 +24,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
     /// </summary>
     public static partial class DatabasesOperationsExtensions
     {
-            /// <summary>
-            /// Deletes the Azure SQL database replication link with the given ID. Cannot
-            /// be done during failover.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database that has the replication link to be
-            /// dropped.
-            /// </param>
-            /// <param name='linkId'>
-            /// The ID of the replication link to be deleted.
-            /// </param>
-            public static void DeleteReplicationLink(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName, string linkId)
-            {
-                operations.DeleteReplicationLinkAsync(resourceGroupName, serverName, databaseName, linkId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the Azure SQL database replication link with the given ID. Cannot
             /// be done during failover.
@@ -79,30 +54,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.DeleteReplicationLinkWithHttpMessagesAsync(resourceGroupName, serverName, databaseName, linkId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets information about an Azure SQL database replication link.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database to get the link for.
-            /// </param>
-            /// <param name='linkId'>
-            /// The replication link ID to be retrieved.
-            /// </param>
-            public static ReplicationLinkInner GetReplicationLink(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName, string linkId)
-            {
-                return operations.GetReplicationLinkAsync(resourceGroupName, serverName, databaseName, linkId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about an Azure SQL database replication link.
             /// </summary>
@@ -133,31 +85,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Failover the Azure SQL database replication link with the given ID.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database that has the replication link to be
-            /// failed over.
-            /// </param>
-            /// <param name='linkId'>
-            /// The ID of the replication link to be failed over.
-            /// </param>
-            public static void FailoverReplicationLink(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName, string linkId)
-            {
-                operations.FailoverReplicationLinkAsync(resourceGroupName, serverName, databaseName, linkId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Failover the Azure SQL database replication link with the given ID.
             /// </summary>
@@ -186,32 +114,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.FailoverReplicationLinkWithHttpMessagesAsync(resourceGroupName, serverName, databaseName, linkId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Force failover the Azure SQL database replication link with the given ID
-            /// which may result in data loss.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database that has the replication link to be
-            /// failed over.
-            /// </param>
-            /// <param name='linkId'>
-            /// The ID of the replication link to be failed over.
-            /// </param>
-            public static void FailoverReplicationLinkAllowDataLoss(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName, string linkId)
-            {
-                operations.FailoverReplicationLinkAllowDataLossAsync(resourceGroupName, serverName, databaseName, linkId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Force failover the Azure SQL database replication link with the given ID
             /// which may result in data loss.
@@ -241,27 +144,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.FailoverReplicationLinkAllowDataLossWithHttpMessagesAsync(resourceGroupName, serverName, databaseName, linkId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets information about Azure SQL database replication links.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database to retrieve links for.
-            /// </param>
-            public static IEnumerable<ReplicationLinkInner> ListReplicationLinks(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName)
-            {
-                return operations.ListReplicationLinksAsync(resourceGroupName, serverName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about Azure SQL database replication links.
             /// </summary>
@@ -289,27 +172,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Pause an Azure SQL Data Warehouse database.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL Data Warehouse database to pause.
-            /// </param>
-            public static void PauseDataWarehouse(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName)
-            {
-                operations.PauseDataWarehouseAsync(resourceGroupName, serverName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Pause an Azure SQL Data Warehouse database.
             /// </summary>
@@ -334,27 +197,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.PauseDataWarehouseWithHttpMessagesAsync(resourceGroupName, serverName, databaseName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Resume an Azure SQL Data Warehouse database.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL Data Warehouse database to resume.
-            /// </param>
-            public static void ResumeDataWarehouse(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName)
-            {
-                operations.ResumeDataWarehouseAsync(resourceGroupName, serverName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Resume an Azure SQL Data Warehouse database.
             /// </summary>
@@ -379,28 +222,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.ResumeDataWarehouseWithHttpMessagesAsync(resourceGroupName, serverName, databaseName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Returns a list of Azure SQL database restore points.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database from which to retrieve available restore
-            /// points.
-            /// </param>
-            public static IEnumerable<RestorePointInner> ListRestorePoints(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName)
-            {
-                return operations.ListRestorePointsAsync(resourceGroupName, serverName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns a list of Azure SQL database restore points.
             /// </summary>
@@ -429,32 +251,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new Azure SQL database or updates an existing Azure SQL database.
-            /// Location is a required property in the request body, and it must be the
-            /// same as the location of the SQL server.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database to be operated on (updated or created).
-            /// </param>
-            /// <param name='parameters'>
-            /// The required parameters for creating or updating a database.
-            /// </param>
-            public static DatabaseInner CreateOrUpdate(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName, DatabaseInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, serverName, databaseName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new Azure SQL database or updates an existing Azure SQL database.
             /// Location is a required property in the request body, and it must be the
@@ -487,27 +284,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an Azure SQL database.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database to be deleted.
-            /// </param>
-            public static void Delete(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName)
-            {
-                operations.DeleteAsync(resourceGroupName, serverName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an Azure SQL database.
             /// </summary>
@@ -532,32 +309,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, serverName, databaseName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets information about an Azure SQL database.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database to be retrieved.
-            /// </param>
-            /// <param name='expand'>
-            /// The comma separated list of child objects to expand in the response.
-            /// Possible properties: serviceTierAdvisors, upgradeHint,
-            /// transparentDataEncryption.
-            /// </param>
-            public static DatabaseInner Get(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName, string expand = default(string))
-            {
-                return operations.GetAsync(resourceGroupName, serverName, databaseName, expand).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about an Azure SQL database.
             /// </summary>
@@ -590,24 +342,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about an Azure SQL database.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            public static IEnumerable<DatabaseInner> ListByServer(this IDatabasesOperations operations, string resourceGroupName, string serverName)
-            {
-                return operations.ListByServerAsync(resourceGroupName, serverName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about an Azure SQL database.
             /// </summary>
@@ -632,27 +367,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about Azure SQL database usages.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database.
-            /// </param>
-            public static IEnumerable<DatabaseMetric> ListUsages(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName)
-            {
-                return operations.ListUsagesAsync(resourceGroupName, serverName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about Azure SQL database usages.
             /// </summary>
@@ -680,30 +395,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about a service tier advisor.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of database.
-            /// </param>
-            /// <param name='serviceTierAdvisorName'>
-            /// The name of service tier advisor.
-            /// </param>
-            public static ServiceTierAdvisorInner GetServiceTierAdvisor(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName, string serviceTierAdvisorName)
-            {
-                return operations.GetServiceTierAdvisorAsync(resourceGroupName, serverName, databaseName, serviceTierAdvisorName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about a service tier advisor.
             /// </summary>
@@ -734,27 +426,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about service tier advisors for specified database.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of database.
-            /// </param>
-            public static IEnumerable<ServiceTierAdvisorInner> ListServiceTierAdvisors(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName)
-            {
-                return operations.ListServiceTierAdvisorsAsync(resourceGroupName, serverName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about service tier advisors for specified database.
             /// </summary>
@@ -782,33 +454,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates or updates an Azure SQL Database Transparent Data Encryption
-            /// Operation.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database for which setting the Transparent Data
-            /// Encryption applies.
-            /// </param>
-            /// <param name='status'>
-            /// The status of the Azure SQL Database Transparent Data Encryption. Possible
-            /// values include: 'Enabled', 'Disabled'
-            /// </param>
-            public static TransparentDataEncryptionInner CreateOrUpdateTransparentDataEncryptionConfiguration(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName, TransparentDataEncryptionStates? status = default(TransparentDataEncryptionStates?))
-            {
-                return operations.CreateOrUpdateTransparentDataEncryptionConfigurationAsync(resourceGroupName, serverName, databaseName, status).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates an Azure SQL Database Transparent Data Encryption
             /// Operation.
@@ -842,28 +488,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets an Azure SQL Database Transparent Data Encryption Response.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database for which the Transparent Data
-            /// Encryption applies.
-            /// </param>
-            public static TransparentDataEncryptionInner GetTransparentDataEncryptionConfiguration(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName)
-            {
-                return operations.GetTransparentDataEncryptionConfigurationAsync(resourceGroupName, serverName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets an Azure SQL Database Transparent Data Encryption Response.
             /// </summary>
@@ -892,29 +517,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns an Azure SQL Database Transparent Data Encryption Activity
-            /// Response.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database for which the Transparent Data
-            /// Encryption applies.
-            /// </param>
-            public static IEnumerable<TransparentDataEncryptionActivity> ListTransparentDataEncryptionActivity(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName)
-            {
-                return operations.ListTransparentDataEncryptionActivityAsync(resourceGroupName, serverName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns an Azure SQL Database Transparent Data Encryption Activity
             /// Response.
@@ -944,31 +547,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Failover the Azure SQL database replication link with the given ID.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database that has the replication link to be
-            /// failed over.
-            /// </param>
-            /// <param name='linkId'>
-            /// The ID of the replication link to be failed over.
-            /// </param>
-            public static void BeginFailoverReplicationLink(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName, string linkId)
-            {
-                operations.BeginFailoverReplicationLinkAsync(resourceGroupName, serverName, databaseName, linkId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Failover the Azure SQL database replication link with the given ID.
             /// </summary>
@@ -997,32 +576,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.BeginFailoverReplicationLinkWithHttpMessagesAsync(resourceGroupName, serverName, databaseName, linkId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Force failover the Azure SQL database replication link with the given ID
-            /// which may result in data loss.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database that has the replication link to be
-            /// failed over.
-            /// </param>
-            /// <param name='linkId'>
-            /// The ID of the replication link to be failed over.
-            /// </param>
-            public static void BeginFailoverReplicationLinkAllowDataLoss(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName, string linkId)
-            {
-                operations.BeginFailoverReplicationLinkAllowDataLossAsync(resourceGroupName, serverName, databaseName, linkId).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Force failover the Azure SQL database replication link with the given ID
             /// which may result in data loss.
@@ -1052,27 +606,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.BeginFailoverReplicationLinkAllowDataLossWithHttpMessagesAsync(resourceGroupName, serverName, databaseName, linkId, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Pause an Azure SQL Data Warehouse database.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL Data Warehouse database to pause.
-            /// </param>
-            public static void BeginPauseDataWarehouse(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName)
-            {
-                operations.BeginPauseDataWarehouseAsync(resourceGroupName, serverName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Pause an Azure SQL Data Warehouse database.
             /// </summary>
@@ -1097,27 +631,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.BeginPauseDataWarehouseWithHttpMessagesAsync(resourceGroupName, serverName, databaseName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Resume an Azure SQL Data Warehouse database.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL Data Warehouse database to resume.
-            /// </param>
-            public static void BeginResumeDataWarehouse(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName)
-            {
-                operations.BeginResumeDataWarehouseAsync(resourceGroupName, serverName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Resume an Azure SQL Data Warehouse database.
             /// </summary>
@@ -1142,32 +656,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.BeginResumeDataWarehouseWithHttpMessagesAsync(resourceGroupName, serverName, databaseName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Creates a new Azure SQL database or updates an existing Azure SQL database.
-            /// Location is a required property in the request body, and it must be the
-            /// same as the location of the SQL server.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database to be operated on (updated or created).
-            /// </param>
-            /// <param name='parameters'>
-            /// The required parameters for creating or updating a database.
-            /// </param>
-            public static DatabaseInner BeginCreateOrUpdate(this IDatabasesOperations operations, string resourceGroupName, string serverName, string databaseName, DatabaseInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, serverName, databaseName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new Azure SQL database or updates an existing Azure SQL database.
             /// Location is a required property in the request body, and it must be the

--- a/src/ResourceManagement/Sql/Generated/ElasticPoolsOperationsExtensions.cs
+++ b/src/ResourceManagement/Sql/Generated/ElasticPoolsOperationsExtensions.cs
@@ -24,32 +24,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
     /// </summary>
     public static partial class ElasticPoolsOperationsExtensions
     {
-            /// <summary>
-            /// Creates a new Azure SQL elastic pool or updates an existing Azure SQL
-            /// elastic pool.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='elasticPoolName'>
-            /// The name of the Azure SQL Elastic Pool to be operated on (Updated or
-            /// created).
-            /// </param>
-            /// <param name='parameters'>
-            /// The required parameters for creating or updating an Elastic Pool.
-            /// </param>
-            public static ElasticPoolInner CreateOrUpdate(this IElasticPoolsOperations operations, string resourceGroupName, string serverName, string elasticPoolName, ElasticPoolInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, serverName, elasticPoolName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new Azure SQL elastic pool or updates an existing Azure SQL
             /// elastic pool.
@@ -82,27 +57,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes the Azure SQL elastic pool.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='elasticPoolName'>
-            /// The name of the Azure SQL Elastic Pool to be deleted.
-            /// </param>
-            public static void Delete(this IElasticPoolsOperations operations, string resourceGroupName, string serverName, string elasticPoolName)
-            {
-                operations.DeleteAsync(resourceGroupName, serverName, elasticPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes the Azure SQL elastic pool.
             /// </summary>
@@ -127,27 +82,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, serverName, elasticPoolName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets information about an Azure SQL elastic pool.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='elasticPoolName'>
-            /// The name of the Azure SQL Elastic Pool to be retrieved.
-            /// </param>
-            public static ElasticPoolInner Get(this IElasticPoolsOperations operations, string resourceGroupName, string serverName, string elasticPoolName)
-            {
-                return operations.GetAsync(resourceGroupName, serverName, elasticPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about an Azure SQL elastic pool.
             /// </summary>
@@ -175,24 +110,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about Azure SQL elastic pools.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            public static IEnumerable<ElasticPoolInner> ListByServer(this IElasticPoolsOperations operations, string resourceGroupName, string serverName)
-            {
-                return operations.ListByServerAsync(resourceGroupName, serverName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about Azure SQL elastic pools.
             /// </summary>
@@ -217,28 +135,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about Azure SQL elastic pool activities.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='elasticPoolName'>
-            /// The name of the Azure SQL Elastic Pool for which to get the current
-            /// activity.
-            /// </param>
-            public static IEnumerable<ElasticPoolActivityInner> ListActivity(this IElasticPoolsOperations operations, string resourceGroupName, string serverName, string elasticPoolName)
-            {
-                return operations.ListActivityAsync(resourceGroupName, serverName, elasticPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about Azure SQL elastic pool activities.
             /// </summary>
@@ -267,28 +164,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about activity on Azure SQL databases inside of an
-            /// Azure SQL elastic pool.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='elasticPoolName'>
-            /// The name of the Azure SQL Elastic Pool.
-            /// </param>
-            public static IEnumerable<ElasticPoolDatabaseActivityInner> ListDatabaseActivity(this IElasticPoolsOperations operations, string resourceGroupName, string serverName, string elasticPoolName)
-            {
-                return operations.ListDatabaseActivityAsync(resourceGroupName, serverName, elasticPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about activity on Azure SQL databases inside of an
             /// Azure SQL elastic pool.
@@ -317,31 +193,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about an Azure SQL database inside of an Azure SQL elastic
-            /// pool.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='elasticPoolName'>
-            /// The name of the Azure SQL Elastic Pool to be retrieved.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database to be retrieved.
-            /// </param>
-            public static DatabaseInner GetDatabase(this IElasticPoolsOperations operations, string resourceGroupName, string serverName, string elasticPoolName, string databaseName)
-            {
-                return operations.GetDatabaseAsync(resourceGroupName, serverName, elasticPoolName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about an Azure SQL database inside of an Azure SQL elastic
             /// pool.
@@ -373,28 +225,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about an Azure SQL database inside of an Azure SQL
-            /// elastic pool.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='elasticPoolName'>
-            /// The name of the Azure SQL Elastic Pool to be retrieved.
-            /// </param>
-            public static IEnumerable<DatabaseInner> ListDatabases(this IElasticPoolsOperations operations, string resourceGroupName, string serverName, string elasticPoolName)
-            {
-                return operations.ListDatabasesAsync(resourceGroupName, serverName, elasticPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about an Azure SQL database inside of an Azure SQL
             /// elastic pool.
@@ -423,32 +254,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new Azure SQL elastic pool or updates an existing Azure SQL
-            /// elastic pool.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='elasticPoolName'>
-            /// The name of the Azure SQL Elastic Pool to be operated on (Updated or
-            /// created).
-            /// </param>
-            /// <param name='parameters'>
-            /// The required parameters for creating or updating an Elastic Pool.
-            /// </param>
-            public static ElasticPoolInner BeginCreateOrUpdate(this IElasticPoolsOperations operations, string resourceGroupName, string serverName, string elasticPoolName, ElasticPoolInner parameters)
-            {
-                return operations.BeginCreateOrUpdateAsync(resourceGroupName, serverName, elasticPoolName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new Azure SQL elastic pool or updates an existing Azure SQL
             /// elastic pool.

--- a/src/ResourceManagement/Sql/Generated/RecommendedElasticPoolsOperationsExtensions.cs
+++ b/src/ResourceManagement/Sql/Generated/RecommendedElasticPoolsOperationsExtensions.cs
@@ -24,27 +24,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
     /// </summary>
     public static partial class RecommendedElasticPoolsOperationsExtensions
     {
-            /// <summary>
-            /// Gets information about an Azure SQL Recommended Elastic Pool.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='recommendedElasticPoolName'>
-            /// The name of the Azure SQL Recommended Elastic Pool to be retrieved.
-            /// </param>
-            public static RecommendedElasticPoolInner Get(this IRecommendedElasticPoolsOperations operations, string resourceGroupName, string serverName, string recommendedElasticPoolName)
-            {
-                return operations.GetAsync(resourceGroupName, serverName, recommendedElasticPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about an Azure SQL Recommended Elastic Pool.
             /// </summary>
@@ -72,31 +52,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about an Azure SQL database inside of an Azure SQL
-            /// Recommended Elastic Pool.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='recommendedElasticPoolName'>
-            /// The name of the Azure SQL Elastic Pool to be retrieved.
-            /// </param>
-            /// <param name='databaseName'>
-            /// The name of the Azure SQL database to be retrieved.
-            /// </param>
-            public static DatabaseInner GetDatabases(this IRecommendedElasticPoolsOperations operations, string resourceGroupName, string serverName, string recommendedElasticPoolName, string databaseName)
-            {
-                return operations.GetDatabasesAsync(resourceGroupName, serverName, recommendedElasticPoolName, databaseName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about an Azure SQL database inside of an Azure SQL
             /// Recommended Elastic Pool.
@@ -128,24 +84,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about Azure SQL Recommended Elastic Pools.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            public static IEnumerable<RecommendedElasticPoolInner> List(this IRecommendedElasticPoolsOperations operations, string resourceGroupName, string serverName)
-            {
-                return operations.ListAsync(resourceGroupName, serverName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about Azure SQL Recommended Elastic Pools.
             /// </summary>
@@ -170,28 +109,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about an Azure SQL database inside of an Azure SQL
-            /// Recommended Elastic Pool.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='recommendedElasticPoolName'>
-            /// The name of the Azure SQL Recommended Elastic Pool to be retrieved.
-            /// </param>
-            public static IEnumerable<DatabaseInner> ListDatabases(this IRecommendedElasticPoolsOperations operations, string resourceGroupName, string serverName, string recommendedElasticPoolName)
-            {
-                return operations.ListDatabasesAsync(resourceGroupName, serverName, recommendedElasticPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about an Azure SQL database inside of an Azure SQL
             /// Recommended Elastic Pool.
@@ -220,27 +138,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about an recommended elastic pool metrics.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='recommendedElasticPoolName'>
-            /// The name of the Azure SQL Recommended Elastic Pool to be retrieved.
-            /// </param>
-            public static IEnumerable<RecommendedElasticPoolMetric> ListMetrics(this IRecommendedElasticPoolsOperations operations, string resourceGroupName, string serverName, string recommendedElasticPoolName)
-            {
-                return operations.ListMetricsAsync(resourceGroupName, serverName, recommendedElasticPoolName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about an recommended elastic pool metrics.
             /// </summary>

--- a/src/ResourceManagement/Sql/Generated/ServersOperationsExtensions.cs
+++ b/src/ResourceManagement/Sql/Generated/ServersOperationsExtensions.cs
@@ -24,30 +24,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
     /// </summary>
     public static partial class ServersOperationsExtensions
     {
-            /// <summary>
-            /// Creates or updates an Azure SQL server firewall rule.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='firewallRuleName'>
-            /// The name of the Azure SQL server firewall rule.
-            /// </param>
-            /// <param name='parameters'>
-            /// The required parameters for creating or updating a firewall rule.
-            /// </param>
-            public static ServerFirewallRuleInner CreateOrUpdateFirewallRule(this IServersOperations operations, string resourceGroupName, string serverName, string firewallRuleName, ServerFirewallRuleInner parameters)
-            {
-                return operations.CreateOrUpdateFirewallRuleAsync(resourceGroupName, serverName, firewallRuleName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates or updates an Azure SQL server firewall rule.
             /// </summary>
@@ -78,27 +55,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes an Azure SQL server firewall rule.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='firewallRuleName'>
-            /// The name of the Azure SQL server firewall rule.
-            /// </param>
-            public static void DeleteFirewallRule(this IServersOperations operations, string resourceGroupName, string serverName, string firewallRuleName)
-            {
-                operations.DeleteFirewallRuleAsync(resourceGroupName, serverName, firewallRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes an Azure SQL server firewall rule.
             /// </summary>
@@ -123,27 +80,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.DeleteFirewallRuleWithHttpMessagesAsync(resourceGroupName, serverName, firewallRuleName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Returns an Azure SQL server firewall rule.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='firewallRuleName'>
-            /// The name of the Azure SQL server firewall rule.
-            /// </param>
-            public static ServerFirewallRuleInner GetFirewallRule(this IServersOperations operations, string resourceGroupName, string serverName, string firewallRuleName)
-            {
-                return operations.GetFirewallRuleAsync(resourceGroupName, serverName, firewallRuleName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns an Azure SQL server firewall rule.
             /// </summary>
@@ -171,24 +108,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns a list of Azure SQL server firewall rules.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            public static IEnumerable<ServerFirewallRuleInner> ListFirewallRules(this IServersOperations operations, string resourceGroupName, string serverName)
-            {
-                return operations.ListFirewallRulesAsync(resourceGroupName, serverName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns a list of Azure SQL server firewall rules.
             /// </summary>
@@ -213,17 +133,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about an Azure SQL server.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IEnumerable<ServerInner> List(this IServersOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about an Azure SQL server.
             /// </summary>
@@ -241,27 +151,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Creates a new Azure SQL server.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='parameters'>
-            /// The required parameters for creating or updating a server.
-            /// </param>
-            public static ServerInner CreateOrUpdate(this IServersOperations operations, string resourceGroupName, string serverName, ServerInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, serverName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Creates a new Azure SQL server.
             /// </summary>
@@ -289,24 +179,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a SQL server.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            public static void Delete(this IServersOperations operations, string resourceGroupName, string serverName)
-            {
-                operations.DeleteAsync(resourceGroupName, serverName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a SQL server.
             /// </summary>
@@ -328,24 +201,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, serverName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Gets information about an Azure SQL server.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            public static ServerInner GetByResourceGroup(this IServersOperations operations, string resourceGroupName, string serverName)
-            {
-                return operations.GetByResourceGroupAsync(resourceGroupName, serverName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about an Azure SQL server.
             /// </summary>
@@ -370,21 +226,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about an Azure SQL server.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            public static IEnumerable<ServerInner> ListByResourceGroup(this IServersOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about an Azure SQL server.
             /// </summary>
@@ -406,24 +248,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about Azure SQL server usage.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            public static IEnumerable<ServerMetric> ListUsages(this IServersOperations operations, string resourceGroupName, string serverName)
-            {
-                return operations.ListUsagesAsync(resourceGroupName, serverName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about Azure SQL server usage.
             /// </summary>
@@ -448,27 +273,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets information about an Azure SQL database Service Objective.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            /// <param name='serviceObjectiveName'>
-            /// The name of the service objective to retrieve.
-            /// </param>
-            public static ServiceObjectiveInner GetServiceObjective(this IServersOperations operations, string resourceGroupName, string serverName, string serviceObjectiveName)
-            {
-                return operations.GetServiceObjectiveAsync(resourceGroupName, serverName, serviceObjectiveName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets information about an Azure SQL database Service Objective.
             /// </summary>
@@ -496,24 +301,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
             }
 
-            /// <summary>
-            /// Returns information about Azure SQL database Service Objectives.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group that contains the resource. You can obtain
-            /// this value from the Azure Resource Manager API or the portal.
-            /// </param>
-            /// <param name='serverName'>
-            /// The name of the Azure SQL server.
-            /// </param>
-            public static IEnumerable<ServiceObjectiveInner> ListServiceObjectives(this IServersOperations operations, string resourceGroupName, string serverName)
-            {
-                return operations.ListServiceObjectivesAsync(resourceGroupName, serverName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns information about Azure SQL database Service Objectives.
             /// </summary>

--- a/src/ResourceManagement/Sql/RecommendedElasticPoolImpl.cs
+++ b/src/ResourceManagement/Sql/RecommendedElasticPoolImpl.cs
@@ -73,10 +73,10 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:CD775E31F43CBA6304D6EEA9E01682A1:FE7D9343E169D0420CF0E1FC9A9A3736
         public IReadOnlyList<Microsoft.Azure.Management.Sql.Fluent.ISqlDatabase> ListDatabases()
         {
-            var databases = Manager.Inner.RecommendedElasticPools.ListDatabases(
+            var databases = Extensions.Synchronize(() => Manager.Inner.RecommendedElasticPools.ListDatabasesAsync(
                 ResourceGroupName(),
                 SqlServerName(),
-                Name());
+                Name()));
 
             return databases.Select(databaseInner => (ISqlDatabase)new SqlDatabaseImpl(
                 databaseInner.Name,
@@ -117,11 +117,11 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:1C25D7B8D9084176A24655682A78634D:F7EA0DF49958322A52E6952D781B9782
         public ISqlDatabase GetDatabase(string databaseName)
         {
-            DatabaseInner databaseInner = Manager.Inner.RecommendedElasticPools.GetDatabases(
+            DatabaseInner databaseInner = Extensions.Synchronize(() => Manager.Inner.RecommendedElasticPools.GetDatabasesAsync(
                 ResourceGroupName(),
                 SqlServerName(),
                 Name(),
-                databaseName);
+                databaseName));
 
             return new SqlDatabaseImpl(databaseInner.Name, databaseInner, Manager);
         }
@@ -129,10 +129,10 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:77909FCEE2BCE7A1585A5D65D695B384:13846C17B14D55E5F3A4AE220EAFBEDC
         public IReadOnlyList<IRecommendedElasticPoolMetric> ListMetrics()
         {
-            var metricInner = Manager.Inner.RecommendedElasticPools.ListMetrics(
+            var metricInner = Extensions.Synchronize(() => Manager.Inner.RecommendedElasticPools.ListMetricsAsync(
                 ResourceGroupName(),
                 SqlServerName(),
-                Name());
+                Name()));
             return metricInner.Select(recommendedElasticPoolMetricInner => (IRecommendedElasticPoolMetric)new RecommendedElasticPoolMetricImpl(recommendedElasticPoolMetricInner)).ToList();
         }
 

--- a/src/ResourceManagement/Sql/ReplicationLinkImpl.cs
+++ b/src/ResourceManagement/Sql/ReplicationLinkImpl.cs
@@ -80,11 +80,11 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:65E6085BB9054A86F6A84772E3F5A9EC:5DF2D34B34E97D7C050D4229F8A0ABE1
         public void Delete()
         {
-            this.innerCollection.DeleteReplicationLink(
-            this.ResourceGroupName(),
-            this.SqlServerName(),
-            this.DatabaseName(),
-            this.Name());
+            Extensions.Synchronize(() => this.innerCollection.DeleteReplicationLinkAsync(
+                        this.ResourceGroupName(),
+                        this.SqlServerName(),
+                        this.DatabaseName(),
+                        this.Name()));
         }
 
         ///GENMHASH:DD6979366C7B4F3C6845144DBE9E011A:E0A904BDF0C6E5F4C37230C1174B190E

--- a/src/ResourceManagement/Sql/ReplicationLinkImpl.cs
+++ b/src/ResourceManagement/Sql/ReplicationLinkImpl.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:DD6979366C7B4F3C6845144DBE9E011A:E0A904BDF0C6E5F4C37230C1174B190E
         public void ForceFailoverAllowDataLoss()
         {
-            ForceFailoverAllowDataLossAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => ForceFailoverAllowDataLossAsync());
         }
         public async Task ForceFailoverAllowDataLossAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:75146396042F3B3D55B973EBEDF73CD2:6BA113CAE218C7605AC4729294DDB001
         public void Failover()
         {
-            FailoverAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => FailoverAsync());
         }
         public async Task FailoverAsync(CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/src/ResourceManagement/Sql/SqlDatabaseImpl.cs
+++ b/src/ResourceManagement/Sql/SqlDatabaseImpl.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:65E6085BB9054A86F6A84772E3F5A9EC:EBCADD6850E9711DA91415429B1577E3
         public void Delete()
         {
-            Manager.Inner.Databases.Delete(ResourceGroupName, SqlServerName(), Name);
+            Extensions.Synchronize(() => Manager.Inner.Databases.DeleteAsync(ResourceGroupName, SqlServerName(), Name));
         }
 
         ///GENMHASH:B23645FC2F779DBC6F44B880C488B561:FD8121B9F8029AC826DD64E68A0C727C
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         {
             if (Inner.UpgradeHint == null)
             {
-                SetInner(Manager.Inner.Databases.Get(ResourceGroupName, SqlServerName(), Name, "upgradeHint"));
+                SetInner(Extensions.Synchronize(() => Manager.Inner.Databases.GetAsync(ResourceGroupName, SqlServerName(), Name, "upgradeHint")));
             }
             if (Inner.UpgradeHint != null)
             {
@@ -166,8 +166,8 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:94274C9965DC54702B64A387A19F1F2B:CBA2A056219E542449E5F7E9EBA4B7D8
         public IReadOnlyDictionary<string, Microsoft.Azure.Management.Sql.Fluent.IReplicationLink> ListReplicationLinks()
         {
-            var replicationLinks = Manager.Inner.Databases.ListReplicationLinks(
-                ResourceGroupName, SqlServerName(), Name);
+            var replicationLinks = Extensions.Synchronize(() => Manager.Inner.Databases.ListReplicationLinksAsync(
+                ResourceGroupName, SqlServerName(), Name));
 
             IDictionary<string, IReplicationLink> result = new Dictionary<string, IReplicationLink>();
             foreach (var replicationLink in replicationLinks)
@@ -197,8 +197,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         {
             Func<DatabaseMetric, DatabaseMetricImpl> convertor = (databaseMetricInner) => new DatabaseMetricImpl(databaseMetricInner);
 
-            return Manager.Inner.Databases
-                .ListUsages(ResourceGroupName,SqlServerName(),Name)
+            return Extensions.Synchronize(() => Manager.Inner.Databases.ListUsagesAsync(ResourceGroupName,SqlServerName(),Name))
                 .Select(inner => convertor(inner)).ToList();
         }
 
@@ -236,10 +235,11 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         public ITransparentDataEncryption GetTransparentDataEncryption()
         {
             return new TransparentDataEncryptionImpl(
-                Manager.Inner.Databases.GetTransparentDataEncryptionConfiguration(
+                Extensions.Synchronize(() => Manager.Inner.Databases.GetTransparentDataEncryptionConfigurationAsync(
                     ResourceGroupName,
                     SqlServerName(),
-                    Name), Manager.Inner.Databases);
+                    Name)), 
+                Manager.Inner.Databases);
         }
 
         ///GENMHASH:4002186478A1CB0B59732EBFB18DEB3A:D460F07553280DBC1866880BA0BD8AEF
@@ -269,8 +269,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         {
             Func<RestorePointInner, RestorePointImpl> convertor = (restorePointInner) => new RestorePointImpl(restorePointInner);
 
-            return Manager.Inner.Databases
-                .ListRestorePoints(ResourceGroupName, SqlServerName(), Name)
+            return Extensions.Synchronize(() => Manager.Inner.Databases.ListRestorePointsAsync(ResourceGroupName, SqlServerName(), Name))
                 .Select(inner => convertor(inner)).ToList();
         }
 
@@ -330,7 +329,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
             var serviceTierAdvisorMap = new Dictionary<string, IServiceTierAdvisor>();
 
             foreach (var serviceTierAdvisorInner
-                in Manager.Inner.Databases.ListServiceTierAdvisors(ResourceGroupName, SqlServerName(), Name))
+                in Extensions.Synchronize(() => Manager.Inner.Databases.ListServiceTierAdvisorsAsync(ResourceGroupName, SqlServerName(), Name)))
             {
                 serviceTierAdvisorMap.Add(serviceTierAdvisorInner.Name, new ServiceTierAdvisorImpl(serviceTierAdvisorInner,
                     Manager.Inner.Databases));

--- a/src/ResourceManagement/Sql/SqlElasticPoolImpl.cs
+++ b/src/ResourceManagement/Sql/SqlElasticPoolImpl.cs
@@ -43,10 +43,10 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:C183D7089E5DF699C59758CC103308DF:9A4ADAD649EDB890CDCEB767D8708E33
         public IReadOnlyList<IElasticPoolActivity> ListActivities()
         {
-            var activities = Manager.Inner.ElasticPools.ListActivity(
+            var activities = Extensions.Synchronize(() => Manager.Inner.ElasticPools.ListActivityAsync(
                 ResourceGroupName,
                 SqlServerName(),
-                Name);
+                Name));
 
             var activitiesToReturn = new List<IElasticPoolActivity>();
             foreach (var elasticPoolActivityInner in activities)
@@ -110,10 +110,10 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:CD775E31F43CBA6304D6EEA9E01682A1:2A3515CB32DF22200CBB032FFC4BCCFC
         public IReadOnlyList<ISqlDatabase> ListDatabases()
         {
-            var databases = Manager.Inner.ElasticPools.ListDatabases(
+            var databases = Extensions.Synchronize(() => Manager.Inner.ElasticPools.ListDatabasesAsync(
                         ResourceGroupName,
                         SqlServerName(),
-                        Name);
+                        Name));
             return databases.Select((databaseInner) => (ISqlDatabase)new SqlDatabaseImpl(
                 databaseInner.Name,
                 databaseInner,
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:65E6085BB9054A86F6A84772E3F5A9EC:EBCADD6850E9711DA91415429B1577E3
         public void Delete()
         {
-            Manager.Inner.ElasticPools.Delete(ResourceGroupName, SqlServerName(), Name);
+            Extensions.Synchronize(() => Manager.Inner.ElasticPools.DeleteAsync(ResourceGroupName, SqlServerName(), Name));
         }
 
         ///GENMHASH:D7949083DDCDE361387E2A975A1A1DE5:D78C4C70C8A28CECCD68CF0E66EED127
@@ -155,10 +155,10 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:DA730BE4F3BEA4D8DCD1631C079435CB:2D0DE4C2F41ED4D39BD2E654A3511EEE
         public IReadOnlyList<Microsoft.Azure.Management.Sql.Fluent.IElasticPoolDatabaseActivity> ListDatabaseActivities()
         {
-            var databaseActivities = Manager.Inner.ElasticPools.ListDatabaseActivity(
+            var databaseActivities = Extensions.Synchronize(() => Manager.Inner.ElasticPools.ListDatabaseActivityAsync(
                     ResourceGroupName,
                     SqlServerName(),
-                    Name);
+                    Name));
             return databaseActivities.Select((elasticPoolDatabaseActivityInner) => (IElasticPoolDatabaseActivity)new ElasticPoolDatabaseActivityImpl(elasticPoolDatabaseActivityInner)).ToList();
         }
 
@@ -171,11 +171,11 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:1C25D7B8D9084176A24655682A78634D:ABBCB4CE203E2AC2B27991A84095239D
         public ISqlDatabase GetDatabase(string databaseName)
         {
-            DatabaseInner database = Manager.Inner.ElasticPools.GetDatabase(
+            DatabaseInner database = Extensions.Synchronize(() => Manager.Inner.ElasticPools.GetDatabaseAsync(
                 ResourceGroupName,
                 SqlServerName(),
                 Name,
-                databaseName);
+                databaseName));
             return new SqlDatabaseImpl(database.Name, database, Manager);
         }
 

--- a/src/ResourceManagement/Sql/SqlFirewallRuleImpl.cs
+++ b/src/ResourceManagement/Sql/SqlFirewallRuleImpl.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:65E6085BB9054A86F6A84772E3F5A9EC:11CCB9FA7CDA7C4110B5B485953F2C3A
         public void Delete()
         {
-            Manager.Inner.Servers.DeleteFirewallRule(ResourceGroupName, SqlServerName(), Name);
+            Extensions.Synchronize(() => Manager.Inner.Servers.DeleteFirewallRuleAsync(ResourceGroupName, SqlServerName(), Name));
         }
 
         ///GENMHASH:6ADF1ABD01F52EF2AB48EBDB916AC61B:0E617A4FA7C8B0429E44FA81A0CA93AE

--- a/src/ResourceManagement/Sql/SqlServerImpl.cs
+++ b/src/ResourceManagement/Sql/SqlServerImpl.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.Sql.Fluent
 {
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Models;
     using ResourceManager.Fluent;
     using ResourceManager.Fluent.Core.ResourceActions;
@@ -90,9 +91,9 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:2A59E18DA93663D485FB24124FE696D7:A9A12F1824E7FC07247043927FEEBFC2
         public IList<IServiceObjective> ListServiceObjectives()
         {
-            var serviceObjectives = Manager.Inner.Servers.ListServiceObjectives(
+            var serviceObjectives = Extensions.Synchronize(() => Manager.Inner.Servers.ListServiceObjectivesAsync(
                 ResourceGroupName,
-                Name);
+                Name));
             return serviceObjectives.Select((serviceObjectiveInner) => (IServiceObjective)new ServiceObjectiveImpl(
                 serviceObjectiveInner, Manager.Inner.Servers)).ToList();
         }
@@ -114,9 +115,9 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:42238C96020583EAD41C40C184F554ED:69F489ECA959B263C944C8127108388F
         public IReadOnlyDictionary<string, Microsoft.Azure.Management.Sql.Fluent.IRecommendedElasticPool> ListRecommendedElasticPools()
         {
-            var recommendedElasticPools = Manager.Inner.RecommendedElasticPools.List(
+            var recommendedElasticPools = Extensions.Synchronize(() => Manager.Inner.RecommendedElasticPools.ListAsync(
                 ResourceGroupName,
-                Name);
+                Name));
 
             return new ReadOnlyDictionary<string, IRecommendedElasticPool>(recommendedElasticPools.ToDictionary(
                     recommendedElasticPoolInner => recommendedElasticPoolInner.Name,
@@ -177,9 +178,9 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:0E666BFDFC9A666CA31FD735D7839414:2AAE577C01D4088729534C3BC39664A7
         public IReadOnlyList<IServerMetric> ListUsages()
         {
-            var usages = Manager.Inner.Servers.ListUsages(
+            var usages = Extensions.Synchronize(() => Manager.Inner.Servers.ListUsagesAsync(
                 ResourceGroupName,
-                Name);
+                Name));
             return usages.Select((serverMetricInner) => (IServerMetric)new ServerMetricImpl(serverMetricInner)).ToList();
         }
 
@@ -275,7 +276,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         public IServiceObjective GetServiceObjective(string serviceObjectiveName)
         {
             return new ServiceObjectiveImpl(
-                Manager.Inner.Servers.GetServiceObjective(ResourceGroupName, Name, serviceObjectiveName),
+                Extensions.Synchronize(() => Manager.Inner.Servers.GetServiceObjectiveAsync(ResourceGroupName, Name, serviceObjectiveName)),
                 Manager.Inner.Servers);
         }
 

--- a/src/ResourceManagement/Sql/SqlWarehouseImpl.cs
+++ b/src/ResourceManagement/Sql/SqlWarehouseImpl.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Azure.Management.Sql.Fluent
 {
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
     using Models;
     using System.Threading;
     using System.Threading.Tasks;
@@ -24,7 +25,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:638E920B34EB7CDD894A8A261D1A3364:F65A55844E1B000D318C0439E7EDE006
         public void ResumeDataWarehouse()
         {
-            ResumeDataWarehouseAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => ResumeDataWarehouseAsync());
         }
 
         public async Task ResumeDataWarehouseAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -39,7 +40,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:CC45B434E5AD72F7D764B575FE4DBBB0:BA80FAB6E26489720ABD292F74B22257
         public void PauseDataWarehouse()
         {
-            PauseDataWarehouseAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            Extensions.Synchronize(() => PauseDataWarehouseAsync());
         }
 
         public async Task PauseDataWarehouseAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/Sql/TransparentDataEncryptionImpl.cs
+++ b/src/ResourceManagement/Sql/TransparentDataEncryptionImpl.cs
@@ -22,10 +22,11 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         ///GENMHASH:C183D7089E5DF699C59758CC103308DF:0F2852A05859CF21CF78B54DB31431CD
         public IReadOnlyList<Microsoft.Azure.Management.Sql.Fluent.ITransparentDataEncryptionActivity> ListActivities()
         {
-            return this.databasesInner.ListTransparentDataEncryptionActivity(
-                this.ResourceGroupName(),
-                this.SqlServerName(),
-                this.DatabaseName()).Select(transparentDataEncryptionActivity => new TransparentDataEncryptionActivityImpl(transparentDataEncryptionActivity)).ToList();
+            return Extensions.Synchronize(() => this.databasesInner.ListTransparentDataEncryptionActivityAsync(
+                    this.ResourceGroupName(),
+                    this.SqlServerName(),
+                    this.DatabaseName()))
+                .Select(transparentDataEncryptionActivity => new TransparentDataEncryptionActivityImpl(transparentDataEncryptionActivity)).ToList();
         }
 
         ///GENMHASH:E9EDBD2E8DC2C547D1386A58778AA6B9:9FE42D967416923E070F823D07063A47
@@ -51,11 +52,11 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         {
             Inner.Status = transparentDataEncryptionState;
             this.SetInner(
-                this.databasesInner.CreateOrUpdateTransparentDataEncryptionConfiguration(
+                Extensions.Synchronize(() => this.databasesInner.CreateOrUpdateTransparentDataEncryptionConfigurationAsync(
                     this.ResourceGroupName(),
                     this.SqlServerName(),
                     this.DatabaseName(),
-                    Inner.Status));
+                    Inner.Status)));
 
             return this;
         }

--- a/src/ResourceManagement/Storage/Generated/StorageAccountsOperationsExtensions.cs
+++ b/src/ResourceManagement/Storage/Generated/StorageAccountsOperationsExtensions.cs
@@ -24,19 +24,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
     /// </summary>
     public static partial class StorageAccountsOperationsExtensions
     {
-            /// <summary>
-            /// Checks that the storage account name is valid and is not already in use.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='name'>
-            /// </param>
-            public static CheckNameAvailabilityResultInner CheckNameAvailability(this IStorageAccountsOperations operations, string name)
-            {
-                return operations.CheckNameAvailabilityAsync(name).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks that the storage account name is valid and is not already in use.
             /// </summary>
@@ -56,32 +44,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
                 }
             }
 
-            /// <summary>
-            /// Asynchronously creates a new storage account with the specified parameters.
-            /// If an account is already created and a subsequent create request is issued
-            /// with different properties, the account properties will be updated. If an
-            /// account is already created and a subsequent create or update request is
-            /// issued with the exact same set of properties, the request will succeed.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group within the user's subscription.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the storage account within the specified resource group.
-            /// Storage account names must be between 3 and 24 characters in length and use
-            /// numbers and lower-case letters only.
-            /// </param>
-            /// <param name='parameters'>
-            /// The parameters to provide for the created account.
-            /// </param>
-            public static StorageAccountInner Create(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountCreateParametersInner parameters)
-            {
-                return operations.CreateAsync(resourceGroupName, accountName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Asynchronously creates a new storage account with the specified parameters.
             /// If an account is already created and a subsequent create request is issued
@@ -114,25 +77,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a storage account in Microsoft Azure.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group within the user's subscription.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the storage account within the specified resource group.
-            /// Storage account names must be between 3 and 24 characters in length and use
-            /// numbers and lower-case letters only.
-            /// </param>
-            public static void Delete(this IStorageAccountsOperations operations, string resourceGroupName, string accountName)
-            {
-                operations.DeleteAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a storage account in Microsoft Azure.
             /// </summary>
@@ -155,27 +100,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, accountName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Returns the properties for the specified storage account including but not
-            /// limited to name, SKU name, location, and account status. The ListKeys
-            /// operation should be used to retrieve storage keys.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group within the user's subscription.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the storage account within the specified resource group.
-            /// Storage account names must be between 3 and 24 characters in length and use
-            /// numbers and lower-case letters only.
-            /// </param>
-            public static StorageAccountInner GetProperties(this IStorageAccountsOperations operations, string resourceGroupName, string accountName)
-            {
-                return operations.GetPropertiesAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Returns the properties for the specified storage account including but not
             /// limited to name, SKU name, location, and account status. The ListKeys
@@ -203,37 +128,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
                 }
             }
 
-            /// <summary>
-            /// The update operation can be used to update the SKU, encryption, access
-            /// tier, or tags for a storage account. It can also be used to map the account
-            /// to a custom domain. Only one custom domain is supported per storage
-            /// account; the replacement/change of custom domain is not supported. In order
-            /// to replace an old custom domain, the old value must be cleared/unregistered
-            /// before a new value can be set. The update of multiple properties is
-            /// supported. This call does not change the storage keys for the account. If
-            /// you want to change the storage account keys, use the regenerate keys
-            /// operation. The location and name of the storage account cannot be changed
-            /// after creation.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group within the user's subscription.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the storage account within the specified resource group.
-            /// Storage account names must be between 3 and 24 characters in length and use
-            /// numbers and lower-case letters only.
-            /// </param>
-            /// <param name='parameters'>
-            /// The parameters to provide for the updated account.
-            /// </param>
-            public static StorageAccountInner Update(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountUpdateParametersInner parameters)
-            {
-                return operations.UpdateAsync(resourceGroupName, accountName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// The update operation can be used to update the SKU, encryption, access
             /// tier, or tags for a storage account. It can also be used to map the account
@@ -271,18 +166,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the storage accounts available under the subscription. Note that
-            /// storage keys are not returned; use the ListKeys operation for this.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IEnumerable<StorageAccountInner> List(this IStorageAccountsOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the storage accounts available under the subscription. Note that
             /// storage keys are not returned; use the ListKeys operation for this.
@@ -301,22 +185,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all the storage accounts available under the given resource group.
-            /// Note that storage keys are not returned; use the ListKeys operation for
-            /// this.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group within the user's subscription.
-            /// </param>
-            public static IEnumerable<StorageAccountInner> ListByResourceGroup(this IStorageAccountsOperations operations, string resourceGroupName)
-            {
-                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all the storage accounts available under the given resource group.
             /// Note that storage keys are not returned; use the ListKeys operation for
@@ -339,25 +208,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists the access keys for the specified storage account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group within the user's subscription.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the storage account within the specified resource group.
-            /// Storage account names must be between 3 and 24 characters in length and use
-            /// numbers and lower-case letters only.
-            /// </param>
-            public static StorageAccountListKeysResultInner ListKeys(this IStorageAccountsOperations operations, string resourceGroupName, string accountName)
-            {
-                return operations.ListKeysAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists the access keys for the specified storage account.
             /// </summary>
@@ -383,27 +234,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
                 }
             }
 
-            /// <summary>
-            /// Regenerates one of the access keys for the specified storage account.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group within the user's subscription.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the storage account within the specified resource group.
-            /// Storage account names must be between 3 and 24 characters in length and use
-            /// numbers and lower-case letters only.
-            /// </param>
-            /// <param name='keyName'>
-            /// </param>
-            public static StorageAccountListKeysResultInner RegenerateKey(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, string keyName)
-            {
-                return operations.RegenerateKeyAsync(resourceGroupName, accountName, keyName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Regenerates one of the access keys for the specified storage account.
             /// </summary>
@@ -431,32 +262,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
                 }
             }
 
-            /// <summary>
-            /// Asynchronously creates a new storage account with the specified parameters.
-            /// If an account is already created and a subsequent create request is issued
-            /// with different properties, the account properties will be updated. If an
-            /// account is already created and a subsequent create or update request is
-            /// issued with the exact same set of properties, the request will succeed.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group within the user's subscription.
-            /// </param>
-            /// <param name='accountName'>
-            /// The name of the storage account within the specified resource group.
-            /// Storage account names must be between 3 and 24 characters in length and use
-            /// numbers and lower-case letters only.
-            /// </param>
-            /// <param name='parameters'>
-            /// The parameters to provide for the created account.
-            /// </param>
-            public static StorageAccountInner BeginCreate(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountCreateParametersInner parameters)
-            {
-                return operations.BeginCreateAsync(resourceGroupName, accountName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Asynchronously creates a new storage account with the specified parameters.
             /// If an account is already created and a subsequent create request is issued

--- a/src/ResourceManagement/Storage/Generated/UsageOperationsExtensions.cs
+++ b/src/ResourceManagement/Storage/Generated/UsageOperationsExtensions.cs
@@ -24,18 +24,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
     /// </summary>
     public static partial class UsageOperationsExtensions
     {
-            /// <summary>
-            /// Gets the current usage count and the limit for the resources under the
-            /// subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IEnumerable<Usage> List(this IUsageOperations operations)
-            {
-                return operations.ListAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets the current usage count and the limit for the resources under the
             /// subscription.

--- a/src/ResourceManagement/Storage/StorageAccount/StorageAccountImpl.cs
+++ b/src/ResourceManagement/Storage/StorageAccount/StorageAccountImpl.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.Management.ResourceManager.Fluent;
 using System.Threading;
 using Microsoft.Azure.Management.Storage.Fluent.StorageAccount.Definition;
 using Microsoft.Azure.Management.Storage.Fluent.StorageAccount.Update;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 
 namespace Microsoft.Azure.Management.Storage.Fluent
 {
@@ -136,7 +137,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
 
         public IReadOnlyList<StorageAccountKey> GetKeys()
         {
-            return GetKeysAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => GetKeysAsync());
         }
 
         public async Task<IReadOnlyList<StorageAccountKey>> GetKeysAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -162,7 +163,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
 
         public IReadOnlyList<StorageAccountKey> RegenerateKey(string keyName)
         {
-            return RegenerateKeyAsync(keyName).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => RegenerateKeyAsync(keyName));
         }
 
         public async Task<IReadOnlyList<StorageAccountKey>> RegenerateKeyAsync(string keyName, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/Storage/StorageAccount/StorageAccountsImpl.cs
+++ b/src/ResourceManagement/Storage/StorageAccount/StorageAccountsImpl.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
         
         public CheckNameAvailabilityResult CheckNameAvailability(string name)
         {
-            return CheckNameAvailabilityAsync(name).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => CheckNameAvailabilityAsync(name));
         }
 
         public async Task<CheckNameAvailabilityResult> CheckNameAvailabilityAsync(string name, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/Storage/Usage/UsagesImpl.cs
+++ b/src/ResourceManagement/Storage/Usage/UsagesImpl.cs
@@ -22,11 +22,13 @@ namespace Microsoft.Azure.Management.Storage.Fluent
 
         public IEnumerable<IStorageUsage> List()
         {
-            if (client.List() == null)
+            var storageUsage = Extensions.Synchronize(() => client.ListAsync());
+            
+            if(storageUsage == null)
             {
                 return new List<IStorageUsage>();
             }
-            return WrapList(client.List());
+            return WrapList(storageUsage);
         }
 
         public async Task<IPagedCollection<IStorageUsage>> ListAsync(bool loadAllPages = true, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/ResourceManagement/TrafficManager/Generated/EndpointsOperationsExtensions.cs
+++ b/src/ResourceManagement/TrafficManager/Generated/EndpointsOperationsExtensions.cs
@@ -22,33 +22,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
     /// </summary>
     public static partial class EndpointsOperationsExtensions
     {
-            /// <summary>
-            /// Update a Traffic Manager endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group containing the Traffic Manager endpoint to
-            /// be updated.
-            /// </param>
-            /// <param name='profileName'>
-            /// The name of the Traffic Manager profile.
-            /// </param>
-            /// <param name='endpointType'>
-            /// The type of the Traffic Manager endpoint to be updated.
-            /// </param>
-            /// <param name='endpointName'>
-            /// The name of the Traffic Manager endpoint to be updated.
-            /// </param>
-            /// <param name='parameters'>
-            /// The Traffic Manager endpoint parameters supplied to the Update operation.
-            /// </param>
-            public static EndpointInner Update(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointType, string endpointName, EndpointInner parameters)
-            {
-                return operations.UpdateAsync(resourceGroupName, profileName, endpointType, endpointName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Update a Traffic Manager endpoint.
             /// </summary>
@@ -82,29 +56,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a Traffic Manager endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group containing the Traffic Manager endpoint.
-            /// </param>
-            /// <param name='profileName'>
-            /// The name of the Traffic Manager profile.
-            /// </param>
-            /// <param name='endpointType'>
-            /// The type of the Traffic Manager endpoint.
-            /// </param>
-            /// <param name='endpointName'>
-            /// The name of the Traffic Manager endpoint.
-            /// </param>
-            public static EndpointInner Get(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointType, string endpointName)
-            {
-                return operations.GetAsync(resourceGroupName, profileName, endpointType, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a Traffic Manager endpoint.
             /// </summary>
@@ -134,34 +86,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or update a Traffic Manager endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group containing the Traffic Manager endpoint to
-            /// be created or updated.
-            /// </param>
-            /// <param name='profileName'>
-            /// The name of the Traffic Manager profile.
-            /// </param>
-            /// <param name='endpointType'>
-            /// The type of the Traffic Manager endpoint to be created or updated.
-            /// </param>
-            /// <param name='endpointName'>
-            /// The name of the Traffic Manager endpoint to be created or updated.
-            /// </param>
-            /// <param name='parameters'>
-            /// The Traffic Manager endpoint parameters supplied to the CreateOrUpdate
-            /// operation.
-            /// </param>
-            public static EndpointInner CreateOrUpdate(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointType, string endpointName, EndpointInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, profileName, endpointType, endpointName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a Traffic Manager endpoint.
             /// </summary>
@@ -196,30 +121,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a Traffic Manager endpoint.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group containing the Traffic Manager endpoint to
-            /// be deleted.
-            /// </param>
-            /// <param name='profileName'>
-            /// The name of the Traffic Manager profile.
-            /// </param>
-            /// <param name='endpointType'>
-            /// The type of the Traffic Manager endpoint to be deleted.
-            /// </param>
-            /// <param name='endpointName'>
-            /// The name of the Traffic Manager endpoint to be deleted.
-            /// </param>
-            public static void Delete(this IEndpointsOperations operations, string resourceGroupName, string profileName, string endpointType, string endpointName)
-            {
-                operations.DeleteAsync(resourceGroupName, profileName, endpointType, endpointName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a Traffic Manager endpoint.
             /// </summary>

--- a/src/ResourceManagement/TrafficManager/Generated/ProfilesOperationsExtensions.cs
+++ b/src/ResourceManagement/TrafficManager/Generated/ProfilesOperationsExtensions.cs
@@ -24,23 +24,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
     /// </summary>
     public static partial class ProfilesOperationsExtensions
     {
-            /// <summary>
-            /// Checks the availability of a Traffic Manager Relative DNS name.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='name'>
-            /// Gets or sets the name of the resource.
-            /// </param>
-            /// <param name='type'>
-            /// Gets or sets the type of the resource.
-            /// </param>
-            public static TrafficManagerNameAvailabilityInner CheckTrafficManagerRelativeDnsNameAvailability(this IProfilesOperations operations, string name = default(string), string type = default(string))
-            {
-                return operations.CheckTrafficManagerRelativeDnsNameAvailabilityAsync(name, type).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Checks the availability of a Traffic Manager Relative DNS name.
             /// </summary>
@@ -64,21 +48,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all Traffic Manager profiles within a resource group.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group containing the Traffic Manager profiles to
-            /// be listed.
-            /// </param>
-            public static IEnumerable<ProfileInner> ListAllInResourceGroup(this IProfilesOperations operations, string resourceGroupName)
-            {
-                return operations.ListAllInResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all Traffic Manager profiles within a resource group.
             /// </summary>
@@ -100,17 +70,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Lists all Traffic Manager profiles within a subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static IEnumerable<ProfileInner> ListAll(this IProfilesOperations operations)
-            {
-                return operations.ListAllAsync().GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Lists all Traffic Manager profiles within a subscription.
             /// </summary>
@@ -128,23 +88,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Gets a Traffic Manager profile.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group containing the Traffic Manager profile.
-            /// </param>
-            /// <param name='profileName'>
-            /// The name of the Traffic Manager profile.
-            /// </param>
-            public static ProfileInner Get(this IProfilesOperations operations, string resourceGroupName, string profileName)
-            {
-                return operations.GetAsync(resourceGroupName, profileName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Gets a Traffic Manager profile.
             /// </summary>
@@ -168,27 +112,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Create or update a Traffic Manager profile.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group containing the Traffic Manager profile.
-            /// </param>
-            /// <param name='profileName'>
-            /// The name of the Traffic Manager profile.
-            /// </param>
-            /// <param name='parameters'>
-            /// The Traffic Manager profile parameters supplied to the CreateOrUpdate
-            /// operation.
-            /// </param>
-            public static ProfileInner CreateOrUpdate(this IProfilesOperations operations, string resourceGroupName, string profileName, ProfileInner parameters)
-            {
-                return operations.CreateOrUpdateAsync(resourceGroupName, profileName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Create or update a Traffic Manager profile.
             /// </summary>
@@ -216,24 +140,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
                 }
             }
 
-            /// <summary>
-            /// Deletes a Traffic Manager profile.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group containing the Traffic Manager profile to be
-            /// deleted.
-            /// </param>
-            /// <param name='profileName'>
-            /// The name of the Traffic Manager profile to be deleted.
-            /// </param>
-            public static void Delete(this IProfilesOperations operations, string resourceGroupName, string profileName)
-            {
-                operations.DeleteAsync(resourceGroupName, profileName).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Deletes a Traffic Manager profile.
             /// </summary>
@@ -255,26 +162,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
                 (await operations.DeleteWithHttpMessagesAsync(resourceGroupName, profileName, null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
-            /// <summary>
-            /// Update a Traffic Manager profile.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='resourceGroupName'>
-            /// The name of the resource group containing the Traffic Manager profile.
-            /// </param>
-            /// <param name='profileName'>
-            /// The name of the Traffic Manager profile.
-            /// </param>
-            /// <param name='parameters'>
-            /// The Traffic Manager profile parameters supplied to the Update operation.
-            /// </param>
-            public static ProfileInner Update(this IProfilesOperations operations, string resourceGroupName, string profileName, ProfileInner parameters)
-            {
-                return operations.UpdateAsync(resourceGroupName, profileName, parameters).GetAwaiter().GetResult();
-            }
-
+            
             /// <summary>
             /// Update a Traffic Manager profile.
             /// </summary>

--- a/src/ResourceManagement/TrafficManager/TrafficManagerProfilesImpl.cs
+++ b/src/ResourceManagement/TrafficManager/TrafficManagerProfilesImpl.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
         ///GENMHASH:EA7883DCA673C6F67CCCF6E8828D7D51:4DBFF5109C555E749B7E1943ECE31E34
         public CheckProfileDnsNameAvailabilityResult CheckDnsNameAvailability(string dnsNameLabel)
         {
-            return CheckDnsNameAvailabilityAsync(dnsNameLabel).ConfigureAwait(false).GetAwaiter().GetResult();
+            return Extensions.Synchronize(() => CheckDnsNameAvailabilityAsync(dnsNameLabel));
         }
 
         public async Task<CheckProfileDnsNameAvailabilityResult> CheckDnsNameAvailabilityAsync(


### PR DESCRIPTION
Fixes issue https://github.com/Azure/azure-sdk-for-net/issues/3238

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
