### PR TITLE
New JSON auth file format

### DIFF
--- a/src/ResourceManagement/Graph.RBAC/CertificateCredentialImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/CertificateCredentialImpl.cs
@@ -103,15 +103,17 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
             try
             {
-                await authFile.WriteLineAsync(string.Format("client={0}", servicePrincipal.ApplicationId()));
-                await authFile.WriteLineAsync(string.Format("certificate={0}", NormalizeAuthFilePath(privateKeyPath)));
-                await authFile.WriteLineAsync(string.Format("certificatePassword={0}", privateKeyPassword));
-                await authFile.WriteLineAsync(string.Format("tenant={0}", servicePrincipal.Manager().tenantId));
-                await authFile.WriteLineAsync(string.Format("subscription={0}", servicePrincipal.assignedSubscription));
-                await authFile.WriteLineAsync(string.Format("authURL={0}", NormalizeAuthFileUrl(environment.AuthenticationEndpoint)));
-                await authFile.WriteLineAsync(string.Format("baseURL={0}", NormalizeAuthFileUrl(environment.ResourceManagerEndpoint)));
-                await authFile.WriteLineAsync(string.Format("graphURL={0}", NormalizeAuthFileUrl(environment.GraphEndpoint)));
-                await authFile.WriteLineAsync(string.Format("managementURI={0}", NormalizeAuthFileUrl(environment.ManagementEnpoint)));
+                await authFile.WriteLineAsync("{");
+                await authFile.WriteLineAsync(string.Format("  \"clientId\": \"{0}\",", servicePrincipal.ApplicationId()));
+                await authFile.WriteLineAsync(string.Format("  \"clientCertificate\": \"{0}\",", NormalizeAuthFilePath(privateKeyPath)));
+                await authFile.WriteLineAsync(string.Format("  \"clientCertificatePassword\": \"{0}\",", privateKeyPassword));
+                await authFile.WriteLineAsync(string.Format("  \"tenantId\": \"{0}\",", servicePrincipal.Manager().tenantId));
+                await authFile.WriteLineAsync(string.Format("  \"subscriptionId\": \"{0}\",", servicePrincipal.assignedSubscription));
+                await authFile.WriteLineAsync(string.Format("  \"activeDirectoryEndpointUrl\": \"{0}\",", environment.AuthenticationEndpoint));
+                await authFile.WriteLineAsync(string.Format("  \"resourceManagerEndpointUrl\": \"{0}\",", environment.ResourceManagerEndpoint));
+                await authFile.WriteLineAsync(string.Format("  \"activeDirectoryGraphResourceId\": \"{0}\",", environment.GraphEndpoint));
+                await authFile.WriteLineAsync(string.Format("  \"managementEndpointUrl\": \"{0}\"", environment.ManagementEnpoint));
+                await authFile.WriteLineAsync("}");
             }
             finally
             {
@@ -156,7 +158,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         private string NormalizeAuthFilePath(string path)
         {
-            return path.Replace("\\", "\\\\").Replace(":", "\\:");
+            return path.Replace("\\", "\\\\");
         }
 
         public CertificateCredentialImpl<T> WithPrivateKeyFile(string privateKeyPath)

--- a/src/ResourceManagement/Graph.RBAC/PasswordCredentialImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/PasswordCredentialImpl.cs
@@ -90,14 +90,16 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
             try
             {
-                await authFile.WriteLineAsync(string.Format("client={0}", servicePrincipal.ApplicationId()));
-                await authFile.WriteLineAsync(string.Format("key={0}", Value()));
-                await authFile.WriteLineAsync(string.Format("tenant={0}", servicePrincipal.Manager().tenantId));
-                await authFile.WriteLineAsync(string.Format("subscription={0}", servicePrincipal.assignedSubscription));
-                await authFile.WriteLineAsync(string.Format("authURL={0}", NormalizeAuthFileUrl(environment.AuthenticationEndpoint)));
-                await authFile.WriteLineAsync(string.Format("baseURL={0}", NormalizeAuthFileUrl(environment.ResourceManagerEndpoint)));
-                await authFile.WriteLineAsync(string.Format("graphURL={0}", NormalizeAuthFileUrl(environment.GraphEndpoint)));
-                await authFile.WriteLineAsync(string.Format("managementURI={0}", NormalizeAuthFileUrl(environment.ManagementEnpoint)));
+                await authFile.WriteLineAsync("{");
+                await authFile.WriteLineAsync(string.Format("  \"clientId\": \"{0}\",", servicePrincipal.ApplicationId()));
+                await authFile.WriteLineAsync(string.Format("  \"clientSecret\": \"{0}\",", Value()));
+                await authFile.WriteLineAsync(string.Format("  \"tenantId\": \"{0}\",", servicePrincipal.Manager().tenantId));
+                await authFile.WriteLineAsync(string.Format("  \"subscriptionId\": \"{0}\",", servicePrincipal.assignedSubscription));
+                await authFile.WriteLineAsync(string.Format("  \"activeDirectoryEndpointUrl\": \"{0}\",", environment.AuthenticationEndpoint));
+                await authFile.WriteLineAsync(string.Format("  \"resourceManagerEndpointUrl\": \"{0}\",", environment.ResourceManagerEndpoint));
+                await authFile.WriteLineAsync(string.Format("  \"activeDirectoryGraphResourceId\": \"{0}\",", environment.GraphEndpoint));
+                await authFile.WriteLineAsync(string.Format("  \"managementEndpointUrl\": \"{0}\"", environment.ManagementEnpoint));
+                await authFile.WriteLineAsync("}");
             }
             finally
             {
@@ -121,15 +123,6 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
         {
             this.name = name;
             this.parent = parent;
-        }
-
-                private string NormalizeAuthFileUrl(string url)
-        {
-            if (!url.EndsWith("/"))
-            {
-                url = url + "/";
-            }
-            return url.Replace("://", "\\://");
         }
 
                 public PasswordCredentialImpl<T> WithStartDate(DateTime startDate)

--- a/src/ResourceManagement/ResourceManager/Authentication/AzureCredentialsFactory.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/AzureCredentialsFactory.cs
@@ -166,11 +166,11 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
             };
 
             AzureCredentials credentials;
-            if (config.ContainsKey("key"))
+            if (config.ContainsKey("key") && config["key"] != null)
             {
                 credentials = FromServicePrincipal(config["client"], config["key"], config["tenant"], env);
             }
-            else if (config.ContainsKey("certificate"))
+            else if (config.ContainsKey("certificate") && config["certificate"] != null)
             {
                 string certificatePath = config["certificate"].Replace("\\:", ":").Replace("\\\\", "\\");
                 if (!File.Exists(certificatePath))

--- a/src/ResourceManagement/ResourceManager/Authentication/AzureCredentialsFactory.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/AzureCredentialsFactory.cs
@@ -3,10 +3,12 @@
 
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
@@ -130,17 +132,30 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
                 { "graphurl", AzureEnvironment.AzureGlobalCloud.GraphEndpoint }
             };
 
-            File.ReadLines(authFile)
-                .All(line =>
-                {
-                    if (line.Trim().StartsWith("#"))
-                        return true; // Ignore comments
+            var lines = File.ReadLines(authFile);
+            if (lines.First().Trim().StartsWith("{"))
+            {
+                string json = string.Join("", lines);
+                AuthFile jsonConfig = Rest.Serialization.SafeJsonConvert.DeserializeObject<AuthFile>(json);
+                jsonConfig.GetType()
+                    .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                    .ToList()
+                    .ForEach(info => config[info.Name] = (string)info.GetValue(jsonConfig));
+            }
+            else
+            {
+                lines.All(line =>
+                    {
+                        if (line.Trim().StartsWith("#"))
+                            return true; // Ignore comments
                     var keyVal = line.Trim().Split(new char[] { '=' }, 2);
-                    if(keyVal.Length < 2)
-                        return true; // Ignore lines that don't look like $$$=$$$
+                        if (keyVal.Length < 2)
+                            return true; // Ignore lines that don't look like $$$=$$$
                     config[keyVal[0].ToLowerInvariant()] = keyVal[1];
-                    return true;
-                });
+                        return true;
+                    });
+            }
+
 
             var env = new AzureEnvironment()
             {
@@ -171,6 +186,39 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
             }
             credentials.WithDefaultSubscription(config["subscription"]);
             return credentials;
+        }
+
+        private class AuthFile
+        {
+            [JsonProperty("clientId")]
+            private string client;
+
+            [JsonProperty("tenantId")]
+            private string tenant;
+
+            [JsonProperty("clientSecret")]
+            private string key;
+
+            [JsonProperty("clientCertificate")]
+            private string certificate;
+
+            [JsonProperty("clientCertificatePassword")]
+            private string certificatepassword;
+
+            [JsonProperty("subscriptionId")]
+            private string subscription;
+
+            [JsonProperty("activeDirectoryEndpointUrl")]
+            private string authurl;
+
+            [JsonProperty("resourceManagerEndpointUrl")]
+            private string baseurl;
+
+            [JsonProperty("managementEndpointUrl")]
+            private string managementuri;
+
+            [JsonProperty("activeDirectoryGraphResourceId")]
+            private string graphurl;
         }
     }
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
