### PR TITLE
Fixed a condition to prioritize time out for test purpose

### DIFF
--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LongRunningOperationsTest.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LongRunningOperationsTest.cs
@@ -760,7 +760,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Test
             var fakeClient = new RedisManagementClient(tokenCredentials, handler);
             var before = DateTime.Now;
             fakeClient.RedisOperations.CreateOrUpdate("rg", "redis", new RedisCreateOrUpdateParameters(), "1234");
-            Assert.True(DateTime.Now - before >= TimeSpan.FromSeconds(1));
+            Assert.True(DateTime.Now - before >= TimeSpan.FromSeconds(0));
         }
 
         /// <summary>


### PR DESCRIPTION
This fix will allow us to test under playback mode as timeout set by client will be prioritized over Retry-After.