### PR TITLE
CheckNameAvailabilityResult.IsAvailalbe -> CheckNameAvailabilityResult.IsAvailable for Azure Storage

### DIFF
--- a/Tests/Fluent.Tests/Storage/StorageAccountsTests.cs
+++ b/Tests/Fluent.Tests/Storage/StorageAccountsTests.cs
@@ -30,7 +30,7 @@ namespace Fluent.Tests.Storage
                         .StorageAccounts
                         .CheckNameAvailability(stgName);
                     Assert.NotNull(availabilityResult);
-                    Assert.True(availabilityResult.IsAvailalbe);
+                    Assert.True(availabilityResult.IsAvailable);
 
                     var storageAccount = storageManager.StorageAccounts.Define(stgName)
                         .WithRegion(Region.USEast2)
@@ -59,7 +59,7 @@ namespace Fluent.Tests.Storage
                         .CheckNameAvailability(stgName);
 
                     Assert.NotNull(availabilityResult);
-                    Assert.False(availabilityResult.IsAvailalbe);
+                    Assert.False(availabilityResult.IsAvailable);
                     Assert.NotNull(availabilityResult.Reason);
 
                     // Get
@@ -134,7 +134,7 @@ namespace Fluent.Tests.Storage
                         .StorageAccounts
                         .CheckNameAvailability(stgName);
                     Assert.NotNull(availabilityResult);
-                    Assert.True(availabilityResult.IsAvailalbe);
+                    Assert.True(availabilityResult.IsAvailable);
 
                     var storageAccount = storageManager.StorageAccounts.Define(stgName)
                         .WithRegion(Region.USEast2)

--- a/src/ResourceManagement/Storage/CheckNameAvailabilityResult.cs
+++ b/src/ResourceManagement/Storage/CheckNameAvailabilityResult.cs
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
 namespace Microsoft.Azure.Management.Storage.Fluent
 {
     using Microsoft.Azure.Management.Storage.Fluent.Models;
@@ -7,7 +10,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
     /// <summary>
     /// The  com.microsoft.azure.management.storage.StorageAccounts.checkNameAvailability action result.
     /// </summary>
-///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnN0b3JhZ2UuQ2hlY2tOYW1lQXZhaWxhYmlsaXR5UmVzdWx0
+    ///GENTHASH:Y29tLm1pY3Jvc29mdC5henVyZS5tYW5hZ2VtZW50LnN0b3JhZ2UuQ2hlY2tOYW1lQXZhaWxhYmlsaXR5UmVzdWx0
     public class CheckNameAvailabilityResult
     {
         private readonly CheckNameAvailabilityResultInner inner;
@@ -20,6 +23,21 @@ namespace Microsoft.Azure.Management.Storage.Fluent
         internal CheckNameAvailabilityResult(CheckNameAvailabilityResultInner inner)
         {
             this.inner = inner;
+        }
+
+        /// <return>
+        /// A boolean value that indicates whether the name is available for
+        /// you to use. If true, the name is available. If false, the name has
+        /// already been taken or invalid and cannot be used.
+        /// </return>
+        ///GENMHASH:ECE9AA3B22E6D72ED037B235766E650D:4F919944D8D2F904C2402C730D63DA07
+        [Obsolete("Please use IsAvailable instead")]
+        public bool? IsAvailalbe
+        {
+            get
+            {
+                return IsAvailable;
+            }
         }
 
         /// <return>

--- a/src/ResourceManagement/Storage/CheckNameAvailabilityResult.cs
+++ b/src/ResourceManagement/Storage/CheckNameAvailabilityResult.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Management.Storage.Fluent
         /// already been taken or invalid and cannot be used.
         /// </return>
         ///GENMHASH:ECE9AA3B22E6D72ED037B235766E650D:4F919944D8D2F904C2402C730D63DA07
-        public bool? IsAvailalbe
+        public bool? IsAvailable
         {
             get
             {


### PR DESCRIPTION
## Description
Fixes #3618 and marks the old property as obsolete.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

R# & VS runner are not discovering the tests in VS 2017 Update 3.1, somehow.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.

This is not applicable I presume?