### PR TITLE
Network watcher sample

### DIFF
--- a/Samples/Network/ManageNetworkWatcher.cs
+++ b/Samples/Network/ManageNetworkWatcher.cs
@@ -1,0 +1,283 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.Management.Compute.Fluent;
+using Microsoft.Azure.Management.Compute.Fluent.Models;
+using Microsoft.Azure.Management.Fluent;
+using Microsoft.Azure.Management.Network.Fluent;
+using Microsoft.Azure.Management.Network.Fluent.Models;
+using Microsoft.Azure.Management.ResourceManager.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+using Microsoft.Azure.Management.Samples.Common;
+using Microsoft.Azure.Management.Storage.Fluent;
+
+namespace ManageNetworkWatcher
+{
+    public class Program
+    {
+        private static readonly string ResourceGroupName = SdkContext.RandomResourceName("rgNEMV", 24);
+        private static readonly Region region = Region.USWestCentral;
+
+        /**
+         * Azure Network sample for managing network watcher -
+         *  - Create Network Watcher
+         *	- Manage packet capture – track traffic to and from a virtual machine
+         *   	Create a VM
+         *      Start a packet capture
+         *      Stop a packet capture
+         *      Get a packet capture
+         *      Delete a packet capture
+         *      Download a packet capture
+         *  - Verify IP flow – verify if traffic is allowed to or from a virtual machine
+         *      Get the IP address of a NIC on a virtual machine
+         *      Test IP flow on the NIC
+         *  - Analyze next hop – get the next hop type and IP address for a virtual machine
+         *  - Retrieve network topology for a resource group
+         *  - Analyze Virtual Machine Security by examining effective network security rules applied to a VM
+         *      Get security group view for the VM
+         *  - Configure Network Security Group Flow Logs
+         *      Get flow log settings
+         *      Enable NSG flow log
+         *      Disable NSG flow log
+         *      Download a flow log
+         *  - Delete network watcher
+         */
+        public static void RunSample(IAzure azure)
+        {
+            string nwName = SdkContext.RandomResourceName("nw", 8);
+
+            string userName = "tirekicker";
+            string vnetName = SdkContext.RandomResourceName("vnet", 20);
+            string subnetName = "subnet1";
+            string nsgName = SdkContext.RandomResourceName("nsg", 20);
+            string dnsLabel = SdkContext.RandomResourceName("pipdns", 20);
+            string rgName = SdkContext.RandomResourceName("rg", 24);
+            string saName = SdkContext.RandomResourceName("sa", 24);
+            string vmName = SdkContext.RandomResourceName("vm", 24);
+            string packetCaptureName = SdkContext.RandomResourceName("pc", 8);
+            INetworkWatcher nw = null;
+            try
+            {
+                //============================================================
+                // Create network watcher
+                Utilities.Log("Creating network watcher...");
+                nw = azure.NetworkWatchers.Define(nwName)
+                    .WithRegion(region)
+                    .WithNewResourceGroup()
+                    .Create();
+
+                Utilities.Log("Created network watcher");
+                // Print the network watcher
+                Utilities.Print(nw);
+
+                //============================================================
+                // Manage packet capture – track traffic to and from a virtual machine
+
+                // Create network security group, virtual network and VM; add packetCapture extension to enable packet capture
+                Utilities.Log("Creating network security group...");
+                INetworkSecurityGroup nsg = azure.NetworkSecurityGroups.Define(nsgName)
+                    .WithRegion(region)
+                    .WithNewResourceGroup(rgName)
+                    .DefineRule("DenyInternetInComing")
+                        .DenyInbound()
+                        .FromAddress("INTERNET")
+                        .FromAnyPort()
+                        .ToAnyAddress()
+                        .ToPort(443)
+                        .WithAnyProtocol()
+                        .Attach()
+                    .Create();
+                Utilities.Log("Creating virtual network...");
+                INetwork virtualNetwork = azure.Networks.Define(vnetName)
+                    .WithRegion(region)
+                    .WithExistingResourceGroup(rgName)
+                    .WithAddressSpace("192.168.0.0/16")
+                    .DefineSubnet(subnetName)
+                        .WithAddressPrefix("192.168.2.0/24")
+                        .WithExistingNetworkSecurityGroup(nsg)
+                        .Attach()
+                    .Create();
+                Utilities.Log("Creating virtual machine...");
+                IVirtualMachine vm = azure.VirtualMachines.Define(vmName)
+                    .WithRegion(region)
+                    .WithExistingResourceGroup(rgName)
+                    .WithExistingPrimaryNetwork(virtualNetwork)
+                    .WithSubnet(subnetName)
+                    .WithPrimaryPrivateIPAddressDynamic()
+                    .WithNewPrimaryPublicIPAddress(dnsLabel)
+                    .WithPopularLinuxImage(KnownLinuxVirtualMachineImage.UbuntuServer14_04_Lts)
+                    .WithRootUsername(userName)
+                    .WithRootPassword("Abcdef.123456")
+                    .WithSize(VirtualMachineSizeTypes.StandardA1)
+                    .DefineNewExtension("packetCapture")
+                        .WithPublisher("Microsoft.Azure.NetworkWatcher")
+                        .WithType("NetworkWatcherAgentLinux")
+                        .WithVersion("1.4")
+                        .WithMinorVersionAutoUpgrade()
+                        .Attach()
+                    .Create();
+
+                // Create storage account
+                Utilities.Log("Creating storage account...");
+                IStorageAccount storageAccount = azure.StorageAccounts.Define(saName)
+                    .WithRegion(region)
+                    .WithExistingResourceGroup(rgName)
+                    .Create();
+
+                // Start a packet capture
+                Utilities.Log("Creating packet capture...");
+                IPacketCapture packetCapture = nw.PacketCaptures
+                    .Define(packetCaptureName)
+                    .WithTarget(vm.Id)
+                    .WithStorageAccountId(storageAccount.Id)
+                    .WithTimeLimitInSeconds(1500)
+                    .DefinePacketCaptureFilter
+                        .WithProtocol(PcProtocol.TCP)
+                        .WithLocalIPAddresses(new List<string>() { "127.0.0.1", "127.0.0.5" })
+                        .Attach()
+                    .Create();
+                Utilities.Log("Created packet capture");
+                Utilities.Print(packetCapture);
+
+                // Stop a packet capture
+                Utilities.Log("Stopping packet capture...");
+                packetCapture.Stop();
+                Utilities.Print(packetCapture);
+
+                // Get a packet capture
+                Utilities.Log("Getting packet capture...");
+                IPacketCapture packetCapture1 = nw.PacketCaptures.GetByName(packetCaptureName);
+                Utilities.Print(packetCapture1);
+
+                // Delete a packet capture
+                Utilities.Log("Deleting packet capture");
+                nw.PacketCaptures.DeleteByName(packetCapture.Name);
+
+                // Download a packet capture
+
+
+                //============================================================
+                // Verify IP flow – verify if traffic is allowed to or from a virtual machine
+                // Get the IP address of a NIC on a virtual machine
+                String ipAddress = vm.GetPrimaryNetworkInterface().PrimaryPrivateIP;
+                // Test IP flow on the NIC
+                Utilities.Log("Verifying IP flow for vm id " + vm.Id + "...");
+                IVerificationIPFlow verificationIPFlow = nw.VerifyIPFlow
+                    .WithTargetResourceId(vm.Id)
+                    .WithDirection(Direction.Outbound)
+                    .WithProtocol(Protocol.TCP)
+                    .WithLocalIPAddress(ipAddress)
+                    .WithRemoteIPAddress("8.8.8.8")
+                    .WithLocalPort("443")
+                    .WithRemotePort("443")
+                    .Execute();
+                Utilities.Print(verificationIPFlow);
+
+                //============================================================
+                // Analyze next hop – get the next hop type and IP address for a virtual machine
+                Utilities.Log("Calculating next hop...");
+                INextHop nextHop = nw.NextHop.WithTargetResourceId(vm.Id)
+                    .WithSourceIPAddress(ipAddress)
+                    .WithDestinationIPAddress("8.8.8.8")
+                    .Execute();
+                Utilities.Print(nextHop);
+
+                //============================================================
+                // Retrieve network topology for a resource group
+                Utilities.Log("Getting topology...");
+                ITopology topology = nw.GetTopology(rgName);
+                Utilities.Print(topology);
+
+                //============================================================
+                // Analyze Virtual Machine Security by examining effective network security rules applied to a VM
+                // Get security group view for the VM
+                Utilities.Log("Getting security group view for a vm");
+                ISecurityGroupView sgViewResult = nw.GetSecurityGroupView(vm.Id);
+                Utilities.Print(sgViewResult);
+
+                //============================================================
+                // Configure Network Security Group Flow Logs
+
+                // Get flow log settings
+                IFlowLogSettings flowLogSettings =
+                    nw.GetFlowLogSettings(vm.GetPrimaryNetworkInterface().NetworkSecurityGroupId);
+                Utilities.Print(flowLogSettings);
+
+                // Enable NSG flow log
+                flowLogSettings.Update()
+                    .WithLogging()
+                    .WithStorageAccount(storageAccount.Id)
+                    .WithRetentionPolicyDays(5)
+                    .WithRetentionPolicyEnabled()
+                    .Apply();
+                Utilities.Print(flowLogSettings);
+
+                // Disable NSG flow log
+                flowLogSettings.Update()
+                    .WithoutLogging()
+                    .Apply();
+                Utilities.Print(flowLogSettings);
+
+                // Download a flow log
+
+                //============================================================
+                // Delete network watcher
+                Utilities.Log("Deleting network watcher");
+                azure.NetworkWatchers.DeleteById(nw.Id);
+                Utilities.Log("Deleted network watcher");
+            }
+            finally
+            {
+                try
+                {
+                    if (nw != null)
+                    {
+                        Utilities.Log("Deleting network watcher: " + nw.Name);
+                        azure.NetworkWatchers.DeleteById(nw.Id);
+                    }
+                    Utilities.Log("Deleting Resource Group: " + rgName);
+                    azure.ResourceGroups.DeleteByName(rgName);
+                    Utilities.Log("Deleted Resource Group: " + rgName);
+                }
+                catch (NullReferenceException)
+                {
+                    Utilities.Log("Did not create any resources in Azure. No clean up is necessary");
+                }
+                catch (Exception ex)
+                {
+                    Utilities.Log(ex);
+                }
+            }
+        }
+
+        public static void Main(string[] args)
+        {
+            try
+            {
+                //=================================================================
+                // Authenticate
+                var credentials =
+                    SdkContext.AzureCredentialsFactory.FromFile(
+                        Environment.GetEnvironmentVariable("AZURE_AUTH_LOCATION"));
+
+                var azure = Azure.Configure()
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
+                    .Authenticate(credentials)
+                    .WithDefaultSubscription();
+
+                // Print selected subscription
+                Utilities.Log("Selected subscription: " + azure.SubscriptionId);
+                RunSample(azure);
+            }
+            catch (Exception ex)
+            {
+                Utilities.Log(ex);
+            }
+        }
+    }
+}

--- a/Samples/Utilities.cs
+++ b/Samples/Utilities.cs
@@ -1830,8 +1830,12 @@ namespace Microsoft.Azure.Management.Samples.Common
                 }
                 sb.Append("\n\t\tSubnet:").Append(sgni.SecurityRuleAssociations.SubnetAssociation.Id);
                 printSecurityRule(sb, sgni.SecurityRuleAssociations.SubnetAssociation.SecurityRules);
-                sb.Append("\n\t\tNetwork interface:").Append(sgni.SecurityRuleAssociations.NetworkInterfaceAssociation.Id);
-                printSecurityRule(sb, sgni.SecurityRuleAssociations.NetworkInterfaceAssociation.SecurityRules);
+                if (sgni.SecurityRuleAssociations.NetworkInterfaceAssociation != null)
+                {
+                    sb.Append("\n\t\tNetwork interface:")
+                        .Append(sgni.SecurityRuleAssociations.NetworkInterfaceAssociation.Id);
+                    printSecurityRule(sb, sgni.SecurityRuleAssociations.NetworkInterfaceAssociation.SecurityRules);
+                }
                 sb.Append("\n\t\tDefault security rules:");
                 printSecurityRule(sb, sgni.SecurityRuleAssociations.DefaultSecurityRules);
             }
@@ -1854,6 +1858,15 @@ namespace Microsoft.Azure.Management.Samples.Common
                     .Append("\n\t\t\tDescription: ").Append(rule.Description)
                     .Append("\n\t\t\tProvisioning state: ").Append(rule.ProvisioningState);
             }
+        }
+
+        public static void Print(INextHop resource)
+        {
+            StringBuilder sb = new StringBuilder("Next hop: ")
+                .Append("Next hop type: ").Append(resource.NextHopType)
+                .Append("\n\tNext hop ip address: ").Append(resource.NextHopIpAddress)
+                .Append("\n\tRoute table id: ").Append(resource.RouteTableId);
+            Utilities.Log(sb.ToString());
         }
 
         public static void CreateCertificate(string domainName, string pfxPath, string password)

--- a/Samples/Utilities.cs
+++ b/Samples/Utilities.cs
@@ -37,6 +37,7 @@ using Microsoft.Azure.Management.DocumentDB.Fluent.Models;
 using Microsoft.Azure.Management.Compute.Fluent.Models;
 using Microsoft.Azure.Management.Graph.RBAC.Fluent;
 using Microsoft.Azure.Management.Graph.RBAC.Fluent.Models;
+using Microsoft.Azure.Management.Network.Fluent.Models;
 
 namespace Microsoft.Azure.Management.Samples.Common
 {
@@ -1729,6 +1730,130 @@ namespace Microsoft.Azure.Management.Samples.Common
                 .Append("\n\tPrincipal Id: ").Append(roleAssignment.PrincipalId)
                 .Append("\n\tRole Definition Id: ").Append(roleAssignment.RoleDefinitionId);
             Utilities.Log(builder.ToString());
+        }
+
+        public static void Print(INetworkWatcher nw)
+        {
+            StringBuilder builder = new StringBuilder()
+                .Append("Network Watcher: ").Append(nw.Id)
+                .Append("\n\tName: ").Append(nw.Name)
+                .Append("\n\tResource group name: ").Append(nw.ResourceGroupName)
+                .Append("\n\tRegion name: ").Append(nw.RegionName);
+            Utilities.Log(builder.ToString());
+        }
+
+        public static void Print(IPacketCapture resource)
+        {
+            StringBuilder sb = new StringBuilder().Append("Packet Capture: ").Append(resource.Id)
+                .Append("\n\tName: ").Append(resource.Name)
+                .Append("\n\tTarget id: ").Append(resource.TargetId)
+                .Append("\n\tTime limit in seconds: ").Append(resource.TimeLimitInSeconds)
+                .Append("\n\tBytes to capture per packet: ").Append(resource.BytesToCapturePerPacket)
+                .Append("\n\tProvisioning state: ").Append(resource.ProvisioningState)
+                .Append("\n\tStorage location:")
+                .Append("\n\tStorage account id: ").Append(resource.StorageLocation.StorageId)
+                .Append("\n\tStorage account path: ").Append(resource.StorageLocation.StoragePath)
+                .Append("\n\tFile path: ").Append(resource.StorageLocation.FilePath)
+                .Append("\n\t Packet capture filters: ").Append(resource.Filters.Count);
+            foreach (var filter in resource.Filters)
+            {
+                sb.Append("\n\t\tProtocol: ").Append(filter.Protocol);
+                sb.Append("\n\t\tLocal IP address: ").Append(filter.LocalIPAddress);
+                sb.Append("\n\t\tRemote IP address: ").Append(filter.RemoteIPAddress);
+                sb.Append("\n\t\tLocal port: ").Append(filter.LocalPort);
+                sb.Append("\n\t\tRemote port: ").Append(filter.RemotePort);
+            }
+            Utilities.Log(sb.ToString());
+        }
+
+        public static void Print(IVerificationIPFlow resource)
+        {
+            Utilities.Log(new StringBuilder("IP flow verification: ")
+                .Append("\n\tAccess: ").Append(resource.Access)
+                .Append("\n\tRule name: ").Append(resource.RuleName)
+                .ToString());
+        }
+
+        public static void Print(ITopology resource)
+        {
+            StringBuilder sb = new StringBuilder().Append("Topology: ").Append(resource.Id)
+                .Append("\n\tResource group: ").Append(resource.ResourceGroupName)
+                .Append("\n\tCreated time: ").Append(resource.CreatedTime)
+                .Append("\n\tLast modified time: ").Append(resource.LastModifiedTime);
+            foreach (var tr in resource.Resources.Values)
+            {
+                sb.Append("\n\tTopology resource: ").Append(tr.Id)
+                    .Append("\n\t\tName: ").Append(tr.Name)
+                    .Append("\n\t\tLocation: ").Append(tr.Location)
+                    .Append("\n\t\tAssociations:");
+                foreach (var association in tr.Associations)
+                {
+                    sb.Append("\n\t\t\tName:").Append(association.Name)
+                        .Append("\n\t\t\tResource id:").Append(association.ResourceId)
+                        .Append("\n\t\t\tAssociation type:").Append(association.AssociationType);
+                }
+            }
+            Utilities.Log(sb.ToString());
+        }
+
+        public static void Print(IFlowLogSettings resource)
+        {
+            Utilities.Log(new StringBuilder().Append("Flow log settings: ")
+                .Append("Target resource id: ").Append(resource.TargetResourceId)
+                .Append("\n\tFlow log enabled: ").Append(resource.Enabled)
+                .Append("\n\tStorage account id: ").Append(resource.StorageId)
+                .Append("\n\tRetention policy enabled: ").Append(resource.IsRetentionEnabled)
+                .Append("\n\tRetention policy days: ").Append(resource.RetentionDays)
+                .ToString());
+        }
+
+        public static void Print(ISecurityGroupView resource)
+        {
+            StringBuilder sb = new StringBuilder().Append("Security group view: ")
+                .Append("\n\tVirtual machine id: ").Append(resource.VMId);
+            foreach (var sgni in resource.NetworkInterfaces.Values)
+            {
+                sb.Append("\n\tSecurity group network interface:").Append(sgni.Id)
+                    .Append("\n\t\tSecurity group network interface:")
+                    .Append("\n\t\tEffective security rules:");
+                foreach (var rule in sgni.SecurityRuleAssociations.EffectiveSecurityRules)
+                {
+                    sb.Append("\n\t\t\tName: ").Append(rule.Name)
+                        .Append("\n\t\t\tDirection: ").Append(rule.Direction)
+                        .Append("\n\t\t\tAccess: ").Append(rule.Access)
+                        .Append("\n\t\t\tPriority: ").Append(rule.Priority)
+                        .Append("\n\t\t\tSource address prefix: ").Append(rule.SourceAddressPrefix)
+                        .Append("\n\t\t\tSource port range: ").Append(rule.SourcePortRange)
+                        .Append("\n\t\t\tDestination address prefix: ").Append(rule.DestinationAddressPrefix)
+                        .Append("\n\t\t\tDestination port range: ").Append(rule.DestinationPortRange)
+                        .Append("\n\t\t\tProtocol: ").Append(rule.Protocol);
+                }
+                sb.Append("\n\t\tSubnet:").Append(sgni.SecurityRuleAssociations.SubnetAssociation.Id);
+                printSecurityRule(sb, sgni.SecurityRuleAssociations.SubnetAssociation.SecurityRules);
+                sb.Append("\n\t\tNetwork interface:").Append(sgni.SecurityRuleAssociations.NetworkInterfaceAssociation.Id);
+                printSecurityRule(sb, sgni.SecurityRuleAssociations.NetworkInterfaceAssociation.SecurityRules);
+                sb.Append("\n\t\tDefault security rules:");
+                printSecurityRule(sb, sgni.SecurityRuleAssociations.DefaultSecurityRules);
+            }
+            Utilities.Log(sb.ToString());
+        }
+
+        private static void printSecurityRule(StringBuilder sb, IList<SecurityRuleInner> rules)
+        {
+            foreach (var rule in rules)
+            {
+                sb.Append("\n\t\t\tName: ").Append(rule.Name)
+                    .Append("\n\t\t\tDirection: ").Append(rule.Direction)
+                    .Append("\n\t\t\tAccess: ").Append(rule.Access)
+                    .Append("\n\t\t\tPriority: ").Append(rule.Priority)
+                    .Append("\n\t\t\tSource address prefix: ").Append(rule.SourceAddressPrefix)
+                    .Append("\n\t\t\tSource port range: ").Append(rule.SourcePortRange)
+                    .Append("\n\t\t\tDestination address prefix: ").Append(rule.DestinationAddressPrefix)
+                    .Append("\n\t\t\tDestination port range: ").Append(rule.DestinationPortRange)
+                    .Append("\n\t\t\tProtocol: ").Append(rule.Protocol)
+                    .Append("\n\t\t\tDescription: ").Append(rule.Description)
+                    .Append("\n\t\t\tProvisioning state: ").Append(rule.ProvisioningState);
+            }
         }
 
         public static void CreateCertificate(string domainName, string pfxPath, string password)

--- a/Tests/Samples.Tests/Network.cs
+++ b/Tests/Samples.Tests/Network.cs
@@ -101,11 +101,11 @@ namespace Samples.Tests
 
         [Fact]
         [Trait("Samples", "Network")]
-        public void ManageNetworkWatcher()
+        public void ManageNetworkWatcherTest()
         {
-/*            RunSampleAsTest(
+            RunSampleAsTest(
                 this.GetType().FullName,
-                ManageNetworkWatcher.Program.RunSample);*/
+                ManageNetworkWatcher.Program.RunSample);
         }
     }
 }

--- a/Tests/Samples.Tests/Network.cs
+++ b/Tests/Samples.Tests/Network.cs
@@ -98,5 +98,14 @@ namespace Samples.Tests
                             .GetAwaiter()
                             .GetResult());
         }
+
+        [Fact]
+        [Trait("Samples", "Network")]
+        public void ManageNetworkWatcher()
+        {
+/*            RunSampleAsTest(
+                this.GetType().FullName,
+                ManageNetworkWatcher.Program.RunSample);*/
+        }
     }
 }

--- a/Tests/Samples.Tests/SessionRecords/Samples.Tests.Network/ManageNetworkWatcherTest.json
+++ b/Tests/Samples.Tests/SessionRecords/Samples.Tests.Network/ManageNetworkWatcherTest.json
@@ -1,0 +1,3159 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/nw35590group?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL253MzU1OTBncm91cD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"westcentralus\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "35"
+        ],
+        "x-ms-client-request-id": [
+          "f346b411-6153-46c2-9f68-55edb12446b0"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group\",\r\n  \"name\": \"nw35590group\",\r\n  \"location\": \"westcentralus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "184"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:36:44 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "x-ms-request-id": [
+          "181f6fcb-9a0f-472c-a398-4b6b43cf2cfe"
+        ],
+        "x-ms-correlation-request-id": [
+          "181f6fcb-9a0f-472c-a398-4b6b43cf2cfe"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233644Z:181f6fcb-9a0f-472c-a398-4b6b43cf2cfe"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTA/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "50"
+        ],
+        "x-ms-client-request-id": [
+          "7468fd5f-6d47-4ad1-bd65-8fed9bd733e2"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"nw35590\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590\",\r\n  \"etag\": \"W/\\\"89d23c24-d1d9-4135-a8e7-1c9feb6c32e3\\\"\",\r\n  \"type\": \"Microsoft.Network/networkWatchers\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"runningOperationIds\": []\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "416"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:36:45 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "c186eee1-e6df-4185-8762-14003b2d8b36"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/c186eee1-e6df-4185-8762-14003b2d8b36?api-version=2016-12-01"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1198"
+        ],
+        "x-ms-correlation-request-id": [
+          "12809546-4008-4d1f-99e7-1c4d80d2ae78"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233645Z:12809546-4008-4d1f-99e7-1c4d80d2ae78"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rga48497025653e2a?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"westcentralus\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "35"
+        ],
+        "x-ms-client-request-id": [
+          "96128c27-6c92-4456-8c52-e54ca00920c5"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a\",\r\n  \"name\": \"rga48497025653e2a\",\r\n  \"location\": \"westcentralus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "194"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:36:45 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1197"
+        ],
+        "x-ms-request-id": [
+          "264b70fa-d263-4111-8194-4be1a6c72dc3"
+        ],
+        "x-ms-correlation-request-id": [
+          "264b70fa-d263-4111-8194-4be1a6c72dc3"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233646Z:264b70fa-d263-4111-8194-4be1a6c72dc3"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9uZXR3b3JrU2VjdXJpdHlHcm91cHMvbnNnZWIxNDUyMjAyNmVlP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"securityRules\": [\r\n      {\r\n        \"properties\": {\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"443\",\r\n          \"sourceAddressPrefix\": \"INTERNET\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 100,\r\n          \"direction\": \"Inbound\"\r\n        },\r\n        \"name\": \"DenyInternetInComing\"\r\n      }\r\n    ]\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "487"
+        ],
+        "x-ms-client-request-id": [
+          "17559eaf-a3c5-4518-9d36-81f0fca780c0"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"nsgeb14522026ee\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\",\r\n  \"etag\": \"W/\\\"3e732385-1a91-4008-ac7d-f3ae4c41fb0b\\\"\",\r\n  \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"96453dec-358f-4169-a8ac-de6fed6dc10c\",\r\n    \"securityRules\": [\r\n      {\r\n        \"name\": \"DenyInternetInComing\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/securityRules/DenyInternetInComing\",\r\n        \"etag\": \"W/\\\"3e732385-1a91-4008-ac7d-f3ae4c41fb0b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"443\",\r\n          \"sourceAddressPrefix\": \"INTERNET\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 100,\r\n          \"direction\": \"Inbound\"\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n      {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/AllowVnetInBound\",\r\n        \"etag\": \"W/\\\"3e732385-1a91-4008-ac7d-f3ae4c41fb0b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n        \"etag\": \"W/\\\"3e732385-1a91-4008-ac7d-f3ae4c41fb0b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"description\": \"Allow inbound traffic from azure load balancer\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/DenyAllInBound\",\r\n        \"etag\": \"W/\\\"3e732385-1a91-4008-ac7d-f3ae4c41fb0b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/AllowVnetOutBound\",\r\n        \"etag\": \"W/\\\"3e732385-1a91-4008-ac7d-f3ae4c41fb0b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"description\": \"Allow outbound traffic from all VMs to all VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/AllowInternetOutBound\",\r\n        \"etag\": \"W/\\\"3e732385-1a91-4008-ac7d-f3ae4c41fb0b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/DenyAllOutBound\",\r\n        \"etag\": \"W/\\\"3e732385-1a91-4008-ac7d-f3ae4c41fb0b\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\": \"Outbound\"\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "5881"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:36:46 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "10"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "1418d1f9-9e5b-4482-81fd-435e6d54c8dc"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/1418d1f9-9e5b-4482-81fd-435e6d54c8dc?api-version=2016-12-01"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1196"
+        ],
+        "x-ms-correlation-request-id": [
+          "4b79f8bb-4c8b-471a-931c-bc236cf3cf64"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233647Z:4b79f8bb-4c8b-471a-931c-bc236cf3cf64"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/1418d1f9-9e5b-4482-81fd-435e6d54c8dc?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzE0MThkMWY5LTllNWItNDQ4Mi04MWZkLTQzNWU2ZDU0YzhkYz9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"Succeeded\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:37:17 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "b0ee5553-c6d4-409e-b2fb-2b74d7882857"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14992"
+        ],
+        "x-ms-correlation-request-id": [
+          "1bf5fb28-3e16-469a-b375-0664b1b1527c"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233718Z:1bf5fb28-3e16-469a-b375-0664b1b1527c"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9uZXR3b3JrU2VjdXJpdHlHcm91cHMvbnNnZWIxNDUyMjAyNmVlP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"nsgeb14522026ee\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\",\r\n  \"etag\": \"W/\\\"a133a942-f893-4068-a191-b0b1a2eb4fe9\\\"\",\r\n  \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"96453dec-358f-4169-a8ac-de6fed6dc10c\",\r\n    \"securityRules\": [\r\n      {\r\n        \"name\": \"DenyInternetInComing\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/securityRules/DenyInternetInComing\",\r\n        \"etag\": \"W/\\\"a133a942-f893-4068-a191-b0b1a2eb4fe9\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"443\",\r\n          \"sourceAddressPrefix\": \"INTERNET\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 100,\r\n          \"direction\": \"Inbound\"\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n      {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/AllowVnetInBound\",\r\n        \"etag\": \"W/\\\"a133a942-f893-4068-a191-b0b1a2eb4fe9\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n        \"etag\": \"W/\\\"a133a942-f893-4068-a191-b0b1a2eb4fe9\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"description\": \"Allow inbound traffic from azure load balancer\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/DenyAllInBound\",\r\n        \"etag\": \"W/\\\"a133a942-f893-4068-a191-b0b1a2eb4fe9\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/AllowVnetOutBound\",\r\n        \"etag\": \"W/\\\"a133a942-f893-4068-a191-b0b1a2eb4fe9\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"description\": \"Allow outbound traffic from all VMs to all VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/AllowInternetOutBound\",\r\n        \"etag\": \"W/\\\"a133a942-f893-4068-a191-b0b1a2eb4fe9\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/defaultSecurityRules/DenyAllOutBound\",\r\n        \"etag\": \"W/\\\"a133a942-f893-4068-a191-b0b1a2eb4fe9\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\": \"Outbound\"\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:37:17 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "ETag": [
+          "W/\"a133a942-f893-4068-a191-b0b1a2eb4fe9\""
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "91ae58f0-2756-4a53-95ba-9350c51b681f"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14991"
+        ],
+        "x-ms-correlation-request-id": [
+          "94b06560-1656-4c11-8e8f-1d381979831f"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233718Z:94b06560-1656-4c11-8e8f-1d381979831f"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay92aXJ0dWFsTmV0d29ya3Mvdm5ldDIxMzA0MTI2NDlhMD9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"192.168.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"properties\": {\r\n          \"addressPrefix\": \"192.168.2.0/24\",\r\n          \"networkSecurityGroup\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\"\r\n          }\r\n        },\r\n        \"name\": \"subnet1\"\r\n      }\r\n    ]\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "598"
+        ],
+        "x-ms-client-request-id": [
+          "17704bc0-a435-47d2-b18a-b1a09a63cd19"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"vnet2130412649a0\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0\",\r\n  \"etag\": \"W/\\\"5b10ec74-890c-44d7-9075-eb4ddd457f77\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"d3c862e1-398f-4a24-a040-059bfbb87851\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"192.168.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"subnet1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0/subnets/subnet1\",\r\n        \"etag\": \"W/\\\"5b10ec74-890c-44d7-9075-eb4ddd457f77\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Updating\",\r\n          \"addressPrefix\": \"192.168.2.0/24\",\r\n          \"networkSecurityGroup\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "1313"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:37:18 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "3"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "14bbcc63-c9c7-4991-9e25-086fdb1ab3d9"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/14bbcc63-c9c7-4991-9e25-086fdb1ab3d9?api-version=2016-12-01"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1195"
+        ],
+        "x-ms-correlation-request-id": [
+          "7e1e8187-88ec-4770-a0f8-bdb996c8f78c"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233719Z:7e1e8187-88ec-4770-a0f8-bdb996c8f78c"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/publicIPAddresses/pipeaf23258e0?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9waXBlYWYyMzI1OGUwP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"pipdns1ce64793f5e\"\r\n    }\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "150"
+        ],
+        "x-ms-client-request-id": [
+          "c6c7d93a-7f71-4b63-899f-aa9be4c7d311"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"pipeaf23258e0\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/publicIPAddresses/pipeaf23258e0\",\r\n  \"etag\": \"W/\\\"25102d96-f482-468b-97de-bce4b90fa278\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"c5312c38-b813-411f-83b0-750a6d122c1a\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"pipdns1ce64793f5e\",\r\n      \"fqdn\": \"pipdns1ce64793f5e.westcentralus.cloudapp.azure.com\"\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "725"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:37:20 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "3"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "af29e42e-3468-48e1-8b85-f773e0fade4c"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/af29e42e-3468-48e1-8b85-f773e0fade4c?api-version=2016-12-01"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "x-ms-correlation-request-id": [
+          "b48c1d98-6203-4785-9ff1-733a3dd190aa"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233720Z:b48c1d98-6203-4785-9ff1-733a3dd190aa"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/14bbcc63-c9c7-4991-9e25-086fdb1ab3d9?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzE0YmJjYzYzLWM5YzctNDk5MS05ZTI1LTA4NmZkYjFhYjNkOT9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"Succeeded\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:37:48 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "04c594ac-f668-4a33-ab3e-062c6335a3bd"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14990"
+        ],
+        "x-ms-correlation-request-id": [
+          "4c149e5b-6c09-4a7d-8ee8-cb01944c1e38"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233749Z:4c149e5b-6c09-4a7d-8ee8-cb01944c1e38"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay92aXJ0dWFsTmV0d29ya3Mvdm5ldDIxMzA0MTI2NDlhMD9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"vnet2130412649a0\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0\",\r\n  \"etag\": \"W/\\\"d1830370-dcd2-4f52-840b-ff92108f1952\\\"\",\r\n  \"type\": \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"d3c862e1-398f-4a24-a040-059bfbb87851\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"192.168.0.0/16\"\r\n      ]\r\n    },\r\n    \"dhcpOptions\": {\r\n      \"dnsServers\": []\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"subnet1\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0/subnets/subnet1\",\r\n        \"etag\": \"W/\\\"d1830370-dcd2-4f52-840b-ff92108f1952\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"addressPrefix\": \"192.168.2.0/24\",\r\n          \"networkSecurityGroup\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\": []\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:37:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "ETag": [
+          "W/\"d1830370-dcd2-4f52-840b-ff92108f1952\""
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "03fc37eb-a4e9-429f-ada2-ec1ff38781c6"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14991"
+        ],
+        "x-ms-correlation-request-id": [
+          "6aa80db9-66e2-4edd-96fb-81d67eb58ad5"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233749Z:6aa80db9-66e2-4edd-96fb-81d67eb58ad5"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/af29e42e-3468-48e1-8b85-f773e0fade4c?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2FmMjllNDJlLTM0NjgtNDhlMS04Yjg1LWY3NzNlMGZhZGU0Yz9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"Succeeded\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:37:49 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "13e7948b-b103-4538-b774-8c163521e398"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14989"
+        ],
+        "x-ms-correlation-request-id": [
+          "c3a3259c-22dd-466e-b517-28578f124bcb"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233750Z:c3a3259c-22dd-466e-b517-28578f124bcb"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/publicIPAddresses/pipeaf23258e0?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9waXBlYWYyMzI1OGUwP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"pipeaf23258e0\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/publicIPAddresses/pipeaf23258e0\",\r\n  \"etag\": \"W/\\\"d610e42c-167b-4a01-84c4-6491077bc344\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"c5312c38-b813-411f-83b0-750a6d122c1a\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"pipdns1ce64793f5e\",\r\n      \"fqdn\": \"pipdns1ce64793f5e.westcentralus.cloudapp.azure.com\"\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:37:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "ETag": [
+          "W/\"d610e42c-167b-4a01-84c4-6491077bc344\""
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "95cddc3a-93d3-4991-ba72-c91c75511c93"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14990"
+        ],
+        "x-ms-correlation-request-id": [
+          "ce187230-bd73-41e0-beab-14df4fdfec50"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233750Z:ce187230-bd73-41e0-beab-14df4fdfec50"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9uZXR3b3JrSW50ZXJmYWNlcy9uaWMzMzk2MTUwNGVhNT9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"properties\": {\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0/subnets/subnet1\"\r\n          },\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/publicIPAddresses/pipeaf23258e0\"\r\n          }\r\n        },\r\n        \"name\": \"primary\"\r\n      }\r\n    ],\r\n    \"dnsSettings\": {}\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "697"
+        ],
+        "x-ms-client-request-id": [
+          "741242c1-208b-4b6c-8b84-4fb78c4bb65a"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"nic33961504ea5\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5\",\r\n  \"etag\": \"W/\\\"f7c7dc66-6923-42fb-b436-768d406d5e31\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"dd901eb1-45d5-49fc-9b96-b8caaf423cb1\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"f7c7dc66-6923-42fb-b436-768d406d5e31\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"192.168.2.4\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/publicIPAddresses/pipeaf23258e0\"\r\n          },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"2frmru2phesevicaawn5xodykb.yx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "1737"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:37:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "7bb8131f-823b-472d-ab08-e23864c0e3ab"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/7bb8131f-823b-472d-ab08-e23864c0e3ab?api-version=2016-12-01"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1194"
+        ],
+        "x-ms-correlation-request-id": [
+          "76e5eb45-e6ad-4c97-933b-e1d125093085"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233751Z:76e5eb45-e6ad-4c97-933b-e1d125093085"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9uZXR3b3JrSW50ZXJmYWNlcy9uaWMzMzk2MTUwNGVhNT9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"nic33961504ea5\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5\",\r\n  \"etag\": \"W/\\\"f7c7dc66-6923-42fb-b436-768d406d5e31\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"dd901eb1-45d5-49fc-9b96-b8caaf423cb1\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"f7c7dc66-6923-42fb-b436-768d406d5e31\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"192.168.2.4\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/publicIPAddresses/pipeaf23258e0\"\r\n          },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"2frmru2phesevicaawn5xodykb.yx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:37:51 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "ETag": [
+          "W/\"f7c7dc66-6923-42fb-b436-768d406d5e31\""
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "afc3c424-50a7-4b88-8435-8957925ab0a1"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14989"
+        ],
+        "x-ms-correlation-request-id": [
+          "79e2d9f9-75e1-44ca-b284-9a027334acfb"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233751Z:79e2d9f9-75e1-44ca-b284-9a027334acfb"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9uZXR3b3JrSW50ZXJmYWNlcy9uaWMzMzk2MTUwNGVhNT9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "a06c8e63-511b-4dfc-9fd3-4359a1aea8b3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"nic33961504ea5\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5\",\r\n  \"etag\": \"W/\\\"ee7f058d-c125-412b-8c44-14c1da1cbead\\\"\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"dd901eb1-45d5-49fc-9b96-b8caaf423cb1\",\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"primary\",\r\n        \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5/ipConfigurations/primary\",\r\n        \"etag\": \"W/\\\"ee7f058d-c125-412b-8c44-14c1da1cbead\\\"\",\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"privateIPAddress\": \"192.168.2.4\",\r\n          \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/publicIPAddresses/pipeaf23258e0\"\r\n          },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0/subnets/subnet1\"\r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\": \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\": \"2frmru2phesevicaawn5xodykb.yx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\": \"00-0D-3A-F8-E8-01\",\r\n    \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\": false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\"\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:44:16 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "ETag": [
+          "W/\"ee7f058d-c125-412b-8c44-14c1da1cbead\""
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "a7b6f672-a92a-44ad-9d77-656dbee78b30"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14972"
+        ],
+        "x-ms-correlation-request-id": [
+          "c908c642-225e-4a97-aa80-461a195a0a26"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234417Z:c908c642-225e-4a97-aa80-461a195a0a26"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZXMvdm1mNTg3ODAxNTIyZmQ4OTA/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_A1\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"caching\": \"ReadWrite\",\r\n        \"createOption\": \"fromImage\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\r\n        }\r\n      }\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm8fa4640777\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"adminPassword\": \"Abcdef.123456\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      }\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"properties\": {\r\n            \"primary\": true\r\n          },\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5\"\r\n        }\r\n      ]\r\n    }\r\n  },\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "1085"
+        ],
+        "x-ms-client-request-id": [
+          "8427be99-8003-48a5-af23-296c3807b72a"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"f199b89a-a925-4e8d-9f09-c0b434f91ac1\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_A1\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\"\r\n        }\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm8fa4640777\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\",\r\n  \"name\": \"vmf587801522fd890\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "1352"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:37:52 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/ae5ccf65-b6d2-44bc-b127-5e3aef53e337?api-version=2016-04-30-preview"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131441992991038721"
+        ],
+        "x-ms-request-id": [
+          "ae5ccf65-b6d2-44bc-b127-5e3aef53e337"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1193"
+        ],
+        "x-ms-correlation-request-id": [
+          "5385efe3-b616-4f6f-95d7-eb15897afb3b"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233752Z:5385efe3-b616-4f6f-95d7-eb15897afb3b"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/ae5ccf65-b6d2-44bc-b127-5e3aef53e337?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2FlNWNjZjY1LWI2ZDItNDRiYy1iMTI3LTVlM2FlZjUzZTMzNz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-07-25T16:37:52.6544567-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"ae5ccf65-b6d2-44bc-b127-5e3aef53e337\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:38:22 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131441992991038721"
+        ],
+        "x-ms-request-id": [
+          "082b0b3d-7f4e-4414-a9c9-98797a1b404d"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14988"
+        ],
+        "x-ms-correlation-request-id": [
+          "78ac4018-d1dc-4943-b8bb-4c51d526f415"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233823Z:78ac4018-d1dc-4943-b8bb-4c51d526f415"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/ae5ccf65-b6d2-44bc-b127-5e3aef53e337?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2FlNWNjZjY1LWI2ZDItNDRiYy1iMTI3LTVlM2FlZjUzZTMzNz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-07-25T16:37:52.6544567-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"ae5ccf65-b6d2-44bc-b127-5e3aef53e337\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:38:52 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131441992991038721"
+        ],
+        "x-ms-request-id": [
+          "99193ca7-d6a8-4022-9608-821df5a92a18"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14987"
+        ],
+        "x-ms-correlation-request-id": [
+          "0dfe24d1-44b2-4ed6-8237-eaea4bc99edb"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233853Z:0dfe24d1-44b2-4ed6-8237-eaea4bc99edb"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/ae5ccf65-b6d2-44bc-b127-5e3aef53e337?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zL2FlNWNjZjY1LWI2ZDItNDRiYy1iMTI3LTVlM2FlZjUzZTMzNz9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-07-25T16:37:52.6544567-07:00\",\r\n  \"endTime\": \"2017-07-25T16:39:21.4345596-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"ae5ccf65-b6d2-44bc-b127-5e3aef53e337\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:39:22 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131441992991038721"
+        ],
+        "x-ms-request-id": [
+          "41cf8a9b-a13c-42af-9b46-a39547c48035"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14986"
+        ],
+        "x-ms-correlation-request-id": [
+          "a0b9281c-45be-45dc-bf1d-955e9176ca68"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233923Z:a0b9281c-45be-45dc-bf1d-955e9176ca68"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZXMvdm1mNTg3ODAxNTIyZmQ4OTA/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"f199b89a-a925-4e8d-9f09-c0b434f91ac1\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_A1\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"vmf587801522fd890_OsDisk_1_06d96e0b491747afa6c52b022e07b8e5\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/disks/vmf587801522fd890_OsDisk_1_06d96e0b491747afa6c52b022e07b8e5\"\r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm8fa4640777\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\",\r\n  \"name\": \"vmf587801522fd890\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:39:22 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131441992991038721"
+        ],
+        "x-ms-request-id": [
+          "3130a872-5a2b-4764-b4fb-08fb87f38ffe"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14985"
+        ],
+        "x-ms-correlation-request-id": [
+          "b6b51762-2a8c-4074-acda-196be86f02c7"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233923Z:b6b51762-2a8c-4074-acda-196be86f02c7"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZXMvdm1mNTg3ODAxNTIyZmQ4OTA/YXBpLXZlcnNpb249MjAxNi0wNC0zMC1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "0d21252c-cd69-4ed5-9b76-3b6cfffa0e49"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"vmId\": \"f199b89a-a925-4e8d-9f09-c0b434f91ac1\",\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_A1\"\r\n    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\",\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\": \"vmf587801522fd890_OsDisk_1_06d96e0b491747afa6c52b022e07b8e5\",\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Standard_LRS\",\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/disks/vmf587801522fd890_OsDisk_1_06d96e0b491747afa6c52b022e07b8e5\"\r\n        },\r\n        \"diskSizeGB\": 30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"vm8fa4640777\",\r\n      \"adminUsername\": \"tirekicker\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\": {\r\n      \"networkInterfaces\": [\r\n        {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5\",\r\n          \"properties\": {\r\n            \"primary\": true\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\": \"Microsoft.Azure.NetworkWatcher\",\r\n        \"type\": \"NetworkWatcherAgentLinux\",\r\n        \"typeHandlerVersion\": \"1.4\",\r\n        \"autoUpgradeMinorVersion\": true,\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"westcentralus\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890/extensions/packetCapture\",\r\n      \"name\": \"packetCapture\"\r\n    }\r\n  ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\",\r\n  \"name\": \"vmf587801522fd890\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:40:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131441992991038721"
+        ],
+        "x-ms-request-id": [
+          "8d1f360d-3201-4ac9-a3e7-010d8d84b453"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14980"
+        ],
+        "x-ms-correlation-request-id": [
+          "54d9199f-8ec9-4f14-92f7-dfbe7f257240"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234055Z:54d9199f-8ec9-4f14-92f7-dfbe7f257240"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890/extensions/packetCapture?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZXMvdm1mNTg3ODAxNTIyZmQ4OTAvZXh0ZW5zaW9ucy9wYWNrZXRDYXB0dXJlP2FwaS12ZXJzaW9uPTIwMTYtMDQtMzAtcHJldmlldw==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.NetworkWatcher\",\r\n    \"type\": \"NetworkWatcherAgentLinux\",\r\n    \"typeHandlerVersion\": \"1.4\",\r\n    \"autoUpgradeMinorVersion\": true\r\n  },\r\n  \"location\": \"westcentralus\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "224"
+        ],
+        "x-ms-client-request-id": [
+          "a74f6660-a3da-4a93-9810-b3bd3f7c1ac8"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.NetworkWatcher\",\r\n    \"type\": \"NetworkWatcherAgentLinux\",\r\n    \"typeHandlerVersion\": \"1.4\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"provisioningState\": \"Creating\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n  \"location\": \"westcentralus\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890/extensions/packetCapture\",\r\n  \"name\": \"packetCapture\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "533"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:39:23 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/64f974c1-6b9a-4fe7-9285-14f8325bb5af?api-version=2016-04-30-preview"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131441992991038721"
+        ],
+        "x-ms-request-id": [
+          "64f974c1-6b9a-4fe7-9285-14f8325bb5af"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1198"
+        ],
+        "x-ms-correlation-request-id": [
+          "59cbe82b-d31f-4e06-99bc-42a5aef89afe"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233924Z:59cbe82b-d31f-4e06-99bc-42a5aef89afe"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/64f974c1-6b9a-4fe7-9285-14f8325bb5af?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzY0Zjk3NGMxLTZiOWEtNGZlNy05Mjg1LTE0ZjgzMjViYjVhZj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-07-25T16:39:24.4501579-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"64f974c1-6b9a-4fe7-9285-14f8325bb5af\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:39:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131441992991038721"
+        ],
+        "x-ms-request-id": [
+          "1a9b3942-d514-45b4-8cc8-6971ab4dadf6"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14984"
+        ],
+        "x-ms-correlation-request-id": [
+          "6e671f93-24f0-4830-ab0c-1c4a05745a00"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T233954Z:6e671f93-24f0-4830-ab0c-1c4a05745a00"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/64f974c1-6b9a-4fe7-9285-14f8325bb5af?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzY0Zjk3NGMxLTZiOWEtNGZlNy05Mjg1LTE0ZjgzMjViYjVhZj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-07-25T16:39:24.4501579-07:00\",\r\n  \"status\": \"InProgress\",\r\n  \"name\": \"64f974c1-6b9a-4fe7-9285-14f8325bb5af\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:40:24 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131441992991038721"
+        ],
+        "x-ms-request-id": [
+          "d962aa56-c38d-4979-acec-834e878ae206"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14983"
+        ],
+        "x-ms-correlation-request-id": [
+          "cff1a8f0-9b51-47fa-8b3b-70cd1c1a1c1c"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234025Z:cff1a8f0-9b51-47fa-8b3b-70cd1c1a1c1c"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Compute/locations/westcentralus/operations/64f974c1-6b9a-4fe7-9285-14f8325bb5af?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzY0Zjk3NGMxLTZiOWEtNGZlNy05Mjg1LTE0ZjgzMjViYjVhZj9hcGktdmVyc2lvbj0yMDE2LTA0LTMwLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"startTime\": \"2017-07-25T16:39:24.4501579-07:00\",\r\n  \"endTime\": \"2017-07-25T16:40:34.8554933-07:00\",\r\n  \"status\": \"Succeeded\",\r\n  \"name\": \"64f974c1-6b9a-4fe7-9285-14f8325bb5af\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:40:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131441992991038721"
+        ],
+        "x-ms-request-id": [
+          "9b63495f-e2df-4a34-b27b-1525ec29eec0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14982"
+        ],
+        "x-ms-correlation-request-id": [
+          "51ac03ef-1df8-4367-9595-a57d59b5b66b"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234055Z:51ac03ef-1df8-4367-9595-a57d59b5b66b"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890/extensions/packetCapture?api-version=2016-04-30-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29tcHV0ZS92aXJ0dWFsTWFjaGluZXMvdm1mNTg3ODAxNTIyZmQ4OTAvZXh0ZW5zaW9ucy9wYWNrZXRDYXB0dXJlP2FwaS12ZXJzaW9uPTIwMTYtMDQtMzAtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Compute.Fluent.ComputeManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"publisher\": \"Microsoft.Azure.NetworkWatcher\",\r\n    \"type\": \"NetworkWatcherAgentLinux\",\r\n    \"typeHandlerVersion\": \"1.4\",\r\n    \"autoUpgradeMinorVersion\": true,\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n  \"location\": \"westcentralus\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890/extensions/packetCapture\",\r\n  \"name\": \"packetCapture\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:40:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-served-by": [
+          "6dfd2de3-86d8-422d-aa06-a2464d5b2b43_131441992991038721"
+        ],
+        "x-ms-request-id": [
+          "596e5b55-9c12-41b3-8a98-3ec2a39ba08f"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14981"
+        ],
+        "x-ms-correlation-request-id": [
+          "e0c0e2b4-f8b2-4927-8d84-7082a66d552a"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234055Z:e0c0e2b4-f8b2-4927-8d84-7082a66d552a"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Storage/storageAccounts/saa2694916db5694b?api-version=2016-01-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3RvcmFnZS9zdG9yYWdlQWNjb3VudHMvc2FhMjY5NDkxNmRiNTY5NGI/YXBpLXZlcnNpb249MjAxNi0wMS0wMQ==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard_GRS\"\r\n  },\r\n  \"kind\": \"Storage\",\r\n  \"location\": \"westcentralus\",\r\n  \"tags\": {}\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "118"
+        ],
+        "x-ms-client-request-id": [
+          "10832572-a46e-423b-bdae-2f000881ac06"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Storage.Fluent.StorageManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:40:56 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Storage/operations/d6a772d2-5312-470b-a5c1-2622b853e4f9?monitor=true&api-version=2016-01-01"
+        ],
+        "Retry-After": [
+          "17"
+        ],
+        "Server": [
+          "Microsoft-Azure-Storage-Resource-Provider/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1197"
+        ],
+        "x-ms-request-id": [
+          "5f67a445-b0b1-4ecd-bf98-4e62ec178ca7"
+        ],
+        "x-ms-correlation-request-id": [
+          "5f67a445-b0b1-4ecd-bf98-4e62ec178ca7"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234056Z:5f67a445-b0b1-4ecd-bf98-4e62ec178ca7"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Storage/operations/d6a772d2-5312-470b-a5c1-2622b853e4f9?monitor=true&api-version=2016-01-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3RvcmFnZS9vcGVyYXRpb25zL2Q2YTc3MmQyLTUzMTItNDcwYi1hNWMxLTI2MjJiODUzZTRmOT9tb25pdG9yPXRydWUmYXBpLXZlcnNpb249MjAxNi0wMS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Storage.Fluent.StorageManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Storage/storageAccounts/saa2694916db5694b\",\r\n  \"kind\": \"Storage\",\r\n  \"location\": \"westcentralus\",\r\n  \"name\": \"saa2694916db5694b\",\r\n  \"properties\": {\r\n    \"creationTime\": \"2017-07-25T23:40:56.5511438Z\",\r\n    \"primaryEndpoints\": {\r\n      \"blob\": \"https://saa2694916db5694b.blob.core.windows.net/\",\r\n      \"file\": \"https://saa2694916db5694b.file.core.windows.net/\",\r\n      \"queue\": \"https://saa2694916db5694b.queue.core.windows.net/\",\r\n      \"table\": \"https://saa2694916db5694b.table.core.windows.net/\"\r\n    },\r\n    \"primaryLocation\": \"westcentralus\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"secondaryLocation\": \"westus2\",\r\n    \"statusOfPrimary\": \"available\",\r\n    \"statusOfSecondary\": \"available\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Standard_GRS\",\r\n    \"tier\": \"Standard\"\r\n  },\r\n  \"tags\": {},\r\n  \"type\": \"Microsoft.Storage/storageAccounts\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:41:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-Azure-Storage-Resource-Provider/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "ed018be5-d49b-4709-baf6-733e49e1bd83"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14979"
+        ],
+        "x-ms-correlation-request-id": [
+          "ed018be5-d49b-4709-baf6-733e49e1bd83"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234127Z:ed018be5-d49b-4709-baf6-733e49e1bd83"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/packetCaptures/pc31930?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvcGFja2V0Q2FwdHVyZXMvcGMzMTkzMD9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"target\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\",\r\n    \"timeLimitInSeconds\": 1500,\r\n    \"storageLocation\": {\r\n      \"storageId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Storage/storageAccounts/saa2694916db5694b\"\r\n    },\r\n    \"filters\": [\r\n      {\r\n        \"protocol\": \"TCP\"\r\n      }\r\n    ]\r\n  }\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "499"
+        ],
+        "x-ms-client-request-id": [
+          "c21211ae-3d15-44ae-9008-20bc49993471"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"pc31930\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/packetCaptures/pc31930\",\r\n  \"etag\": \"W/\\\"0e5dc430-cece-4edb-8471-2c8a411f6514\\\"\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"target\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\",\r\n    \"bytesToCapturePerPacket\": 0,\r\n    \"totalBytesPerSession\": 1073741824,\r\n    \"timeLimitInSeconds\": 1500,\r\n    \"storageLocation\": {\r\n      \"storageId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Storage/storageAccounts/saa2694916db5694b\",\r\n      \"storagePath\": \"https://saa2694916db5694b.blob.core.windows.net/network-watcher-logs/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rga48497025653e2a/providers/microsoft.compute/virtualmachines/vmf587801522fd890/2017/07/25/packetcapture_23_41_28_027.cap\"\r\n    },\r\n    \"filters\": [\r\n      {\r\n        \"protocol\": \"TCP\",\r\n        \"localIPAddress\": \"\",\r\n        \"localPort\": \"\",\r\n        \"remoteIPAddress\": \"\",\r\n        \"remotePort\": \"\"\r\n      }\r\n    ]\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "1257"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:41:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "10"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "0e6f223d-fa53-454d-93a6-d9dc9b433c8c"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/0e6f223d-fa53-454d-93a6-d9dc9b433c8c?api-version=2016-12-01"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1196"
+        ],
+        "x-ms-correlation-request-id": [
+          "dc5b317a-55d6-4048-8993-c38a37bb0dd9"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234127Z:dc5b317a-55d6-4048-8993-c38a37bb0dd9"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/0e6f223d-fa53-454d-93a6-d9dc9b433c8c?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzBlNmYyMjNkLWZhNTMtNDU0ZC05M2E2LWQ5ZGM5YjQzM2M4Yz9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:41:57 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Retry-After": [
+          "10"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "bff42500-43e8-49d2-9247-d7104ca28a6e"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14978"
+        ],
+        "x-ms-correlation-request-id": [
+          "7fd6a90f-b61f-44bb-ab8d-cc046dee9980"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234158Z:7fd6a90f-b61f-44bb-ab8d-cc046dee9980"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/0e6f223d-fa53-454d-93a6-d9dc9b433c8c?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzBlNmYyMjNkLWZhNTMtNDU0ZC05M2E2LWQ5ZGM5YjQzM2M4Yz9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"Succeeded\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:42:28 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "f7d241d8-2df2-4c2c-bca9-b82c14e7b31f"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14977"
+        ],
+        "x-ms-correlation-request-id": [
+          "735d1a96-dcdc-49f3-891b-1a1ca19095d1"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234228Z:735d1a96-dcdc-49f3-891b-1a1ca19095d1"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/packetCaptures/pc31930?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvcGFja2V0Q2FwdHVyZXMvcGMzMTkzMD9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"pc31930\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/packetCaptures/pc31930\",\r\n  \"etag\": \"W/\\\"30c44e91-af9b-4c15-a6d5-4a8648e9570e\\\"\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"target\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\",\r\n    \"bytesToCapturePerPacket\": 0,\r\n    \"totalBytesPerSession\": 1073741824,\r\n    \"timeLimitInSeconds\": 1500,\r\n    \"storageLocation\": {\r\n      \"storageId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Storage/storageAccounts/saa2694916db5694b\",\r\n      \"storagePath\": \"https://saa2694916db5694b.blob.core.windows.net/network-watcher-logs/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rga48497025653e2a/providers/microsoft.compute/virtualmachines/vmf587801522fd890/2017/07/25/packetcapture_23_41_28_027.cap\"\r\n    },\r\n    \"filters\": [\r\n      {\r\n        \"protocol\": \"TCP\",\r\n        \"localIPAddress\": \"\",\r\n        \"localPort\": \"\",\r\n        \"remoteIPAddress\": \"\",\r\n        \"remotePort\": \"\"\r\n      }\r\n    ]\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:42:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "ETag": [
+          "W/\"30c44e91-af9b-4c15-a6d5-4a8648e9570e\""
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "c6da845a-161d-4154-a390-2d7b6727f609"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14976"
+        ],
+        "x-ms-correlation-request-id": [
+          "44b34b52-5f74-466c-9d73-75c5bc858167"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234229Z:44b34b52-5f74-466c-9d73-75c5bc858167"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/packetCaptures/pc31930?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvcGFja2V0Q2FwdHVyZXMvcGMzMTkzMD9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "b10b0208-e6ac-4a8e-b3b1-413474af5f62"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"pc31930\",\r\n  \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/packetCaptures/pc31930\",\r\n  \"etag\": \"W/\\\"622321f4-0eba-4b9f-b39d-ce2bcf581df8\\\"\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"target\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\",\r\n    \"bytesToCapturePerPacket\": 0,\r\n    \"totalBytesPerSession\": 1073741824,\r\n    \"timeLimitInSeconds\": 1500,\r\n    \"storageLocation\": {\r\n      \"storageId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Storage/storageAccounts/saa2694916db5694b\",\r\n      \"storagePath\": \"https://saa2694916db5694b.blob.core.windows.net/network-watcher-logs/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rga48497025653e2a/providers/microsoft.compute/virtualmachines/vmf587801522fd890/2017/07/25/packetcapture_23_41_28_027.cap\"\r\n    },\r\n    \"filters\": [\r\n      {\r\n        \"protocol\": \"TCP\",\r\n        \"localIPAddress\": \"\",\r\n        \"localPort\": \"\",\r\n        \"remoteIPAddress\": \"\",\r\n        \"remotePort\": \"\"\r\n      }\r\n    ]\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:43:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "ETag": [
+          "W/\"622321f4-0eba-4b9f-b39d-ce2bcf581df8\""
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "1077d7ec-7828-4651-81ac-73a40690831f"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14974"
+        ],
+        "x-ms-correlation-request-id": [
+          "55fa1db4-1f6b-4be8-bb79-66fbeaad2e53"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234329Z:55fa1db4-1f6b-4be8-bb79-66fbeaad2e53"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/packetCaptures/pc31930/stop?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvcGFja2V0Q2FwdHVyZXMvcGMzMTkzMC9zdG9wP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "542a6706-f033-492b-b647-70c72320a437"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:42:41 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operationResults/1b4a98a6-bb7f-4554-87e4-d87d7a0354fe?api-version=2016-12-01"
+        ],
+        "Retry-After": [
+          "10"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "1b4a98a6-bb7f-4554-87e4-d87d7a0354fe"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/1b4a98a6-bb7f-4554-87e4-d87d7a0354fe?api-version=2016-12-01"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1195"
+        ],
+        "x-ms-correlation-request-id": [
+          "614f204e-67ab-4649-89b5-e8a1f6359821"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234242Z:614f204e-67ab-4649-89b5-e8a1f6359821"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/1b4a98a6-bb7f-4554-87e4-d87d7a0354fe?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzFiNGE5OGE2LWJiN2YtNDU1NC04N2U0LWQ4N2Q3YTAzNTRmZT9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"Succeeded\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:43:11 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "09244d00-e0b7-42ee-8e37-307c23653100"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14975"
+        ],
+        "x-ms-correlation-request-id": [
+          "a73ff5a7-c97b-4e98-bf52-a7e0d5e913e8"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234312Z:a73ff5a7-c97b-4e98-bf52-a7e0d5e913e8"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/packetCaptures/pc31930?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvcGFja2V0Q2FwdHVyZXMvcGMzMTkzMD9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "dfdb2fe8-e191-4adc-bb09-357d9c66c44c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:43:46 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operationResults/0a6d8b77-dddf-4a09-bd59-dcdec4c4fae7?api-version=2016-12-01"
+        ],
+        "Retry-After": [
+          "10"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "0a6d8b77-dddf-4a09-bd59-dcdec4c4fae7"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/0a6d8b77-dddf-4a09-bd59-dcdec4c4fae7?api-version=2016-12-01"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1194"
+        ],
+        "x-ms-correlation-request-id": [
+          "bb28e16b-8d35-46cc-921e-5ab39321214e"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234346Z:bb28e16b-8d35-46cc-921e-5ab39321214e"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/0a6d8b77-dddf-4a09-bd59-dcdec4c4fae7?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzBhNmQ4Yjc3LWRkZGYtNGEwOS1iZDU5LWRjZGVjNGM0ZmFlNz9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"Succeeded\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 25 Jul 2017 23:44:16 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "53c3c300-5041-466a-bc05-6dad3e025012"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14973"
+        ],
+        "x-ms-correlation-request-id": [
+          "c7b519c0-e3c5-46a5-b54b-909c64d156bb"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20170725T234417Z:c7b519c0-e3c5-46a5-b54b-909c64d156bb"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/ipFlowVerify?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvaXBGbG93VmVyaWZ5P2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"targetResourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\",\r\n  \"direction\": \"Outbound\",\r\n  \"protocol\": \"TCP\",\r\n  \"localPort\": \"443\",\r\n  \"remotePort\": \"443\",\r\n  \"localIPAddress\": \"192.168.2.4\",\r\n  \"remoteIPAddress\": \"8.8.8.8\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "342"
+        ],
+        "x-ms-client-request-id": [
+          "46279630-dfad-4b93-abe1-57c8215973ba"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"access\": \"Allow\",\r\n  \"ruleName\": \"defaultSecurityRules/AllowInternetOutBound\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:03:42 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operationResults/4587c4fb-1fc9-4de8-8727-5c4020b25d9e?api-version=2016-12-01"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "4587c4fb-1fc9-4de8-8727-5c4020b25d9e"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "x-ms-correlation-request-id": [
+          "e2f86fab-d623-4c73-ac86-6dcfa208b442"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000342Z:e2f86fab-d623-4c73-ac86-6dcfa208b442"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/nextHop?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvbmV4dEhvcD9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"targetResourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\",\r\n  \"sourceIPAddress\": \"192.168.2.4\",\r\n  \"destinationIPAddress\": \"8.8.8.8\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "251"
+        ],
+        "x-ms-client-request-id": [
+          "9d542b2b-a0aa-4d44-ba95-63dbfc71dfd3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "null",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "4"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:04:02 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operationResults/46b8e2cd-39ce-495c-8962-053ccd2ee531?api-version=2016-12-01"
+        ],
+        "Retry-After": [
+          "10"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "46b8e2cd-39ce-495c-8962-053ccd2ee531"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1198"
+        ],
+        "x-ms-correlation-request-id": [
+          "f1ee371f-0ef8-4db4-b15d-4b7629a1134d"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000402Z:f1ee371f-0ef8-4db4-b15d-4b7629a1134d"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operationResults/46b8e2cd-39ce-495c-8962-053ccd2ee531?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25SZXN1bHRzLzQ2YjhlMmNkLTM5Y2UtNDk1Yy04OTYyLTA1M2NjZDJlZTUzMT9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"nextHopType\": \"Internet\",\r\n  \"routeTableId\": \"System Route\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:04:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operationResults/46b8e2cd-39ce-495c-8962-053ccd2ee531?api-version=2016-12-01"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "46b8e2cd-39ce-495c-8962-053ccd2ee531"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14995"
+        ],
+        "x-ms-correlation-request-id": [
+          "2d6459d6-a3b0-491b-bf9f-0802c56cb55b"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000432Z:2d6459d6-a3b0-491b-bf9f-0802c56cb55b"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/topology?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvdG9wb2xvZ3k/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"targetResourceGroupName\": \"rga48497025653e2a\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "54"
+        ],
+        "x-ms-client-request-id": [
+          "70d567c5-5e6b-4714-bbb9-0a4197e0e6d9"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"786381c0-ecc4-4df7-af24-3095c123ce02\",\r\n  \"createdDateTime\": \"2017-07-26T00:04:32.6674599Z\",\r\n  \"lastModified\": \"2017-07-25T23:39:41.6822795Z\",\r\n  \"resources\": [\r\n    {\r\n      \"name\": \"vnet2130412649a0\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0\",\r\n      \"location\": \"westcentralus\",\r\n      \"associations\": [\r\n        {\r\n          \"name\": \"subnet1\",\r\n          \"resourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0/subnets/subnet1\",\r\n          \"associationType\": \"Contains\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"subnet1\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0/subnets/subnet1\",\r\n      \"location\": \"westcentralus\",\r\n      \"associations\": []\r\n    },\r\n    {\r\n      \"name\": \"vmf587801522fd890\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\",\r\n      \"location\": \"westcentralus\",\r\n      \"associations\": [\r\n        {\r\n          \"name\": \"nic33961504ea5\",\r\n          \"resourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5\",\r\n          \"associationType\": \"Contains\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"nic33961504ea5\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5\",\r\n      \"location\": \"westcentralus\",\r\n      \"associations\": [\r\n        {\r\n          \"name\": \"vmf587801522fd890\",\r\n          \"resourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\",\r\n          \"associationType\": \"Associated\"\r\n        },\r\n        {\r\n          \"name\": \"subnet1\",\r\n          \"resourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0/subnets/subnet1\",\r\n          \"associationType\": \"Associated\"\r\n        },\r\n        {\r\n          \"name\": \"pipeaf23258e0\",\r\n          \"resourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/publicIPAddresses/pipeaf23258e0\",\r\n          \"associationType\": \"Associated\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"nsgeb14522026ee\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\",\r\n      \"location\": \"westcentralus\",\r\n      \"associations\": [\r\n        {\r\n          \"name\": \"subnet1\",\r\n          \"resourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0/subnets/subnet1\",\r\n          \"associationType\": \"Associated\"\r\n        },\r\n        {\r\n          \"name\": \"DenyInternetInComing\",\r\n          \"resourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/securityRules/DenyInternetInComing\",\r\n          \"associationType\": \"Contains\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"DenyInternetInComing\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/securityRules/DenyInternetInComing\",\r\n      \"location\": \"westcentralus\",\r\n      \"associations\": []\r\n    },\r\n    {\r\n      \"name\": \"pipeaf23258e0\",\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/publicIPAddresses/pipeaf23258e0\",\r\n      \"location\": \"westcentralus\",\r\n      \"associations\": [\r\n        {\r\n          \"name\": \"nic33961504ea5\",\r\n          \"resourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5\",\r\n          \"associationType\": \"Associated\"\r\n        }\r\n      ]\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:04:31 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operationResults/f5eb603a-2ae6-453e-a5ed-f610b02b70d5?api-version=2016-12-01"
+        ],
+        "Retry-After": [
+          "10"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "f5eb603a-2ae6-453e-a5ed-f610b02b70d5"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/f5eb603a-2ae6-453e-a5ed-f610b02b70d5?api-version=2016-12-01"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1197"
+        ],
+        "x-ms-correlation-request-id": [
+          "b282909d-9e00-48c8-a718-6fffaaeb8efc"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000432Z:b282909d-9e00-48c8-a718-6fffaaeb8efc"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/securityGroupView?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvc2VjdXJpdHlHcm91cFZpZXc/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"targetResourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Compute/virtualMachines/vmf587801522fd890\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "176"
+        ],
+        "x-ms-client-request-id": [
+          "3ce40fcb-9d0e-4cc6-8029-626619f3cce9"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"networkInterfaces\": [\r\n    {\r\n      \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkInterfaces/nic33961504ea5\",\r\n      \"securityRuleAssociations\": {\r\n        \"subnetAssociation\": {\r\n          \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/virtualNetworks/vnet2130412649a0/subnets/subnet1\",\r\n          \"securityRules\": [\r\n            {\r\n              \"name\": \"DenyInternetInComing\",\r\n              \"id\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee/securityRules/DenyInternetInComing\",\r\n              \"etag\": \"W/\\\"61247e59-7393-4347-98e7-84ef6a871ec4\\\"\",\r\n              \"properties\": {\r\n                \"provisioningState\": \"Succeeded\",\r\n                \"protocol\": \"*\",\r\n                \"sourcePortRange\": \"*\",\r\n                \"destinationPortRange\": \"443\",\r\n                \"sourceAddressPrefix\": \"INTERNET\",\r\n                \"destinationAddressPrefix\": \"*\",\r\n                \"access\": \"Deny\",\r\n                \"priority\": 100,\r\n                \"direction\": \"Inbound\"\r\n              }\r\n            }\r\n          ]\r\n        },\r\n        \"defaultSecurityRules\": [\r\n          {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\": \"/subscriptions//resourceGroups//providers/Microsoft.Network/networkSecurityGroups//defaultSecurityRules/\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\n            \"id\": \"/subscriptions//resourceGroups//providers/Microsoft.Network/networkSecurityGroups//defaultSecurityRules/\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic from azure load balancer\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"AzureLoadBalancer\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"DenyAllInBound\",\r\n            \"id\": \"/subscriptions//resourceGroups//providers/Microsoft.Network/networkSecurityGroups//defaultSecurityRules/\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Deny all inbound traffic\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\": 65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowVnetOutBound\",\r\n            \"id\": \"/subscriptions//resourceGroups//providers/Microsoft.Network/networkSecurityGroups//defaultSecurityRules/\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic from all VMs to all VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"AllowInternetOutBound\",\r\n            \"id\": \"/subscriptions//resourceGroups//providers/Microsoft.Network/networkSecurityGroups//defaultSecurityRules/\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\": \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n            \"name\": \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions//resourceGroups//providers/Microsoft.Network/networkSecurityGroups//defaultSecurityRules/\",\r\n            \"properties\": {\r\n              \"provisioningState\": \"Succeeded\",\r\n              \"description\": \"Deny all outbound traffic\",\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\": 65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n          }\r\n        ],\r\n        \"effectiveSecurityRules\": [\r\n          {\r\n            \"name\": \"DefaultOutboundDenyAll\",\r\n            \"protocol\": \"All\",\r\n            \"sourcePortRange\": \"0-65535\",\r\n            \"destinationPortRange\": \"0-65535\",\r\n            \"sourceAddressPrefix\": \"*\",\r\n            \"destinationAddressPrefix\": \"*\",\r\n            \"access\": \"Deny\",\r\n            \"priority\": 65500,\r\n            \"direction\": \"Outbound\"\r\n          },\r\n          {\r\n            \"name\": \"DefaultRule_AllowVnetOutBound\",\r\n            \"protocol\": \"All\",\r\n            \"sourcePortRange\": \"0-65535\",\r\n            \"destinationPortRange\": \"0-65535\",\r\n            \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n            \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n            \"expandedSourceAddressPrefix\": [\r\n              \"192.168.0.0/16\",\r\n              \"168.63.129.16/32\"\r\n            ],\r\n            \"expandedDestinationAddressPrefix\": [\r\n              \"192.168.0.0/16\",\r\n              \"168.63.129.16/32\"\r\n            ],\r\n            \"access\": \"Allow\",\r\n            \"priority\": 65000,\r\n            \"direction\": \"Outbound\"\r\n          },\r\n          {\r\n            \"name\": \"DefaultRule_AllowInternetOutBound\",\r\n            \"protocol\": \"All\",\r\n            \"sourcePortRange\": \"0-65535\",\r\n            \"destinationPortRange\": \"0-65535\",\r\n            \"sourceAddressPrefix\": \"0.0.0.0/0\",\r\n            \"destinationAddressPrefix\": \"Internet\",\r\n            \"expandedDestinationAddressPrefix\": [\r\n              \"32.0.0.0/3\",\r\n              \"4.0.0.0/6\",\r\n              \"2.0.0.0/7\",\r\n              \"1.0.0.0/8\",\r\n              \"12.0.0.0/6\",\r\n              \"8.0.0.0/7\",\r\n              \"11.0.0.0/8\",\r\n              \"64.0.0.0/3\",\r\n              \"112.0.0.0/5\",\r\n              \"120.0.0.0/6\",\r\n              \"124.0.0.0/7\",\r\n              \"126.0.0.0/8\",\r\n              \"128.0.0.0/3\",\r\n              \"176.0.0.0/4\",\r\n              \"160.0.0.0/5\",\r\n              \"170.0.0.0/7\",\r\n              \"168.0.0.0/8\",\r\n              \"169.0.0.0/9\",\r\n              \"169.128.0.0/10\",\r\n              \"169.192.0.0/11\",\r\n              \"169.224.0.0/12\",\r\n              \"169.240.0.0/13\",\r\n              \"169.248.0.0/14\",\r\n              \"169.252.0.0/15\",\r\n              \"169.255.0.0/16\",\r\n              \"174.0.0.0/7\",\r\n              \"173.0.0.0/8\",\r\n              \"172.128.0.0/9\",\r\n              \"172.64.0.0/10\",\r\n              \"172.32.0.0/11\",\r\n              \"172.0.0.0/12\",\r\n              \"208.0.0.0/4\",\r\n              \"200.0.0.0/5\",\r\n              \"194.0.0.0/7\",\r\n              \"193.0.0.0/8\",\r\n              \"192.64.0.0/10\",\r\n              \"192.32.0.0/11\",\r\n              \"192.16.0.0/12\",\r\n              \"192.8.0.0/13\",\r\n              \"192.4.0.0/14\",\r\n              \"192.2.0.0/15\",\r\n              \"192.1.0.0/16\",\r\n              \"192.0.128.0/17\",\r\n              \"192.0.64.0/18\",\r\n              \"192.0.32.0/19\",\r\n              \"192.0.16.0/20\",\r\n              \"192.0.8.0/21\",\r\n              \"192.0.4.0/22\",\r\n              \"192.0.0.0/23\",\r\n              \"192.0.3.0/24\",\r\n              \"192.192.0.0/10\",\r\n              \"192.128.0.0/11\",\r\n              \"192.176.0.0/12\",\r\n              \"192.160.0.0/13\",\r\n              \"192.172.0.0/14\",\r\n              \"192.170.0.0/15\",\r\n              \"192.169.0.0/16\",\r\n              \"196.0.0.0/7\",\r\n              \"199.0.0.0/8\",\r\n              \"198.128.0.0/9\",\r\n              \"198.64.0.0/10\",\r\n              \"198.32.0.0/11\",\r\n              \"198.0.0.0/12\",\r\n              \"198.24.0.0/13\",\r\n              \"198.20.0.0/14\",\r\n              \"198.16.0.0/15\",\r\n              \"104.0.0.0/5\",\r\n              \"96.0.0.0/6\",\r\n              \"102.0.0.0/7\",\r\n              \"101.0.0.0/8\",\r\n              \"100.128.0.0/9\",\r\n              \"100.0.0.0/10\",\r\n              \"16.0.0.0/5\",\r\n              \"28.0.0.0/6\",\r\n              \"26.0.0.0/7\",\r\n              \"24.0.0.0/8\"\r\n            ],\r\n            \"access\": \"Allow\",\r\n            \"priority\": 65001,\r\n            \"direction\": \"Outbound\"\r\n          },\r\n          {\r\n            \"name\": \"DefaultRule_DenyAllOutBound\",\r\n            \"protocol\": \"All\",\r\n            \"sourcePortRange\": \"0-65535\",\r\n            \"destinationPortRange\": \"0-65535\",\r\n            \"sourceAddressPrefix\": \"0.0.0.0/0\",\r\n            \"destinationAddressPrefix\": \"0.0.0.0/0\",\r\n            \"access\": \"Deny\",\r\n            \"priority\": 65500,\r\n            \"direction\": \"Outbound\"\r\n          },\r\n          {\r\n            \"name\": \"DefaultInboundDenyAll\",\r\n            \"protocol\": \"All\",\r\n            \"sourcePortRange\": \"0-65535\",\r\n            \"destinationPortRange\": \"0-65535\",\r\n            \"sourceAddressPrefix\": \"*\",\r\n            \"destinationAddressPrefix\": \"*\",\r\n            \"access\": \"Deny\",\r\n            \"priority\": 65500,\r\n            \"direction\": \"Inbound\"\r\n          },\r\n          {\r\n            \"name\": \"DefaultRule_AllowVnetInBound\",\r\n            \"protocol\": \"All\",\r\n            \"sourcePortRange\": \"0-65535\",\r\n            \"destinationPortRange\": \"0-65535\",\r\n            \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n            \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n            \"expandedSourceAddressPrefix\": [\r\n              \"192.168.0.0/16\",\r\n              \"168.63.129.16/32\"\r\n            ],\r\n            \"expandedDestinationAddressPrefix\": [\r\n              \"192.168.0.0/16\",\r\n              \"168.63.129.16/32\"\r\n            ],\r\n            \"access\": \"Allow\",\r\n            \"priority\": 65000,\r\n            \"direction\": \"Inbound\"\r\n          },\r\n          {\r\n            \"name\": \"DefaultRule_AllowAzureLoadBalancerInBound\",\r\n            \"protocol\": \"All\",\r\n            \"sourcePortRange\": \"0-65535\",\r\n            \"destinationPortRange\": \"0-65535\",\r\n            \"sourceAddressPrefix\": \"AzureLoadBalancer\",\r\n            \"destinationAddressPrefix\": \"0.0.0.0/0\",\r\n            \"expandedSourceAddressPrefix\": [\r\n              \"168.63.129.16/32\"\r\n            ],\r\n            \"access\": \"Allow\",\r\n            \"priority\": 65001,\r\n            \"direction\": \"Inbound\"\r\n          },\r\n          {\r\n            \"name\": \"DefaultRule_DenyAllInBound\",\r\n            \"protocol\": \"All\",\r\n            \"sourcePortRange\": \"0-65535\",\r\n            \"destinationPortRange\": \"0-65535\",\r\n            \"sourceAddressPrefix\": \"0.0.0.0/0\",\r\n            \"destinationAddressPrefix\": \"0.0.0.0/0\",\r\n            \"access\": \"Deny\",\r\n            \"priority\": 65500,\r\n            \"direction\": \"Inbound\"\r\n          },\r\n          {\r\n            \"name\": \"UserRule_DenyInternetInComing\",\r\n            \"protocol\": \"All\",\r\n            \"sourcePortRange\": \"0-65535\",\r\n            \"destinationPortRange\": \"443-443\",\r\n            \"sourceAddressPrefix\": \"Internet\",\r\n            \"destinationAddressPrefix\": \"0.0.0.0/0\",\r\n            \"expandedSourceAddressPrefix\": [\r\n              \"32.0.0.0/3\",\r\n              \"4.0.0.0/6\",\r\n              \"2.0.0.0/7\",\r\n              \"1.0.0.0/8\",\r\n              \"12.0.0.0/6\",\r\n              \"8.0.0.0/7\",\r\n              \"11.0.0.0/8\",\r\n              \"64.0.0.0/3\",\r\n              \"112.0.0.0/5\",\r\n              \"120.0.0.0/6\",\r\n              \"124.0.0.0/7\",\r\n              \"126.0.0.0/8\",\r\n              \"128.0.0.0/3\",\r\n              \"176.0.0.0/4\",\r\n              \"160.0.0.0/5\",\r\n              \"170.0.0.0/7\",\r\n              \"168.0.0.0/8\",\r\n              \"169.0.0.0/9\",\r\n              \"169.128.0.0/10\",\r\n              \"169.192.0.0/11\",\r\n              \"169.224.0.0/12\",\r\n              \"169.240.0.0/13\",\r\n              \"169.248.0.0/14\",\r\n              \"169.252.0.0/15\",\r\n              \"169.255.0.0/16\",\r\n              \"174.0.0.0/7\",\r\n              \"173.0.0.0/8\",\r\n              \"172.128.0.0/9\",\r\n              \"172.64.0.0/10\",\r\n              \"172.32.0.0/11\",\r\n              \"172.0.0.0/12\",\r\n              \"208.0.0.0/4\",\r\n              \"200.0.0.0/5\",\r\n              \"194.0.0.0/7\",\r\n              \"193.0.0.0/8\",\r\n              \"192.64.0.0/10\",\r\n              \"192.32.0.0/11\",\r\n              \"192.16.0.0/12\",\r\n              \"192.8.0.0/13\",\r\n              \"192.4.0.0/14\",\r\n              \"192.2.0.0/15\",\r\n              \"192.1.0.0/16\",\r\n              \"192.0.128.0/17\",\r\n              \"192.0.64.0/18\",\r\n              \"192.0.32.0/19\",\r\n              \"192.0.16.0/20\",\r\n              \"192.0.8.0/21\",\r\n              \"192.0.4.0/22\",\r\n              \"192.0.0.0/23\",\r\n              \"192.0.3.0/24\",\r\n              \"192.192.0.0/10\",\r\n              \"192.128.0.0/11\",\r\n              \"192.176.0.0/12\",\r\n              \"192.160.0.0/13\",\r\n              \"192.172.0.0/14\",\r\n              \"192.170.0.0/15\",\r\n              \"192.169.0.0/16\",\r\n              \"196.0.0.0/7\",\r\n              \"199.0.0.0/8\",\r\n              \"198.128.0.0/9\",\r\n              \"198.64.0.0/10\",\r\n              \"198.32.0.0/11\",\r\n              \"198.0.0.0/12\",\r\n              \"198.24.0.0/13\",\r\n              \"198.20.0.0/14\",\r\n              \"198.16.0.0/15\",\r\n              \"104.0.0.0/5\",\r\n              \"96.0.0.0/6\",\r\n              \"102.0.0.0/7\",\r\n              \"101.0.0.0/8\",\r\n              \"100.128.0.0/9\",\r\n              \"100.0.0.0/10\",\r\n              \"16.0.0.0/5\",\r\n              \"28.0.0.0/6\",\r\n              \"26.0.0.0/7\",\r\n              \"24.0.0.0/8\"\r\n            ],\r\n            \"access\": \"Deny\",\r\n            \"priority\": 100,\r\n            \"direction\": \"Inbound\"\r\n          }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:04:40 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operationResults/92b0c1d7-14e7-499a-9dfe-9edbbebef355?api-version=2016-12-01"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "92b0c1d7-14e7-499a-9dfe-9edbbebef355"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1196"
+        ],
+        "x-ms-correlation-request-id": [
+          "59bd47e8-9f33-4796-bb2e-c7f0eacf8b1c"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000440Z:59bd47e8-9f33-4796-bb2e-c7f0eacf8b1c"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/queryFlowLogStatus?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvcXVlcnlGbG93TG9nU3RhdHVzP2FwaS12ZXJzaW9uPTIwMTYtMTItMDE=",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"targetResourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "180"
+        ],
+        "x-ms-client-request-id": [
+          "416bd412-ad4e-4b4c-b934-fb579ec617d8"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"targetResourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\",\r\n  \"properties\": {\r\n    \"enabled\": false,\r\n    \"retentionPolicy\": {\r\n      \"days\": 0,\r\n      \"enabled\": false\r\n    }\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:05:04 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "ed2c32f1-83d8-4d1d-8d68-effd2deceb5b"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1195"
+        ],
+        "x-ms-correlation-request-id": [
+          "00d80549-c2fa-4a26-b94f-d8c7a6667c01"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000505Z:00d80549-c2fa-4a26-b94f-d8c7a6667c01"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/configureFlowLog?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvY29uZmlndXJlRmxvd0xvZz9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"targetResourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\",\r\n  \"properties\": {\r\n    \"storageId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Storage/storageAccounts/saa2694916db5694b\",\r\n    \"enabled\": true,\r\n    \"retentionPolicy\": {\r\n      \"days\": 5,\r\n      \"enabled\": true\r\n    }\r\n  }\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "469"
+        ],
+        "x-ms-client-request-id": [
+          "7468ae2f-a835-4080-b27f-18cde5e8aad4"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"targetResourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\",\r\n  \"properties\": {\r\n    \"storageId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Storage/storageAccounts/saa2694916db5694b\",\r\n    \"enabled\": true,\r\n    \"retentionPolicy\": {\r\n      \"days\": 5,\r\n      \"enabled\": true\r\n    }\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:05:06 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "da391599-16d5-4d8c-807f-b40f09591966"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1194"
+        ],
+        "x-ms-correlation-request-id": [
+          "5edee907-2ebb-4cdf-aa2d-9f0a10501ca2"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000507Z:5edee907-2ebb-4cdf-aa2d-9f0a10501ca2"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590/configureFlowLog?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTAvY29uZmlndXJlRmxvd0xvZz9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"targetResourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\",\r\n  \"properties\": {\r\n    \"storageId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Storage/storageAccounts/saa2694916db5694b\",\r\n    \"enabled\": false,\r\n    \"retentionPolicy\": {\r\n      \"days\": 5,\r\n      \"enabled\": true\r\n    }\r\n  }\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "470"
+        ],
+        "x-ms-client-request-id": [
+          "7e5f5ba2-2301-4b6d-9384-d3d22aaad993"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"targetResourceId\": \"/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/rga48497025653e2a/providers/Microsoft.Network/networkSecurityGroups/nsgeb14522026ee\",\r\n  \"properties\": {\r\n    \"storageId\": \"\",\r\n    \"enabled\": false,\r\n    \"retentionPolicy\": {\r\n      \"days\": 0,\r\n      \"enabled\": false\r\n    }\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:05:08 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "fff1738a-4c8c-44ef-96e9-cd778d92f62f"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1193"
+        ],
+        "x-ms-correlation-request-id": [
+          "169a65a2-3890-491d-a9d9-fadf8a443dc8"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000508Z:169a65a2-3890-491d-a9d9-fadf8a443dc8"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourceGroups/nw35590group/providers/Microsoft.Network/networkWatchers/nw35590?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlR3JvdXBzL253MzU1OTBncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1dhdGNoZXJzL253MzU1OTA/YXBpLXZlcnNpb249MjAxNi0xMi0wMQ==",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "8f40070b-6a00-464c-affd-bea7fcadf765"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:05:08 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operationResults/23b424b2-5ddd-4a60-9474-f4e774e2ccb1?api-version=2016-12-01"
+        ],
+        "Retry-After": [
+          "10"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-id": [
+          "23b424b2-5ddd-4a60-9474-f4e774e2ccb1"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/23b424b2-5ddd-4a60-9474-f4e774e2ccb1?api-version=2016-12-01"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1192"
+        ],
+        "x-ms-correlation-request-id": [
+          "e10aea70-ad01-4559-a9ee-56b2c6a913b6"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000509Z:e10aea70-ad01-4559-a9ee-56b2c6a913b6"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/providers/Microsoft.Network/locations/westcentralus/operations/23b424b2-5ddd-4a60-9474-f4e774e2ccb1?api-version=2016-12-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2NhdGlvbnMvd2VzdGNlbnRyYWx1cy9vcGVyYXRpb25zLzIzYjQyNGIyLTVkZGQtNGE2MC05NDc0LWY0ZTc3NGUyY2NiMT9hcGktdmVyc2lvbj0yMDE2LTEyLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Network.Fluent.NetworkManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"Succeeded\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:05:39 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "f7930a50-27aa-428e-becd-961e0c85c03f"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14994"
+        ],
+        "x-ms-correlation-request-id": [
+          "b124bc72-ce7e-4a34-b9e7-a7160c80aac8"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000539Z:b124bc72-ce7e-4a34-b9e7-a7160c80aac8"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/rga48497025653e2a?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL3JnYTQ4NDk3MDI1NjUzZTJhP2FwaS12ZXJzaW9uPTIwMTYtMDItMDE=",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "cc5f9ace-6561-4804-acf7-2124ed1557ae"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:05:40 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1SR0E0ODQ5NzAyNTY1M0UyQS1XRVNUQ0VOVFJBTFVTIiwiam9iTG9jYXRpb24iOiJ3ZXN0Y2VudHJhbHVzIn0?api-version=2016-02-01"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1191"
+        ],
+        "x-ms-request-id": [
+          "1b8678da-45e8-4e9f-93a0-7ae3eef2597c"
+        ],
+        "x-ms-correlation-request-id": [
+          "1b8678da-45e8-4e9f-93a0-7ae3eef2597c"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000540Z:1b8678da-45e8-4e9f-93a0-7ae3eef2597c"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/resourcegroups/nw35590group?api-version=2016-02-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvYzU0OWY0NzUtZGVlOC00MjhjLWJiMTktODI5YTU1ZTUyZjc3L3Jlc291cmNlZ3JvdXBzL253MzU1OTBncm91cD9hcGktdmVyc2lvbj0yMDE2LTAyLTAx",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "6d2f0bac-a404-480e-9a62-dc1bd157954a"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.Fluent.ResourceManagementClient/1.1.3.0",
+          "MacAddressHash/7c3a3501c5ea63957db496f8b2943497e5c3e1534588af7bf28d1653c85ff607"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 26 Jul 2017 00:05:40 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/c549f475-dee8-428c-bb19-829a55e52f77/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1OVzM1NTkwR1JPVVAtV0VTVENFTlRSQUxVUyIsImpvYkxvY2F0aW9uIjoid2VzdGNlbnRyYWx1cyJ9?api-version=2016-02-01"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1190"
+        ],
+        "x-ms-request-id": [
+          "a2b1fb12-f91f-4b72-8c60-75961532fbcf"
+        ],
+        "x-ms-correlation-request-id": [
+          "a2b1fb12-f91f-4b72-8c60-75961532fbcf"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20170726T000540Z:a2b1fb12-f91f-4b72-8c60-75961532fbcf"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    }
+  ],
+  "Names": {
+    "ManageNetworkWatcherTest": [
+      "nw35590",
+      "vnet2130412649a0",
+      "nsgeb14522026ee",
+      "pipdns1ce64793f5e",
+      "rga48497025653e2a",
+      "saa2694916db5694b",
+      "vmf587801522fd890",
+      "pc31930",
+      "rgnemv0df9302848d68",
+      "nic33961504ea5",
+      "pipeaf23258e0",
+      "vm8fa4640777"
+    ]
+  },
+  "Variables": {
+    "ServicePrincipal": "4c660ecb-cff1-401f-9d6e-047022d2b5e3",
+    "AADTenant": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+    "SubscriptionId": "c549f475-dee8-428c-bb19-829a55e52f77"
+  }
+}

--- a/src/ResourceManagement/Azure.Fluent/Azure.cs
+++ b/src/ResourceManagement/Azure.Fluent/Azure.cs
@@ -154,6 +154,15 @@ namespace Microsoft.Azure.Management.Fluent
             }
         }
 
+        /// <returns>entry point to managing network watchers</returns>
+        public INetworkWatchers NetworkWatchers
+        {
+            get
+            {
+                return networkManager.NetworkWatchers;
+            }
+        }
+
         /// <returns>entry point to managing deployments</returns>
         public IDeployments Deployments
         {
@@ -632,6 +641,8 @@ namespace Microsoft.Azure.Management.Fluent
         ILoadBalancers LoadBalancers { get; }
 
         IApplicationGateways ApplicationGateways { get; }
+
+        INetworkWatchers NetworkWatchers { get; }
 
         IWebApps WebApps { get; }
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
