### PR TITLE
[ClientRuntime] Fixed polymorphic deserialization

### DIFF
--- a/src/SDKs/Network/Network.Tests/Properties/launchSettings.json
+++ b/src/SDKs/Network/Network.Tests/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "test": {
-      "commandName": "test",
-      "sdkVersion": "dnx-coreclr-win-x64.1.0.0-rc1-update1"
-    }
-  }
-}

--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/JsonSerializationTests.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/JsonSerializationTests.cs
@@ -25,8 +25,26 @@ namespace Microsoft.Rest.ClientRuntime.Tests
         public void PolymorphicSerializeWorks()
         {
             Zoo zoo = new Zoo() { Id = 1 };
-            zoo.Animals.Add(new Dog() { Name = "Fido", LikesDogfood = true });
-            zoo.Animals.Add(new Cat() { Name = "Felix", LikesMice = false, Dislikes = new Dog() { Name = "Angry", LikesDogfood = true } });
+            zoo.Animals.Add(new Dog() {
+                Name = "Fido",
+                LikesDogfood = true
+            });
+            zoo.Animals.Add(new Cat() {
+                Name = "Felix",
+                LikesMice = false,
+                Dislikes = new Dog() {
+                    Name = "Angry",
+                    LikesDogfood = true
+                },
+                BestFriend = new Animal() {
+                    Name = "Rudy the Rabbit",
+                    BestFriend = new Cat()
+                    {
+                        Name = "Jango",
+                        LikesMice = true
+                    }
+                }
+            });
             var serializeSettings = new JsonSerializerSettings();
             serializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
             serializeSettings.Converters.Add(new PolymorphicSerializeJsonConverter<Animal>("dType"));
@@ -41,6 +59,8 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             Assert.Equal(zoo.Animals[0].GetType(), zoo2.Animals[0].GetType());
             Assert.Equal(zoo.Animals[1].GetType(), zoo2.Animals[1].GetType());
             Assert.Equal(((Cat)zoo.Animals[1]).Dislikes.GetType(), ((Cat)zoo2.Animals[1]).Dislikes.GetType());
+            Assert.Equal(zoo.Animals[1].BestFriend.GetType(), zoo2.Animals[1].BestFriend.GetType());
+            Assert.Equal(zoo.Animals[1].BestFriend.BestFriend.GetType(), zoo2.Animals[1].BestFriend.BestFriend.GetType());
             Assert.Contains("dType", serializedJson);
         }
 

--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/PolymorphicJsonConverterTests.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/PolymorphicJsonConverterTests.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+using Newtonsoft.Json;
+using Microsoft.Rest.Serialization;
+
+namespace Microsoft.Rest.ClientRuntime.Tests
+{
+    public class PolymorphicJsonConverterTests
+    {
+        // Example hierarchy
+        // Naming convention:  nameof(U).StartsWith(nameof(T))  <=>  U : T
+
+        private class Model { }
+        private class ModelX : Model { }
+        private class ModelXA : ModelX { }
+        private class ModelXB : ModelX { }
+        private class ModelXAA : ModelXA { }
+        private class ModelXAB : ModelXA { }
+        private class ModelXABA : ModelXAB { }
+        private class ModelXABB : ModelXAB { }
+
+        // JsonConverters
+
+        private static JsonConverter SerializeJsonConverter => new PolymorphicSerializeJsonConverter<ModelX>("type");
+        private static JsonConverter DeserializeJsonConverter => new PolymorphicDeserializeJsonConverter<ModelX>("type");
+
+        // helpers
+
+        private static T RoundTrip<T>(Model instance)
+        {
+            var json = JsonConvert.SerializeObject(instance, SerializeJsonConverter);
+            return JsonConvert.DeserializeObject<T>(json, DeserializeJsonConverter);
+        }
+
+        private static void AssertRoundTrips<T>(T instance) where T : Model
+        {
+            var typeStatic = typeof(T);
+            var typeDynamicIn = instance.GetType();
+            var typeDynamicOut = RoundTrip<T>(instance).GetType();
+            Assert.True(typeDynamicIn == typeDynamicOut, $"Round-tripping a '{typeStatic.Name}' unexpectedly failed: '{typeDynamicIn.Name}' -> '{typeDynamicOut.Name}'");
+        }
+
+        private static void AssertRoundTripFails<T>(Model instance)
+        {
+            var typeStatic = typeof(T);
+            var typeDynamicIn = instance.GetType();
+            var typeDynamicOut = RoundTrip<T>(instance).GetType();
+            Assert.True(typeDynamicIn != typeDynamicOut, $"Round-tripping a '{typeStatic.Name}' unexpectedly succeeded: '{typeDynamicIn.Name}' -> '{typeDynamicOut.Name}'");
+        }
+
+        [Fact]
+        public void RoundTripping()
+        {
+            // Note: only Model itself succeeds since we put the discriminator on ModelX
+            AssertRoundTrips<Model>(new Model());
+            AssertRoundTripFails<Model>(new ModelX());
+            AssertRoundTripFails<Model>(new ModelXA());
+            AssertRoundTripFails<Model>(new ModelXB());
+            AssertRoundTripFails<Model>(new ModelXAA());
+            AssertRoundTripFails<Model>(new ModelXAB());
+            AssertRoundTripFails<Model>(new ModelXABA());
+            AssertRoundTripFails<Model>(new ModelXABB());
+
+            AssertRoundTripFails<ModelX>(new Model());
+            AssertRoundTrips<ModelX>(new ModelX());
+            AssertRoundTrips<ModelX>(new ModelXA());
+            AssertRoundTrips<ModelX>(new ModelXB());
+            AssertRoundTrips<ModelX>(new ModelXAA());
+            AssertRoundTrips<ModelX>(new ModelXAB());
+            AssertRoundTrips<ModelX>(new ModelXABA());
+            AssertRoundTrips<ModelX>(new ModelXABB());
+
+            AssertRoundTripFails<ModelXA>(new Model());
+            AssertRoundTripFails<ModelXA>(new ModelX());
+            AssertRoundTrips<ModelXA>(new ModelXA());
+            AssertRoundTripFails<ModelXA>(new ModelXB());
+            AssertRoundTrips<ModelXA>(new ModelXAA());
+            AssertRoundTrips<ModelXA>(new ModelXAB());
+            AssertRoundTrips<ModelXA>(new ModelXABA());
+            AssertRoundTrips<ModelXA>(new ModelXABB());
+
+            AssertRoundTripFails<ModelXB>(new Model());
+            AssertRoundTripFails<ModelXB>(new ModelX());
+            AssertRoundTripFails<ModelXB>(new ModelXA());
+            AssertRoundTrips<ModelXB>(new ModelXB());
+            AssertRoundTripFails<ModelXB>(new ModelXAA());
+            AssertRoundTripFails<ModelXB>(new ModelXAB());
+            AssertRoundTripFails<ModelXB>(new ModelXABA());
+            AssertRoundTripFails<ModelXB>(new ModelXABB());
+
+            AssertRoundTripFails<ModelXAA>(new Model());
+            AssertRoundTripFails<ModelXAA>(new ModelX());
+            AssertRoundTripFails<ModelXAA>(new ModelXA());
+            AssertRoundTripFails<ModelXAA>(new ModelXB());
+            AssertRoundTrips<ModelXAA>(new ModelXAA());
+            AssertRoundTripFails<ModelXAA>(new ModelXAB());
+            AssertRoundTripFails<ModelXAA>(new ModelXABA());
+            AssertRoundTripFails<ModelXAA>(new ModelXABB());
+
+            AssertRoundTripFails<ModelXAB>(new Model());
+            AssertRoundTripFails<ModelXAB>(new ModelX());
+            AssertRoundTripFails<ModelXAB>(new ModelXA());
+            AssertRoundTripFails<ModelXAB>(new ModelXB());
+            AssertRoundTripFails<ModelXAB>(new ModelXAA());
+            AssertRoundTrips<ModelXAB>(new ModelXAB());
+            AssertRoundTrips<ModelXAB>(new ModelXABA());
+            AssertRoundTrips<ModelXAB>(new ModelXABB());
+
+            AssertRoundTripFails<ModelXABA>(new Model());
+            AssertRoundTripFails<ModelXABA>(new ModelX());
+            AssertRoundTripFails<ModelXABA>(new ModelXA());
+            AssertRoundTripFails<ModelXABA>(new ModelXB());
+            AssertRoundTripFails<ModelXABA>(new ModelXAA());
+            AssertRoundTripFails<ModelXABA>(new ModelXAB());
+            AssertRoundTrips<ModelXABA>(new ModelXABA());
+            AssertRoundTripFails<ModelXABA>(new ModelXABB());
+
+            AssertRoundTripFails<ModelXABB>(new Model());
+            AssertRoundTripFails<ModelXABB>(new ModelX());
+            AssertRoundTripFails<ModelXABB>(new ModelXA());
+            AssertRoundTripFails<ModelXABB>(new ModelXB());
+            AssertRoundTripFails<ModelXABB>(new ModelXAA());
+            AssertRoundTripFails<ModelXABB>(new ModelXAB());
+            AssertRoundTripFails<ModelXABB>(new ModelXABA());
+            AssertRoundTrips<ModelXABB>(new ModelXABB());
+        }
+    }
+}

--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/Resources/Animal.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/Resources/Animal.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Resources
     [JsonObject("animal")]
     public class Animal
     {
+        [JsonProperty("bestFriend")]
+        public Animal BestFriend { get; set; }
+
         [JsonProperty("name")]
         public string Name { get; set; }
     }

--- a/src/SdkCommon/ClientRuntime/ClientRuntime/Serialization/PolymorphicJsonConverter.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime/Serialization/PolymorphicJsonConverter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Rest.Serialization
                 throw new ArgumentNullException("baseType");
             }
             foreach (TypeInfo type in baseType.GetTypeInfo().Assembly.DefinedTypes
-                .Where(t => t.Namespace == baseType.Namespace && t != baseType.GetTypeInfo() && t.IsSubclassOf(baseType)))
+                .Where(t => t.Namespace == baseType.Namespace && baseType.GetTypeInfo().IsAssignableFrom(t)))
             {
                 string typeName = type.Name;
                 if (type.GetCustomAttributes<JsonObjectAttribute>().Any())

--- a/tools/generate.cmd
+++ b/tools/generate.cmd
@@ -21,12 +21,13 @@ if not x%pot_help%==x%pot_help:?=% (set req_help=T)
 if not "%req_help%" == "" (
     echo.
     echo Usage: generate.cmd
-    echo             ^<RP, e.g. 'network/resource-manager'^>
+    echo             ^<service, e.g. 'network/resource-manager'^>
     echo             ^<AutoRest version, defaults to 'latest'^>
     echo             ^<GitHub user of azure-rest-api-specs repo, defaults to 'Azure'^>
-    echo             ^<Branch of azure-rest-api-specs repo, defaults to 'current'^>
+    echo             ^<Branch or commit ID of azure-rest-api-specs repo, defaults to 'current'^>
     echo.
     echo Example: generate.cmd monitor/data-plane 1.1.0 olydis new-cool-feature
+    echo Note: If you are calling an SDK's generate.cmd, the first parameter is already provided for you.
     echo.
     echo To display this help, run either of
     echo      generate.cmd help

--- a/tools/generate.cmd
+++ b/tools/generate.cmd
@@ -9,6 +9,10 @@ setlocal
 :: help requested?
 set pot_help=%1%2
 if "%pot_help%"==""            (set req_help=T)
+if "%2"=="help"                (set req_help=T)
+if "%2"=="-help"               (set req_help=T)
+if "%2"=="--help"              (set req_help=T)
+if "%2"=="/help"               (set req_help=T)
 if "%pot_help%"=="help"        (set req_help=T)
 if "%pot_help%"=="-help"       (set req_help=T)
 if "%pot_help%"=="--help"      (set req_help=T)
@@ -25,7 +29,6 @@ if not "%req_help%" == "" (
     echo Example: generate.cmd monitor/data-plane 1.1.0 olydis new-cool-feature
     echo.
     echo To display this help, run either of
-    echo      generate.cmd
     echo      generate.cmd help
     echo      generate.cmd -help
     echo      generate.cmd --help

--- a/tools/generateMetadata.ps1
+++ b/tools/generateMetadata.ps1
@@ -4,7 +4,14 @@ Write-Host ""
 Write-Host "1) azure-rest-api-specs repository information"
 Write-Host "GitHub user:" $Args[0]
 Write-Host "Branch:     " $Args[1]
-Write-Host "Commit:     " (Invoke-RestMethod "https://api.github.com/repos/$($Args[0])/azure-rest-api-specs/branches/$($Args[1])").commit.sha
+Try
+{
+    Write-Host "Commit:     " (Invoke-RestMethod "https://api.github.com/repos/$($Args[0])/azure-rest-api-specs/branches/$($Args[1])").commit.sha
+}
+Catch
+{
+    # if the above REST call fails, a commit ID was passed, so we already got the information we need
+}
 
 Write-Host ""
 Write-Host "2) AutoRest information"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

# Issue 1 (see 1st commit for repro): Multi-level inheritance
Happens when `<static type of property> != <base type> && <static type of property> != <leaf type> && <dynamic type of property> == <leaf type>`
Then `<dynamic type of property> != <leaf type>` after round trip.

### Description
Polymorphic deserialization has broken cases. Consider the following scenario:
``` C#
class A {}
class B : A {}
class C : B {}
```

An API method returning an `A` will call `JsonConvert.DeserializeObject<A>(...response body...)`. The `PolymorphicDeserializeJsonConverter` we have will *successfully* deserialize objects of dynamic type `A`, `B` and `C` using the discriminator.
Now, there may be another API method returning `B`. AutoRest will (reasonably) emit `JsonConvert.DeserializeObject<B>(...response body...)`. Note that the service may return an object of dynamic type `B` or `C`. However, `PolymorphicDeserializeJsonConverter` will not be aware that it *still applies* so we will always deserialize into `B`!

### Summary
Current behavior: `PolymorphicDeserializeJsonConverter` only works correctly for `JsonConvert.DeserializeObject<T>` where `T = <root type>` (the root type is the type that the `discriminator` was declared on)
Expected behavior: `PolymorphicDeserializeJsonConverter` works correctly for `JsonConvert.DeserializeObject<T>` where `T : <root type>`, i.e. `T` is any type in the inheritance hierarchy.

Note that this problem is only exposed for hierarchies of depth at least 2 since otherwise you are dealing with either the root type (which the converter works fine for) or a leaf type (which works fine natively).

Related issue: https://github.com/Azure/autorest/issues/2430

# Issue 2 (see 2nd commit for repro): Polymorphic property on base class of polymorphic hierarchy
Happens when `<static type of property's declaring class> == <base type> && <dynamic type of property's declaring class> == <base type> && <dynamic type of property> != <static type of property>`
Then `<dynamic type of property> == <static type of property>` after round trip.

### Description
Consider the following scenario:
``` C#
class A { public A Friend { get; set; } }
class B : A {}
```

Then

``` C#
new A { Friend = new A() } // round trips
new A { Friend = new B() } // fails round trip ("Friend" will have dyn. type A!)
new B { Friend = new A() } // round trips
new B { Friend = new B() } // round trips
```

### Summary
When polymorphic types are deserialized and the base type is detected (above: `A`), the object is deserialized with the default deserializer, i.e. without passing along the polymorphic deserializer.
As a result, any properties (transitively) of the object will be naively deserialized into their static types.


<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.
