### PR TITLE
Updates to handle non-standard error status code during LRO

### DIFF
--- a/src/SDKs/Cdn/Cdn.Tests/Cdn.Tests.csproj
+++ b/src/SDKs/Cdn/Cdn.Tests/Cdn.Tests.csproj
@@ -10,11 +10,8 @@
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>    
-    <PackageReference Include="Microsoft.Azure.ResourceManager" Version="1.1.0-preview" />
-
+  <ItemGroup>
     <ProjectReference Include="..\Management.Cdn\Microsoft.Azure.Management.Cdn.csproj" />
-    <!--<PackageReference Include="Microsoft.Azure.Management.Cdn" Version="3.0.1-preview" />-->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LROOpertionTestResponses.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LROOpertionTestResponses.cs
@@ -159,6 +159,51 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Tests
 
         }
 
+        static internal IEnumerable<HttpResponseMessage> MockLROLocHdrNonStandardTerminalStatus()
+        {
+            var response1 = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"
+                    {
+                    ""location"": ""East US"",
+                      ""etag"": ""9d8d7ed9-7422-46be-82b3-94c5345f6099"",
+                      ""tags"": {},
+                      ""properties"": {
+                            ""clusterVersion"": ""0.0.1000.0"",
+                            ""osType"": ""Linux"",                            
+                            ""provisioningState"": ""InProgress"",
+                            ""clusterState"": ""Accepted"",
+                            ""createdDate"": ""2017-07-25T21:48:17.427"",
+                            ""quotaInfo"": 
+                                {
+                                    ""coresUsed"": ""200""
+                                },
+                            }
+                    }
+            ")
+            };
+            response1.Headers.Add("Location", "https://management.azure.com:090/subscriptions/56b5e0a9-b645-407d-99b0-c64f86013e3d/resourcegroups/sjrg8116/providers/Microsoft.StreamAnalytics/streamingjobs/sj3215/functions/function5403/OperationResults/f5dca005-e2ba-47d7-bf6e-4b3276e6bff9");
+            yield return response1;
+
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"
+                {
+                  ""status"": ""TestFailed"",
+                  ""error"":
+                    {
+                        ""code"": ""BadRequest"",
+                        ""message"": ""DeploymentDocument 'HiveConfigurationValidator' failed the validation.Error: 'Cannot connect to Hive metastore using user provided connection string'"",
+                        ""details"": null
+                    }
+                }
+            ")
+            };
+
+            yield return response2;
+
+        }
+
         #region Provisioning States
         static internal IEnumerable<HttpResponseMessage> MockAsyncOperaionWithMissingProvisioningState()
         {

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LongRunningOperationsTest.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LongRunningOperationsTest.cs
@@ -677,7 +677,19 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Test
             }
         }
 
-        
+        /// <summary>
+        /// Test
+        /// </summary>
+        [Fact]
+        public void TestLROWithNonStandardTerminalStatus()
+        {
+            var tokenCredentials = new TokenCredentials("123", "abc");
+            var handler = new PlaybackTestHandler(LROResponse.MockLROLocHdrNonStandardTerminalStatus());
+            var fakeClient = new RedisManagementClient(tokenCredentials, handler);
+            fakeClient.LongRunningOperationInitialTimeout = fakeClient.LongRunningOperationRetryTimeout = 0;
 
+            var foo = fakeClient.RedisOperations.PostWithHttpMessagesAsync("rg", "redis", "1234").ConfigureAwait(false).GetAwaiter().GetResult();            
+            Assert.Equal<string>("OK", foo.Response.StatusCode.ToString());
+        }
     }
 }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Microsoft.Rest.ClientRuntime.Azure.csproj
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Microsoft.Rest.ClientRuntime.Azure.csproj
@@ -4,7 +4,7 @@
     <PackageId>Microsoft.Rest.ClientRuntime.Azure</PackageId>
     <Description>Provides common error handling, tracing, and HTTP/REST-based pipeline manipulation.</Description>
     <AssemblyTitle>Client Runtime for Microsoft Azure Libraries</AssemblyTitle>
-    <Version>3.4.0</Version>
+    <Version>3.3.9</Version>
     <AssemblyName>Microsoft.Rest.ClientRuntime.Azure</AssemblyName>
     <PackageTags>Microsoft Azure AutoRest ClientRuntime REST  $(NugetCommonTags) $(NugetCommonProfileTags)</PackageTags>
   </PropertyGroup>

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Rest Azure Client Runtime")]
 [assembly: AssemblyDescription("Client infrastructure for Azure client libraries.")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.4.0.0")]
+[assembly: AssemblyFileVersion("3.3.9.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]

--- a/tools/buildTargets/common.Build.props
+++ b/tools/buildTargets/common.Build.props
@@ -48,11 +48,3 @@
     </Otherwise>
   </Choose>
 </Project>
-
-<!--
-    <PostBuildEvent>      
-    </PostBuildEvent>
-    <PreBuildEvent>
-      <CallTarget Targets="PrintStuff"/>
-    </PreBuildEvent>
-    -->


### PR DESCRIPTION
- Updates to handle non-standard error status code during LRO with LocationHeader
for e.g. during LRO a response might contain the status as TestFailed which is a non-standard terminal status.
- Added tests to cover the same scenario. 
- Updated ClientRuntime.Azure version.
- Cleaned up minor inconsistency in CDN test project file