### PR TITLE
Fix parameter name and structure for radius server setting for VpnGat…

### DIFF
--- a/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetworkGateway.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetworkGateway.cs
@@ -63,11 +63,6 @@ namespace Microsoft.Azure.Management.Network.Models
         /// configurations.</param>
         /// <param name="bgpSettings">Virtual network gateway's BGP speaker
         /// settings.</param>
-        /// <param name="radiusServer">The radius server address property of
-        /// the VirtualNetworkGateway resource for vpn client
-        /// connection.</param>
-        /// <param name="radiusSecret">The radius secret property of the
-        /// VirtualNetworkGateway resource for vpn client connection.</param>
         /// <param name="resourceGuid">The resource GUID property of the
         /// VirtualNetworkGateway resource.</param>
         /// <param name="provisioningState">The provisioning state of the
@@ -75,7 +70,7 @@ namespace Microsoft.Azure.Management.Network.Models
         /// 'Deleting', and 'Failed'.</param>
         /// <param name="etag">Gets a unique read-only string that changes
         /// whenever the resource is updated.</param>
-        public VirtualNetworkGateway(string id = default(string), string name = default(string), string type = default(string), string location = default(string), IDictionary<string, string> tags = default(IDictionary<string, string>), IList<VirtualNetworkGatewayIPConfiguration> ipConfigurations = default(IList<VirtualNetworkGatewayIPConfiguration>), string gatewayType = default(string), string vpnType = default(string), bool? enableBgp = default(bool?), bool? activeActive = default(bool?), SubResource gatewayDefaultSite = default(SubResource), VirtualNetworkGatewaySku sku = default(VirtualNetworkGatewaySku), VpnClientConfiguration vpnClientConfiguration = default(VpnClientConfiguration), BgpSettings bgpSettings = default(BgpSettings), string radiusServer = default(string), string radiusSecret = default(string), string resourceGuid = default(string), string provisioningState = default(string), string etag = default(string))
+        public VirtualNetworkGateway(string id = default(string), string name = default(string), string type = default(string), string location = default(string), IDictionary<string, string> tags = default(IDictionary<string, string>), IList<VirtualNetworkGatewayIPConfiguration> ipConfigurations = default(IList<VirtualNetworkGatewayIPConfiguration>), string gatewayType = default(string), string vpnType = default(string), bool? enableBgp = default(bool?), bool? activeActive = default(bool?), SubResource gatewayDefaultSite = default(SubResource), VirtualNetworkGatewaySku sku = default(VirtualNetworkGatewaySku), VpnClientConfiguration vpnClientConfiguration = default(VpnClientConfiguration), BgpSettings bgpSettings = default(BgpSettings), string resourceGuid = default(string), string provisioningState = default(string), string etag = default(string))
             : base(id, name, type, location, tags)
         {
             IpConfigurations = ipConfigurations;
@@ -87,8 +82,6 @@ namespace Microsoft.Azure.Management.Network.Models
             Sku = sku;
             VpnClientConfiguration = vpnClientConfiguration;
             BgpSettings = bgpSettings;
-            RadiusServer = radiusServer;
-            RadiusSecret = radiusSecret;
             ResourceGuid = resourceGuid;
             ProvisioningState = provisioningState;
             Etag = etag;
@@ -162,20 +155,6 @@ namespace Microsoft.Azure.Management.Network.Models
         /// </summary>
         [JsonProperty(PropertyName = "properties.bgpSettings")]
         public BgpSettings BgpSettings { get; set; }
-
-        /// <summary>
-        /// Gets or sets the radius server address property of the
-        /// VirtualNetworkGateway resource for vpn client connection.
-        /// </summary>
-        [JsonProperty(PropertyName = "properties.radiusServer")]
-        public string RadiusServer { get; set; }
-
-        /// <summary>
-        /// Gets or sets the radius secret property of the
-        /// VirtualNetworkGateway resource for vpn client connection.
-        /// </summary>
-        [JsonProperty(PropertyName = "properties.radiusSecret")]
-        public string RadiusSecret { get; set; }
 
         /// <summary>
         /// Gets or sets the resource GUID property of the

--- a/src/SDKs/Network/Management.Network/Generated/Models/VpnClientConfiguration.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/VpnClientConfiguration.cs
@@ -42,12 +42,19 @@ namespace Microsoft.Azure.Management.Network.Models
         /// Virtual network gateway.</param>
         /// <param name="vpnClientProtocols">VpnClientProtocols for Virtual
         /// network gateway.</param>
-        public VpnClientConfiguration(AddressSpace vpnClientAddressPool = default(AddressSpace), IList<VpnClientRootCertificate> vpnClientRootCertificates = default(IList<VpnClientRootCertificate>), IList<VpnClientRevokedCertificate> vpnClientRevokedCertificates = default(IList<VpnClientRevokedCertificate>), IList<string> vpnClientProtocols = default(IList<string>))
+        /// <param name="radiusServerAddress">The radius server address
+        /// property of the VirtualNetworkGateway resource for vpn client
+        /// connection.</param>
+        /// <param name="radiusServerSecret">The radius secret property of the
+        /// VirtualNetworkGateway resource for vpn client connection.</param>
+        public VpnClientConfiguration(AddressSpace vpnClientAddressPool = default(AddressSpace), IList<VpnClientRootCertificate> vpnClientRootCertificates = default(IList<VpnClientRootCertificate>), IList<VpnClientRevokedCertificate> vpnClientRevokedCertificates = default(IList<VpnClientRevokedCertificate>), IList<string> vpnClientProtocols = default(IList<string>), string radiusServerAddress = default(string), string radiusServerSecret = default(string))
         {
             VpnClientAddressPool = vpnClientAddressPool;
             VpnClientRootCertificates = vpnClientRootCertificates;
             VpnClientRevokedCertificates = vpnClientRevokedCertificates;
             VpnClientProtocols = vpnClientProtocols;
+            RadiusServerAddress = radiusServerAddress;
+            RadiusServerSecret = radiusServerSecret;
             CustomInit();
         }
 
@@ -81,6 +88,20 @@ namespace Microsoft.Azure.Management.Network.Models
         /// </summary>
         [JsonProperty(PropertyName = "vpnClientProtocols")]
         public IList<string> VpnClientProtocols { get; set; }
+
+        /// <summary>
+        /// Gets or sets the radius server address property of the
+        /// VirtualNetworkGateway resource for vpn client connection.
+        /// </summary>
+        [JsonProperty(PropertyName = "radiusServerAddress")]
+        public string RadiusServerAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the radius secret property of the
+        /// VirtualNetworkGateway resource for vpn client connection.
+        /// </summary>
+        [JsonProperty(PropertyName = "radiusServerSecret")]
+        public string RadiusServerSecret { get; set; }
 
     }
 }


### PR DESCRIPTION
…eways.

Fix parameter name and structure for radius server setting for
VpnGateways.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.

The Rest-API-Spec PR for this change is here:
https://github.com/Azure/azure-rest-api-specs/pull/1484 
