### PR TITLE
[ClientRuntime] Added PATCH as a valid method when Created status is returned on LRO

### DIFF
--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/AzureClientExtensions.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/AzureClientExtensions.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Rest.Azure
             var statusCode = initialResponse.Response.StatusCode;
             var method = initialResponse.Request.Method;
             if (statusCode == HttpStatusCode.OK || statusCode == HttpStatusCode.Accepted ||
-                (statusCode == HttpStatusCode.Created && method == HttpMethod.Put) ||
+                (statusCode == HttpStatusCode.Created && (method == HttpMethod.Put || method == new HttpMethod("PATCH"))) ||
                 (statusCode == HttpStatusCode.NoContent && (method == HttpMethod.Delete || method == HttpMethod.Post)))
             {
                 return false;


### PR DESCRIPTION
## Description

As per https://github.com/Azure/azure-sdk-for-net/issues/3592 , PATCH long running operations return a 'Created' HTTP status code. This change adds this as a valid response.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [X] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [X] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [X] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [X] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
