### PR TITLE
Fixes for AzureEnvironment.cs

### DIFF
--- a/src/ResourceManagement/ResourceManager/AzureEnvironment.cs
+++ b/src/ResourceManagement/ResourceManager/AzureEnvironment.cs
@@ -28,9 +28,9 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
             };
             AzureUSGovernment = new AzureEnvironment()
             {
-                AuthenticationEndpoint = "https://login-us.microsoftonline.com/",
-                ResourceManagerEndpoint = "https://management.core.usgovcloudapi.net/",
-                ManagementEnpoint = "https://management.core.usgovcloudapi.net/",
+                AuthenticationEndpoint = "https://login.microsoftonline.us/",
+                ResourceManagerEndpoint = "https://management.usgovcloudapi.net/",
+                ManagementEnpoint = "https://management.usgovcloudapi.net/",
                 GraphEndpoint = "https://graph.windows.net/",
                 StorageEndpointSuffix = ".core.usgovcloudapi.net"
             };


### PR DESCRIPTION
The Management and ResourceManager endpoints for Fairfax are incorrect. The authentication endpoint is deprecated and Azure documentation suggests using the newer endpoint at https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-developer-guide

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
