### PR TITLE
Added customization in RecoveryServices client and updated Microsoft.Rest.ClientRuntime to 2.3.10

### DIFF
--- a/src/SDKs/RecoveryServices/Management.RecoveryServices/Customizations/RecoveryServicesClient.cs
+++ b/src/SDKs/RecoveryServices/Management.RecoveryServices/Customizations/RecoveryServicesClient.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Management.RecoveryServices
 {
     public partial class RecoveryServicesClient
     {
-        bool DisableDispose { get; set; }
+        public bool DisableDispose { get; set; } = false;
 
         protected RecoveryServicesClient(HttpClient httpClient, params DelegatingHandler[] handlers)
         {
@@ -39,9 +39,14 @@ namespace Microsoft.Azure.Management.RecoveryServices
             DisableDispose = disableDispose;
         }
 
+        public void SetHttpClient(HttpClient client)
+        {
+            HttpClient = client;
+        }
+
         protected override void Dispose(bool disposing)
         {
-            if (DisableDispose)
+            if (!DisableDispose)
             {
                 base.Dispose(disposing);
             }

--- a/src/SDKs/RecoveryServices/Management.RecoveryServices/Microsoft.Azure.Management.RecoveryServices.csproj
+++ b/src/SDKs/RecoveryServices/Management.RecoveryServices/Microsoft.Azure.Management.RecoveryServices.csproj
@@ -11,6 +11,9 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+  </ItemGroup>
 </Project>
   <!--
   <ItemGroup>

--- a/src/SDKs/RecoveryServices/Management.RecoveryServices/Microsoft.Azure.Management.RecoveryServices.csproj
+++ b/src/SDKs/RecoveryServices/Management.RecoveryServices/Microsoft.Azure.Management.RecoveryServices.csproj
@@ -11,9 +11,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Update="Microsoft.Rest.ClientRuntime" Version="2.3.8" />
-  </ItemGroup>
 </Project>
   <!--
   <ItemGroup>

--- a/src/SDKs/RecoveryServices/Management.RecoveryServices/Microsoft.Azure.Management.RecoveryServices.csproj
+++ b/src/SDKs/RecoveryServices/Management.RecoveryServices/Microsoft.Azure.Management.RecoveryServices.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+    <PackageReference Update="Microsoft.Rest.ClientRuntime" Version="2.3.8" />
   </ItemGroup>
 </Project>
   <!--


### PR DESCRIPTION
**Following items in this PR:**
1. Added customizations in RecoveryServices Client.
2. Updated Microsoft.Rest.ClientRuntime to use 2.3.10

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
