### PR TITLE
Retry-After header is honored for LRO

### DIFF
--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LROOpertionTestResponses.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LROOpertionTestResponses.cs
@@ -1107,5 +1107,129 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Tests
             yield return response2;
         }
 
+        static internal IEnumerable<HttpResponseMessage> MockPatchWithRetryAfterTwoTries()
+        {
+            var response1 = new HttpResponseMessage(HttpStatusCode.Accepted)
+            {
+                Content = new StringContent(@"")
+            };
+            response1.Headers.Add("Location", "http://custom/location/status");
+            response1.Headers.Add("Retry-After", "3");
+
+            yield return response1;
+
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{ \"properties\": { }, \"id\": \"100\", \"name\": \"foo\" }")
+            };
+
+            yield return response2;
+        }
+
+        static internal IEnumerable<HttpResponseMessage> MockCreateOrUpdateWithDifferentRetryAfterValues()
+        {
+            var response1 = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"
+                {
+                    ""location"": ""North US"",
+                    ""tags"": {
+                        ""key1"": ""value 1"",
+                        ""key2"": ""value 2""
+                        },
+    
+                    ""properties"": { 
+                        ""provisioningState"": ""InProgerss"",
+                        ""comment"": ""Resource defined structure""
+                    }
+                }")
+            };
+            response1.Headers.Add("Azure-AsyncOperation", "http://custom/status");
+            response1.Headers.Add("Retry-After", "2");
+
+            yield return response1;
+
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"
+                {
+                    ""status"" : ""InProgerss"", 
+                    ""properties"": { 
+                        ""provisioningState"": ""InProgerss"",
+                        ""comment"": ""Resource getting created""
+                    }
+                }")
+            };            
+            response2.Headers.Add("Retry-After", "5");
+
+            yield return response2;
+
+            var response3 = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"
+                {
+                    ""status"" : ""Succeeded"", 
+                    ""properties"": {
+                        ""id"": ""100"",
+                        ""name"": ""foo""
+                    }
+                }")
+            };
+
+            yield return response3;
+
+            var response4 = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"
+                {
+                    ""status"" : ""Succeeded"", 
+                    ""properties"": {
+                        ""id"": ""100"",
+                        ""name"": ""foo""
+                    }
+                }")
+            };
+
+            yield return response4;
+        }
+
+        static internal IEnumerable<HttpResponseMessage> MockCreateWithRetryAfterDefaultMin()
+        {
+            var response1 = new HttpResponseMessage(HttpStatusCode.Accepted)
+            {
+                Content = new StringContent(@"")
+            };
+            response1.Headers.Add("Location", "http://custom/location/status");
+            response1.Headers.Add("Retry-After", "0");
+
+            yield return response1;
+
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{ \"properties\": { }, \"id\": \"100\", \"name\": \"foo\" }")
+            };
+
+            yield return response2;
+        }
+
+        static internal IEnumerable<HttpResponseMessage> MockCreateWithRetryAfterDefaultMax()
+        {
+            var response1 = new HttpResponseMessage(HttpStatusCode.Accepted)
+            {
+                Content = new StringContent(@"")
+            };
+            response1.Headers.Add("Location", "http://custom/location/status");
+            response1.Headers.Add("Retry-After", "50");
+
+            yield return response1;
+
+            var response2 = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{ \"properties\": { }, \"id\": \"100\", \"name\": \"foo\" }")
+            };
+
+            yield return response2;
+        }
+
     }
 }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LongRunningOperationsTest.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LongRunningOperationsTest.cs
@@ -506,20 +506,6 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Test
             }
         }
 
-        /// <summary>
-        /// Test
-        /// </summary>
-        [Fact]
-        public void TestCreateOrUpdateWithRetryAfter()
-        {
-            var tokenCredentials = new TokenCredentials("123", "abc");
-            var handler = new PlaybackTestHandler(LROResponse.MockCreateOrUpdateWithRetryAfterTwoTries());
-            var fakeClient = new RedisManagementClient(tokenCredentials, handler);
-            var now = DateTime.Now;
-            fakeClient.RedisOperations.CreateOrUpdate("rg", "redis", new RedisCreateOrUpdateParameters(), "1234");
-
-            Assert.True(DateTime.Now - now >= TimeSpan.FromSeconds(2));
-        }
 
         /// <summary>
         /// Test
@@ -600,20 +586,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Test
             Assert.Equal("Long running operation failed with status 'InternalServerError'.", ex.Message);
         }
 
-        /// <summary>
-        /// Test
-        /// </summary>
-        [Fact]
-        public void TestDeleteWithRetryAfter()
-        {
-            var tokenCredentials = new TokenCredentials("123", "abc");
-            var handler = new PlaybackTestHandler(LROResponse.MockDeleteWithRetryAfterTwoTries());
-            var fakeClient = new RedisManagementClient(tokenCredentials, handler);
-            var now = DateTime.Now;
-            fakeClient.RedisOperations.Delete("rg", "redis", "1234");
-            
-            Assert.True(DateTime.Now - now >= TimeSpan.FromSeconds(2));
-        }
+
 
 
         /// <summary>
@@ -690,6 +663,99 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Test
 
             var foo = fakeClient.RedisOperations.PostWithHttpMessagesAsync("rg", "redis", "1234").ConfigureAwait(false).GetAwaiter().GetResult();            
             Assert.Equal<string>("OK", foo.Response.StatusCode.ToString());
+        }
+    }
+
+    /// <summary>
+    /// Tests for Retry-After header
+    /// </summary>
+    public class LRO_RetryAfterTests
+    {
+
+        /// <summary>
+        /// Test
+        /// </summary>
+        [Fact]
+        public void TestCreateOrUpdateWithRetryAfter()
+        {
+            var tokenCredentials = new TokenCredentials("123", "abc");
+            var handler = new PlaybackTestHandler(LROResponse.MockCreateOrUpdateWithRetryAfterTwoTries());
+            var fakeClient = new RedisManagementClient(tokenCredentials, handler);
+            var now = DateTime.Now;
+            fakeClient.RedisOperations.CreateOrUpdate("rg", "redis", new RedisCreateOrUpdateParameters(), "1234");
+
+            Assert.True(DateTime.Now - now >= TimeSpan.FromSeconds(2));
+        }
+
+        /// <summary>
+        /// Test
+        /// </summary>
+        [Fact]
+        public void TestDeleteWithRetryAfter()
+        {
+            var tokenCredentials = new TokenCredentials("123", "abc");
+            var handler = new PlaybackTestHandler(LROResponse.MockDeleteWithRetryAfterTwoTries());
+            var fakeClient = new RedisManagementClient(tokenCredentials, handler);
+            var now = DateTime.Now;
+            fakeClient.RedisOperations.Delete("rg", "redis", "1234");               
+
+            Assert.True(DateTime.Now - now >= TimeSpan.FromSeconds(2));
+        }
+
+        /// <summary>
+        /// Test
+        /// </summary>
+        [Fact]
+        public void TestPatchWithRetryAfter()
+        {
+            var tokenCredentials = new TokenCredentials("123", "abc");
+            var handler = new PlaybackTestHandler(LROResponse.MockPatchWithRetryAfterTwoTries());
+            var fakeClient = new RedisManagementClient(tokenCredentials, handler);            
+            var now = DateTime.Now;
+            fakeClient.RedisOperations.Patch("rg", "redis", new RedisCreateOrUpdateParameters(), "1234");
+            Assert.True(DateTime.Now - now >= TimeSpan.FromSeconds(2));
+        }
+
+        /// <summary>
+        /// Test
+        /// </summary>
+        [Fact]
+        public void TestCreateWithDifferentRetryAfter()
+        {
+            var tokenCredentials = new TokenCredentials("123", "abc");
+            var handler = new PlaybackTestHandler(LROResponse.MockCreateOrUpdateWithDifferentRetryAfterValues());
+            var fakeClient = new RedisManagementClient(tokenCredentials, handler);
+            var before = DateTime.Now;
+            fakeClient.RedisOperations.CreateOrUpdate("rg", "redis", new RedisCreateOrUpdateParameters(), "1234");
+            Assert.True(DateTime.Now - before >= TimeSpan.FromSeconds(7));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Fact]
+        public void TestCreateWithRetryAfterDefaultMin()
+        {
+            var tokenCredentials = new TokenCredentials("123", "abc");
+            var handler = new PlaybackTestHandler(LROResponse.MockCreateWithRetryAfterDefaultMin());
+            var fakeClient = new RedisManagementClient(tokenCredentials, handler);
+            var before = DateTime.Now;
+            fakeClient.RedisOperations.CreateOrUpdate("rg", "redis", new RedisCreateOrUpdateParameters(), "1234");
+            Assert.True(DateTime.Now - before >= TimeSpan.FromSeconds(1));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Fact]
+        public void TestCreateWithRetryAfterDefaultMax()
+        {
+            var tokenCredentials = new TokenCredentials("123", "abc");
+            var handler = new PlaybackTestHandler(LROResponse.MockCreateWithRetryAfterDefaultMax());
+            var fakeClient = new RedisManagementClient(tokenCredentials, handler);
+            var before = DateTime.Now;
+            fakeClient.RedisOperations.CreateOrUpdate("rg", "redis", new RedisCreateOrUpdateParameters(), "1234");
+            Assert.True(DateTime.Now - before >= TimeSpan.FromSeconds(40));
         }
     }
 }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/Microsoft.Rest.ClientRuntime.Azure.Tests.csproj
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/Microsoft.Rest.ClientRuntime.Azure.Tests.csproj
@@ -2,14 +2,13 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('CR.test.reference.props'))" />
   <PropertyGroup>
     <Description>Test Project for Microsoft.Rest.ClientRuntime.Azure</Description>
-    <VersionPrefix>2.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
     <AssemblyName>Microsoft.Rest.ClientRuntime.Azure.Tests</AssemblyName>
     <PackageId>Microsoft.Rest.ClientRuntime.Azure.Tests</PackageId>
     <PackageTags>Rest ClientRuntime Azure Test $(NugetCommonTags) $(NugetCommonProfileTags)</PackageTags>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-    <TestProjectType>true</TestProjectType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp1.1|AnyCPU'">
     <NoWarn>1701;1702;1705</NoWarn>
@@ -19,13 +18,7 @@
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="[2.2.12,3.0.0)" />
   </ItemGroup>
   <ItemGroup>
-    <!--<PackageReference Include="Microsoft.Rest.ClientRuntime" Version="[2.3.6,3.0)" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="[3.3.5,4.0.0)" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="[2.2.12,3.0.0)" />-->
-
     <ProjectReference Include="..\ClientRuntime.Azure\Microsoft.Rest.ClientRuntime.Azure.csproj" />
-    <!--<ProjectReference Include="..\..\ClientRuntime\ClientRuntime\Microsoft.Rest.ClientRuntime.csproj" />-->
-    <!--<ProjectReference Include="..\..\ClientRuntime.Azure.Authentication\Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj" />-->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/Sample/RedisManagementClient.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/Sample/RedisManagementClient.cs
@@ -761,6 +761,24 @@ namespace Microsoft.Azure.Management.Redis
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="operations"></param>
+        /// <param name="resoruceGroupName"></param>
+        /// <param name="name"></param>
+        /// <param name="parameters"></param>
+        /// <param name="subscriptionId"></param>
+        /// <returns></returns>
+        public static RedisResource Patch(this IRedisOperations operations, string resoruceGroupName, string name, RedisCreateOrUpdateParameters parameters, string subscriptionId)
+        {
+            return Task.Factory.StartNew((object s) =>
+            {
+                return ((IRedisOperations)s).PatchAsync(resoruceGroupName, name, parameters, subscriptionId);
+            }
+            ,operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
         /// Create a redis cache, or replace (overwrite/recreate, with
         /// potential downtime) an existing cache
         /// </summary>
@@ -841,6 +859,22 @@ namespace Microsoft.Azure.Management.Redis
         public static async Task<RedisResource> CreateOrUpdateAsync(this IRedisOperations operations, string resourceGroupName, string name, RedisCreateOrUpdateParameters parameters, string subscriptionId, CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             AzureOperationResponse<RedisResource> result = await operations.CreateOrUpdateWithHttpMessagesAsync(resourceGroupName, name, parameters, subscriptionId, cancellationToken).ConfigureAwait(false);
+            return result.Body;
+        }
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="operations"></param>
+        /// <param name="resourceGroupName"></param>
+        /// <param name="name"></param>
+        /// <param name="parameters"></param>
+        /// <param name="subscriptionId"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public static async Task<RedisResource> PatchAsync(this IRedisOperations operations, string resourceGroupName, string name, RedisCreateOrUpdateParameters parameters, string subscriptionId, CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            AzureOperationResponse<RedisResource> result = await operations.PatchWithHttpMessagesAsync(resourceGroupName, name, parameters, subscriptionId, cancellationToken).ConfigureAwait(false);
             return result.Body;
         }
 
@@ -1065,6 +1099,9 @@ namespace Microsoft.Azure.Management.Redis
         
         Task<AzureOperationResponse<RedisResource>> CreateOrUpdateWithHttpMessagesAsync(string resourceGroupName, string name, RedisCreateOrUpdateParameters parameters, string subscriptionId, CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
+        Task<AzureOperationResponse<RedisResource>> PatchWithHttpMessagesAsync(string resourceGroupName, string name, RedisCreateOrUpdateParameters parameters, string subscriptionId,
+                                                                                                CancellationToken cancellationToken = default(CancellationToken));
+
         /// <summary>
         /// Create a redis cache, or replace (overwrite/recreate, with
         /// potential downtime) an existing cache
@@ -1175,25 +1212,19 @@ namespace Microsoft.Azure.Management.Redis
         }
 
         /// <summary>
-        /// Create a redis cache, or replace (overwrite/recreate, with
-        /// potential downtime) an existing cache
+        /// 
         /// </summary>
-        /// <param name='resourceGroupName'>
-        /// Required.
-        /// </param>
-        /// <param name='name'>
-        /// Required.
-        /// </param>
-        /// <param name='parameters'>
-        /// Required.
-        /// </param>
-        /// <param name='subscriptionId'>
-        /// Required.
-        /// </param>
-        /// <param name='cancellationToken'>
-        /// Cancellation token.
-        /// </param>
-        public async Task<AzureOperationResponse<RedisResource>> BeginCreateOrUpdateWithHttpMessagesAsync(string resourceGroupName, string name, RedisCreateOrUpdateParameters parameters, string subscriptionId, CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <param name="resourceGroupName"></param>
+        /// <param name="name"></param>
+        /// <param name="parameters"></param>
+        /// <param name="subscriptionId"></param>
+        /// <param name="httpMethod"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<AzureOperationResponse<RedisResource>> BeginCreateOrUpdateWithHttpMessagesAsync(string resourceGroupName,
+                                                                                                    string name, RedisCreateOrUpdateParameters parameters,
+                                                                                                    string subscriptionId, HttpMethod httpMethod,
+                                                                                                    CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Validate
             if (resourceGroupName == null)
@@ -1250,7 +1281,7 @@ namespace Microsoft.Azure.Management.Redis
 
             // Create HTTP transport objects
             HttpRequestMessage httpRequest = new HttpRequestMessage();
-            httpRequest.Method = HttpMethod.Put;
+            httpRequest.Method = httpMethod;
             httpRequest.RequestUri = new Uri(url);
 
             // Set Headers
@@ -1291,7 +1322,7 @@ namespace Microsoft.Azure.Management.Redis
                 }
                 ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
                 ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
-                    
+
                 if (shouldTrace)
                 {
                     ServiceClientTracing.Error(invocationId, ex);
@@ -1318,7 +1349,29 @@ namespace Microsoft.Azure.Management.Redis
             return result;
         }
 
-        public async Task<AzureOperationResponse<RedisResource>> CreateOrUpdateWithHttpMessagesAsync(string resourceGroupName, string name, RedisCreateOrUpdateParameters parameters, string subscriptionId, CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<RedisResource>> PatchWithHttpMessagesAsync(string resourceGroupName, string name, RedisCreateOrUpdateParameters parameters, string subscriptionId, 
+                                                                                                CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Send Request
+            AzureOperationResponse<RedisResource> response = await BeginCreateOrUpdateWithHttpMessagesAsync(
+                resourceGroupName,
+                name,
+                parameters,
+                subscriptionId,
+                new HttpMethod("PATCH"),
+                cancellationToken);
+
+            Debug.Assert(response.Response.StatusCode == HttpStatusCode.OK ||
+                         response.Response.StatusCode == HttpStatusCode.Created ||
+                         response.Response.StatusCode == HttpStatusCode.Accepted);
+
+            return await this.Client.GetPutOrPatchOperationResultAsync(response,
+                null,
+                cancellationToken);
+        }
+        public async Task<AzureOperationResponse<RedisResource>> CreateOrUpdateWithHttpMessagesAsync(string resourceGroupName, string name, 
+                                                                                                     RedisCreateOrUpdateParameters parameters, string subscriptionId, 
+                                                                                                     CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // Send Request
             AzureOperationResponse<RedisResource> response = await BeginCreateOrUpdateWithHttpMessagesAsync(
@@ -1328,13 +1381,43 @@ namespace Microsoft.Azure.Management.Redis
                 subscriptionId,
                 cancellationToken);
 
-            Debug.Assert(response.Response.StatusCode == HttpStatusCode.OK || 
+            Debug.Assert(response.Response.StatusCode == HttpStatusCode.OK ||
                          response.Response.StatusCode == HttpStatusCode.Created ||
                          response.Response.StatusCode == HttpStatusCode.Accepted);
 
-            return await this.Client.GetPutOrPatchOperationResultAsync(response, 
+            return await this.Client.GetPutOrPatchOperationResultAsync(response,
                 null,
                 cancellationToken);
+        }
+
+
+            /// <summary>
+            /// Create a redis cache, or replace (overwrite/recreate, with
+            /// potential downtime) an existing cache
+            /// </summary>
+            /// <param name='resourceGroupName'>
+            /// Required.
+            /// </param>
+            /// <param name='name'>
+            /// Required.
+            /// </param>
+            /// <param name='parameters'>
+            /// Required.
+            /// </param>
+            /// <param name='subscriptionId'>
+            /// Required.
+            /// </param>
+            /// <param name='httpMethod'>
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// Cancellation token.
+            /// </param>
+            public async Task<AzureOperationResponse<RedisResource>> BeginCreateOrUpdateWithHttpMessagesAsync(string resourceGroupName, 
+                                                                                                    string name, RedisCreateOrUpdateParameters parameters, 
+                                                                                                    string subscriptionId, 
+                                                                                                    CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            return await BeginCreateOrUpdateWithHttpMessagesAsync(resourceGroupName, name, parameters, subscriptionId, HttpMethod.Put, cancellationToken);
         }
 
         /// <summary>

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/AzureClientExtensions.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/AzureClientExtensions.cs
@@ -1,21 +1,21 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Rest.ClientRuntime.Azure.Properties;
-using Microsoft.Rest.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
 namespace Microsoft.Rest.Azure
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Rest.ClientRuntime.Azure.Properties;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
     public static partial class AzureClientExtensions
     {
         /// <summary>
@@ -106,7 +106,7 @@ namespace Microsoft.Rest.Azure
             while (!AzureAsyncOperation.TerminalStatuses.Any(s => s.Equals(pollingState.Status,
                 StringComparison.OrdinalIgnoreCase)))
             {
-                await Task.Delay(pollingState.DelayInMilliseconds, cancellationToken).ConfigureAwait(false);
+                await Task.Delay(pollingState.DelayBetweenPolling, cancellationToken).ConfigureAwait(false);
 
                 if (!string.IsNullOrEmpty(pollingState.AzureAsyncOperationHeaderLink))
                 {
@@ -349,7 +349,7 @@ namespace Microsoft.Rest.Azure
             var statusCode = initialResponse.Response.StatusCode;
             var method = initialResponse.Request.Method;
             if (statusCode == HttpStatusCode.OK || statusCode == HttpStatusCode.Accepted ||
-                (statusCode == HttpStatusCode.Created && method == HttpMethod.Put) ||
+                (statusCode == HttpStatusCode.Created && (method == HttpMethod.Put)) ||
                 (statusCode == HttpStatusCode.NoContent && (method == HttpMethod.Delete || method == HttpMethod.Post)))
             {
                 return false;

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/AzureLROOperationExtensions.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/AzureLROOperationExtensions.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Rest.Azure
 
     public static partial class AzureClientExtensions
     {
-
         /// <summary>
         /// Updates PollingState from Location header.
         /// </summary>

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Microsoft.Rest.ClientRuntime.Azure.csproj
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Microsoft.Rest.ClientRuntime.Azure.csproj
@@ -4,7 +4,7 @@
     <PackageId>Microsoft.Rest.ClientRuntime.Azure</PackageId>
     <Description>Provides common error handling, tracing, and HTTP/REST-based pipeline manipulation.</Description>
     <AssemblyTitle>Client Runtime for Microsoft Azure Libraries</AssemblyTitle>
-    <Version>3.3.9</Version>
+    <Version>3.4.0</Version>
     <AssemblyName>Microsoft.Rest.ClientRuntime.Azure</AssemblyName>
     <PackageTags>Microsoft Azure AutoRest ClientRuntime REST  $(NugetCommonTags) $(NugetCommonProfileTags)</PackageTags>
   </PropertyGroup>

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/PollingState.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/PollingState.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using Microsoft.Rest.ClientRuntime.Azure.Properties;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
 
 namespace Microsoft.Rest.Azure
 {
@@ -18,6 +19,18 @@ namespace Microsoft.Rest.Azure
     /// <typeparam name="THeader">Type of resource header.</typeparam>
     internal class PollingState<TBody, THeader> where TBody : class where THeader : class
     {
+#if DEBUG
+        const int DEFAULT_MIN_DELAY_SECONDS = 1;
+        const int DEFAULT_MAX_DELAY_SECONDS = 40;
+#else
+        // Delay values are in seconds
+        const int DEFAULT_MIN_DELAY_SECONDS = 10;
+        const int DEFAULT_MAX_DELAY_SECONDS = 600;
+#endif
+
+        private int _retryAfterInSeconds;
+
+
         /// <summary>
         /// Initializes an instance of PollingState.
         /// </summary>
@@ -25,7 +38,7 @@ namespace Microsoft.Rest.Azure
         /// <param name="retryTimeout">Default timeout.</param>
         public PollingState(HttpOperationResponse<TBody, THeader> response, int? retryTimeout)
         {
-            _retryTimeout = retryTimeout;
+            RetryAfterInSeconds = retryTimeout.HasValue ? retryTimeout.Value : AzureAsyncOperation.DefaultDelay;
             Response = response.Response;
             Request = response.Request;
             Resource = response.Body;
@@ -136,6 +149,11 @@ namespace Microsoft.Rest.Azure
                     {
                         LocationHeaderLink = _response.Headers.GetValues("Location").FirstOrDefault();
                     }
+                    
+                    if (_response.Headers.Contains("Retry-After"))
+                    {
+                        RetryAfterInSeconds = int.Parse(_response.Headers.GetValues("Retry-After").FirstOrDefault(), CultureInfo.InvariantCulture);
+                    }
                 }
             }
         }
@@ -160,27 +178,77 @@ namespace Microsoft.Rest.Azure
         /// </summary>
         public THeader ResourceHeaders { get; set; }
 
-        private int? _retryTimeout;
+        //private int? _retryTimeout;
 
         /// <summary>
         /// Gets long running operation delay in milliseconds.
         /// </summary>
+        [Obsolete("DelayInMilliseconds property will be deprecated in future releases. You should start using DelayBetweenPolling")]
         public int DelayInMilliseconds
         {
             get
             {
-                if (_retryTimeout != null)
-                {
-                    return _retryTimeout.Value * 1000;
-                }
-                if (Response != null && Response.Headers.Contains("Retry-After"))
-                {
-                    return int.Parse(Response.Headers.GetValues("Retry-After").FirstOrDefault(),
-                        CultureInfo.InvariantCulture) * 1000;
-                }
-                return AzureAsyncOperation.DefaultDelay * 1000;
+                return RetryAfterInSeconds * 1000;
             }
         }
+
+        /// <summary>
+        /// Long running operation polling delay
+        /// </summary>
+        public TimeSpan DelayBetweenPolling
+        {
+            get
+            {
+                return TimeSpan.FromSeconds(RetryAfterInSeconds);
+            }
+        }
+
+        /// <summary>
+        /// Initially this is initialized with LongRunningOperationRetryTimeout value
+        /// Verify min/max allowed value according to ARM spec (especially minimum value for throttling at ARM level)
+        /// We want this to be int value and not int? because this value will always have a default non-zero/non-null value
+        /// </summary>
+        internal int RetryAfterInSeconds
+        {
+            get
+            {
+                return _retryAfterInSeconds;
+            }
+
+            set
+            {
+                _retryAfterInSeconds = ValidateRetryAfterValue(value);
+            }
+        }
+
+
+        private int ValidateRetryAfterValue(int? currentValue)
+        {
+            if (currentValue.HasValue)
+            {
+                if (currentValue < DEFAULT_MIN_DELAY_SECONDS)
+                    currentValue = DEFAULT_MIN_DELAY_SECONDS;
+                else if (currentValue > DEFAULT_MAX_DELAY_SECONDS)
+                    currentValue = DEFAULT_MAX_DELAY_SECONDS;
+            }
+            else
+            {
+                currentValue = AzureAsyncOperation.DefaultDelay;
+            }
+
+            return currentValue.Value;
+        }
+        
+        //internal int GetRetryAfterValueFromHeader(HttpResponseMessage responseMessage)
+        //{
+        //    int retryAfter = 0;
+        //    if (responseMessage != null && responseMessage.Headers.Contains("Retry-After"))
+        //    {
+        //        retryAfter = int.Parse(responseMessage.Headers.GetValues("Retry-After").FirstOrDefault(), CultureInfo.InvariantCulture);
+        //    }
+
+        //    return retryAfter;
+        //}
 
         /// <summary>
         /// Gets CloudException from current instance.  

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Rest Azure Client Runtime")]
 [assembly: AssemblyDescription("Client infrastructure for Azure client libraries.")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.3.9.0")]
+[assembly: AssemblyFileVersion("3.4.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]


### PR DESCRIPTION
Fixes #3447 
- Retry-After header is honored for LRO polling.
- Added tests. 
- Added LRO Patch scenario test.
- Cleaned up PollingState: 
Obsolete DelayInMillisecond propety, introduced DelayBetweenPolling property that returns TimeSpan. Bumped version.
